### PR TITLE
Use most recent MathCell

### DIFF
--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/Console.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/Console.java
@@ -49,7 +49,7 @@ public class Console {
 					"\n" + //
 					"<body>\n" + //
 					"\n" + //
-					"<script src=\"https://cdn.jsdelivr.net/gh/paulmasson/mathcell@1.3.0/build/mathcell.js\"></script>\n"
+					"<script src=\"https://cdn.jsdelivr.net/gh/paulmasson/mathcell@1.7.0/build/mathcell.js\"></script>\n"
 					+ //
 					"<script src=\"https://cdn.jsdelivr.net/gh/mathjax/MathJax@2.7.5/MathJax.js?config=TeX-AMS_HTML\"></script>"
 					+ //


### PR DESCRIPTION
Since the documentation is always for the most current version, you should probably use it here. You might want to update the three examples as well unless they are working fine. 