### PR TITLE
Improve and speed up ArchUnit tests

### DIFF
--- a/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/io/system/archunit/ArchUnitTests.java
+++ b/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/io/system/archunit/ArchUnitTests.java
@@ -2,221 +2,103 @@ package org.matheclipse.io.system.archunit;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
-
-import org.matheclipse.core.expression.F;
-
+import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
+import org.junit.runner.RunWith;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
-import com.tngtech.archunit.core.domain.JavaClasses;
-import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchIgnore;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchUnitRunner;
 import com.tngtech.archunit.lang.ArchRule;
 
-import junit.framework.TestCase;
+@RunWith(ArchUnitRunner.class)
+@AnalyzeClasses(packages = "org")
+public class ArchUnitTests {
 
-public class ArchUnitTests extends TestCase {
-  public ArchUnitTests() {
-    super("ArchUnitTests");
-  }
+  @ArchTest
+  public static final ArchRule consoleMethods = methods().that() //
+      .areDeclaredIn(org.matheclipse.io.eval.Console.class).and().doNotHaveName("main") //
+      .should().notBePublic().andShould().notBeProtected();
 
-  public void testConsoleMethods() {
-    JavaClasses importedClasses = new ClassFileImporter().importPackages("org.matheclipse.io.eval");
+  @ArchTest
+  public static final ArchRule MMAConsoleMethods = methods().that() //
+      .areDeclaredIn(org.matheclipse.io.eval.MMAConsole.class).and().doNotHaveName("main") //
+      .should().notBePublic().andShould().notBeProtected();
 
-    ArchRule rule =
-        methods()
-            .that()
-            .areDeclaredIn("org.matheclipse.io.eval.Console")
-            .and()
-            .doNotHaveName("main")
-            .should()
-            .notBePublic()
-            .andShould()
-            .notBeProtected();
-    rule.check(importedClasses);
-  }
+  @ArchIgnore
+  @ArchTest
+  public static final ArchRule expession_data_access = classes().that() //
+      .resideInAPackage("org.matheclipse.core.expression.data..") //
+      .should().onlyBeAccessed().byAnyPackage("org.matheclipse.core.expression..");
 
-  public void testMMAConsoleMethods() {
-    JavaClasses importedClasses = new ClassFileImporter().importPackages("org.matheclipse.io.eval");
+  @ArchTest
+  public static final ArchRule expession_access =
+      classes().that().resideInAPackage("org.matheclipse.core.expression..")
+          .and(new DescribedPredicate<JavaClass>("") {
+            @Override
+            public boolean apply(JavaClass arg0) {
+              return arg0.getSimpleName().equals("AST") || arg0.getSimpleName().equals("ExprField")
+                  || arg0.getSimpleName().equals("ExprID");
+            }
+          })
+          // TODO change dependency from "org.matheclipse.core.convert"
+          .should().onlyBeAccessed().byAnyPackage("org.matheclipse.core.expression..");
 
-    ArchRule rule =
-        methods()
-            .that()
-            .areDeclaredIn("org.matheclipse.io.eval.MMAConsole")
-            .and()
-            .doNotHaveName("main")
-            .should()
-            .notBePublic()
-            .andShould()
-            .notBeProtected();
-    rule.check(importedClasses);
-  }
+  @ArchTest
+  public static final ArchRule AST0 = classes().that() //
+      .resideInAPackage("org.matheclipse.core.expression..").and().haveSimpleName("AST0") //
+      .should().onlyBeAccessed().byAnyPackage("org.matheclipse.core.expression..");
 
-//  public void test_expession_data_access() {
-//    JavaClasses importedClasses = new ClassFileImporter().importPackages("org.matheclipse");
-//
-//    ArchRule myRule =
-//        classes()
-//            .that()
-//            .resideInAPackage("org.matheclipse.core.expression.data..")
-//            .should()
-//            .onlyBeAccessed()
-//            .byAnyPackage("org.matheclipse.core.expression..");
-//
-//    myRule.check(importedClasses);
-//  }
+  @ArchTest
+  public static final ArchRule AST1 = classes().that() //
+      .resideInAPackage("org.matheclipse.core.expression..").and().haveSimpleName("AST1") //
+      .should().onlyBeAccessed().byAnyPackage("org.matheclipse.core.expression..");
 
-  public void test_expession_access() {
-    JavaClasses importedClasses = new ClassFileImporter().importPackages("org.matheclipse");
+  @ArchTest
+  public static final ArchRule AST2 = classes().that() //
+      .resideInAPackage("org.matheclipse.core.expression..").and().haveSimpleName("AST2") //
+      .should().onlyBeAccessed().byAnyPackage("org.matheclipse.core.expression..");
 
-    ArchRule myRule =
-        classes()
-            .that()
-            .resideInAPackage("org.matheclipse.core.expression..")
-            .and(
-                new DescribedPredicate<JavaClass>("") {
-                  @Override
-                  public boolean apply(JavaClass arg0) {
-                    return arg0.getSimpleName().equals("AST")
-                        || arg0.getSimpleName().equals("ExprField")
-                        || arg0.getSimpleName().equals("ExprID");
-                  }
-                })
-            // TODO change dependency from "org.matheclipse.core.convert"
-            .should()
-            .onlyBeAccessed()
-            .byAnyPackage("org.matheclipse.core.expression..");
-
-    myRule.check(importedClasses);
-  }
-
-  public void testAST0() {
-    JavaClasses importedClasses = new ClassFileImporter().importPackages("org.matheclipse");
-
-    ArchRule myRule =
-        classes()
-            .that()
-            .resideInAPackage("org.matheclipse.core.expression..")
-            .and()
-            .haveSimpleName("AST0")
-            .should()
-            .onlyBeAccessed()
-            .byAnyPackage("org.matheclipse.core.expression..");
-
-    myRule.check(importedClasses);
-  }
-
-  public void testAST1() {
-    JavaClasses importedClasses = new ClassFileImporter().importPackages("org.matheclipse");
-
-    ArchRule myRule =
-        classes()
-            .that()
-            .resideInAPackage("org.matheclipse.core.expression..")
-            .and()
-            .haveSimpleName("AST1")
-            .should()
-            .onlyBeAccessed()
-            .byAnyPackage("org.matheclipse.core.expression..");
-
-    myRule.check(importedClasses);
-  }
-
-  public void testAST2() {
-    JavaClasses importedClasses = new ClassFileImporter().importPackages("org.matheclipse");
-
-    ArchRule myRule =
-        classes()
-            .that()
-            .resideInAPackage("org.matheclipse.core.expression..")
-            .and()
-            .haveSimpleName("AST2")
-            .should()
-            .onlyBeAccessed()
-            .byAnyPackage("org.matheclipse.core.expression..");
-
-    myRule.check(importedClasses);
-  }
-
-  public void testAST3() {
-    JavaClasses importedClasses = new ClassFileImporter().importPackages("org.matheclipse");
-
-    ArchRule myRule =
-        classes()
-            .that()
-            .resideInAPackage("org.matheclipse.core.expression..")
-            .and()
-            .haveSimpleName("AST3")
-            .should()
-            .onlyBeAccessed()
-            .byAnyPackage("org.matheclipse.core.expression..");
-
-    myRule.check(importedClasses);
-  }
+  @ArchTest
+  public static final ArchRule AST3 = classes().that() //
+      .resideInAPackage("org.matheclipse.core.expression..").and().haveSimpleName("AST3") //
+      .should().onlyBeAccessed().byAnyPackage("org.matheclipse.core.expression..");
 
   /**
    * <p>
-   * Split in packages <code>org.matheclipse.core..</code> and <code>org.matheclipse.parser..</code>.
-   * <code>org.matheclipse.parser..</code> should not call Symja <code>IExpr</code> object hierarchy.
+   * Split in packages <code>org.matheclipse.core..</code> and
+   * <code>org.matheclipse.parser..</code>. <code>org.matheclipse.parser..</code> should not call
+   * Symja <code>IExpr</code> object hierarchy.
    * </p>
-   * <b>Note:</b>The <code>ExprParser</code> in package <code>org.matheclipse.core.parser..</code> is allowed to call
-   * Symja <code>IExpr</<code> object hierarchy.
+   * <b>Note:</b>The <code>ExprParser</code> in package <code>org.matheclipse.core.parser..</code>
+   * is allowed to call Symja <code>IExpr</<code> object hierarchy.
    */
-  public void testNoIExprInParser() {
-    JavaClasses importedClasses = new ClassFileImporter().importPackages("org.matheclipse");
+  @ArchTest
+  public static final ArchRule noIExprInParser = classes().that() //
+      .haveSimpleName("IExpr").or().haveSimpleName("IAST") //
+      .should().onlyBeAccessed().byAnyPackage("org.matheclipse..");
 
-    ArchRule rule =
-        classes()
-            .that()
-            .haveSimpleName("IExpr")
-            .or()
-            .haveSimpleName("IAST")
-            .should()
-            .onlyBeAccessed()
-            .byAnyPackage( //
-                "org.matheclipse..");
-    rule.check(importedClasses);
-  }
+  // LogicNG library
+  @ArchTest
+  public static final ArchRule LogicNG = classes().that() //
+      .resideInAPackage("org.logicng..") //
+      .should().onlyBeAccessed().byAnyPackage("org.logicng..", "..core.builtin..");
 
-  public void testLogicNG() {
-    // LogicNG library
-    JavaClasses importedClasses = new ClassFileImporter().importPackages("org");
+  // JGraphT library
+  // TODO reduce package dependencies
+  @ArchTest
+  public static final ArchRule jGraphT = classes().that().resideInAPackage("org.jgrapht..") //
+      .should().onlyBeAccessed().byAnyPackage( //
+          "org.jgrapht..", //
+          "..io.builtin..", //
+          "..core.builtin..", //
+          "..core.expression", //
+          "..core.expression.data", //
+          "..core.reflection.system..");
 
-    ArchRule myRule =
-        classes()
-            .that()
-            .resideInAPackage("org.logicng..")
-            .should()
-            .onlyBeAccessed()
-            .byAnyPackage("org.logicng..", "..core.builtin..");
-
-    myRule.check(importedClasses);
-  }
-
-  public void testJGraphT() {
-    // JGraphT library
-    // TODO reduce package dependencies
-    JavaClasses importedClasses = new ClassFileImporter().importPackages("org");
-
-    ArchRule myRule =
-        classes()
-            .that()
-            .resideInAPackage("org.jgrapht..")
-            .should()
-            .onlyBeAccessed()
-            .byAnyPackage( //
-                "org.jgrapht..", //
-                "..io.builtin..", //
-                "..core.builtin..", //
-                "..core.expression", //
-                "..core.expression.data", //
-                "..core.reflection.system..");
-
-    myRule.check(importedClasses);
-  }
-
-  // public void testCycleDependency() {
-  // JavaClasses importedClasses = new ClassFileImporter().importPackages("org.matheclipse");
-  // ArchRule myRule = slices().matching("..matheclipse.(*)..").should().beFreeOfCycles();
-  // myRule.check(importedClasses);
-  // }
-
+  @ArchIgnore
+  @ArchTest
+  public static final ArchRule cycleDependency = slices().matching("..matheclipse.(*)..") //
+      .should().beFreeOfCycles();
 }

--- a/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/io/system/archunit/CodingRulesTest.java
+++ b/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/io/system/archunit/CodingRulesTest.java
@@ -1,15 +1,4 @@
 package org.matheclipse.io.system.archunit;
-  
-
-import java.util.logging.Logger;
-
-import com.tngtech.archunit.core.domain.JavaClasses;
-import com.tngtech.archunit.junit.AnalyzeClasses;
-import com.tngtech.archunit.junit.ArchTest;
-import com.tngtech.archunit.junit.ArchUnitRunner;
-import com.tngtech.archunit.lang.ArchRule;
-import com.tngtech.archunit.lang.CompositeArchRule;
-import org.junit.runner.RunWith;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
@@ -19,43 +8,55 @@ import static com.tngtech.archunit.library.GeneralCodingRules.NO_CLASSES_SHOULD_
 import static com.tngtech.archunit.library.GeneralCodingRules.NO_CLASSES_SHOULD_USE_FIELD_INJECTION;
 import static com.tngtech.archunit.library.GeneralCodingRules.NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
 import static com.tngtech.archunit.library.GeneralCodingRules.NO_CLASSES_SHOULD_USE_JODATIME;
+import java.util.logging.Logger;
+import org.junit.runner.RunWith;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchIgnore;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchUnitRunner;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.CompositeArchRule;
 
 @RunWith(ArchUnitRunner.class)
 @AnalyzeClasses(packages = "org.matheclipse")
 public class CodingRulesTest {
 
-//    @ArchTest
-//    private final ArchRule no_access_to_standard_streams = NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS;
+  @ArchIgnore
+  @ArchTest
+  private final ArchRule no_access_to_standard_streams = NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS;
 
-//    @ArchTest
-//    private void no_access_to_standard_streams_as_method(JavaClasses classes) {
-//        noClasses().should(ACCESS_STANDARD_STREAMS).check(classes);
-//    }
-//
-//    @ArchTest
-//    private final ArchRule no_generic_exceptions = NO_CLASSES_SHOULD_THROW_GENERIC_EXCEPTIONS;
+  @ArchIgnore
+  @ArchTest
+  private void no_access_to_standard_streams_as_method(JavaClasses classes) {
+    noClasses().should(ACCESS_STANDARD_STREAMS).check(classes);
+  }
 
-    @ArchTest
-    private final ArchRule no_java_util_logging = NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
+  @ArchIgnore
+  @ArchTest
+  private final ArchRule no_generic_exceptions = NO_CLASSES_SHOULD_THROW_GENERIC_EXCEPTIONS;
 
-    @ArchTest
-    private final ArchRule loggers_should_be_private_static_final =
-            fields().that().haveRawType(Logger.class)
-                    .should().bePrivate()
-                    .andShould().beStatic()
-                    .andShould().beFinal()
-                    .because("we agreed on this convention");
+  @ArchTest
+  private final ArchRule no_java_util_logging = NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
 
-    @ArchTest
-    private final ArchRule no_jodatime = NO_CLASSES_SHOULD_USE_JODATIME;
+  @ArchTest
+  private final ArchRule loggers_should_be_private_static_final =
+      fields().that().haveRawType(Logger.class) //
+          .should().bePrivate() //
+          .andShould().beStatic() //
+          .andShould().beFinal() //
+          .because("we agreed on this convention");
 
-    @ArchTest
-    private final ArchRule no_field_injection = NO_CLASSES_SHOULD_USE_FIELD_INJECTION;
+  @ArchTest
+  private final ArchRule no_jodatime = NO_CLASSES_SHOULD_USE_JODATIME;
 
-//    @ArchTest
-//    public static final ArchRule no_classes_should_access_standard_streams_or_throw_generic_exceptions =
-//            CompositeArchRule.of(NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS)
-//                    .and(NO_CLASSES_SHOULD_THROW_GENERIC_EXCEPTIONS);
+  @ArchTest
+  private final ArchRule no_field_injection = NO_CLASSES_SHOULD_USE_FIELD_INJECTION;
 
+  @ArchIgnore
+  @ArchTest
+  public static final ArchRule no_classes_should_access_standard_streams_or_throw_generic_exceptions =
+      CompositeArchRule.of(NO_CLASSES_SHOULD_ACCESS_STANDARD_STREAMS)
+          .and(NO_CLASSES_SHOULD_THROW_GENERIC_EXCEPTIONS);
 }
 

--- a/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/io/system/archunit/CyclicDependencyRulesTest.java
+++ b/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/io/system/archunit/CyclicDependencyRulesTest.java
@@ -1,73 +1,78 @@
 package org.matheclipse.io.system.archunit;
 
-import com.tngtech.archunit.base.DescribedPredicate;
+
+import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
+import org.junit.runner.RunWith;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchIgnore;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.junit.ArchUnitRunner;
 import com.tngtech.archunit.lang.ArchRule;
 import com.tngtech.archunit.library.dependencies.SliceAssignment;
 import com.tngtech.archunit.library.dependencies.SliceIdentifier;
-import org.junit.runner.RunWith;
-
-import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPackage;
-import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
 
 @RunWith(ArchUnitRunner.class)
 @AnalyzeClasses(packages = "org.matheclipse")
 public class CyclicDependencyRulesTest {
 
-//    @ArchTest
-//    public static final ArchRule no_cycles_by_method_calls_between_slices =
-//            slices().matching("..(org.matheclipse).(*)..").namingSlices("$2 of $1").should().beFreeOfCycles();
-//
-//    @ArchTest
-//    public static final ArchRule no_cycles_by_constructor_calls_between_slices =
-//            slices().matching("..(org.matheclipse).(*)..").namingSlices("$2 of $1").should().beFreeOfCycles();
-//
-//    @ArchTest
-//    public static final ArchRule no_cycles_by_inheritance_between_slices =
-//            slices().matching("..(org.matheclipse).(*)..").namingSlices("$2 of $1").should().beFreeOfCycles();
-//
-//    @ArchTest
-//    public static final ArchRule no_cycles_by_field_access_between_slices =
-//            slices().matching("..(org.matheclipse).(*)..").namingSlices("$2 of $1").should().beFreeOfCycles();
-//
-//    @ArchTest
-//    public static final ArchRule no_cycles_by_member_dependencies_between_slices =
-//            slices().matching("..(org.matheclipse).(*)..").namingSlices("$2 of $1").should().beFreeOfCycles();
-//
-//    @ArchTest
-//    public static final ArchRule no_cycles_in_simple_scenario =
-//            slices().matching("..org.matheclipse.(*)..").namingSlices("$1").should().beFreeOfCycles();
-//
-//    @ArchTest
-//    public static final ArchRule no_cycles_in_complex_scenario =
-//            slices().matching("..(org.matheclipse).(*)..").namingSlices("$2 of $1").should().beFreeOfCycles();
+  @ArchIgnore
+  @ArchTest
+  public static final ArchRule no_cycles_by_method_calls_between_slices = slices()
+      .matching("..(org.matheclipse).(*)..").namingSlices("$2 of $1").should().beFreeOfCycles();
 
-//    @ArchTest
-//    public static final ArchRule no_cycles_in_freely_customized_slices =
-//            slices().assignedFrom(inComplexSliceOneOrTwo())
-//                    .namingSlices("$1[$2]")
-//                    .should().beFreeOfCycles();
-//
-//    private static SliceAssignment inComplexSliceOneOrTwo() {
-//        return new SliceAssignment() {
-//            @Override
-//            public String getDescription() {
-//                return "complex slice one or two";
-//            }
-//
-//            @Override
-//            public SliceIdentifier getIdentifierOf(JavaClass javaClass) {
-//                if (javaClass.getPackageName().contains("complexcycles.slice1")) {
-//                    return SliceIdentifier.of("Complex-Cycle", "One");
-//                }
-//                if (javaClass.getPackageName().contains("complexcycles.slice2")) {
-//                    return SliceIdentifier.of("Complex-Cycle", "Two");
-//                }
-//                return SliceIdentifier.ignore();
-//            }
-//        };
-//    }
+  @ArchIgnore
+  @ArchTest
+  public static final ArchRule no_cycles_by_constructor_calls_between_slices = slices()
+      .matching("..(org.matheclipse).(*)..").namingSlices("$2 of $1").should().beFreeOfCycles();
+
+  @ArchIgnore
+  @ArchTest
+  public static final ArchRule no_cycles_by_inheritance_between_slices = slices()
+      .matching("..(org.matheclipse).(*)..").namingSlices("$2 of $1").should().beFreeOfCycles();
+
+  @ArchIgnore
+  @ArchTest
+  public static final ArchRule no_cycles_by_field_access_between_slices = slices()
+      .matching("..(org.matheclipse).(*)..").namingSlices("$2 of $1").should().beFreeOfCycles();
+
+  @ArchIgnore
+  @ArchTest
+  public static final ArchRule no_cycles_by_member_dependencies_between_slices = slices()
+      .matching("..(org.matheclipse).(*)..").namingSlices("$2 of $1").should().beFreeOfCycles();
+
+  @ArchIgnore
+  @ArchTest
+  public static final ArchRule no_cycles_in_simple_scenario =
+      slices().matching("..org.matheclipse.(*)..").namingSlices("$1").should().beFreeOfCycles();
+
+  @ArchIgnore
+  @ArchTest
+  public static final ArchRule no_cycles_in_complex_scenario = slices()
+      .matching("..(org.matheclipse).(*)..").namingSlices("$2 of $1").should().beFreeOfCycles();
+
+  @ArchIgnore
+  @ArchTest
+  public static final ArchRule no_cycles_in_freely_customized_slices = slices()
+      .assignedFrom(inComplexSliceOneOrTwo()).namingSlices("$1[$2]").should().beFreeOfCycles();
+
+  private static SliceAssignment inComplexSliceOneOrTwo() {
+    return new SliceAssignment() {
+      @Override
+      public String getDescription() {
+        return "complex slice one or two";
+      }
+
+      @Override
+      public SliceIdentifier getIdentifierOf(JavaClass javaClass) {
+        if (javaClass.getPackageName().contains("complexcycles.slice1")) {
+          return SliceIdentifier.of("Complex-Cycle", "One");
+        }
+        if (javaClass.getPackageName().contains("complexcycles.slice2")) {
+          return SliceIdentifier.of("Complex-Cycle", "Two");
+        }
+        return SliceIdentifier.ignore();
+      }
+    };
+  }
 }


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

With this PR I suggest to use the JUnit integration of ArchUnit better. This reduces boiler-plate code and decreses the runtime significantly (more than the factor two with respect to all tests in the package).

For this the test-methods in `ArchUnitTests` now only static fields annotated with @ArchTest and @AnalyzeClasses to
define all rules, like it is described in https://www.archunit.org/userguide/html/000_Index.html#_junit_support.
Because different test used different scope of packages, the class uses the widest scope and analysis all `org` packages.

Furthermore I disabled failing tests instead of commenting them out. This way it is ensured that the tests always compile, because they are kept in sync with the code base when some API evolves.