### PR TITLE
[Build] add Eclipse Maven launch-config to toggle snapshot locking

### DIFF
--- a/symja_android_library/eclipse/toggle-snapshot-version-locking.launch
+++ b/symja_android_library/eclipse/toggle-snapshot-version-locking.launch
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
+    <booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
+    <stringAttribute key="M2_GOALS" value="versions:unlock-snapshots versions:lock-snapshots"/>
+    <booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
+    <booleanAttribute key="M2_OFFLINE" value="false"/>
+    <stringAttribute key="M2_PROFILES" value=""/>
+    <listAttribute key="M2_PROPERTIES">
+        <listEntry value="generateBackupPoms=false"/>
+    </listAttribute>
+    <stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
+    <booleanAttribute key="M2_SKIP_TESTS" value="false"/>
+    <intAttribute key="M2_THREADS" value="1"/>
+    <booleanAttribute key="M2_UPDATE_SNAPSHOTS" value="true"/>
+    <stringAttribute key="M2_USER_SETTINGS" value=""/>
+    <booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
+    <stringAttribute key="org.eclipse.debug.core.ATTR_REFRESH_SCOPE" value="${workspace}"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
+    <stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${project_loc:symja_android_library}"/>
+</launchConfiguration>


### PR DESCRIPTION
As discussed this PR adds a Eclipse launch-configuration for a Maven build that toggles locking of snapshot-dependencies versions.

When a dependency uses a not locked snapshot-version, it is locked to the latest version available (querying the dependency repositories for new snapshots in each run).
When a already locked dependency version is encountered, it is unlocked (i.e. the ordinary `-SNAPSHOT` version suffix is appended to the 'main' version).

In order to update locked versions to the latest snapshots, just run the build twice.

It is a bit unpleasant at the moment that the hipparchus snapshot-dependencies are not locked, while the apfloat dependency is locked. Therefore manual adjustment is probably required after the toggle-snapshot-locking build had run.

With this launch-config, I think the hipparchus snapshot-version can be locked again. 
Alternatively I can set up the launch config to only consider hipparchus.
As you prefer.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)