### PR TITLE
Clean up Maven dependencies

### DIFF
--- a/symja_android_library/matheclipse-api/pom.xml
+++ b/symja_android_library/matheclipse-api/pom.xml
@@ -33,18 +33,23 @@
 		</dependency>
 
 		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>io.undertow</groupId>
 			<artifactId>undertow-core</artifactId>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.lucene</groupId>
-			<artifactId>lucene-core</artifactId>
+			<artifactId>lucene-analyzers-common</artifactId>
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.lucene</groupId>
-			<artifactId>lucene-analyzers-common</artifactId>
+			<groupId>org.commonmark</groupId>
+			<artifactId>commonmark-ext-gfm-tables</artifactId>
 		</dependency>
 
 		<dependency>

--- a/symja_android_library/matheclipse-beakerx/pom.xml
+++ b/symja_android_library/matheclipse-beakerx/pom.xml
@@ -33,12 +33,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.github.twosigma</groupId>
-			<artifactId>beakerx</artifactId>
-			<scope>provided</scope>
-		</dependency>
-
-		<dependency>
 			<groupId>com.github.twosigma.beakerx</groupId>
 			<artifactId>beaker-kernel-base</artifactId>
 		</dependency>

--- a/symja_android_library/matheclipse-core/pom.xml
+++ b/symja_android_library/matheclipse-core/pom.xml
@@ -14,7 +14,7 @@
 	<packaging>jar</packaging>
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>The Symja core module</description>
-	
+
 	<licenses>
 		<license>
 			<name>GNU Lesser General Public License, Version 3</name>
@@ -39,16 +39,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.commonmark</groupId>
-			<artifactId>commonmark</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.commonmark</groupId>
-			<artifactId>commonmark-ext-gfm-tables</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.apfloat</groupId>
 			<artifactId>apfloat</artifactId>
 		</dependency>
@@ -56,11 +46,6 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
 		</dependency>
 
 		<dependency>
@@ -77,11 +62,6 @@
 		<dependency>
 			<groupId>org.choco-solver</groupId>
 			<artifactId>choco-solver</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.hipparchus</groupId>
-			<artifactId>hipparchus-core</artifactId>
 		</dependency>
 
 		<dependency>
@@ -105,21 +85,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.hipparchus</groupId>
-			<artifactId>hipparchus-optim</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.hipparchus</groupId>
-			<artifactId>hipparchus-stat</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>commons-codec</groupId>
-			<artifactId>commons-codec</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
 		</dependency>
@@ -127,11 +92,6 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-csv</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>com.google.code.findbugs</groupId>
-			<artifactId>jsr305</artifactId>
 		</dependency>
 
 		<dependency>

--- a/symja_android_library/matheclipse-external/pom.xml
+++ b/symja_android_library/matheclipse-external/pom.xml
@@ -33,11 +33,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
 			<scope>test</scope>
@@ -50,22 +45,12 @@
 
 		<dependency>
 			<groupId>com.google.guava</groupId>
-			<artifactId>failureaccess</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 		</dependency>
 
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>com.fasterxml.jackson.datatype</groupId>
-			<artifactId>jackson-datatype-jsr310</artifactId>
 		</dependency>
 
 		<dependency>

--- a/symja_android_library/matheclipse-io/pom.xml
+++ b/symja_android_library/matheclipse-io/pom.xml
@@ -40,12 +40,12 @@
 
 		<dependency>
 			<groupId>io.undertow</groupId>
-			<artifactId>undertow-core</artifactId>
+			<artifactId>undertow-servlet</artifactId>
 		</dependency>
 
 		<dependency>
-			<groupId>io.undertow</groupId>
-			<artifactId>undertow-servlet</artifactId>
+			<groupId>org.commonmark</groupId>
+			<artifactId>commonmark-ext-gfm-tables</artifactId>
 		</dependency>
 
 		<dependency>
@@ -61,6 +61,11 @@
 		<dependency>
 			<groupId>org.jsoup</groupId>
 			<artifactId>jsoup</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jsr310</artifactId>
 		</dependency>
 
 		<dependency>

--- a/symja_android_library/pom.xml
+++ b/symja_android_library/pom.xml
@@ -44,7 +44,7 @@
 		<module>matheclipse-gpl</module>
 		<module>matheclipse-api</module>
 		<module>matheclipse-io</module>
