### PR TITLE
Use latest version of Math

### DIFF
--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/Console.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/Console.java
@@ -48,7 +48,7 @@ public class Console {
 					"</head>\n" + //
 					"\n" + //
 					"<body>\n" + //
-					"<script src=\"https://cdn.jsdelivr.net/gh/paulmasson/math@1.2.0/build/math.js\"></script>" + //
+					"<script src=\"https://cdn.jsdelivr.net/gh/paulmasson/math@1.2.1/build/math.js\"></script>" + //
 					"\n" + //
 					"\n" + //
 					"<script src=\"https://cdn.jsdelivr.net/gh/paulmasson/mathcell@1.7.0/build/mathcell.js\"></script>\n"


### PR DESCRIPTION
Version 1.2.0 was a bit of a release mistake, since it's really from a couple months ago and I can't purge the CDN. The current documentation matches 1.2.1 and has a better Gauss hypergeometric function.