### PR TITLE
[Maven-Workflow] fix collection of packaged/deployed jar files

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,8 +28,11 @@ jobs:
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2 
     - run: mvn --batch-mode --update-snapshots verify --file symja_android_library/pom.xml
-    - run: shopt -s globstar
-    - run: mkdir staging && cp **/target/*.jar staging
+    - name: Collect deployed artifacts
+      run: |
+        shopt -s globstar # enable use of double asterisks for multi-directory matches
+        mkdir staging
+        cp **/target/*.jar staging
     - uses: actions/upload-artifact@v2
       with:
         name: Package


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description
As requested in #228 this PR fixes the collection of packaged/deployed artifacts into the staging area.
The problem was caused by double asterisks not being enabled by default in the bash shell.
The implementation of the solution suggested in your forum question (https://github.community/t/maven-cp-target-jar-staging/183191) did not work because with each run-step a new shell process is started (see the corresponding documentation: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsrun). 

So in order to have an effect the command "shopt -s globstar" needs to run in the same shell were it is required.
One solution would be to simply prepend the command which would result in the following line:
`    - run: shopt -s globstar && mkdir staging && cp **/target/*.jar staging`

In order to increase the readability I changed this to a multi-line command and added a name (otherwise it would only use the first line as name which is not very descriptive. Please let me know if you prefer a one-liner.