-	    <module>matheclipse-jar</module> 
+		<module>matheclipse-jar</module>
 		<module>matheclipse-beakerx</module>
 		<module>matheclipse-discord</module>
 	</modules>
@@ -93,12 +93,6 @@
 			</dependency>
 
 			<dependency>
-				<groupId>com.github.twosigma</groupId>
-				<artifactId>beakerx</artifactId>
-				<version>1.3.0</version>
-			</dependency>
-
-			<dependency>
 				<groupId>com.github.twosigma.beakerx</groupId>
 				<artifactId>beaker-kernel-base</artifactId>
 				<version>1.3.0</version>
@@ -111,21 +105,9 @@
 			</dependency>
 
 			<dependency>
-				<groupId>com.google.code.findbugs</groupId>
-				<artifactId>jsr305</artifactId>
-				<version>3.0.0</version>
-			</dependency>
-
-			<dependency>
 				<groupId>com.google.code.gson</groupId>
 				<artifactId>gson</artifactId>
 				<version>2.8.5</version>
-			</dependency>
-
-			<dependency>
-				<groupId>com.google.guava</groupId>
-				<artifactId>failureaccess</artifactId>
-				<version>1.0.1</version>
 			</dependency>
 
 			<dependency>
@@ -220,12 +202,6 @@
 
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>
-				<artifactId>log4j-api</artifactId>
-				<version>2.13.2</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-core</artifactId>
 				<version>2.13.2</version>
 			</dependency>
@@ -233,12 +209,6 @@
 			<dependency>
 				<groupId>org.apache.lucene</groupId>
 				<artifactId>lucene-analyzers-common</artifactId>
-				<version>8.5.1</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.apache.lucene</groupId>
-				<artifactId>lucene-core</artifactId>
 				<version>8.5.1</version>
 			</dependency>
 
@@ -261,12 +231,6 @@
 				<groupId>org.codehaus.janino</groupId>
 				<artifactId>janino</artifactId>
 				<version>3.1.6</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.commonmark</groupId>
-				<artifactId>commonmark</artifactId>
-				<version>0.18.0</version>
 			</dependency>
 
 			<dependency>
@@ -295,12 +259,6 @@
 
 			<dependency>
 				<groupId>org.hipparchus</groupId>
-				<artifactId>hipparchus-core</artifactId>
-				<version>2.0</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.hipparchus</groupId>
 				<artifactId>hipparchus-fft</artifactId>
 				<version>2.0</version>
 			</dependency>
@@ -314,18 +272,6 @@
 			<dependency>
 				<groupId>org.hipparchus</groupId>
 				<artifactId>hipparchus-ode</artifactId>
-				<version>2.0</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.hipparchus</groupId>
-				<artifactId>hipparchus-optim</artifactId>
-				<version>2.0</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.hipparchus</groupId>
-				<artifactId>hipparchus-stat</artifactId>
 				<version>2.0</version>
 			</dependency>
 


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

With this PR I suggest to clean up the dependencies to keep the set of dependencies of each module (especially matheclipse-core) minimal, to not pull unnecessary dependencies.

Furthermore declared transitive compile-dependencies are removed, since they are pulled in automatically. Therefore declaring them is just additional text.
To get an overview about all available dependencies one can for example use the `Dependency-Hierarchy` tab in Eclipse's Pom-Editor.

In detail:
- Move `org.commonmark` dependencies from matheclipse-core to matheclipse-api and matheclipse-io 
- Move `commons-codec` from matheclipse-core to matheclipse-api
- Move `jackson-datatype-jsr310` from matheclipse-external to matheclipse-io

- Remove transitive dependencies of the following dependencies
  + guava
    - failureaccess
    - jsr305
  + jackson-datatype-jsr310
    - jackson-databind
  + commonmark-ext-gfm-tables
    - commonmark
  + lucene-analyzers-common
    - lucene-core
  + log4j-core
    - log4j-api
  + hipparchus-clustering/fft/fitting/ode
    - hipparchus-core
    - hipparchus-optim
    - hipparchus-stat

- Remove unused provided dependency `com.github.twosigma:beakerx`