### PR TITLE
Remove redundant ArchUnit test dependencies

### DIFF
--- a/symja_android_library/matheclipse-io/pom.xml
+++ b/symja_android_library/matheclipse-io/pom.xml
@@ -73,12 +73,6 @@
 
 		<dependency>
 			<groupId>com.tngtech.archunit</groupId>
-			<artifactId>archunit</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>com.tngtech.archunit</groupId>
 			<artifactId>archunit-junit4</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/symja_android_library/pom.xml
+++ b/symja_android_library/pom.xml
@@ -138,12 +138,6 @@
 
 			<dependency>
 				<groupId>com.tngtech.archunit</groupId>
-				<artifactId>archunit</artifactId>
-				<version>0.18.0</version>
-			</dependency>
-
-			<dependency>
-				<groupId>com.tngtech.archunit</groupId>
 				<artifactId>archunit-junit4</artifactId>
 				<version>0.18.0</version>
 			</dependency>


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

The dependency `com.tngtech.archunit:archunit-junit4` has a transitive dependency to `com.tngtech.archunit:archunit`, so there is no need to specify the latter explicitly.

