### PR TITLE
[Core] remove useless if-conditions and restrict constants visibility

### DIFF
--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/AST.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/AST.java
@@ -600,35 +600,28 @@ public class AST extends HMArrayList implements Externalizable {
     if (size > 0 && size < 128) {
       short exprID = S.GLOBAL_IDS_MAP.getShort(head());
       if (exprID >= 0) {
-        if (exprID <= Short.MAX_VALUE) {
-          int exprIDSize = 1;
-          short[] exprIDArray = new short[size];
-          exprIDArray[0] = exprID;
-          for (int i = 1; i < size; i++) {
-            exprID = S.GLOBAL_IDS_MAP.getShort(get(i));
-            if (exprID < 0) {
-              break;
-            }
-            // exprID = temp.getExprID();
-            if (exprID <= Short.MAX_VALUE) {
-              exprIDArray[i] = exprID;
-              exprIDSize++;
-            } else {
-              break;
-            }
+        int exprIDSize = 1;
+        short[] exprIDArray = new short[size];
+        exprIDArray[0] = exprID;
+        for (int i = 1; i < size; i++) {
+          exprID = S.GLOBAL_IDS_MAP.getShort(get(i));
+          if (exprID < 0) {
+            break;
           }
-          // optimized path
-          attributeFlags = (byte) size;
-          objectOutput.writeByte(attributeFlags);
-          objectOutput.writeByte((byte) exprIDSize);
-          for (int i = 0; i < exprIDSize; i++) {
-            objectOutput.writeShort(exprIDArray[i]);
-          }
-          for (int i = exprIDSize; i < size; i++) {
-            objectOutput.writeObject(get(i));
-          }
-          return;
+          exprIDArray[i] = exprID;
+          exprIDSize++;
         }
+        // optimized path
+        attributeFlags = (byte) size;
+        objectOutput.writeByte(attributeFlags);
+        objectOutput.writeByte((byte) exprIDSize);
+        for (int i = 0; i < exprIDSize; i++) {
+          objectOutput.writeShort(exprIDArray[i]);
+        }
+        for (int i = exprIDSize; i < size; i++) {
+          objectOutput.writeObject(get(i));
+        }
+        return;
       }
     }
 

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/AST0.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/AST0.java
@@ -500,36 +500,28 @@ public class AST0 extends AbstractAST implements Externalizable, RandomAccess {
 
     short exprID = S.GLOBAL_IDS_MAP.getShort(head());
     if (exprID >= 0) {
-      // short exprID = temp.getExprID();
-      if (exprID <= Short.MAX_VALUE) {
-        int exprIDSize = 1;
-        short[] exprIDArray = new short[size];
-        exprIDArray[0] = exprID;
-        for (int i = 1; i < size; i++) {
-          exprID = S.GLOBAL_IDS_MAP.getShort(get(i));
-          if (exprID < 0) {
-            break;
-          }
-          // exprID = temp.getExprID();
-          if (exprID <= Short.MAX_VALUE) {
-            exprIDArray[i] = exprID;
-            exprIDSize++;
-          } else {
-            break;
-          }
+      int exprIDSize = 1;
+      short[] exprIDArray = new short[size];
+      exprIDArray[0] = exprID;
+      for (int i = 1; i < size; i++) {
+        exprID = S.GLOBAL_IDS_MAP.getShort(get(i));
+        if (exprID < 0) {
+          break;
         }
-        // optimized path
-        attributeFlags = (byte) size;
-        objectOutput.writeByte(attributeFlags);
-        objectOutput.writeByte((byte) exprIDSize);
-        for (int i = 0; i < exprIDSize; i++) {
-          objectOutput.writeShort(exprIDArray[i]);
-        }
-        for (int i = exprIDSize; i < size; i++) {
-          objectOutput.writeObject(get(i));
-        }
-        return;
+        exprIDArray[i] = exprID;
+        exprIDSize++;
       }
+      // optimized path
+      attributeFlags = (byte) size;
+      objectOutput.writeByte(attributeFlags);
+      objectOutput.writeByte((byte) exprIDSize);
+      for (int i = 0; i < exprIDSize; i++) {
+        objectOutput.writeShort(exprIDArray[i]);
+      }
+      for (int i = exprIDSize; i < size; i++) {
+        objectOutput.writeObject(get(i));
+      }
+      return;
     }
 
     objectOutput.writeByte(attributeFlags);

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/S.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/S.java
@@ -31,10 +31,10 @@ public class S {
    * the internal table of predefined constant expressions {@link #COMMON_IDS} mapped to the
    * corresponding expressions.
    */
-  public static final Object2ShortOpenHashMap<IExpr> GLOBAL_IDS_MAP =
+  static final Object2ShortOpenHashMap<IExpr> GLOBAL_IDS_MAP =
       new Object2ShortOpenHashMap<IExpr>(EXPRID_MAX_BUILTIN_LENGTH + 1000);
 
-  public static final Map<String, ISymbol> HIDDEN_SYMBOLS_MAP =
+  static final Map<String, ISymbol> HIDDEN_SYMBOLS_MAP =
       Config.TRIE_STRING2SYMBOL_BUILDER.withMatch(TrieMatch.EXACT).build(); // Tries.forStrings();
 
   public static IBuiltInSymbol symbol(int id) {
@@ -7652,7 +7652,7 @@ public class S {
   public static final IBuiltInSymbol Right = F.initFinalSymbol("Right", ID.Right);
 
   public static final IBuiltInSymbol RightComposition = F.initFinalSymbol("RightComposition", ID.RightComposition);
-  
+
   /**
    * RogersTanimotoDissimilarity(u, v) - returns the Rogers-Tanimoto dissimilarity between the two
    * boolean 1-D lists `u` and `v`, which is defined as `R / (c_tt + c_ff + R)` where n is `len(u)`,


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

As discussed in #257 this PR reduces the visibility of the static final Maps in `org.matheclipse.core.expression.S` and avoids unnecessary if-conditions that are always evaluate to true.

Those changes are submitted separately in order to keep the changes as small as possible/suitable.
Comparison is performed best with ignored white-space changes.