### PR TITLE
Fix scope of Junit dependencies to "test"

### DIFF
--- a/symja_android_library/pom.xml
+++ b/symja_android_library/pom.xml
@@ -376,12 +376,14 @@
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
 			<version>5.7.2</version>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.junit.vintage</groupId>
 			<artifactId>junit-vintage-engine</artifactId>
 			<version>5.7.2</version>
+			<scope>test</scope>
 		</dependency>
 
 	</dependencies>


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

This PR fixes the scope of the Junit dependencies to `test`. This was forgotten accidentally and caused Symja to have a runtime and compile dependency to junit.