### PR TITLE
Revert "[External] Replace edu.jas sources by Maven dependency (#253/#256)"

### DIFF
--- a/symja_android_library/matheclipse-core/pom.xml
+++ b/symja_android_library/matheclipse-core/pom.xml
@@ -39,11 +39,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>de.uni-mannheim.rz.krum</groupId>
-			<artifactId>jas</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.apfloat</groupId>
 			<artifactId>apfloat</artifactId>
 		</dependency>

--- a/symja_android_library/matheclipse-external/pom.xml
+++ b/symja_android_library/matheclipse-external/pom.xml
@@ -28,6 +28,22 @@
 	<dependencies>
 
 		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>log4j-over-slf4j</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 		</dependency>

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/AlgebraicRootsPrimElem.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/AlgebraicRootsPrimElem.java
@@ -1,0 +1,181 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.Serializable;
+import java.util.List;
+
+import edu.jas.arith.Rational;
+import edu.jas.poly.AlgebraicNumberRing;
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.Complex;
+import edu.jas.root.AlgebraicRoots;
+import edu.jas.root.RealAlgebraicNumber;
+import edu.jas.root.ComplexAlgebraicNumber;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Container for the real and complex algebraic roots of a univariate
+ * polynomial together with primitive element.
+ * @param <C> coefficient type.
+ * @author Heinz Kredel
+ */
+public class AlgebraicRootsPrimElem<C extends GcdRingElem<C> & Rational> 
+             extends AlgebraicRoots<C> implements Serializable {
+
+
+    /**
+     * Primitive Element algebraic roots.
+     */
+    public final PrimitiveElement<C> pelem;
+
+
+    /**
+     * Roots of unity of primitive element origin representations.
+     */
+    public final List<AlgebraicNumber<C>> runit;
+
+
+    /**
+     * Constructor not for use.
+     */
+    protected AlgebraicRootsPrimElem() {
+        throw new IllegalArgumentException("do not use this constructor");
+    }
+
+
+    /**
+     * Constructor.
+     * @param p univariate polynomial
+     * @param cp univariate polynomial with compelx coefficients
+     * @param r list of real algebraic roots
+     * @param c list of complex algebraic roots
+     * @param pe primitive element
+     * @param ru roots of unity of primitive element origin representations
+     */
+    public AlgebraicRootsPrimElem(GenPolynomial<C> p, GenPolynomial<Complex<C>> cp, 
+                    List<RealAlgebraicNumber<C>> r,
+                    List<ComplexAlgebraicNumber<C>> c,
+                    PrimitiveElement<C> pe, List<AlgebraicNumber<C>> ru) {
+        super(p, cp, r, c);
+        this.pelem = pe;
+        this.runit = ru;
+    }
+
+
+    /**
+     * Constructor.
+     * @param ar algebraic roots container
+     * @param pe primitive element
+     */
+    public AlgebraicRootsPrimElem(AlgebraicRoots<C> ar, PrimitiveElement<C> pe) {
+        this(ar.p, ar.cp, ar.real, ar.complex, pe, null); 
+    }
+
+
+    /**
+     * Constructor.
+     * @param ar algebraic roots container
+     * @param pe primitive element
+     * @param ru roots of unity of primitive element origin representations
+     */
+    public AlgebraicRootsPrimElem(AlgebraicRoots<C> ar, PrimitiveElement<C> pe, List<AlgebraicNumber<C>> ru) {
+        this(ar.p, ar.cp, ar.real, ar.complex, pe, ru);
+    }
+
+
+    /**
+     * String representation of AlgebraicRootsPrimElem.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        if (runit == null) {
+            return super.toString();
+        }
+        return super.toString() + ", " + runit.toString();
+        //return "[" + p + ", real=" + real + ", complex=" + complex + ", " + pelem + "]";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Interval.
+     */
+    public String toScript() {
+        // any case
+        StringBuffer sb = new StringBuffer(super.toScript());
+        if (runit == null) {
+            return sb.toString();
+        }
+        sb.append(" [");
+        boolean first = true;
+        for (AlgebraicNumber<C> a : runit) {
+             if (first) {
+                 first = false;
+             } else {
+                 sb.append(", ");
+             }
+             sb.append(a.toScript());
+        }
+        sb.append("] ");
+        return sb.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Interval.
+     */
+    public String toDecimalScript() {
+        // any case
+        return super.toDecimalScript();
+    }
+
+
+    /**
+     * Copy this.
+     * @return a copy of this.
+     */
+    public AlgebraicRootsPrimElem<C> copy() {
+        return new AlgebraicRootsPrimElem<C>(p, cp, real, complex, pelem, runit);
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (!(b instanceof AlgebraicRootsPrimElem)) {
+            return false;
+        }
+        AlgebraicRootsPrimElem<C> a = null;
+        try {
+            a = (AlgebraicRootsPrimElem<C>) b;
+        } catch (ClassCastException e) {
+            return false;
+        }
+                                  // not realy required, since depends on A, B
+        return super.equals(a) && pelem.equals(a.pelem) && runit.equals(a.runit);
+    }
+
+
+    /**
+     * Hash code for this AlgebraicRootsPrimElem.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+                                               // not realy required, since depends on A, B
+        return (161 * super.hashCode() + 37) * pelem.hashCode() + runit.hashCode();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/CPair.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/CPair.java
@@ -1,0 +1,195 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.Serializable;
+
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Serializable subclass to hold pairs of colored polynomials.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+public class CPair<C extends RingElem<C>> implements Serializable, Comparable<CPair<C>> {
+
+
+    public final ColorPolynomial<C> pi;
+
+
+    public final ColorPolynomial<C> pj;
+
+
+    public final int i;
+
+
+    public final int j;
+
+
+    protected int n;
+
+
+    protected boolean toZero = false;
+
+
+    protected boolean useCriterion4 = true;
+
+
+    protected boolean useCriterion3 = true;
+
+
+    /**
+     * Pair constructor.
+     * @param a polynomial i.
+     * @param b polynomial j.
+     * @param i first index.
+     * @param j second index.
+     */
+    public CPair(ColorPolynomial<C> a, ColorPolynomial<C> b, int i, int j) {
+        pi = a;
+        pj = b;
+        this.i = i;
+        this.j = j;
+        this.n = 0;
+        toZero = false; // ok
+    }
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString() {
+        return "pair[" + n + "](" + i + "{" + pi.length() + "}," + j + "{" + pj.length()
+                + "}" + ", r0=" + toZero + ", c4=" + useCriterion4 + ", c3="
+                + useCriterion3 + ")";
+    }
+
+
+    /**
+     * Set removed pair number.
+     * @param n number of this pair generated in OrderedPairlist.
+     */
+    public void pairNumber(int n) {
+        this.n = n;
+    }
+
+
+    /**
+     * Get removed pair number.
+     * @return n number of this pair generated in OrderedPairlist.
+     */
+    public int getPairNumber() {
+        return n;
+    }
+
+
+    /**
+     * Set zero reduction. The S-polynomial of this Pair was reduced to zero.
+     */
+    public void setZero() {
+        toZero = true;
+    }
+
+
+    /**
+     * Is reduced to zero.
+     * @return true if the S-polynomial of this Pair was reduced to zero, else
+     *         false.
+     */
+    public boolean isZero() {
+        return toZero;
+    }
+
+
+    /**
+     * equals.
+     * @param ob an Object.
+     * @return true if this is equal to ob, else false.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object ob) {
+        CPair<C> cp = null;
+        try {
+            cp = (CPair<C>) ob;
+        } catch ( ClassCastException e) {
+            return false;
+        }
+        if ( cp == null ) {
+            return false;
+        }
+        return 0 == compareTo(cp);
+    }
+
+
+    /**
+     * compareTo used in TreeMap. 
+     * Comparison is based on the number of the pairs.
+     * @param p a Pair.
+     * @return 1 if (this &lt; p), 0 if (this == o), -1 if (this &gt; p).
+     */
+    public int compareTo(CPair<C> p) { // not used at moment
+        int x = p.getPairNumber();
+        if (n > x) {
+            return 1;
+        }
+        if (n < x) {
+            return -1;
+        }
+        return 0;
+    }
+
+
+    /**
+     * Hash code for this pair.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = getPairNumber();
+        return h;
+    }
+
+
+    /**
+     * Set useCriterion4.
+     * @param c boolean value to set.
+     */
+    public void setUseCriterion4(boolean c) {
+        this.useCriterion4 = c;
+    }
+
+
+    /**
+     * Get useCriterion4.
+     * @return boolean value.
+     */
+    public boolean getUseCriterion4() {
+        return this.useCriterion4;
+    }
+
+
+    /**
+     * Set useCriterion3.
+     * @param c boolean value to set.
+     */
+    public void setUseCriterion3(boolean c) {
+        this.useCriterion3 = c;
+    }
+
+
+    /**
+     * Get useCriterion3.
+     * @return boolean value.
+     */
+    public boolean getUseCriterion3() {
+        return this.useCriterion3;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/CReductionSeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/CReductionSeq.java
@@ -1,0 +1,547 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.ufd.GCDFactory;
+import edu.jas.ufd.GreatestCommonDivisor;
+
+
+/**
+ * Polynomial parametric ring reduction sequential use algorithm. Implements
+ * normalform, condition construction and polynomial determination.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+public class CReductionSeq<C extends GcdRingElem<C>> implements Serializable
+/* extends ReductionAbstract<C> */
+/* implements CReduction<C> */{
+
+
+    private static final Logger logger = LogManager.getLogger(CReductionSeq.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    private final boolean info = logger.isInfoEnabled();
+
+
+    /**
+     * Greatest common divisor engine.
+     */
+    protected final GreatestCommonDivisor<C> engine;
+
+
+    /**
+     * Polynomial coefficient ring factory.
+     */
+    protected final RingFactory<C> cofac;
+
+
+    /**
+     * Flag if top-reduction only should be used.
+     */
+    protected boolean top = true; // false;
+
+
+    /**
+     * Constructor.
+     * @param rf coefficient factory.
+     */
+    public CReductionSeq(RingFactory<C> rf) {
+        cofac = rf;
+        // System.out.println("cofac = " + cofac);
+        engine = GCDFactory.<C> getImplementation(cofac);
+    }
+
+
+    /**
+     * S-Polynomial.
+     * @param Ap polynomial.
+     * @param Bp polynomial.
+     * @return spol(Ap,Bp) the S-polynomial of Ap and Bp.
+     */
+    public ColorPolynomial<C> SPolynomial(ColorPolynomial<C> Ap, ColorPolynomial<C> Bp) {
+        if (Bp == null || Bp.isZERO()) {
+            return Bp;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+
+        Map.Entry<ExpVector, GenPolynomial<C>> ma = Ap.red.leadingMonomial();
+        Map.Entry<ExpVector, GenPolynomial<C>> mb = Bp.red.leadingMonomial();
+
+        ExpVector e = ma.getKey();
+        ExpVector f = mb.getKey();
+
+        ExpVector g = e.lcm(f); // EVLCM(e,f);
+        ExpVector e1 = g.subtract(e); // EVDIF(g,e);
+        ExpVector f1 = g.subtract(f); // EVDIF(g,f);
+
+        GenPolynomial<C> a = ma.getValue();
+        GenPolynomial<C> b = mb.getValue();
+
+        GenPolynomial<C> c = engine.gcd(a, b);
+        if (!c.isONE()) {
+            // System.out.println("gcd =s " + c);
+            a = a.divide(c);
+            b = b.divide(c);
+        }
+
+        ColorPolynomial<C> App = Ap.multiply(b, e1); // multiplyLeft in poly
+        ColorPolynomial<C> Bpp = Bp.multiply(a, f1); // multiplyLeft in poly
+        ColorPolynomial<C> Cp = App.subtract(Bpp);
+        assert (! g.equals(Cp.getEssentialPolynomial().leadingExpVector())) : "g == lt(Cp)";
+        return Cp;
+    }
+
+
+    /**
+     * Is top reducible.
+     * @param A polynomial.
+     * @param P polynomial list.
+     * @return true if A is top reducible with respect to P.
+     */
+    public boolean isTopReducible(List<ColorPolynomial<C>> P, ColorPolynomial<C> A) {
+        if (P == null || P.isEmpty()) {
+            return false;
+        }
+        if (A == null || A.isZERO()) {
+            return false;
+        }
+        boolean mt = false;
+        ExpVector e = A.leadingExpVector();
+        for (ColorPolynomial<C> p : P) {
+            if (p == null) {
+                return false;
+            }
+            ExpVector f = p.leadingExpVector();
+            if (f == null) {
+                return false;
+            }
+            if (e == null) {
+                return false;
+            }
+            mt = e.multipleOf(f); // EVMT( e, p.leadingExpVector() );
+            if (mt) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    /**
+     * Is reducible.
+     * @param Ap polynomial.
+     * @param Pp polynomial list.
+     * @return true if Ap is reducible with respect to Pp.
+     */
+    public boolean isReducible(List<ColorPolynomial<C>> Pp, ColorPolynomial<C> Ap) {
+        return !isNormalform(Pp, Ap);
+    }
+
+
+    /**
+     * Is in Normalform.
+     * @param Ap polynomial.
+     * @param Pp polynomial list.
+     * @return true if Ap is in normalform with respect to Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public boolean isNormalform(List<ColorPolynomial<C>> Pp, ColorPolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return true;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return true;
+        }
+        int l;
+        ColorPolynomial<C>[] P;
+        synchronized (Pp) {
+            l = Pp.size();
+            P = new ColorPolynomial[l];
+            // P = Pp.toArray();
+            for (int i = 0; i < Pp.size(); i++) {
+                P[i] = Pp.get(i);
+            }
+        }
+        ExpVector[] htl = new ExpVector[l];
+        ColorPolynomial<C>[] p = new ColorPolynomial[l];
+        Map.Entry<ExpVector, GenPolynomial<C>> m;
+        int i;
+        int j = 0;
+        for (i = 0; i < l; i++) {
+            p[i] = P[i];
+            m = p[i].red.leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                j++;
+            }
+        }
+        l = j;
+        boolean mt = false;
+        for (ExpVector e : Ap.red.getMap().keySet()) {
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]); // EVMT( e, htl[i] );
+                if (mt) {
+                    System.out.println("not normalform " + Ap + ", P[i] = " + P[i]);
+                    return false;
+                }
+            }
+            if (top) {
+                return true;
+            }
+        }
+        for (ExpVector e : Ap.white.getMap().keySet()) {
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]); // EVMT( e, htl[i] );
+                if (mt) {
+                    System.out.println("not normalform " + Ap + ", P[i] = " + P[i]);
+                    return false;
+                }
+            }
+            if (top) {
+                return true;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Is in Normalform.
+     * @param Pp polynomial list.
+     * @return true if each Ap in Pp is in normalform with respect to Pp\{Ap}.
+     */
+    public boolean isNormalform(List<ColorPolynomial<C>> Pp) {
+        if (Pp == null || Pp.isEmpty()) {
+            return true;
+        }
+        ColorPolynomial<C> Ap;
+        List<ColorPolynomial<C>> P = new LinkedList<ColorPolynomial<C>>(Pp);
+        int s = P.size();
+        for (int i = 0; i < s; i++) {
+            Ap = P.remove(i);
+            if (!isNormalform(P, Ap)) {
+                return false;
+            }
+            P.add(Ap);
+        }
+        return true;
+    }
+
+
+    /**
+     * Normalform.
+     * @param Ap polynomial.
+     * @param Pp polynomial list.
+     * @param cond condition for these polynomials.
+     * @return nf(Ap) with respect to Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public ColorPolynomial<C> normalform(Condition<C> cond, List<ColorPolynomial<C>> Pp, ColorPolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        Map.Entry<ExpVector, GenPolynomial<C>> m;
+        int l;
+        ColorPolynomial<C>[] P;
+        synchronized (Pp) {
+            l = Pp.size();
+            P = new ColorPolynomial[l];
+            // P = Pp.toArray();
+            for (int i = 0; i < Pp.size(); i++) {
+                P[i] = Pp.get(i);
+            }
+        }
+        ExpVector[] htl = new ExpVector[l];
+        Object[] lbc = new Object[l]; // want C[]
+        ColorPolynomial<C>[] p = new ColorPolynomial[l];
+        int i;
+        int j = 0;
+        for (i = 0; i < l; i++) {
+            if (P[i] == null) {
+                continue;
+            }
+            p[i] = P[i];
+            m = p[i].red.leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        ExpVector e, f;
+        GenPolynomial<C> a;
+        boolean mt = false;
+        GenPolynomial<GenPolynomial<C>> zero = p[0].red.ring.getZERO();
+        ColorPolynomial<C> R = new ColorPolynomial<C>(zero, zero, zero);
+
+        // ColorPolynomial<C> T = null;
+        ColorPolynomial<C> Q = null;
+        ColorPolynomial<C> S = Ap;
+        while (S.length() > 0) {
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            Condition.Color col = cond.color(a);
+            if (col == Condition.Color.GREEN) { // move to green terms
+                GenPolynomial<GenPolynomial<C>> g = S.green.sum(a, e);
+                GenPolynomial<GenPolynomial<C>> r = S.red;
+                GenPolynomial<GenPolynomial<C>> w = S.white;
+                if (S.red.isZERO()) {
+                    w = w.subtract(a, e);
+                } else { // only in minimalGB
+                    logger.info("green_red = " + zero.sum(a, e));
+                    r = r.subtract(a, e);
+                }
+                S = new ColorPolynomial<C>(g, r, w);
+                continue;
+            }
+            //if (col == Condition.Color.WHITE) { // refine condition
+                // System.out.println("white = " + zero.sum(a,e));
+                // return S; // return for new case distinction
+            //}
+            // System.out.println("NF, e = " + e);
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]); // EVMT( e, htl[i] );
+                if (mt)
+                    break;
+            }
+            if (!mt) {
+                // logger.debug("irred");
+                if (top) {
+                    return S;
+                }
+                R = R.sum(a, e);
+                S = S.subtract(a, e);
+                // System.out.println(" S = " + S);
+            } else {
+                f = e;
+                e = e.subtract(htl[i]); // EVDIF( e, htl[i] );
+                // logger.info("red div = " + e);
+                GenPolynomial<C> c = (GenPolynomial<C>) lbc[i];
+                GenPolynomial<C> g = engine.gcd(a, c);
+                if (!g.isONE()) {
+                    // System.out.println("gcd = " + g);
+                    a = a.divide(g);
+                    c = c.divide(g);
+                }
+                S = S.multiply(c);
+                R = R.multiply(c);
+                Q = p[i].multiply(a, e); // multiplyLeft in poly
+                S = S.subtract(Q);
+                assert (! f.equals(S.getEssentialPolynomial().leadingExpVector()) ) : "f == lt(S)";
+            }
+        }
+        return R;
+    }
+
+
+    /*
+     * -------- coloring and condition stuff ------------------------------
+     */
+
+    /**
+     * Case distinction conditions of parametric polynomial list. The returned
+     * condition determines the polynomial list.
+     * @param L list of parametric polynomials.
+     * @return list of conditions as case distinction.
+     */
+    public List<Condition<C>> caseDistinction(List<GenPolynomial<GenPolynomial<C>>> L) {
+        List<Condition<C>> cd = new ArrayList<Condition<C>>();
+        if (L == null || L.size() == 0) {
+            return cd;
+        }
+        for (GenPolynomial<GenPolynomial<C>> A : L) {
+            if (A != null && !A.isZERO()) {
+                cd = caseDistinction(cd, A);
+            }
+        }
+        // System.out.println("cd = " + cd);
+        return cd;
+    }
+
+
+    /**
+     * Case distinction conditions of parametric polynomial list.
+     * @param cd a list of conditions.
+     * @param A a parametric polynomial.
+     * @return list of conditions as case distinction extending the conditions
+     *         in cd.
+     */
+    public List<Condition<C>> caseDistinction(List<Condition<C>> cd, GenPolynomial<GenPolynomial<C>> A) {
+        if (A == null || A.isZERO()) {
+            return cd;
+        }
+        if (cd == null) {
+            cd = new ArrayList<Condition<C>>();
+        }
+        if (cd.size() == 0) { // construct empty condition
+            RingFactory<GenPolynomial<C>> crfac = A.ring.coFac;
+            GenPolynomialRing<C> cfac = (GenPolynomialRing<C>) crfac;
+            Condition<C> sc = new Condition<C>(cfac);
+            cd.add(sc);
+        }
+        GenPolynomial<GenPolynomial<C>> Ap;
+        GenPolynomial<GenPolynomial<C>> Bp;
+
+        List<Condition<C>> C = new ArrayList<Condition<C>>( /* leer! */);
+        for (Condition<C> cond : cd) {
+            // System.out.println("caseDist: " + cond);
+            Condition<C> cz = cond;
+            Ap = A;
+            while (!Ap.isZERO()) {
+                GenPolynomial<C> c = Ap.leadingBaseCoefficient();
+                Bp = Ap.reductum();
+                //System.out.println("to color: " + c);
+                switch (cz.color(c)) {
+                case GREEN:
+                    // System.out.println("color green: " + c);
+                    Ap = Bp;
+                    continue;
+                case RED:
+                    // System.out.println("color red: " + c);
+                    C.add(cz);
+                    // wrong: return C;
+                    Ap = A.ring.getZERO();
+                    continue;
+                    // break;
+                case WHITE:
+                default:
+                    // System.out.println("color white: " + c);
+                    Condition<C> nc = cz.extendNonZero(c);
+                    if (nc != null) { // no contradiction
+                        if (!cz.equals(nc)) {
+                            C.add(nc);
+                        } else {
+                            cz = null;
+                            Ap = A.ring.getZERO();
+                            continue;
+                        }
+                    } else { // contradiction rechecked in determine(c)
+                        //System.out.println("this should not be printed, c  = " + c);
+                        //System.out.println("this should not be printed, cz = " + cz);
+                    }
+                    Condition<C> ez = cz.extendZero(c);
+                    if (ez != null) {
+                        cz = ez;
+                    } else { // contradiction
+                        cz = null;
+                        Ap = A.ring.getZERO();
+                        continue;
+                    }
+                    Ap = Bp;
+                }
+            }
+            // System.out.println("cond cz: " + cz);
+            if (cz == null || cz.isContradictory() || C.contains(cz)) {
+                // System.out.println("not added entry " + cz);
+            } else {
+                C.add(cz);
+            }
+        }
+        // System.out.println("C = " + C);
+        return C;
+    }
+
+
+    /**
+     * Case distinction conditions of parametric polynomial list.
+     * @param A a parametric polynomial.
+     * @param cond a condition.
+     * @return list of case distinction conditions.
+     */
+    public List<Condition<C>> caseDistinction(Condition<C> cond, GenPolynomial<GenPolynomial<C>> A) {
+        List<Condition<C>> cd = new ArrayList<Condition<C>>();
+        if (A == null || A.isZERO()) {
+            return cd;
+        }
+        cd.add(cond);
+        cd = caseDistinction(cd, A);
+        if (info) {
+            StringBuffer s = new StringBuffer("extending condition: " + cond + "\n");
+            s.append("case distinctions: [ \n");
+            for (Condition<C> c : cd) {
+                s.append(c.toString() + "\n");
+            }
+            s.append("]");
+            logger.info(s.toString());
+        }
+        return cd;
+    }
+
+
+    /**
+     * Determine polynomial list.
+     * @param H polynomial list.
+     * @return new determined list of colored systems.
+     */
+    public List<ColoredSystem<C>> determine(List<GenPolynomial<GenPolynomial<C>>> H) {
+        if (H == null || H.size() == 0) {
+            List<ColoredSystem<C>> CS = new ArrayList<ColoredSystem<C>>();
+            return CS;
+        }
+        //System.out.println("of determine     = " + H);
+        Collections.reverse(H);
+        List<Condition<C>> cd = caseDistinction(H);
+        //System.out.println("case Distinction = " + cd);
+        //System.out.println("of determine     = " + H);
+        return determine(cd, H);
+    }
+
+
+    /**
+     * Determine polynomial list.
+     * @param H polynomial list.
+     * @param cd case distiction, a condition list.
+     * @return new determined list of colored systems.
+     */
+    public List<ColoredSystem<C>> determine(List<Condition<C>> cd, List<GenPolynomial<GenPolynomial<C>>> H) {
+        List<ColoredSystem<C>> CS = new ArrayList<ColoredSystem<C>>();
+        if (H == null || H.size() == 0) {
+            return CS;
+        }
+        for (Condition<C> cond : cd) {
+            logger.info("determine wrt cond = " + cond);
+            if (cond.zero.isONE()) { // should not happen
+                System.out.println("ideal is one = " + cond.zero);
+                // continue; // can treat all coeffs as green
+            }
+            // if ( cond.isEmpty() ) { // do not use this code
+            // continue; // can skip condition (?)
+            // }
+            List<ColorPolynomial<C>> S = cond.determine(H);
+            ColoredSystem<C> cs = new ColoredSystem<C>(cond, S);
+            CS.add(cs);
+        }
+        return CS;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/ColorPolynomial.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/ColorPolynomial.java
@@ -1,0 +1,473 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Colored Polynomials with green, red and white coefficients. Not implementing
+ * RingElem. <b>Note:</b> not general purpose, use only in comprehensive GB.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class ColorPolynomial<C extends RingElem<C>> implements Serializable
+/* implements RingElem< ColorPolynomial<C> > */ {
+
+
+    private static final Logger logger = LogManager.getLogger(ColorPolynomial.class);
+
+
+    /**
+     * The part with green (= zero) terms and coefficients.
+     */
+    public final GenPolynomial<GenPolynomial<C>> green;
+
+
+    /**
+     * The part with red (= non zero) terms and coefficients.
+     */
+    public final GenPolynomial<GenPolynomial<C>> red;
+
+
+    /**
+     * The part with white (= unknown color) terms and coefficients.
+     */
+    public final GenPolynomial<GenPolynomial<C>> white;
+
+
+    /**
+     * The constructor creates a colored polynomial from the colored parts.
+     * @param g green colored terms and coefficients.
+     * @param r red colored terms and coefficients.
+     * @param w white colored terms and coefficients.
+     */
+    public ColorPolynomial(GenPolynomial<GenPolynomial<C>> g, GenPolynomial<GenPolynomial<C>> r,
+                    GenPolynomial<GenPolynomial<C>> w) {
+        if (g == null || r == null || w == null) {
+            throw new IllegalArgumentException("g,r,w may not be null");
+        }
+        green = g;
+        red = r;
+        white = w;
+    }
+
+
+    /**
+     * String representation of ColorPolynomial.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer s = new StringBuffer();
+        s.append(":green: ");
+        s.append(green.toString());
+        s.append(" :red: ");
+        s.append(red.toString());
+        s.append(" :white: ");
+        s.append(white.toString());
+        return s.toString();
+    }
+
+
+    /**
+     * Script representation of ColorPolynomial.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    public String toScript() {
+        StringBuffer s = new StringBuffer();
+        s.append(":green: ");
+        s.append(green.toScript());
+        s.append(" :red: ");
+        s.append(red.toScript());
+        s.append(" :white: ");
+        s.append(white.toScript());
+        return s.toString();
+    }
+
+
+    /**
+     * Is this polynomial ZERO.
+     * @return true, if there are only green terms, else false.
+     */
+    public boolean isZERO() {
+        return (red.isZERO() && white.isZERO());
+    }
+
+
+    /**
+     * Is this polynomial ONE.
+     * @return true, if the only non green term is 1, else false.
+     */
+    public boolean isONE() {
+        return ((red.isZERO() && white.isONE()) || (red.isONE() && white.isZERO()));
+    }
+
+
+    /**
+     * Is this polynomial equal to other.
+     * @param p other polynomial.
+     * @return true, if this is equal to other, else false.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object p) {
+        ColorPolynomial<C> cp = null;
+        try {
+            cp = (ColorPolynomial<C>) p;
+        } catch (ClassCastException e) {
+            return false;
+        }
+        if (cp == null) {
+            return false;
+        }
+        return (green.equals(cp.green) && red.equals(cp.red) && white.equals(cp.white));
+    }
+
+
+    /**
+     * Hash code for this colored polynomial.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = green.hashCode();
+        h = h << 11;
+        h += red.hashCode();
+        h = h << 11;
+        h += white.hashCode();
+        return h;
+    }
+
+
+    /**
+     * Is this polynomial determined.
+     * @return true, if there are nonzero red terms or if this == 0, else false.
+     */
+    public boolean isDetermined() {
+        return (!red.isZERO() || white.isZERO());
+    }
+
+
+    /**
+     * Check ordering invariants. TT(green) &gt; LT(red) and TT(red) &gt;
+     * LT(white).
+     * @return true, if all ordering invariants are met, else false.
+     */
+    public boolean checkInvariant() {
+        boolean t = true;
+        ExpVector ttg, ltr, ttr, ltw;
+        Comparator<ExpVector> cmp;
+        if (green.isZERO() && red.isZERO() && white.isZERO()) {
+            return true;
+        }
+        if (green.isZERO() && red.isZERO()) {
+            return true;
+        }
+        if (red.isZERO() && white.isZERO()) {
+            return true;
+        }
+
+        if (!green.isZERO() && !red.isZERO()) {
+            ttg = green.trailingExpVector();
+            ltr = red.leadingExpVector();
+            cmp = green.ring.tord.getDescendComparator();
+            t = t && (cmp.compare(ttg, ltr) < 0);
+        }
+        if (!red.isZERO() && !white.isZERO()) {
+            ttr = red.trailingExpVector();
+            ltw = white.leadingExpVector();
+            cmp = white.ring.tord.getDescendComparator();
+            t = t && (cmp.compare(ttr, ltw) < 0);
+        }
+        if (red.isZERO() && !green.isZERO() && !white.isZERO()) {
+            ttg = green.trailingExpVector();
+            ltw = white.leadingExpVector();
+            cmp = white.ring.tord.getDescendComparator();
+            t = t && (cmp.compare(ttg, ltw) < 0);
+        }
+        if (!t) {
+            System.out.println("not invariant " + this);
+            // throw new RuntimeException("test");
+        }
+        return t;
+    }
+
+
+    /**
+     * Get zero condition on coefficients.
+     * @return green coefficients.
+     */
+    public List<GenPolynomial<C>> getGreenCoefficients() {
+        Collection<GenPolynomial<C>> c = green.getMap().values();
+        return new ArrayList<GenPolynomial<C>>(c);
+    }
+
+
+    /**
+     * Get non zero condition on coefficients.
+     * @return red coefficients.
+     */
+    public List<GenPolynomial<C>> getRedCoefficients() {
+        Collection<GenPolynomial<C>> c = red.getMap().values();
+        return new ArrayList<GenPolynomial<C>>(c);
+    }
+
+
+    /**
+     * Get full polynomial.
+     * @return sum of all parts.
+     */
+    public GenPolynomial<GenPolynomial<C>> getPolynomial() {
+        GenPolynomial<GenPolynomial<C>> f = green.sum(red).sum(white);
+        int s = green.length() + red.length() + white.length();
+        int t = f.length();
+        if (t != s) {
+            throw new RuntimeException("illegal coloring state " + s + " != " + t);
+        }
+        return f;
+    }
+
+
+    /**
+     * Get essential polynomial.
+     * @return sum of red and white parts.
+     */
+    public GenPolynomial<GenPolynomial<C>> getEssentialPolynomial() {
+        GenPolynomial<GenPolynomial<C>> f = red.sum(white);
+        int s = red.length() + white.length();
+        int t = f.length();
+        if (t != s) {
+            logger.warn("incomplete coloring state " + s + " != " + t);
+            logger.info("f = " + f + ", red = " + red + ", white = " + white);
+            //throw new RuntimeException("illegal coloring state " + s + " != " + t);
+        }
+        return f;
+    }
+
+
+    /**
+     * Length of red and white parts.
+     * @return length of essential parts.
+     */
+    public int length() {
+        int s = red.length() + white.length();
+        return s;
+    }
+
+
+    /**
+     * Get leading exponent vector.
+     * @return LT of red or white parts.
+     */
+    public ExpVector leadingExpVector() {
+        if (!red.isZERO()) {
+            return red.leadingExpVector();
+        }
+        return white.leadingExpVector();
+    }
+
+
+    /**
+     * Get leading monomial.
+     * @return LM of red or white parts.
+     */
+    public Map.Entry<ExpVector, GenPolynomial<C>> leadingMonomial() {
+        if (!red.isZERO()) {
+            return red.leadingMonomial();
+        }
+        return white.leadingMonomial();
+    }
+
+
+    /**
+     * ColorPolynomial absolute value.
+     * @return abs(this).
+     */
+    public ColorPolynomial<C> abs() {
+        GenPolynomial<GenPolynomial<C>> g, r, w;
+        int s = green.signum();
+        if (s > 0) {
+            return this;
+        }
+        if (s < 0) {
+            g = green.negate();
+            r = red.negate();
+            w = white.negate();
+            return new ColorPolynomial<C>(g, r, w);
+        }
+        // green == 0
+        g = green;
+        s = red.signum();
+        if (s > 0) {
+            return this;
+        }
+        if (s < 0) {
+            r = red.negate();
+            w = white.negate();
+            return new ColorPolynomial<C>(g, r, w);
+        }
+        // red == 0
+        r = red;
+        s = white.signum();
+        if (s > 0) {
+            return this;
+        }
+        if (s < 0) {
+            w = white.negate();
+            return new ColorPolynomial<C>(g, r, w);
+        }
+        // white == 0
+        w = white;
+        return new ColorPolynomial<C>(g, r, w);
+    }
+
+
+    /**
+     * ColorPolynomial summation. <b>Note:</b> green coefficients stay green,
+     * all others become white.
+     * @param S ColorPolynomial.
+     * @return this+S.
+     */
+    public ColorPolynomial<C> sum(ColorPolynomial<C> S) {
+        GenPolynomial<GenPolynomial<C>> g, r, w;
+        g = green.sum(S.green);
+        r = red.ring.getZERO();
+        w = getEssentialPolynomial().sum(S.getEssentialPolynomial());
+        return new ColorPolynomial<C>(g, r, w);
+    }
+
+
+    /**
+     * ColorPolynomial summation.
+     * @param s GenPolynomial.
+     * @param e exponent vector.
+     * @return this+(c e).
+     */
+    public ColorPolynomial<C> sum(GenPolynomial<C> s, ExpVector e) {
+        GenPolynomial<GenPolynomial<C>> g, r, w;
+        g = green;
+        r = red;
+        w = white;
+        if (green.getMap().keySet().contains(e)) {
+            g = green.sum(s, e);
+        } else if (red.getMap().keySet().contains(e)) {
+            r = red.sum(s, e);
+        } else {
+            w = white.sum(s, e);
+        }
+        return new ColorPolynomial<C>(g, r, w);
+    }
+
+
+    /**
+     * ColorPolynomial subtraction. <b>Note:</b> green coefficients stay green,
+     * all others become white.
+     * @param S ColorPolynomial.
+     * @return this-S.
+     */
+    public ColorPolynomial<C> subtract(ColorPolynomial<C> S) {
+        GenPolynomial<GenPolynomial<C>> g, r, w;
+        g = green.subtract(S.green);
+        r = red.ring.getZERO();
+        w = getEssentialPolynomial().subtract(S.getEssentialPolynomial());
+        return new ColorPolynomial<C>(g, r, w);
+    }
+
+
+    /**
+     * ColorPolynomial subtract.
+     * @param s GenPolynomial.
+     * @param e exponent vector.
+     * @return this-(c e).
+     */
+    public ColorPolynomial<C> subtract(GenPolynomial<C> s, ExpVector e) {
+        GenPolynomial<GenPolynomial<C>> g, r, w;
+        g = green;
+        r = red;
+        w = white;
+        if (green.getMap().keySet().contains(e)) {
+            g = green.subtract(s, e);
+        } else if (red.getMap().keySet().contains(e)) {
+            r = red.subtract(s, e);
+        } else {
+            w = white.subtract(s, e);
+        }
+        return new ColorPolynomial<C>(g, r, w);
+    }
+
+
+    /**
+     * ColorPolynomial multiplication by monomial.
+     * @param s Coefficient.
+     * @param e Expvector.
+     * @return this * (c t).
+     */
+    public ColorPolynomial<C> multiply(GenPolynomial<C> s, ExpVector e) {
+        GenPolynomial<GenPolynomial<C>> g, r, w;
+        if (green instanceof GenSolvablePolynomial) {
+            logger.info("use left multiplication");
+            GenSolvablePolynomial<GenPolynomial<C>> gs, rs, ws;
+            gs = (GenSolvablePolynomial<GenPolynomial<C>>) green;
+            rs = (GenSolvablePolynomial<GenPolynomial<C>>) red;
+            ws = (GenSolvablePolynomial<GenPolynomial<C>>) white;
+            g = gs.multiplyLeft(s, e);
+            r = rs.multiplyLeft(s, e);
+            w = ws.multiplyLeft(s, e);
+        } else {
+            g = green.multiply(s, e);
+            r = red.multiply(s, e);
+            w = white.multiply(s, e);
+        }
+        return new ColorPolynomial<C>(g, r, w);
+    }
+
+
+    /**
+     * ColorPolynomial multiplication by coefficient.
+     * @param s Coefficient.
+     * @return this * (s).
+     */
+    public ColorPolynomial<C> multiply(GenPolynomial<C> s) {
+        GenPolynomial<GenPolynomial<C>> g, r, w;
+        // coefficients commute
+        g = green.multiply(s);
+        r = red.multiply(s);
+        w = white.multiply(s);
+        return new ColorPolynomial<C>(g, r, w);
+    }
+
+
+    /**
+     * ColorPolynomial division by coefficient.
+     * @param s Coefficient.
+     * @return this / (s).
+     */
+    public ColorPolynomial<C> divide(GenPolynomial<C> s) {
+        GenPolynomial<GenPolynomial<C>> g, r, w;
+        g = green.divide(s);
+        r = red.divide(s);
+        w = white.divide(s);
+        return new ColorPolynomial<C>(g, r, w);
+    }
+
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/ColoredSystem.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/ColoredSystem.java
@@ -1,0 +1,376 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Container for a condition, a corresponding colored polynomial list and a
+ * Groebner base pair list.
+ * @param <C> coefficient type
+ */
+public class ColoredSystem<C extends GcdRingElem<C>> {
+
+
+    private static final Logger logger = LogManager.getLogger(ColoredSystem.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Condition determinig this colored system.
+     */
+    public final Condition<C> condition;
+
+
+    /**
+     * Colored polynomials of this system.
+     */
+    public final List<ColorPolynomial<C>> list;
+
+
+    /**
+     * Groebner base pair list of this system.
+     */
+    public final OrderedCPairlist<C> pairlist;
+
+
+    /**
+     * Constructor for a colored polynomial system.
+     * @param cond a condition.
+     * @param S a list of colored polynomials.
+     */
+    public ColoredSystem(Condition<C> cond, List<ColorPolynomial<C>> S) {
+        this(cond, S, null);
+    }
+
+
+    /**
+     * Constructor for a colored polynomial system.
+     * @param cond a condition.
+     * @param S a list of colored polynomials.
+     * @param pl a ordered pair list.
+     */
+    public ColoredSystem(Condition<C> cond, List<ColorPolynomial<C>> S, OrderedCPairlist<C> pl) {
+        this.condition = cond;
+        this.list = S;
+        this.pairlist = pl;
+    }
+
+
+    /**
+     * Copy this colored polynomial system.
+     * @return a clone of this.
+     */
+    public ColoredSystem<C> copy() {
+        return new ColoredSystem<C>(condition, list, pairlist.copy());
+    }
+
+
+    /**
+     * Add to list of colored systems. This is added to the list of colored
+     * systems, if a system with the same condition is not already contained.
+     * @param L a list of colored systems.
+     * @return L.add(this) if this not in L, else L.
+     */
+    public List<ColoredSystem<C>> addToList(List<ColoredSystem<C>> L) {
+        List<ColoredSystem<C>> S = new ArrayList<ColoredSystem<C>>(L.size() + 1);
+        boolean contained = false;
+        for (ColoredSystem<C> x : L) {
+            if (condition.equals(x.condition) && list.equals(x.list)) {
+                logger.info("replaced system = " + x.condition);
+                S.add(this);
+                contained = true;
+            } else { // copy existing
+                // System.out.println("kept system = " + x);
+                S.add(x);
+            }
+        }
+        if (!contained) {
+            S.add(this);
+        }
+        return S;
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer s = new StringBuffer("ColoredSystem: \n");
+        if (list.size() > 0) {
+            s.append("polynomial ring : " + list.get(0).green.ring + "\n");
+        } else {
+            s.append("parameter polynomial ring : " + condition.zero.getRing() + "\n");
+        }
+        s.append("conditions == 0 : " + getConditionZero() + "\n");
+        s.append("conditions != 0 : " + getConditionNonZero() + "\n");
+        if (debug) {
+            s.append("green coefficients:\n" + getGreenCoefficients() + "\n");
+            s.append("red coefficients:\n" + getRedCoefficients() + "\n");
+        }
+        s.append("colored polynomials:\n" + list + "\n");
+        s.append("uncolored polynomials:\n" + getPolynomialList() + "\n");
+        if (debug) {
+            s.append("essential polynomials:\n" + getEssentialPolynomialList() + "\n");
+        }
+        if (pairlist != null) {
+            s.append(pairlist.toString() + "\n");
+        }
+        return s.toString();
+    }
+
+
+    /**
+     * Get the Script representation.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    public String toScript() {
+        StringBuffer s = new StringBuffer("ColoredSystem: \n");
+        if (list.size() > 0) {
+            s.append("polynomial ring : " + list.get(0).green.ring.toScript() + "\n");
+        } else {
+            s.append("parameter polynomial ring : " + condition.zero.getRing().toScript() + "\n");
+        }
+        s.append("conditions == 0 : " + getConditionZero().toString() + "\n");
+        s.append("conditions != 0 : " + getConditionNonZero().toString() + "\n");
+        if (debug) {
+            s.append("green coefficients:\n" + getGreenCoefficients().toString() + "\n");
+            s.append("red coefficients:\n" + getRedCoefficients().toString() + "\n");
+        }
+        s.append("colored polynomials:\n" + list + "\n");
+        s.append("uncolored polynomials:\n" + getPolynomialList() + "\n");
+        if (debug) {
+            s.append("essential polynomials:\n" + getEssentialPolynomialList() + "\n");
+        }
+        if (pairlist != null) {
+            s.append(pairlist.toString() + "\n");
+        }
+        return s.toString();
+    }
+
+
+    /**
+     * Is this colored system equal to other.
+     * @param c other colored system.
+     * @return true, if this is equal to other, else false.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object c) {
+        ColoredSystem<C> cs = null;
+        try {
+            cs = (ColoredSystem<C>) c;
+        } catch (ClassCastException e) {
+            return false;
+        }
+        if (cs == null) {
+            return false;
+        }
+        boolean t = (condition.equals(cs.condition) && list.equals(cs.list));
+        if (!t) {
+            return t;
+        }
+        // now t == true
+        t = pairlist.equals(cs.pairlist);
+        if (!t) {
+            System.out.println("pairlists not equal " + pairlist + ", " + cs.pairlist);
+        }
+        return true; // if lists are equal ignore pairlists
+    }
+
+
+    /**
+     * Hash code for this colored system.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = condition.hashCode();
+        h = h << 17;
+        h += list.hashCode();
+        // h = h << 11;
+        // h += pairlist.hashCode();
+        return h;
+    }
+
+
+    /**
+     * Get zero condition.
+     * @return condition.zero.
+     */
+    public List<GenPolynomial<C>> getConditionZero() {
+        return condition.zero.getList();
+    }
+
+
+    /**
+     * Get non zero condition.
+     * @return condition.nonZero.
+     */
+    public List<GenPolynomial<C>> getConditionNonZero() {
+        return condition.nonZero.mset;
+    }
+
+
+    /**
+     * Get list of red coefficients of polynomials.
+     * @return list of all red coefficients of polynomials.
+     */
+    public List<GenPolynomial<C>> getRedCoefficients() {
+        Set<GenPolynomial<C>> F = new HashSet<GenPolynomial<C>>();
+        for (ColorPolynomial<C> s : list) {
+            F.addAll(s.red.getMap().values());
+        }
+        List<GenPolynomial<C>> M = new ArrayList<GenPolynomial<C>>(F);
+        return M;
+    }
+
+
+    /**
+     * Get list of green coefficients of polynomials.
+     * @return list of all green coefficients of polynomials.
+     */
+    public List<GenPolynomial<C>> getGreenCoefficients() {
+        Set<GenPolynomial<C>> F = new HashSet<GenPolynomial<C>>();
+        for (ColorPolynomial<C> s : list) {
+            F.addAll(s.green.getMap().values());
+        }
+        List<GenPolynomial<C>> M = new ArrayList<GenPolynomial<C>>(F);
+        return M;
+    }
+
+
+    /**
+     * Get list of full polynomials.
+     * @return list of all full polynomials.
+     */
+    public List<GenPolynomial<GenPolynomial<C>>> getPolynomialList() {
+        List<GenPolynomial<GenPolynomial<C>>> F = new ArrayList<GenPolynomial<GenPolynomial<C>>>();
+        for (ColorPolynomial<C> s : list) {
+            F.add(s.getPolynomial());
+        }
+        return F;
+    }
+
+
+    /**
+     * Get list of essential polynomials.
+     * @return list of all essential polynomials.
+     */
+    public List<GenPolynomial<GenPolynomial<C>>> getEssentialPolynomialList() {
+        List<GenPolynomial<GenPolynomial<C>>> F = new ArrayList<GenPolynomial<GenPolynomial<C>>>();
+        for (ColorPolynomial<C> s : list) {
+            F.add(s.getEssentialPolynomial());
+        }
+        return F;
+    }
+
+
+    /**
+     * Check invariants. Check if all polynomials are determined and if the
+     * color of all coefficients is correct with respect to the condition.
+     * @return true, if all invariants are met, else false.
+     */
+    public boolean checkInvariant() {
+        if (!isDetermined()) {
+            return false;
+        }
+        if (!condition.isDetermined(list)) {
+            return false;
+        }
+        // Condition<C> cond = condition;
+        for (ColorPolynomial<C> s : list) {
+            if (!s.checkInvariant()) {
+                System.out.println("notInvariant " + s);
+                System.out.println("condition:   " + condition);
+                return false;
+            }
+            for (GenPolynomial<C> g : s.green.getMap().values()) {
+                if (condition.color(g) != Condition.Color.GREEN) {
+                    System.out.println("notGreen   " + g);
+                    System.out.println("condition: " + condition);
+                    System.out.println("colors:    " + s);
+                    return false;
+                }
+            }
+            for (GenPolynomial<C> r : s.red.getMap().values()) {
+                if (condition.color(r) != Condition.Color.RED) {
+                    System.out.println("notRed     " + r);
+                    System.out.println("condition: " + condition);
+                    System.out.println("colors:    " + s);
+                    return false;
+                }
+            }
+            for (GenPolynomial<C> w : s.white.getMap().values()) {
+                if (condition.color(w) != Condition.Color.WHITE) {
+                    // System.out.println("notWhite " + w);
+                    // System.out.println("condition: " + condition);
+                    // System.out.println("colors: " + s);
+                    continue; // no error
+                    // return false;
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Is this colored system completely determined.
+     * @return true, if each ColorPolynomial is determined, else false.
+     */
+    public boolean isDetermined() {
+        for (ColorPolynomial<C> s : list) {
+            if (s.isZERO()) {
+                continue;
+            }
+            if (!s.isDetermined()) {
+                System.out.println("not simple determined " + s);
+                System.out.println("condition:            " + condition);
+                return false;
+            }
+            if (!condition.isDetermined(s)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Re determine colorings of polynomials.
+     * @return colored system with re determined colored polynomials.
+     */
+    public ColoredSystem<C> reDetermine() {
+        if (condition == null || condition.zero.isONE()) {
+            return this;
+        }
+        List<ColorPolynomial<C>> Sn = new ArrayList<ColorPolynomial<C>>(list.size());
+        for (ColorPolynomial<C> c : list) {
+            ColorPolynomial<C> a = condition.reDetermine(c);
+            // if ( !a.isZERO() ) {
+            Sn.add(a); // must also add zeros
+            // }
+        }
+        return new ColoredSystem<C>(condition, Sn, pairlist);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/ComprehensiveGroebnerBaseSeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/ComprehensiveGroebnerBaseSeq.java
@@ -1,0 +1,719 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.GroebnerBase;
+import edu.jas.gb.SolvableGroebnerBase;
+import edu.jas.gbufd.GBFactory;
+import edu.jas.gbufd.SGBFactory;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.GenSolvablePolynomialRing;
+import edu.jas.poly.PolynomialList;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.ufd.SquarefreeAbstract;
+import edu.jas.ufd.SquarefreeFactory;
+
+
+/**
+ * Comprehensive Groebner Base sequential algorithm. Implements faithful
+ * comprehensive Groebner bases via Groebner systems and CGB test.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class ComprehensiveGroebnerBaseSeq<C extends GcdRingElem<C>>
+/* extends GroebnerBaseAbstract<GenPolynomial<C>> */{
+
+
+    private static final Logger logger = LogManager.getLogger(ComprehensiveGroebnerBaseSeq.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Squarefree for coefficient content and primitive parts.
+     */
+    protected final SquarefreeAbstract<C> engine;
+
+
+    /*
+     * Flag if gcd engine should be used.
+     */
+    //private final boolean notFaithfull = false;
+
+
+    /**
+     * Comprehensive reduction engine.
+     */
+    protected final CReductionSeq<C> cred;
+
+
+    /**
+     * Polynomial coefficient ring factory.
+     */
+    protected final RingFactory<C> cofac;
+
+
+    /**
+     * Constructor.
+     * @param rf base coefficient ring factory.
+     */
+    public ComprehensiveGroebnerBaseSeq(RingFactory<C> rf) {
+        this(new CReductionSeq<C>(rf), rf);
+    }
+
+
+    /**
+     * Constructor.
+     * @param red C-pseudo-Reduction engine
+     * @param rf base coefficient ring factory.
+     */
+    @SuppressWarnings("unchecked")
+    public ComprehensiveGroebnerBaseSeq(CReductionSeq<C> red, RingFactory<C> rf) {
+        // super(null); // red not possible since type of type
+        cred = red;
+        cofac = rf;
+        // selection for C but used for R:
+        //engine e = GCDFactory.<C> getImplementation(cofac);
+        engine = SquarefreeFactory.<C> getImplementation(rf);
+    }
+
+
+    /**
+     * Comprehensive-Groebner base test.
+     * @param F polynomial list.
+     * @return true, if F is a Comprehensive-Groebner base, else false.
+     */
+    // @Override
+    public boolean isGB(List<GenPolynomial<GenPolynomial<C>>> F) {
+        return isGB(0, F);
+    }
+
+
+    /**
+     * Comprehensive-Groebner base test.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return true, if F is a Comprehensive-Groebner base, else false.
+     */
+    // @Override
+    public boolean isGB(int modv, List<GenPolynomial<GenPolynomial<C>>> F) {
+        // return isGBcol( modv, F );
+        return isGBsubst(modv, F);
+    }
+
+
+    /**
+     * Comprehensive-Groebner base test using colored systems.
+     * @param F polynomial list.
+     * @return true, if F is a Comprehensive-Groebner base, else false.
+     */
+    // @Override
+    public boolean isGBcol(List<GenPolynomial<GenPolynomial<C>>> F) {
+        return isGBcol(0, F);
+    }
+
+
+    /**
+     * Comprehensive-Groebner base test using colored systems.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return true, if F is a Comprehensive-Groebner base, else false.
+     */
+    // @Override
+    public boolean isGBcol(int modv, List<GenPolynomial<GenPolynomial<C>>> F) {
+        if (F == null || F.size() == 0) {
+            return true;
+        }
+        List<ColoredSystem<C>> CS = cred.determine(F);
+        return isGBsys(modv, CS);
+    }
+
+
+    /**
+     * Comprehensive-Groebner system test.
+     * @param CS list of colored systems.
+     * @return true, if CS is a Comprehensive-Groebner system, else false.
+     */
+    // @Override
+    public boolean isGBsys(List<ColoredSystem<C>> CS) {
+        return isGBsys(0, CS);
+    }
+
+
+    /**
+     * Comprehensive-Groebner system test.
+     * @param modv module variable number, unused.
+     * @param CS list of colored systems.
+     * @return true, if CS is a Comprehensive-Groebner system, else false.
+     */
+    // @Override
+    public boolean isGBsys(int modv, List<ColoredSystem<C>> CS) {
+        if (CS == null || CS.size() == 0) {
+            return true;
+        }
+        if (modv != 0) {
+            throw new IllegalArgumentException("modv !0 not supported.");
+        }
+        ColorPolynomial<C> p, q, h, hp;
+        for (ColoredSystem<C> cs : CS) {
+            if (debug) {
+                if (!cs.isDetermined()) {
+                    System.out.println("not determined, cs = " + cs);
+                    return false;
+                }
+                if (!cs.checkInvariant()) {
+                    System.out.println("not invariant, cs = " + cs);
+                    return false;
+                }
+            }
+            Condition<C> cond = cs.condition;
+            List<ColorPolynomial<C>> S = cs.list;
+            int k = S.size();
+            for (int j = 0; j < k; j++) {
+                p = S.get(j);
+                for (int l = j + 1; l < k; l++) {
+                    q = S.get(l);
+                    h = cred.SPolynomial(p, q);
+                    // System.out.println("spol(a,b) = " + h);
+                    h = cred.normalform(cond, S, h);
+                    // System.out.println("NF(spol(a,b)) = " + h);
+                    if (debug) {
+                        if (!cred.isNormalform(S, h)) {
+                            System.out.println("not normalform, h = " + h);
+                            System.out.println("cs = " + cs);
+                            return false;
+                        }
+                    }
+                    if (!h.isZERO()) {
+                        hp = cond.reDetermine(h);
+                        if (!hp.isZERO()) {
+                            System.out.println("p = " + p);
+                            System.out.println("q = " + q);
+                            System.out.println("not zero:   NF(spol(p,q))  = " + h);
+                            System.out.println("redetermine(NF(spol(p,q))) = " + hp);
+                            System.out.println("cs = " + cs);
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Comprehensive-Groebner base test using substitution.
+     * @param F polynomial list.
+     * @return true, if F is a Comprehensive-Groebner base, else false.
+     */
+    // @Override
+    public boolean isGBsubst(List<GenPolynomial<GenPolynomial<C>>> F) {
+        return isGBsubst(0, F);
+    }
+
+
+    /**
+     * Comprehensive-Groebner base test using substitution.
+     * @param modv module variable number, unused.
+     * @param F polynomial list.
+     * @return true, if F is a Comprehensive-Groebner base, else false.
+     */
+    // @Override
+    public boolean isGBsubst(int modv, List<GenPolynomial<GenPolynomial<C>>> F) {
+        if (F == null || F.isEmpty()) {
+            return true;
+        }
+        if (modv != 0) {
+            throw new IllegalArgumentException("modv !0 not supported.");
+        }
+        GenPolynomial<GenPolynomial<C>> f = F.get(0); // assert non Zero
+        GenPolynomialRing<GenPolynomial<C>> cf = f.ring;
+
+        List<ColoredSystem<C>> CS = cred.determine(F);
+        if (logger.isDebugEnabled()) {
+            logger.info("determined polynomials =\n" + CS);
+        }
+        // substitute zero conditions into parameter coefficients and test
+        for (ColoredSystem<C> cs : CS) {
+            Ideal<C> id = cs.condition.zero;
+            ResidueRing<C> r = new ResidueRing<C>(id);
+            //GroebnerBase<Residue<C>> bb = new GroebnerBasePseudoSeq<Residue<C>>(r);
+            List<GenPolynomial<Residue<C>>> list;
+            boolean t;
+            if (cf instanceof GenSolvablePolynomialRing) {
+                GenSolvablePolynomialRing<Residue<C>> rf = new GenSolvablePolynomialRing<Residue<C>>(r, cf);
+                List<GenSolvablePolynomial<GenPolynomial<C>>> rel = ((GenSolvablePolynomialRing<GenPolynomial<C>>) cf).table
+                                .relationList();
+                List<GenPolynomial<Residue<C>>> relres = PolyUtilApp.<C> toResidue(rf,
+                                PolynomialList.<GenPolynomial<C>> castToList(rel));
+                rf.addRelations(relres);
+                //System.out.println("rf = " + rf.toScript());
+                list = PolyUtilApp.<C> toResidue(rf, F);
+                SolvableGroebnerBase<Residue<C>> bb = SGBFactory.getImplementation(r);
+                t = bb.isLeftGB(PolynomialList.<Residue<C>> castToSolvableList(list));
+            } else {
+                GenPolynomialRing<Residue<C>> rf = new GenPolynomialRing<Residue<C>>(r, cf);
+                //System.out.println("rf = " + rf.toScript());
+                list = PolyUtilApp.<C> toResidue(rf, F);
+                GroebnerBase<Residue<C>> bb = GBFactory.getImplementation(r);
+                t = bb.isGB(list);
+            }
+            if (!t) {
+                System.out.println("test condition = " + cs.condition);
+                System.out.println("test ideal     = " + id.toScript());
+                System.out.println("test F         = " + F);
+                System.out.println("no GB for residue coefficients = " + list);
+                return false;
+            }
+        }
+
+        // substitute random ideal into parameter coefficients and test
+        GenPolynomialRing<C> ccf = (GenPolynomialRing<C>) cf.coFac;
+        int nv = ccf.nvar - 2;
+        if (nv < 1) {
+            nv = 1;
+        }
+        List<GenPolynomial<C>> il = new ArrayList<GenPolynomial<C>>();
+        int i = 0;
+        //int j = 1;
+        while (i < nv) {
+            //j++;
+            GenPolynomial<C> p = ccf.random(3, 3, 3, 0.3f); //j + 1);
+            // System.out.println("p = " + p);
+            if (p.isConstant()) {
+                continue;
+            }
+            if (p.isZERO()) {
+                continue;
+            }
+            p = engine.squarefreePart(p);
+            il.add(p);
+            i++;
+        }
+        logger.info("random ideal = " + il);
+        Ideal<C> id = new Ideal<C>(ccf, il);
+        ResidueRing<C> r = new ResidueRing<C>(id);
+        //GroebnerBase<Residue<C>> bb = new GroebnerBasePseudoSeq<Residue<C>>(r);
+        List<GenPolynomial<Residue<C>>> list;
+        boolean t;
+        if (cf instanceof GenSolvablePolynomialRing) {
+            GenSolvablePolynomialRing<Residue<C>> rf = new GenSolvablePolynomialRing<Residue<C>>(r, cf);
+            List<GenSolvablePolynomial<GenPolynomial<C>>> rel = ((GenSolvablePolynomialRing<GenPolynomial<C>>) cf).table
+                            .relationList();
+            List<GenPolynomial<Residue<C>>> relres = PolyUtilApp.<C> toResidue(rf,
+                            PolynomialList.<GenPolynomial<C>> castToList(rel));
+            rf.addRelations(relres);
+            //System.out.println("rf = " + rf.toScript());
+            list = PolyUtilApp.<C> toResidue(rf, F);
+            SolvableGroebnerBase<Residue<C>> bb = SGBFactory.getImplementation(r);
+            t = bb.isLeftGB(PolynomialList.<Residue<C>> castToSolvableList(list));
+        } else {
+            GenPolynomialRing<Residue<C>> rf = new GenPolynomialRing<Residue<C>>(r, cf);
+            //System.out.println("rf = " + rf.toScript());
+            list = PolyUtilApp.<C> toResidue(rf, F);
+            GroebnerBase<Residue<C>> bb = GBFactory.getImplementation(r);
+            t = bb.isGB(list);
+        }
+        if (!t) {
+            System.out.println("test random ideal = " + id.toScript());
+            System.out.println("no GB for residue coefficients = " + list);
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Comprehensive-Groebner system test.
+     * @param F Groebner system.
+     * @return true, if F is a Comprehensive-Groebner system, else false.
+     */
+    // @Override
+    public boolean isGBsys(GroebnerSystem<C> F) {
+        return isGBsys(0, F.list);
+    }
+
+
+    /**
+     * Comprehensive-Groebner base test.
+     * @param F Groebner system.
+     * @return true, if F is a Comprehensive-Groebner base, else false.
+     */
+    // @Override
+    public boolean isCGB(GroebnerSystem<C> F) {
+        return isGB(F.getCGB());
+    }
+
+
+    /**
+     * Comprehensive-Groebner system and base test.
+     * @param F Groebner system.
+     * @return true, if F is a Comprehensive-Groebner system and base, else
+     *         false.
+     */
+    // @Override
+    public boolean isGB(GroebnerSystem<C> F) {
+        return isGBsys(0, F.list) && isGB(F.getCGB());
+    }
+
+
+    /**
+     * Comprehensive Groebner base system using pairlist class.
+     * @param F polynomial list.
+     * @return GBsys(F) a Comprehensive Groebner system of F.
+     */
+    // @Override
+    // @SuppressWarnings("unchecked")
+    public GroebnerSystem<C> GBsys(List<GenPolynomial<GenPolynomial<C>>> F) {
+        if (F == null) {
+            return null;
+        }
+        List<ColoredSystem<C>> CSp = new ArrayList<ColoredSystem<C>>();
+        if (F.size() == 0) {
+            return new GroebnerSystem<C>(CSp);
+        }
+        // extract coefficient factory
+        GenPolynomial<GenPolynomial<C>> f = F.get(0);
+        GenPolynomialRing<GenPolynomial<C>> fac = f.ring;
+        // determine polynomials
+        List<ColoredSystem<C>> CS = cred.determine(F);
+        // System.out.println("CS = " + CS);
+        // CS.remove(0); // empty colored system
+        if (logger.isInfoEnabled()) {
+            logger.info("determined polynomials =\n" + CS);
+        }
+
+        // setup pair lists
+        List<ColoredSystem<C>> CSs = new ArrayList<ColoredSystem<C>>();
+        ColoredSystem<C> css;
+        for (ColoredSystem<C> cs : CS) {
+            OrderedCPairlist<C> pairlist = new OrderedCPairlist<C>(fac);
+            for (ColorPolynomial<C> p : cs.list) {
+                // System.out.println("p = " + p);
+                pairlist.put(p);
+            }
+            css = new ColoredSystem<C>(cs.condition, cs.list, pairlist);
+            CSs.add(css);
+        }
+
+        // main loop
+        List<ColoredSystem<C>> CSb = new ArrayList<ColoredSystem<C>>();
+        List<ColoredSystem<C>> ncs;
+        List<ColoredSystem<C>> CSh; //, CSbh;
+        ColoredSystem<C> cs;
+        List<ColorPolynomial<C>> G;
+        OrderedCPairlist<C> pairlist;
+        Condition<C> cond;
+        int si = 0;
+        while (CSs.size() > 0) {
+            cs = CSs.get(0); // remove(0);
+            si++;
+            logger.info("poped GBsys number    " + si + " with condition = " + cs.condition);
+            logger.info("poped GBsys (remaining " + (CSs.size() - 1) + ") with pairlist  = " + cs.pairlist);
+            if (!cs.isDetermined()) {
+                cs = cs.reDetermine();
+            }
+            pairlist = cs.pairlist;
+            G = cs.list;
+            cond = cs.condition;
+            // logger.info( pairlist.toString() );
+
+            CPair<C> pair;
+            ColorPolynomial<C> pi;
+            ColorPolynomial<C> pj;
+            ColorPolynomial<C> S;
+            // GenPolynomial<GenPolynomial<C>> H;
+            ColorPolynomial<C> H;
+            while (pairlist.hasNext()) {
+                pair = pairlist.removeNext();
+                if (pair == null)
+                    continue;
+
+                pi = pair.pi;
+                pj = pair.pj;
+                if (debug) {
+                    logger.info("pi    = " + pi);
+                    logger.info("pj    = " + pj);
+                }
+
+                S = cred.SPolynomial(pi, pj);
+                if (S.isZERO()) {
+                    pair.setZero();
+                    continue;
+                }
+                if (debug) {
+                    // logger.info("ht(S) = " + S.leadingExpVector() );
+                    logger.info("S = " + S);
+                }
+
+                H = cred.normalform(cond, G, S);
+                if (H.isZERO()) {
+                    pair.setZero();
+                    continue;
+                }
+                if (debug) {
+                    logger.info("ht(H) = " + H.leadingExpVector());
+                }
+
+                H = H.abs();
+                if (debug) {
+                    logger.debug("H = " + H);
+                }
+                logger.info("H = " + H);
+                if (!H.isZERO()) {
+                    //CSh = new ArrayList<ColoredSystem<C>>();
+                    ncs = determineAddPairs(cs, H);
+                    if (ncs.size() == 0) {
+                        continue;
+                    }
+                    cs = ncs.remove(0); // remove other?
+                    pairlist = cs.pairlist;
+                    G = cs.list;
+                    cond = cs.condition;
+                    logger.info("replaced main branch = " + cond);
+                    logger.info("#new systems       = " + ncs.size());
+                    int yi = CSs.size();
+                    for (ColoredSystem<C> x : ncs) {
+                        if (!x.isDetermined()) {
+                            x = x.reDetermine();
+                        }
+                        CSs = x.addToList(CSs);
+                    }
+                    logger.info("#new systems added = " + (CSs.size() - yi));
+                }
+            }
+            // all s-pols reduce to zero in this branch
+            if (!cs.isDetermined()) {
+                cs = cs.reDetermine();
+            }
+            CSb.add(cs);
+            CSs.remove(0);
+            logger.info("done with = " + cs.condition);
+        }
+        // all branches done
+        CSh = new ArrayList<ColoredSystem<C>>();
+        for (ColoredSystem<C> x : CSb) {
+            // System.out.println("G = " + x.list );
+            if (!x.isDetermined()) {
+                x = x.reDetermine();
+            }
+            cs = minimalGB(x);
+            // System.out.println("min(G) = " + cs.list );
+            if (!cs.isDetermined()) {
+                cs = cs.reDetermine();
+            }
+            // cs = new ColoredSystem<C>( x.condition, G, x.pairlist );
+            CSh.add(cs);
+            logger.info("#sequential done = " + x.condition);
+            logger.info(x.pairlist.toString());
+        }
+        CSb = new ArrayList<ColoredSystem<C>>(CSh);
+        return new GroebnerSystem<C>(CSb);
+    }
+
+
+    /**
+     * Determine polynomial relative to a condition of a colored system and add
+     * pairs.
+     * @param cs a colored system.
+     * @param A color polynomial.
+     * @return list of colored systems, the conditions extending the condition
+     *         of cs.
+     */
+    public List<ColoredSystem<C>> determineAddPairs(ColoredSystem<C> cs, ColorPolynomial<C> A) {
+        List<ColoredSystem<C>> NCS = new ArrayList<ColoredSystem<C>>();
+        if (A == null || A.isZERO()) {
+            // NCS.add( cs );
+            return NCS;
+        }
+        List<ColorPolynomial<C>> S = cs.list;
+        Condition<C> cond = cs.condition; // .clone(); done in Condition
+        // itself
+        OrderedCPairlist<C> pl = cs.pairlist;
+
+        List<ColorPolynomial<C>> Sp;
+        ColorPolynomial<C> nz;
+        ColoredSystem<C> NS;
+        // if ( A.isDetermined() ) { ... } // dont use this
+        // System.out.println("to determine = " + A);
+        GenPolynomial<GenPolynomial<C>> Ap = A.getPolynomial();
+        List<Condition<C>> cd = cred.caseDistinction(cond, Ap);
+        logger.info("# cases = " + cd.size());
+        for (Condition<C> cnd : cd) {
+            //nz = cnd.determine(Ap);
+            nz = cnd.reDetermine(A);
+            if (nz.isZERO()) {
+                logger.info("zero determined nz = " + nz);
+                Sp = new ArrayList<ColorPolynomial<C>>(S);
+                OrderedCPairlist<C> PL = pl.copy();
+                NS = new ColoredSystem<C>(cnd, Sp, PL);
+                try {
+                    if (!NS.isDetermined()) {
+                        NS = NS.reDetermine();
+                    }
+                } catch (RuntimeException e) {
+                    System.out.println("Contradiction in NS_0 = " + NS);
+                    //e.printStackTrace();
+                    continue;
+                }
+                NCS = NS.addToList(NCS);
+                continue;
+            }
+            if (S.contains(nz)) {
+                System.out.println("*** S.contains(nz) ***");
+                continue;
+            }
+            logger.info("new determined nz = " + nz);
+            Sp = new ArrayList<ColorPolynomial<C>>(S);
+            Sp.add(nz);
+            OrderedCPairlist<C> PL = pl.copy();
+            PL.put(nz);
+            NS = new ColoredSystem<C>(cnd, Sp, PL);
+            try {
+                if (!NS.isDetermined()) {
+                    NS = NS.reDetermine();
+                }
+            } catch (RuntimeException e) {
+                System.out.println("Contradiction in NS = " + NS);
+                //e.printStackTrace();
+                continue;
+            }
+            NCS = NS.addToList(NCS);
+        }
+        // System.out.println("new determination = " + NCS);
+        return NCS;
+    }
+
+
+    /**
+     * Comprehensive Groebner base via Groebner system.
+     * @param F polynomial list.
+     * @return GB(F) a Comprehensive Groebner base of F.
+     */
+    // @Override
+    // @SuppressWarnings("unchecked")
+    public List<GenPolynomial<GenPolynomial<C>>> GB(List<GenPolynomial<GenPolynomial<C>>> F) {
+        if (F == null) {
+            return F;
+        }
+        // compute Groebner system
+        GroebnerSystem<C> gs = GBsys(F);
+        // System.out.println("\n\nGBsys = " + gs);
+        return gs.getCGB();
+    }
+
+
+    /**
+     * Minimal ordered Groebner basis.
+     * @param cs colored system.
+     * @return a reduced Groebner base of Gp.
+     */
+    // @Override
+    public ColoredSystem<C> minimalGB(ColoredSystem<C> cs) {
+        // List<ColorPolynomial<C>> Gp ) {
+        if (cs == null || cs.list == null || cs.list.size() <= 1) {
+            return cs;
+        }
+        // remove zero polynomials
+        List<ColorPolynomial<C>> G = new ArrayList<ColorPolynomial<C>>(cs.list.size());
+        for (ColorPolynomial<C> a : cs.list) {
+            if (a != null && !a.isZERO()) { // always true in GB()
+                // already positive a = a.abs();
+                G.add(a);
+            }
+        }
+        if (G.size() <= 1) {
+            return new ColoredSystem<C>(cs.condition, G, cs.pairlist);
+        }
+        // System.out.println("G check " + G);
+        // remove top reducible polynomials
+        Condition<C> cond = cs.condition;
+        ColorPolynomial<C> a, b;
+        List<ColorPolynomial<C>> F;
+        F = new ArrayList<ColorPolynomial<C>>(G.size());
+        while (G.size() > 0) {
+            a = G.remove(0);
+            b = a;
+            // System.out.println("check " + b);
+            //if (false) {
+            //    if (a.red.leadingBaseCoefficient().isConstant()) { // dont drop
+            //        // these
+            //        F.add(a);
+            //        continue;
+            //    }
+            //}
+            if (cred.isTopReducible(G, a) || cred.isTopReducible(F, a)) {
+                // drop polynomial
+                if (debug) {
+                    // System.out.println("trying to drop " + a);
+                    List<ColorPolynomial<C>> ff;
+                    ff = new ArrayList<ColorPolynomial<C>>(G);
+                    ff.addAll(F);
+                    a = cred.normalform(cond, ff, a);
+                    try {
+                        a = cond.reDetermine(a);
+                    } catch (RuntimeException ignored) {
+                    }
+                    if (!a.isZERO()) {
+                        logger.error("nf(a) != 0 " + b + ", " + a);
+                        F.add(b);
+                    }
+                }
+            } else {
+                F.add(a);
+            }
+        }
+        G = F;
+        if (G.size() <= 1) {
+            return new ColoredSystem<C>(cs.condition, G, cs.pairlist);
+        }
+        Collections.reverse(G); // important for lex GB
+        // reduce remaining polynomials
+        int len = G.size();
+        int i = 0;
+        while (i < len) {
+            a = G.remove(0);
+            b = a;
+            ExpVector e = a.red.leadingExpVector();
+            // System.out.println("reducing " + a);
+            a = cred.normalform(cond, G, a); // unchanged by top reduction
+            // System.out.println("reduced " + a);
+            try {
+                a = cond.reDetermine(a);
+            } catch (RuntimeException ignored) {
+            }
+            ExpVector f = a.red.leadingExpVector();
+            // a = ##engine.basePrimitivePart(a); //a.monic(); was not required
+            // a = a.abs();
+            // a = red.normalform( F, a );
+            if (e.equals(f)) {
+                G.add(a); // adds as last
+            } else { // should not happen
+                if (debug) {
+                    logger.error("nf(a) not determined " + b + ", " + a);
+                }
+                G.add(b); // adds as last
+            }
+            i++;
+        }
+        return new ColoredSystem<C>(cs.condition, G, cs.pairlist);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/Condition.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/Condition.java
@@ -1,0 +1,491 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gbufd.MultiplicativeSet;
+import edu.jas.gbufd.MultiplicativeSetSquarefree;
+//import edu.jas.gbufd.MultiplicativeSetFactors;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Condition. Container for an ideal of polynomials considered to be zero and a
+ * multiplicative set of polynomials considered to be non-zero.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+public class Condition<C extends GcdRingElem<C>> implements Serializable {
+
+
+    private static final Logger logger = LogManager.getLogger(Condition.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Colors.
+     */
+    public static enum Color {
+        GREEN, RED, WHITE
+    };
+
+
+    /**
+     * Data structure for condition zero.
+     */
+    public final Ideal<C> zero;
+
+
+    /**
+     * Data structure for condition non-zero.
+     */
+    public final MultiplicativeSet<C> nonZero;
+
+
+    /**
+     * Condition constructor. Constructs an empty condition with squarefree
+     * multiplicative set.
+     * @param ring polynomial ring factory for coefficients.
+     */
+    public Condition(GenPolynomialRing<C> ring) {
+        this(new Ideal<C>(ring), new MultiplicativeSetSquarefree<C>(ring));
+        //this(new Ideal<C>(ring), new MultiplicativeSetFactors<C>(ring));
+        //if (ring == null) { // too late to test
+        //    throw new IllegalArgumentException("only for non null rings");
+        //}
+    }
+
+
+    /**
+     * Condition constructor. Constructs a condition with squarefree
+     * multiplicative set.
+     * @param z an ideal of zero polynomials.
+     */
+    public Condition(Ideal<C> z) {
+        this(z, new MultiplicativeSetSquarefree<C>(z.list.ring));
+        //this(z,new MultiplicativeSetFactors<C>(z.list.ring));
+    }
+
+
+    /**
+     * Condition constructor.
+     * @param nz a list of non-zero polynomials.
+     */
+    public Condition(MultiplicativeSet<C> nz) {
+        this(new Ideal<C>(nz.ring), nz);
+    }
+
+
+    /**
+     * Condition constructor.
+     * @param z an ideal of zero polynomials.
+     * @param nz a list of non-zero polynomials.
+     */
+    public Condition(Ideal<C> z, MultiplicativeSet<C> nz) {
+        if (z == null || nz == null) {
+            throw new IllegalArgumentException("only for non null condition parts");
+        }
+        zero = z;
+        nonZero = nz;
+    }
+
+
+    /**
+     * toString.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "Condition[ 0 == " + zero.getList().toString() + ", 0 != " + nonZero.mset.toString() + " ]";
+    }
+
+
+    /**
+     * toScript.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    public String toScript() {
+        return "Condition[ 0 == " + zero.getList().toString() + ", 0 != " + nonZero.mset.toString() + " ]";
+    }
+
+
+    /**
+     * equals.
+     * @param ob an Object.
+     * @return true if this is equal to o, else false.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object ob) {
+        Condition<C> c = null;
+        try {
+            c = (Condition<C>) ob;
+        } catch (ClassCastException e) {
+            return false;
+        }
+        if (c == null) {
+            return false;
+        }
+        if (!zero.equals(c.zero)) {
+            return false;
+        }
+        if (!nonZero.equals(c.nonZero)) {
+            return false;
+        }
+        // better:
+        //if ( nonZero.removeFactors(c.nonZero).size() != 0 ) {
+        //    return false;
+        //}
+        //if ( c.nonZero.removeFactors(nonZero).size() != 0 ) {
+        //    return false;
+        //}
+        return true;
+    }
+
+
+    /**
+     * Hash code for this condition.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = zero.getList().hashCode();
+        h = h << 17;
+        h += nonZero.hashCode();
+        // h = h << 11;
+        // h += pairlist.hashCode();
+        return h;
+    }
+
+
+    /**
+     * Is empty condition.
+     * @return true if this is the empty condition, else false.
+     */
+    public boolean isEmpty() {
+        return (zero.isZERO() && nonZero.isEmpty());
+    }
+
+
+    /**
+     * Is contradictory.
+     * @return true if this condition is contradictory, else false.
+     */
+    public boolean isContradictory() {
+        if (zero.isZERO()) {
+            return false;
+        }
+        boolean t = zero.isONE();
+        if (t) {
+            logger.info("contradiction zero.isONE(): " + this);
+            return t;
+        }
+        for (GenPolynomial<C> p : zero.getList()) {
+            t = nonZero.contains(p);
+            if (t) {
+                logger.info("contradiction nonZero.contains(zero): " + this + ", pol = " + p);
+                return t;
+            }
+        }
+        for (GenPolynomial<C> p : nonZero.mset) {
+            t = zero.contains(p);
+            if (t) {
+                logger.info("contradiction zero.contains(nonZero): " + this + ", pol = " + p);
+                return t;
+            }
+        }
+        return false;
+    }
+
+
+    /**
+     * Extend condition with zero polynomial.
+     * @param z a polynomial to be treated as zero.
+     * @return new condition.
+     */
+    public Condition<C> extendZero(GenPolynomial<C> z) {
+        // assert color(z) == white 
+        z = z.monic();
+        Ideal<C> idz = zero.sum(z);
+        logger.info("added to ideal: " + z);
+
+        Condition<C> nc = new Condition<C>(idz, nonZero);
+        //if (true) {
+        return nc.simplify();
+        //}
+        //return nc;
+    }
+
+
+    /**
+     * Extend condition with non-zero polynomial.
+     * @param nz a polynomial to be treated as non-zero.
+     * @return new condition.
+     */
+    public Condition<C> extendNonZero(GenPolynomial<C> nz) {
+        // assert color(nz) == white 
+        GenPolynomial<C> n = zero.normalform(nz).monic();
+        if (n == null || n.isZERO()) {
+            return this;
+        }
+        MultiplicativeSet<C> ms = nonZero.add(n);
+        logger.info("added to non zero: " + n);
+
+        Condition<C> nc = new Condition<C>(zero, ms);
+        //if (true) {
+        return nc.simplify();
+        //}
+        //return nc;
+    }
+
+
+    /**
+     * Simplify zero and non-zero polynomial conditions.
+     * @return new simplified condition.
+     */
+    public Condition<C> simplify() {
+        //if (false) { // no simplification
+        //    return this;
+        //}
+        Ideal<C> idz = zero.squarefree();
+        if (!idz.getList().equals(zero.getList())) {
+            logger.info("simplify squarefree: " + zero.getList() + " to " + idz.getList());
+        }
+        List<GenPolynomial<C>> ml = idz.normalform(nonZero.mset);
+        MultiplicativeSet<C> ms = nonZero;
+        if (!ml.equals(nonZero.mset)) {
+            if (ml.size() != nonZero.mset.size()) {
+                logger.info("contradiction(==0):");
+                logger.info("simplify normalform contradiction: " + nonZero.mset + " to " + ml);
+                return null;
+            }
+            logger.info("simplify normalform: " + nonZero.mset + " to " + ml);
+            ms = nonZero.replace(ml);
+        }
+        List<GenPolynomial<C>> Z = ms.removeFactors(idz.getList());
+        if (!Z.equals(idz.getList())) {
+            if (Z.size() != idz.getList().size()) { // never true
+                logger.info("contradiction(!=0):");
+                logger.info("simplify removeFactors contradiction: " + idz.getList() + " to " + Z);
+                return null;
+            }
+            logger.info("simplify removeFactors: " + idz.getList() + " to " + Z);
+            idz = new Ideal<C>(zero.getRing(), Z); // changes ideal
+        }
+        Condition<C> nc = new Condition<C>(idz, ms);
+        if (nc.isContradictory()) { // eventually a factor became 1
+            logger.info("simplify contradiction: " + nc);
+            return null;
+        }
+        if (idz.equals(zero) && ms.equals(nonZero)) {
+            return this;
+        }
+        logger.info("condition simplified: " + this + " to " + nc);
+        //if (false) { // no further simplification
+        //    return nc;
+        //}
+        return nc.simplify();
+    }
+
+
+    /**
+     * Determine color of polynomial.
+     * @param c polynomial to be colored.
+     * @return color of c.
+     */
+    public Color color(GenPolynomial<C> c) {
+        GenPolynomial<C> m = zero.normalform(c).monic();
+        //non-sense: m = nonZero.removeFactors(m);
+        if (m.isZERO()) { // zero.contains(m)
+            // System.out.println("m in id = " + m);
+            return Color.GREEN;
+        }
+        if (m.isConstant()) {
+            // System.out.println("m constant " + m);
+            return Color.RED;
+        }
+        if (nonZero.contains(m) || nonZero.contains(c)) {
+            // System.out.println("m or c in nonzero " + m);
+            return Color.RED;
+        }
+        //System.out.println("m white " + m + ", c = " + c);
+        return Color.WHITE;
+    }
+
+
+    /**
+     * Determine polynomial. If this condition does not determine the
+     * polynomial, then a run-time exception is thrown.
+     * @param A polynomial.
+     * @return new determined colored polynomial.
+     */
+    public ColorPolynomial<C> determine(GenPolynomial<GenPolynomial<C>> A) {
+        ColorPolynomial<C> cp = null;
+        if (A == null) {
+            return cp;
+        }
+        GenPolynomial<GenPolynomial<C>> zero = A.ring.getZERO();
+        GenPolynomial<GenPolynomial<C>> green = zero;
+        GenPolynomial<GenPolynomial<C>> red = zero;
+        GenPolynomial<GenPolynomial<C>> white = zero;
+        if (A.isZERO()) {
+            cp = new ColorPolynomial<C>(green, red, white);
+            return cp;
+        }
+        GenPolynomial<GenPolynomial<C>> Ap = A;
+        GenPolynomial<GenPolynomial<C>> Bp;
+        while (!Ap.isZERO()) {
+            Map.Entry<ExpVector, GenPolynomial<C>> m = Ap.leadingMonomial();
+            ExpVector e = m.getKey();
+            GenPolynomial<C> c = m.getValue();
+            Bp = Ap.reductum();
+            // System.out.println( "color(" + c + ") = " + color(c) );
+            switch (color(c)) {
+            case GREEN:
+                green = green.sum(c, e);
+                Ap = Bp;
+                continue;
+            case RED:
+                red = red.sum(c, e);
+                white = Bp;
+                return new ColorPolynomial<C>(green, red, white);
+                // since break is not possible
+            case WHITE:
+            default:
+                logger.info("recheck undetermined coeff c = " + c + ", cond = " + this);
+                if (extendZero(c) == null) { // contradiction if colored green
+                    logger.info("recheck assume red");
+                    red = red.sum(c, e); // assume red
+                    white = Bp;
+                    return new ColorPolynomial<C>(green, red, white);
+                }
+                if (extendNonZero(c) == null) { // contradiction if colored red
+                    logger.info("recheck assume green");
+                    green = green.sum(c, e); // assume green
+                    Ap = Bp;
+                    continue;
+                }
+                System.out.println("undetermined cond       = " + this);
+                System.out.println("undetermined poly     A = " + A);
+                System.out.println("undetermined poly green = " + green);
+                System.out.println("undetermined poly   red = " + red);
+                System.out.println("undetermined poly    Bp = " + Bp);
+                System.out.println("undetermined coeff    c = " + c);
+                throw new RuntimeException("undetermined, c is white = " + c);
+                // is catched in minimalGB
+            }
+        }
+        cp = new ColorPolynomial<C>(green, red, white);
+        // System.out.println("determined = " + cp);
+        return cp;
+    }
+
+
+    /**
+     * Determine list of polynomials. If this condition does not determine all
+     * polynomials, then a run-time exception is thrown. The returned list does
+     * not contain polynomials with all green terms.
+     * @param L list of polynomial.
+     * @return new determined list of colored polynomials.
+     */
+    public List<ColorPolynomial<C>> determine(List<GenPolynomial<GenPolynomial<C>>> L) {
+        List<ColorPolynomial<C>> cl = null;
+        if (L == null) {
+            return cl;
+        }
+        cl = new ArrayList<ColorPolynomial<C>>(L.size());
+        for (GenPolynomial<GenPolynomial<C>> A : L) {
+            ColorPolynomial<C> c = determine(A);
+            if (c != null && !c.isZERO()) {
+                cl.add(c);
+            }
+        }
+        return cl;
+    }
+
+
+    /**
+     * Re determine colored polynomial.
+     * @param s colored polynomial.
+     * @return determined colored polynomial wrt. this.conditions.
+     */
+    public ColorPolynomial<C> reDetermine(ColorPolynomial<C> s) {
+        ColorPolynomial<C> p = determine(s.getEssentialPolynomial());
+        // assume green terms stay green wrt. this condition
+        GenPolynomial<GenPolynomial<C>> g = s.green.sum(p.green);
+        p = new ColorPolynomial<C>(g, p.red, p.white);
+        return p;
+    }
+
+
+    /**
+     * Re determine list of colored polynomials.
+     * @param S list of colored polynomials.
+     * @return list of determined colored polynomials wrt. this.conditions.
+     */
+    public List<ColorPolynomial<C>> reDetermine(List<ColorPolynomial<C>> S) {
+        if (S == null || S.isEmpty()) {
+            return S;
+        }
+        List<ColorPolynomial<C>> P = new ArrayList<ColorPolynomial<C>>();
+        for (ColorPolynomial<C> s : S) {
+            ColorPolynomial<C> p = reDetermine(s);
+            P.add(p);
+        }
+        return P;
+    }
+
+
+    /**
+     * Is determined colored polynomial.
+     * @param s colored polynomial.
+     * @return true if the colored polynomial is correctly determined wrt.
+     *         this.condition.
+     */
+    public boolean isDetermined(ColorPolynomial<C> s) {
+        ColorPolynomial<C> p = determine(s.getPolynomial());
+        boolean t = p.equals(s);
+        if (!t) {
+            System.out.println("not determined s    = " + s);
+            System.out.println("not determined p    = " + p);
+            System.out.println("not determined cond = " + this);
+        }
+        return t;
+    }
+
+
+    /**
+     * Is determined list of colored polynomial.
+     * @param S list of colored polynomials.
+     * @return true if the colored polynomials in S are correctly determined
+     *         wrt. this.condition.
+     */
+    public boolean isDetermined(List<ColorPolynomial<C>> S) {
+        if (S == null) {
+            return true;
+        }
+        for (ColorPolynomial<C> p : S) {
+            if (!isDetermined(p)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/Dimension.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/Dimension.java
@@ -1,0 +1,96 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Set;
+
+
+/**
+ * Container for dimension parameters.
+ * @author Heinz Kredel
+ */
+public class Dimension implements Serializable {
+
+
+    /**
+     * Ideal dimension.
+     */
+    public final int d;
+
+
+    /**
+     * Indices of a maximal independent set (of variables).
+     */
+    public final Set<Integer> S;
+
+
+    /**
+     * Set of indices of all maximal independent sets (of variables).
+     */
+    public final Set<Set<Integer>> M;
+
+
+    /**
+     * Names of all variables.
+     */
+    public final String[] v;
+
+
+    /**
+     * Constructor.
+     * @param d ideal dimension.
+     * @param S indices of a maximal independent set (of variables)
+     * @param M set of indices of all maximal independent sets (of variables)
+     * @param v names of all variables
+     */
+    public Dimension(int d, Set<Integer> S, Set<Set<Integer>> M, String[] v) {
+        this.d = d;
+        this.S = S;
+        this.M = M;
+        this.v = Arrays.copyOf(v,v.length); // > Java-5
+    }
+
+
+    /**
+     * String representation of the ideal.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer("Dimension( " + d + ", ");
+        if (v == null) {
+            sb.append("" + S + ", " + M + " )");
+            return sb.toString();
+        }
+        String[] s = new String[S.size()];
+        int j = 0;
+        for (Integer i : S) {
+            s[j] = v[i];
+            j++;
+        }
+        sb.append(Arrays.toString(s) + ", ");
+        sb.append("[ ");
+        boolean first = true;
+        for (Set<Integer> m : M) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append(", ");
+            }
+            s = new String[m.size()];
+            j = 0;
+            for (Integer i : m) {
+                s[j] = v[i];
+                j++;
+            }
+            sb.append(Arrays.toString(s));
+        }
+        sb.append(" ] )");
+        return sb.toString();
+    }
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/Examples.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/Examples.java
@@ -1,0 +1,764 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.jas.arith.BigDecimal;
+import edu.jas.arith.BigInteger;
+import edu.jas.arith.BigRational;
+import edu.jas.arith.ModInteger;
+import edu.jas.arith.ModIntegerRing;
+import edu.jas.arith.Product;
+import edu.jas.arith.ProductRing;
+import edu.jas.gb.Cyclic;
+import edu.jas.gb.GroebnerBase;
+import edu.jas.gb.GroebnerBaseAbstract;
+import edu.jas.gbufd.GBFactory;
+import edu.jas.gbufd.RGroebnerBasePseudoSeq;
+import edu.jas.gbufd.RReductionSeq;
+import edu.jas.kern.ComputerThreads;
+import edu.jas.kern.Scripting;
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.AlgebraicNumberRing;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.GenPolynomialTokenizer;
+import edu.jas.poly.PolynomialList;
+import edu.jas.poly.TermOrder;
+import edu.jas.ufd.Quotient;
+import edu.jas.ufd.QuotientRing;
+
+
+/**
+ * Examples for application usage.
+ * @author Christoph Zengler
+ * @author Heinz Kredel
+ */
+
+public class Examples {
+
+
+    /**
+     * main.
+     */
+    public static void main(String[] args) {
+        if (args.length > 0) {
+            example1();
+            example2();
+            example3();
+            example4();
+        }
+        example5();
+        example6();
+        example10();
+        example11();
+        example12();
+        ComputerThreads.terminate();
+    }
+
+
+    /**
+     * example1. cyclic n-th roots polynomial systems.
+     */
+    public static void example1() {
+        int n = 4;
+        Cyclic cy = new Cyclic(n);
+        System.out.println("ring = " + cy.ring);
+        List<GenPolynomial<BigInteger>> cp = cy.cyclicPolys();
+        System.out.println("cp = " + cp + "\n");
+
+        List<GenPolynomial<BigInteger>> gb;
+        //GroebnerBase<BigInteger> sgb = new GroebnerBaseSeq<BigInteger>();
+        GroebnerBase<BigInteger> sgb = GBFactory.getImplementation(cy.ring.coFac);
+        gb = sgb.GB(cp);
+        System.out.println("gb = " + gb);
+    }
+
+
+    /**
+     * example2. abtract types:
+     * List&lt;GenPolynomial&lt;Product&lt;Residue&lt;BigRational&gt;&gt;&gt;&gt;.
+     */
+    public static void example2() {
+        List<GenPolynomial<Product<Residue<BigRational>>>> L = null;
+        L = new ArrayList<GenPolynomial<Product<Residue<BigRational>>>>();
+
+        BigRational bfac = new BigRational(1);
+        String[] cvars = new String[] { "x", "y", "z" };
+        GenPolynomialRing<BigRational> pfac = null;
+        pfac = new GenPolynomialRing<BigRational>(bfac, cvars);
+
+        List<GenPolynomial<BigRational>> F = null;
+        F = new ArrayList<GenPolynomial<BigRational>>();
+
+        GenPolynomial<BigRational> p = null;
+        for (int i = 0; i < 2; i++) {
+            p = pfac.random(5, 4, 3, 0.4f);
+            if (!p.isConstant()) {
+                F.add(p);
+            }
+        }
+        //System.out.println("F = " + F);
+
+        Ideal<BigRational> id = new Ideal<BigRational>(pfac, F);
+        id.doGB();
+        if (id.isONE() || id.isZERO()) {
+            System.out.println("id zero or one = " + id);
+            return;
+        }
+        ResidueRing<BigRational> rr = new ResidueRing<BigRational>(id);
+        System.out.println("rr = " + rr);
+
+        ProductRing<Residue<BigRational>> pr = null;
+        pr = new ProductRing<Residue<BigRational>>(rr, 3);
+
+        String[] vars = new String[] { "a", "b" };
+        GenPolynomialRing<Product<Residue<BigRational>>> fac;
+        fac = new GenPolynomialRing<Product<Residue<BigRational>>>(pr, vars);
+
+        GenPolynomial<Product<Residue<BigRational>>> pp;
+        for (int i = 0; i < 1; i++) {
+            pp = fac.random(2, 4, 4, 0.4f);
+            if (!pp.isConstant()) {
+                L.add(pp);
+            }
+        }
+        System.out.println("L = " + L);
+
+        //PolynomialList<Product<Residue<BigRational>>> Lp = null;
+        //Lp = new PolynomialList<Product<Residue<BigRational>>>(fac,L);
+        //System.out.println("Lp = " + Lp);
+
+        GroebnerBase<Product<Residue<BigRational>>> bb = new RGroebnerBasePseudoSeq<Product<Residue<BigRational>>>(
+                        pr);
+
+        System.out.println("isGB(L) = " + bb.isGB(L));
+
+        List<GenPolynomial<Product<Residue<BigRational>>>> G = null;
+
+        G = bb.GB(L);
+        System.out.println("G = " + G);
+        System.out.println("isGB(G) = " + bb.isGB(G));
+    }
+
+
+    /**
+     * example3. abtract types: GB of List&lt;GenPolynomial&lt;Residue&lt;BigRational&gt;&gt;&gt;.
+     */
+    public static void example3() {
+        List<GenPolynomial<Residue<BigRational>>> L = null;
+        L = new ArrayList<GenPolynomial<Residue<BigRational>>>();
+
+        BigRational bfac = new BigRational(1);
+        String[] cvars = new String[] { "x", "y", "z" };
+        GenPolynomialRing<BigRational> pfac = null;
+        pfac = new GenPolynomialRing<BigRational>(bfac, cvars);
+
+        List<GenPolynomial<BigRational>> F = null;
+        F = new ArrayList<GenPolynomial<BigRational>>();
+
+        GenPolynomial<BigRational> p = null;
+        for (int i = 0; i < 2; i++) {
+            p = pfac.random(5, 5, 5, 0.4f);
+            //p = pfac.parse("x0^2 -2" );
+            if (!p.isConstant()) {
+                F.add(p);
+            }
+        }
+        //System.out.println("F = " + F);
+
+        Ideal<BigRational> id = new Ideal<BigRational>(pfac, F);
+        id.doGB();
+        if (id.isONE() || id.isZERO()) {
+            System.out.println("id zero or one = " + id);
+            return;
+        }
+        ResidueRing<BigRational> rr = new ResidueRing<BigRational>(id);
+        System.out.println("rr = " + rr);
+
+        String[] vars = new String[] { "a", "b" };
+        GenPolynomialRing<Residue<BigRational>> fac;
+        fac = new GenPolynomialRing<Residue<BigRational>>(rr, vars);
+
+        GenPolynomial<Residue<BigRational>> pp;
+        for (int i = 0; i < 2; i++) {
+            pp = fac.random(2, 4, 6, 0.2f);
+            if (!pp.isConstant()) {
+                L.add(pp);
+            }
+        }
+        System.out.println("L = " + L);
+
+        GroebnerBase<Residue<BigRational>> bb;
+        //bb = new GroebnerBasePseudoSeq<Residue<BigRational>>(rr);
+        bb = GBFactory.getImplementation(rr);
+
+        System.out.println("isGB(L) = " + bb.isGB(L));
+
+        List<GenPolynomial<Residue<BigRational>>> G = null;
+
+        G = bb.GB(L);
+        System.out.println("G = " + G);
+        System.out.println("isGB(G) = " + bb.isGB(G));
+    }
+
+
+    /**
+     * example4. abtract types: comprehensive GB of
+     * List&lt;GenPolynomial&lt;GenPolynomial&lt;BigRational&gt;&gt;&gt;.
+     */
+    public static void example4() {
+        int kl = 2;
+        int ll = 3;
+        int el = 3;
+        float q = 0.2f; //0.4f
+        GenPolynomialRing<BigRational> cfac;
+        GenPolynomialRing<GenPolynomial<BigRational>> fac;
+
+        List<GenPolynomial<GenPolynomial<BigRational>>> L;
+
+        ComprehensiveGroebnerBaseSeq<BigRational> bb;
+
+        GenPolynomial<GenPolynomial<BigRational>> a, b, c;
+
+        BigRational coeff = new BigRational(kl);
+        String[] cv = { "a", "b" };
+        cfac = new GenPolynomialRing<BigRational>(coeff, cv);
+        String[] v = { "x", "y" };
+        fac = new GenPolynomialRing<GenPolynomial<BigRational>>(cfac, v);
+        bb = new ComprehensiveGroebnerBaseSeq<BigRational>(coeff);
+
+        L = new ArrayList<GenPolynomial<GenPolynomial<BigRational>>>();
+
+        a = fac.random(kl, ll, el, q);
+        b = fac.random(kl, ll, el, q);
+        c = a; //c = fac.random(kl, ll, el, q );
+
+        if (a.isZERO() || b.isZERO() || c.isZERO()) {
+            return;
+        }
+
+        L.add(a);
+        System.out.println("CGB exam L = " + L);
+        L = bb.GB(L);
+        System.out.println("CGB( L )   = " + L);
+        System.out.println("isCGB( L ) = " + bb.isGB(L));
+
+        L.add(b);
+        System.out.println("CGB exam L = " + L);
+        L = bb.GB(L);
+        System.out.println("CGB( L )   = " + L);
+        System.out.println("isCGB( L ) = " + bb.isGB(L));
+
+        L.add(c);
+        System.out.println("CGB exam L = " + L);
+        L = bb.GB(L);
+        System.out.println("CGB( L )   = " + L);
+        System.out.println("isCGB( L ) = " + bb.isGB(L));
+    }
+
+
+    /**
+     * example5. comprehensive GB of
+     * List&lt;GenPolynomial&lt;GenPolynomial&lt;BigRational&gt;&gt;&gt; and GB for regular ring.
+     */
+    public static void example5() {
+        int kl = 2;
+        int ll = 4;
+        int el = 3;
+        float q = 0.3f; //0.4f
+        GenPolynomialRing<BigRational> cfac;
+        GenPolynomialRing<GenPolynomial<BigRational>> fac;
+
+        List<GenPolynomial<GenPolynomial<BigRational>>> L;
+
+        ComprehensiveGroebnerBaseSeq<BigRational> bb;
+
+        GenPolynomial<GenPolynomial<BigRational>> a;
+        GenPolynomial<GenPolynomial<BigRational>> b;
+        GenPolynomial<GenPolynomial<BigRational>> c;
+
+        BigRational coeff = new BigRational(kl);
+        String[] cv = { "a", "b" };
+        cfac = new GenPolynomialRing<BigRational>(coeff, cv);
+        String[] v = { "x", "y" };
+        fac = new GenPolynomialRing<GenPolynomial<BigRational>>(cfac, v);
+        bb = new ComprehensiveGroebnerBaseSeq<BigRational>(coeff);
+
+        L = new ArrayList<GenPolynomial<GenPolynomial<BigRational>>>();
+
+        a = fac.random(kl, ll, el, q);
+        b = fac.random(kl, ll, el, q);
+        c = a; //c = fac.random(kl, ll, el, q );
+
+        if (a.isZERO() || b.isZERO() || c.isZERO()) {
+            return;
+        }
+
+        L.add(a);
+        L.add(b);
+        L.add(c);
+        System.out.println("CGB exam L = " + L);
+        GroebnerSystem<BigRational> sys = bb.GBsys(L);
+        boolean ig = bb.isGB(sys.getCGB());
+        System.out.println("CGB( L )   = " + sys.getCGB());
+        System.out.println("isCGB( L ) = " + ig);
+
+        List<GenPolynomial<Product<Residue<BigRational>>>> Lr, bLr;
+        RReductionSeq<Product<Residue<BigRational>>> res = new RReductionSeq<Product<Residue<BigRational>>>();
+
+        Lr = PolyUtilApp.<BigRational> toProductRes(sys.list);
+        bLr = res.booleanClosure(Lr);
+
+        System.out.println("booleanClosed(Lr)   = " + bLr);
+
+        if (bLr.size() > 0) {
+            GroebnerBase<Product<Residue<BigRational>>> rbb = new RGroebnerBasePseudoSeq<Product<Residue<BigRational>>>(
+                            bLr.get(0).ring.coFac);
+            System.out.println("isRegularGB(Lr) = " + rbb.isGB(bLr));
+        }
+    }
+
+
+    /**
+     * Example GBase and real root.
+     */
+    @SuppressWarnings("unchecked")
+    public static void example6() {
+        BigRational coeff = new BigRational();
+        GroebnerBase<BigRational> gb = GBFactory.getImplementation(coeff);
+
+        String exam = "(x,y,z) L " + "( " + "( x^2 - 2 ), ( y^2 - 3 ), ( z^2 + x * y )" + ") ";
+        Reader source = new StringReader(exam);
+        GenPolynomialTokenizer parser = new GenPolynomialTokenizer(source);
+        PolynomialList<BigRational> F = null;
+
+        try {
+            F = (PolynomialList<BigRational>) parser.nextPolynomialSet();
+        } catch (ClassCastException e) {
+            e.printStackTrace();
+            return;
+        } catch (IOException e) {
+            e.printStackTrace();
+            return;
+        }
+        System.out.println("F = " + F);
+
+        List<GenPolynomial<BigRational>> G = gb.GB(F.list);
+
+        PolynomialList<BigRational> Gp = new PolynomialList<BigRational>(F.ring, G);
+        System.out.println("G = " + Gp);
+
+        // compute real roots of the ideal
+        Ideal<BigRational> I = new Ideal<BigRational>(Gp);
+        List<IdealWithRealAlgebraicRoots<BigRational>> Ir = PolyUtilApp.<BigRational> realAlgebraicRoots(I);
+        for (IdealWithRealAlgebraicRoots<BigRational> R : Ir) {
+            R.doDecimalApproximation();
+            for (List<BigDecimal> Dr : R.decimalApproximation()) {
+                System.out.println(Dr.toString());
+            }
+            System.out.println();
+        }
+    }
+
+
+    /**
+     * example7. Coefficients in Boolean residue class ring.
+     */
+    public static void example7() {
+        String[] vars = { "v3", "v2", "v1" };
+
+        ModIntegerRing z2 = new ModIntegerRing(2);
+        GenPolynomialRing<ModInteger> z2p = new GenPolynomialRing<ModInteger>(z2, vars.length, new TermOrder(
+                        TermOrder.INVLEX), vars);
+        List<GenPolynomial<ModInteger>> fieldPolynomials = new ArrayList<GenPolynomial<ModInteger>>();
+
+        //add v1^2 + v1, v2^2 + v2, v3^2 + v3 to fieldPolynomials
+        for (int i = 0; i < vars.length; i++) {
+            GenPolynomial<ModInteger> var = z2p.univariate(i);
+            fieldPolynomials.add(var.multiply(var).sum(var));
+        }
+
+
+        Ideal<ModInteger> fieldPolys = new Ideal<ModInteger>(z2p, fieldPolynomials);
+        ResidueRing<ModInteger> ring = new ResidueRing<ModInteger>(fieldPolys);
+        String[] mvars = { "mv3", "mv2", "mv1" };
+        GenPolynomialRing<Residue<ModInteger>> ringp = new GenPolynomialRing<Residue<ModInteger>>(ring,
+                        mvars.length, mvars);
+
+        List<GenPolynomial<Residue<ModInteger>>> polynomials = new ArrayList<GenPolynomial<Residue<ModInteger>>>();
+
+        GenPolynomial<Residue<ModInteger>> v1 = ringp.univariate(0);
+        GenPolynomial<Residue<ModInteger>> v2 = ringp.univariate(1);
+        GenPolynomial<Residue<ModInteger>> v3 = ringp.univariate(2);
+        GenPolynomial<Residue<ModInteger>> notV1 = v1.sum(ringp.ONE);
+        GenPolynomial<Residue<ModInteger>> notV2 = v2.sum(ringp.ONE);
+        GenPolynomial<Residue<ModInteger>> notV3 = v3.sum(ringp.ONE);
+
+        //v1*v2
+        GenPolynomial<Residue<ModInteger>> p1 = v1.multiply(v2);
+
+        //v1*v2 + v1 + v2 + 1
+        GenPolynomial<Residue<ModInteger>> p2 = notV1.multiply(notV2);
+
+        //v1*v3 + v1 + v3 + 1
+        GenPolynomial<Residue<ModInteger>> p3 = notV1.multiply(notV3);
+
+        polynomials.add(p1);
+        polynomials.add(p2);
+        polynomials.add(p3);
+
+        //GroebnerBase<Residue<ModInteger>> gb = new GroebnerBasePseudoSeq<Residue<ModInteger>>(ring);
+        GroebnerBase<Residue<ModInteger>> gb = GBFactory.getImplementation(ring);
+        List<GenPolynomial<Residue<ModInteger>>> G = gb.GB(polynomials);
+
+        System.out.println(G);
+    }
+
+
+    /**
+     * example8. Coefficients in Boolean residue class ring with cuppling of
+     * variables.
+     */
+    public static void example8() {
+        String[] vars = { "v3", "v2", "v1" };
+
+        ModIntegerRing z2 = new ModIntegerRing(2);
+        GenPolynomialRing<ModInteger> z2p = new GenPolynomialRing<ModInteger>(z2, vars.length, new TermOrder(
+                        TermOrder.INVLEX), vars);
+        List<GenPolynomial<ModInteger>> fieldPolynomials = new ArrayList<GenPolynomial<ModInteger>>();
+
+        //add v1^2 + v1, v2^2 + v2, v3^2 + v3 to fieldPolynomials
+        for (int i = 0; i < vars.length; i++) {
+            GenPolynomial<ModInteger> var = z2p.univariate(i);
+            fieldPolynomials.add(var.multiply(var).sum(var));
+        }
+
+
+        Ideal<ModInteger> fieldPolys = new Ideal<ModInteger>(z2p, fieldPolynomials);
+        ResidueRing<ModInteger> ring = new ResidueRing<ModInteger>(fieldPolys);
+        String[] mvars = { "mv3", "mv2", "mv1" };
+        GenPolynomialRing<Residue<ModInteger>> ringp = new GenPolynomialRing<Residue<ModInteger>>(ring,
+                        mvars.length, mvars);
+
+        List<GenPolynomial<Residue<ModInteger>>> polynomials = new ArrayList<GenPolynomial<Residue<ModInteger>>>();
+
+        GenPolynomial<Residue<ModInteger>> v1 = ringp.univariate(0);
+        GenPolynomial<Residue<ModInteger>> v2 = ringp.univariate(1);
+        GenPolynomial<Residue<ModInteger>> v3 = ringp.univariate(2);
+        GenPolynomial<Residue<ModInteger>> notV1 = v1.sum(ringp.ONE);
+        GenPolynomial<Residue<ModInteger>> notV2 = v2.sum(ringp.ONE);
+        GenPolynomial<Residue<ModInteger>> notV3 = v3.sum(ringp.ONE);
+
+        //v1*v2
+        GenPolynomial<Residue<ModInteger>> p1 = v1.multiply(v2);
+
+        //v1*v2 + v1 + v2 + 1
+        GenPolynomial<Residue<ModInteger>> p2 = notV1.multiply(notV2);
+
+        //v1*v3 + v1 + v3 + 1
+        GenPolynomial<Residue<ModInteger>> p3 = notV1.multiply(notV3);
+
+        polynomials.add(p1);
+        polynomials.add(p2);
+        polynomials.add(p3);
+
+        List<Residue<ModInteger>> gens = ring.generators();
+        System.out.println("gens = " + gens);
+        GenPolynomial<Residue<ModInteger>> mv3v3 = v3.subtract(gens.get(1));
+        GenPolynomial<Residue<ModInteger>> mv2v2 = v2.subtract(gens.get(2));
+        GenPolynomial<Residue<ModInteger>> mv1v1 = v1.subtract(gens.get(3));
+
+        System.out.println("mv3v3 = " + mv3v3);
+        System.out.println("mv2v2 = " + mv2v2);
+        System.out.println("mv1v1 = " + mv1v1);
+
+        polynomials.add(mv3v3);
+        polynomials.add(mv2v2);
+        polynomials.add(mv1v1);
+
+        //GroebnerBase<Residue<ModInteger>> gb = new GroebnerBasePseudoSeq<Residue<ModInteger>>(ring);
+        GroebnerBase<Residue<ModInteger>> gb = GBFactory.getImplementation(ring);
+
+        List<GenPolynomial<Residue<ModInteger>>> G = gb.GB(polynomials);
+
+        System.out.println(G);
+    }
+
+
+    /**
+     * example9. Groebner base and dimension.
+     */
+    public static void example9() {
+        String[] vars = { "d1", "d2", "d3", "p1a", "p1b", "p1c", "p2a", "p2b", "p2c", "p3a", "p3b", "p3c",
+                "p4a", "p4b", "p4c", "A", "B", "C", "D" };
+
+        BigRational br = new BigRational();
+        GenPolynomialRing<BigRational> pring = new GenPolynomialRing<BigRational>(br, vars);
+        //GenPolynomialRing<BigRational> pring = new GenPolynomialRing<BigRational>(br, vars.length, new TermOrder(TermOrder.INVLEX), vars);
+
+        GenPolynomial<BigRational> e1 = pring.parse("A*p1a+B*p1b+C*p1c+D"); // (1)
+        GenPolynomial<BigRational> e2 = pring.parse("A*p2a+B*p2b+C*p2c+D"); // (2)
+        GenPolynomial<BigRational> e3 = pring.parse("A*p3a+B*p3b+C*p3c+D"); // (3)
+        GenPolynomial<BigRational> e4 = pring.parse("A*p4a+B*p4b+C*p4c+D"); // (4)
+        GenPolynomial<BigRational> e5 = pring.parse("p2a-p3a"); // (5)
+        GenPolynomial<BigRational> e6 = pring.parse("p2b-p3b"); // (6)
+        GenPolynomial<BigRational> e7 = pring.parse("p2c-p3c"); // (7)
+        GenPolynomial<BigRational> e8 = pring.parse("(p2a-p1a)^2+(p2b-p1b)^2+(p2c-p1c)^2-d1^2"); // (8)
+        GenPolynomial<BigRational> e9 = pring.parse("(p4a-p3a)^2+(p4b-p3b)^2+(p4c-p3c)^2-d2^2"); // (9)
+
+        List<GenPolynomial<BigRational>> cp = new ArrayList<GenPolynomial<BigRational>>(9);
+        cp.add(e1);
+        cp.add(e2);
+        cp.add(e3);
+        cp.add(e4);
+        cp.add(e5);
+        cp.add(e6);
+        cp.add(e7);
+        cp.add(e8);
+        cp.add(e9);
+
+        GenPolynomial<BigRational> e10 = pring.parse("(p4a-p1a)^2+(p4b-p1b)^2+(p4c-p1c)^2-d3^2"); // (10)
+        cp.add(e10);
+
+        List<GenPolynomial<BigRational>> gb;
+        GroebnerBase<BigRational> sgb = GBFactory.getImplementation(br);
+        gb = sgb.GB(cp);
+        //System.out.println("gb = " + gb);
+
+        PolynomialList<BigRational> pl = new PolynomialList<BigRational>(pring, gb);
+        Ideal<BigRational> id = new Ideal<BigRational>(pl, true);
+        System.out.println("cp = " + cp);
+        System.out.println("id = " + id);
+
+        Dimension dim = id.dimension();
+        System.out.println("dim = " + dim);
+    }
+
+
+    /**
+     * example10. abtract types: GB of
+     * List&lt;GenPolynomial&lt;AlgebraicNumber&lt;Quotient
+     * &lt;AlgebraicNumber&lt;BigRational&gt;&gt;&gt;&gt;&gt;.
+     */
+    public static void example10() {
+        Scripting.setLang(Scripting.Lang.Ruby);
+        BigRational bfac = new BigRational(1);
+        GenPolynomialRing<BigRational> pfac;
+        pfac = new GenPolynomialRing<BigRational>(bfac, new String[] { "w2" });
+        System.out.println("pfac = " + pfac.toScript());
+
+        // p = w2^2 - 2
+        GenPolynomial<BigRational> p = pfac.univariate(0, 2).subtract(pfac.fromInteger(2L));
+        System.out.println("p = " + p.toScript());
+
+        AlgebraicNumberRing<BigRational> afac;
+        afac = new AlgebraicNumberRing<BigRational>(p, true);
+        System.out.println("afac = " + afac.toScript());
+
+        GenPolynomialRing<AlgebraicNumber<BigRational>> pafac;
+        pafac = new GenPolynomialRing<AlgebraicNumber<BigRational>>(afac, new String[] { "x" });
+        System.out.println("pafac = " + pafac.toScript());
+
+        QuotientRing<AlgebraicNumber<BigRational>> qafac;
+        qafac = new QuotientRing<AlgebraicNumber<BigRational>>(pafac);
+        System.out.println("qafac = " + qafac.toScript());
+
+        GenPolynomialRing<Quotient<AlgebraicNumber<BigRational>>> pqafac;
+        pqafac = new GenPolynomialRing<Quotient<AlgebraicNumber<BigRational>>>(qafac, new String[] { "wx" });
+        System.out.println("pqafac = " + pqafac.toScript());
+        List<GenPolynomial<Quotient<AlgebraicNumber<BigRational>>>> qgen = pqafac.generators();
+        System.out.println("qgen = " + qgen);
+
+        // q = wx^2 - x
+        GenPolynomial<Quotient<AlgebraicNumber<BigRational>>> q;
+        q = pqafac.univariate(0, 2).subtract(qgen.get(2));
+        System.out.println("q = " + q.toScript());
+
+        AlgebraicNumberRing<Quotient<AlgebraicNumber<BigRational>>> aqafac;
+        aqafac = new AlgebraicNumberRing<Quotient<AlgebraicNumber<BigRational>>>(q, true);
+        System.out.println("aqafac = " + aqafac.toScript());
+
+        GenPolynomialRing<AlgebraicNumber<Quotient<AlgebraicNumber<BigRational>>>> paqafac;
+        paqafac = new GenPolynomialRing<AlgebraicNumber<Quotient<AlgebraicNumber<BigRational>>>>(aqafac,
+                        new String[] { "y", "z" });
+        System.out.println("paqafac = " + paqafac.toScript());
+
+        List<GenPolynomial<AlgebraicNumber<Quotient<AlgebraicNumber<BigRational>>>>> L;
+        L = new ArrayList<GenPolynomial<AlgebraicNumber<Quotient<AlgebraicNumber<BigRational>>>>>();
+
+        GenPolynomial<AlgebraicNumber<Quotient<AlgebraicNumber<BigRational>>>> pp;
+        /*
+        for (int i = 0; i < 2; i++) {
+            pp = paqafac.random(2, 3, 3, 0.2f);
+            System.out.println("pp = " + pp.toScript());
+            if (pp.isConstant()) {
+                pp = paqafac.univariate(0,3);
+            }
+            L.add(pp);
+        }
+        */
+        pp = paqafac.parse("(( y^2 - x )*( z^2 - 2 ) )");
+        System.out.println("pp = " + pp.toScript());
+        L.add(pp);
+        pp = paqafac.parse("( y^2 z - x^3 z - w2*wx )");
+        System.out.println("pp = " + pp.toScript());
+        L.add(pp);
+        //System.out.println("L = " + L);
+
+        GroebnerBaseAbstract<AlgebraicNumber<Quotient<AlgebraicNumber<BigRational>>>> bb;
+        //bb = new GroebnerBaseSeq<AlgebraicNumber<Quotient<AlgebraicNumber<BigRational>>>>(); //aqafac);
+        bb = GBFactory.getImplementation(aqafac);
+        //bb = GBFactory.getProxy(aqafac);
+
+        System.out.println("isGB(L) = " + bb.isGB(L));
+
+        long t = System.currentTimeMillis();
+        List<GenPolynomial<AlgebraicNumber<Quotient<AlgebraicNumber<BigRational>>>>> G = bb.GB(L);
+        t = System.currentTimeMillis() - t;
+        System.out.println("time = " + t + " milliseconds");
+        //System.out.println("G = " + G);
+        for (GenPolynomial<AlgebraicNumber<Quotient<AlgebraicNumber<BigRational>>>> g : G) {
+            System.out.println("g = " + g.toScript());
+        }
+        System.out.println("isGB(G) = " + bb.isGB(G));
+        bb.terminate();
+    }
+
+
+    /**
+     * example11. abtract types: GB of List&lt;GenPolynomial&lt;BigRational&gt;&gt;&gt;.
+     */
+    public static void example11() {
+        Scripting.setLang(Scripting.Lang.Ruby);
+        BigRational bfac = new BigRational(1);
+        GenPolynomialRing<BigRational> pfac;
+        String[] vars = new String[] { "w2", "xi", "x", "wx", "y", "z" };
+        TermOrder to = new TermOrder(TermOrder.INVLEX);
+        pfac = new GenPolynomialRing<BigRational>(bfac, vars, to);
+        System.out.println("pfac = " + pfac.toScript());
+
+        List<GenPolynomial<BigRational>> L = new ArrayList<GenPolynomial<BigRational>>();
+        GenPolynomial<BigRational> pp;
+        pp = pfac.parse("( w2^2 - 2 )");
+        System.out.println("pp = " + pp.toScript());
+        L.add(pp);
+        pp = pfac.parse("( wx^2 - x )");
+        System.out.println("pp = " + pp.toScript());
+        L.add(pp);
+        pp = pfac.parse("( xi * x - 1 )");
+        System.out.println("pp = " + pp.toScript());
+        L.add(pp);
+        pp = pfac.parse("(( y^2 - x )*( z^2 - 2 ) )");
+        System.out.println("pp = " + pp.toScript());
+        L.add(pp);
+        pp = pfac.parse("( y^2 z - x^3 z - w2*wx )");
+        System.out.println("pp = " + pp.toScript());
+        L.add(pp);
+
+        GroebnerBaseAbstract<BigRational> bb;
+        //bb = new GroebnerBaseSeq<BigRational>(); //bfac);
+        bb = GBFactory.getImplementation(bfac);
+        //bb = GBFactory.getProxy(bfac);
+
+        System.out.println("isGB(L) = " + bb.isGB(L));
+        long t = System.currentTimeMillis();
+        List<GenPolynomial<BigRational>> G = bb.GB(L);
+        t = System.currentTimeMillis() - t;
+        System.out.println("time = " + t + " milliseconds");
+        for (GenPolynomial<BigRational> g : G) {
+            System.out.println("g = " + g.toScript());
+        }
+        System.out.println("isGB(G) = " + bb.isGB(G));
+        bb.terminate();
+    }
+
+
+    /**
+     * example12. abtract types: GB of
+     * List&lt;GenPolynomial&lt;Quotient&lt;BigRational&gt;&gt;&gt;&gt;.
+     */
+    public static void example12() {
+        Scripting.setLang(Scripting.Lang.Ruby);
+        BigRational bfac = new BigRational(1);
+        GenPolynomialRing<BigRational> cfac;
+        String[] cvars = new String[] { "x" };
+        TermOrder to = new TermOrder(TermOrder.INVLEX);
+        cfac = new GenPolynomialRing<BigRational>(bfac, cvars, to);
+        System.out.println("cfac = " + cfac.toScript());
+
+        QuotientRing<BigRational> qfac;
+        qfac = new QuotientRing<BigRational>(cfac);
+        System.out.println("qfac = " + qfac.toScript());
+
+        String[] vars = new String[] { "w2", "wx", "y", "z" };
+        GenPolynomialRing<Quotient<BigRational>> pfac;
+        pfac = new GenPolynomialRing<Quotient<BigRational>>(qfac, vars, to);
+        System.out.println("pfac = " + pfac.toScript());
+
+        List<GenPolynomial<Quotient<BigRational>>> L = new ArrayList<GenPolynomial<Quotient<BigRational>>>();
+        GenPolynomial<Quotient<BigRational>> pp;
+        pp = pfac.parse("( w2^2 - 2 )");
+        System.out.println("pp = " + pp.toScript());
+        L.add(pp);
+        pp = pfac.parse("( wx^2 - x )");
+        System.out.println("pp = " + pp.toScript());
+        L.add(pp);
+        pp = pfac.parse("(( y^2 - x )*( z^2 - 2 ) )");
+        System.out.println("pp = " + pp.toScript());
+        L.add(pp);
+        pp = pfac.parse("( y^2 z - x^3 z - w2*wx )");
+        System.out.println("pp = " + pp.toScript());
+        L.add(pp);
+
+        GroebnerBaseAbstract<Quotient<BigRational>> bb;
+        //bb = new GroebnerBaseSeq<Quotient<BigRational>>(); //bfac);
+
+        // sequential
+        bb = GBFactory.getImplementation(qfac);
+        System.out.println("isGB(L) = " + bb.isGB(L));
+        long t = System.currentTimeMillis();
+        List<GenPolynomial<Quotient<BigRational>>> G = bb.GB(L);
+        t = System.currentTimeMillis() - t;
+        System.out.println("time = " + t + " milliseconds");
+        for (GenPolynomial<Quotient<BigRational>> g : G) {
+            System.out.println("g = " + g.toScript());
+        }
+        System.out.println("isGB(G) = " + bb.isGB(G));
+        bb.terminate();
+
+        // parallel
+        bb = GBFactory.getProxy(qfac);
+        System.out.println("isGB(L) = " + bb.isGB(L));
+        t = System.currentTimeMillis();
+        G = bb.GB(L);
+        t = System.currentTimeMillis() - t;
+        System.out.println("time = " + t + " milliseconds");
+        for (GenPolynomial<Quotient<BigRational>> g : G) {
+            System.out.println("g = " + g.toScript());
+        }
+        System.out.println("isGB(G) = " + bb.isGB(G));
+        bb.terminate();
+
+        // builder
+        bb = GBAlgorithmBuilder.polynomialRing(pfac).fractionFree().syzygyPairlist().parallel(3).build();
+        System.out.println("isGB(L) = " + bb.isGB(L));
+        t = System.currentTimeMillis();
+        G = bb.GB(L);
+        t = System.currentTimeMillis() - t;
+        System.out.println("time = " + t + " milliseconds");
+        for (GenPolynomial<Quotient<BigRational>> g : G) {
+            System.out.println("g = " + g.toScript());
+        }
+        System.out.println("isGB(G) = " + bb.isGB(G));
+        bb.terminate();
+    }
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/ExamplesGeoTheorems.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/ExamplesGeoTheorems.java
@@ -1,0 +1,362 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.jas.arith.BigRational;
+import edu.jas.gb.GBOptimized;
+import edu.jas.gb.GBProxy;
+import edu.jas.gb.GroebnerBase;
+import edu.jas.gb.GroebnerBaseAbstract;
+import edu.jas.gb.GroebnerBaseParallel;
+import edu.jas.gbufd.GBFactory;
+import edu.jas.kern.ComputerThreads;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolynomialList;
+
+
+/**
+ * ExamplesGeoTheorems for Groebner base usage.
+ * @author GeoGebra developers
+ * @author Kovács Zoltán
+ * @author Heinz Kredel
+ */
+public class ExamplesGeoTheorems {
+
+
+    /**
+     * main.
+     */
+    public static void main(String[] args) {
+        example10();
+        example11();
+        example12();
+        example13();
+        example14();
+        example15();
+        example16();
+        example17();
+        ComputerThreads.terminate();
+    }
+
+
+    /**
+     * get Pappus Example.
+     */
+    public static List<GenPolynomial<BigRational>> getExample() {
+        String[] vars = { "a1", "a2", "b1", "b2", "c1", "c2", "d1", "d2", "e1", "e2", "f1", "f2", "g1", "g2",
+                "h1", "h2", "i1", "i2", "j1", "j2", "z1", "z2", "z3" };
+
+        BigRational br = new BigRational();
+        GenPolynomialRing<BigRational> pring = new GenPolynomialRing<BigRational>(br, vars);
+
+        GenPolynomial<BigRational> e1 = pring.parse("(a1*(b2 - c2) + a2*( - b1 + c1) + b1*c2 - b2*c1)");
+        GenPolynomial<BigRational> e2 = pring.parse("(d1*(e2 - f2) + d2*( - e1 + f1) + e1*f2 - e2*f1)");
+        GenPolynomial<BigRational> e3 = pring.parse("(a1*( - e2 + h2) + a2*(e1 - h1) - e1*h2 + e2*h1)");
+        GenPolynomial<BigRational> e4 = pring.parse("(b1*(d2 - h2) + b2*( - d1 + h1) + d1*h2 - d2*h1)");
+        GenPolynomial<BigRational> e5 = pring.parse("(c1*(d2 - i2) + c2*( - d1 + i1) + d1*i2 - d2*i1)");
+        GenPolynomial<BigRational> e6 = pring.parse("(a1*( - f2 + i2) + a2*(f1 - i1) - f1*i2 + f2*i1)");
+        GenPolynomial<BigRational> e7 = pring.parse("(c1*(e2 - j2) + c2*( - e1 + j1) + e1*j2 - e2*j1)");
+        GenPolynomial<BigRational> e8 = pring.parse("(b1*( - f2 + j2) + b2*(f1 - j1) - f1*j2 + f2*j1)");
+        GenPolynomial<BigRational> e9 = pring
+                        .parse("(a1*(b2*z2 - d2*z2) + a2*( - b1*z2 + d1*z2) + b1*d2*z2 - b2*d1*z2 - 1)");
+        GenPolynomial<BigRational> e10 = pring
+                        .parse("(a1*(b2*z3 - e2*z3) + a2*( - b1*z3 + e1*z3) + b1*e2*z3 - b2*e1*z3 - 1)");
+        GenPolynomial<BigRational> e11 = pring
+                        .parse("(h1*(i2*z1 - j2*z1) + h2*( - i1*z1 + j1*z1) + i1*j2*z1 - i2*j1*z1 - 1)");
+
+        List<GenPolynomial<BigRational>> cp = new ArrayList<GenPolynomial<BigRational>>(11);
+        cp.add(e1);
+        cp.add(e2);
+        cp.add(e3);
+        cp.add(e4);
+        cp.add(e5);
+        cp.add(e6);
+        cp.add(e7);
+        cp.add(e8);
+        cp.add(e9);
+        cp.add(e10);
+        cp.add(e11);
+        return cp;
+    }
+
+
+    /**
+     * Example Pappus, sequential.
+     */
+    public static void example10() {
+        List<GenPolynomial<BigRational>> cp = getExample();
+        BigRational br = new BigRational();
+        GenPolynomialRing<BigRational> pring = cp.get(0).ring;
+
+        GroebnerBase<BigRational> sgb = GBFactory.getImplementation(br);
+        List<GenPolynomial<BigRational>> gb;
+        long t;
+        t = System.currentTimeMillis();
+        gb = sgb.GB(cp);
+        t = System.currentTimeMillis() - t;
+        //System.out.println("gb = " + gb);
+        System.out.println("time(gb) = " + t);
+        t = System.currentTimeMillis();
+        gb = sgb.GB(cp);
+        t = System.currentTimeMillis() - t;
+        //System.out.println("gb = " + gb);
+        System.out.println("time(gb) = " + t);
+
+        PolynomialList<BigRational> pl = new PolynomialList<BigRational>(pring, gb);
+        Ideal<BigRational> id = new Ideal<BigRational>(pl, true);
+        System.out.println("cp = " + cp);
+        System.out.println("id = " + id);
+
+        Dimension dim = id.dimension();
+        System.out.println("dim = " + dim);
+    }
+
+
+    /**
+     * Example Pappus, parallel proxy.
+     */
+    public static void example11() {
+        List<GenPolynomial<BigRational>> cp = getExample();
+        BigRational br = new BigRational();
+        GenPolynomialRing<BigRational> pring = cp.get(0).ring;
+
+        GroebnerBaseAbstract<BigRational> sgb = GBFactory.getProxy(br);
+        List<GenPolynomial<BigRational>> gb;
+        long t;
+        t = System.currentTimeMillis();
+        gb = sgb.GB(cp);
+        t = System.currentTimeMillis() - t;
+        //System.out.println("gb = " + gb);
+        System.out.println("time(proxy-gb) = " + t);
+        t = System.currentTimeMillis();
+        gb = sgb.GB(cp);
+        t = System.currentTimeMillis() - t;
+        //System.out.println("gb = " + gb);
+        System.out.println("time(proxy-gb) = " + t);
+
+        PolynomialList<BigRational> pl = new PolynomialList<BigRational>(pring, gb);
+        Ideal<BigRational> id = new Ideal<BigRational>(pl, true);
+        System.out.println("cp = " + cp);
+        System.out.println("id = " + id);
+
+        Dimension dim = id.dimension();
+        System.out.println("dim = " + dim);
+        sgb.terminate();
+    }
+
+
+    /**
+     * Example Pappus, optimized term order.
+     */
+    public static void example12() {
+        List<GenPolynomial<BigRational>> cp = getExample();
+        BigRational br = new BigRational();
+        GenPolynomialRing<BigRational> pring = cp.get(0).ring;
+
+        GroebnerBaseAbstract<BigRational> sgb = GBFactory.getImplementation(br);
+        GroebnerBaseAbstract<BigRational> ogb = new GBOptimized<BigRational>(sgb, true); // false no change for GB == 1
+        List<GenPolynomial<BigRational>> gb;
+        long t;
+        t = System.currentTimeMillis();
+        gb = ogb.GB(cp);
+        t = System.currentTimeMillis() - t;
+        //System.out.println("gb = " + gb);
+        System.out.println("time(optimized-gb) = " + t);
+        t = System.currentTimeMillis();
+        gb = ogb.GB(cp);
+        t = System.currentTimeMillis() - t;
+        //System.out.println("gb = " + gb);
+        System.out.println("time(optimized-gb) = " + t);
+
+        PolynomialList<BigRational> pl = new PolynomialList<BigRational>(pring, gb);
+        Ideal<BigRational> id = new Ideal<BigRational>(pl, true);
+        System.out.println("cp = " + cp);
+        System.out.println("id = " + id);
+
+        Dimension dim = id.dimension();
+        System.out.println("dim = " + dim);
+        ogb.terminate();
+    }
+
+
+    /**
+     * Example Pappus, optimized term order and parallel proxy.
+     */
+    public static void example13() {
+        List<GenPolynomial<BigRational>> cp = getExample();
+        BigRational br = new BigRational();
+        GenPolynomialRing<BigRational> pring = cp.get(0).ring;
+
+        GroebnerBaseAbstract<BigRational> sgb = GBFactory.getProxy(br);
+        GroebnerBaseAbstract<BigRational> ogb = new GBOptimized<BigRational>(sgb, true); // false no change for GB == 1
+        List<GenPolynomial<BigRational>> gb;
+        long t;
+        t = System.currentTimeMillis();
+        gb = ogb.GB(cp);
+        t = System.currentTimeMillis() - t;
+        //System.out.println("gb = " + gb);
+        System.out.println("time(optimized-proxy-gb) = " + t);
+        t = System.currentTimeMillis();
+        gb = ogb.GB(cp);
+        t = System.currentTimeMillis() - t;
+        //System.out.println("gb = " + gb);
+        System.out.println("time(optimized-proxy-gb) = " + t);
+
+        PolynomialList<BigRational> pl = new PolynomialList<BigRational>(pring, gb);
+        Ideal<BigRational> id = new Ideal<BigRational>(pl, true);
+        System.out.println("cp = " + cp);
+        System.out.println("id = " + id);
+
+        Dimension dim = id.dimension();
+        System.out.println("dim = " + dim);
+        ogb.terminate();
+    }
+
+
+    /**
+     * Example Pappus, fraction free.
+     */
+    public static void example14() {
+        List<GenPolynomial<BigRational>> cp = getExample();
+        BigRational br = new BigRational();
+        GenPolynomialRing<BigRational> pring = cp.get(0).ring;
+
+        GroebnerBaseAbstract<BigRational> sgb = GBFactory.getImplementation(br, GBFactory.Algo.ffgb);
+        List<GenPolynomial<BigRational>> gb;
+        long t;
+        t = System.currentTimeMillis();
+        gb = sgb.GB(cp);
+        t = System.currentTimeMillis() - t;
+        //System.out.println("gb = " + gb);
+        System.out.println("time(fraction-free-gb) = " + t);
+        t = System.currentTimeMillis();
+        gb = sgb.GB(cp);
+        t = System.currentTimeMillis() - t;
+        //System.out.println("gb = " + gb);
+        System.out.println("time(fraction-free-gb) = " + t);
+
+        PolynomialList<BigRational> pl = new PolynomialList<BigRational>(pring, gb);
+        Ideal<BigRational> id = new Ideal<BigRational>(pl, true);
+        System.out.println("cp = " + cp);
+        System.out.println("id = " + id);
+
+        Dimension dim = id.dimension();
+        System.out.println("dim = " + dim);
+        sgb.terminate();
+    }
+
+
+    /**
+     * Example Pappus, optimized and fraction free.
+     */
+    public static void example15() {
+        List<GenPolynomial<BigRational>> cp = getExample();
+        BigRational br = new BigRational();
+        GenPolynomialRing<BigRational> pring = cp.get(0).ring;
+
+        GroebnerBaseAbstract<BigRational> sgb = GBFactory.getImplementation(br, GBFactory.Algo.ffgb);
+        GroebnerBaseAbstract<BigRational> ogb = new GBOptimized<BigRational>(sgb, true); // false no change for GB == 1
+        List<GenPolynomial<BigRational>> gb;
+        long t;
+        t = System.currentTimeMillis();
+        gb = ogb.GB(cp);
+        t = System.currentTimeMillis() - t;
+        //System.out.println("gb = " + gb);
+        System.out.println("time(optimized-fraction-free-gb) = " + t);
+        t = System.currentTimeMillis();
+        gb = ogb.GB(cp);
+        t = System.currentTimeMillis() - t;
+        //System.out.println("gb = " + gb);
+        System.out.println("time(optimized-fraction-free-gb) = " + t);
+
+        PolynomialList<BigRational> pl = new PolynomialList<BigRational>(pring, gb);
+        Ideal<BigRational> id = new Ideal<BigRational>(pl, true);
+        System.out.println("cp = " + cp);
+        System.out.println("id = " + id);
+
+        Dimension dim = id.dimension();
+        System.out.println("dim = " + dim);
+        ogb.terminate();
+    }
+
+
+    /**
+     * Example Pappus, proxy, optimized and fraction free.
+     */
+    public static void example16() {
+        List<GenPolynomial<BigRational>> cp = getExample();
+        BigRational br = new BigRational();
+        GenPolynomialRing<BigRational> pring = cp.get(0).ring;
+
+        GroebnerBaseAbstract<BigRational> sgb = GBFactory.getImplementation(br, GBFactory.Algo.ffgb);
+        GroebnerBaseAbstract<BigRational> ogb = new GBOptimized<BigRational>(sgb, true); // false no change for GB == 1
+        GroebnerBaseAbstract<BigRational> pgb = new GroebnerBaseParallel<BigRational>();
+        GroebnerBaseAbstract<BigRational> opgb = new GBOptimized<BigRational>(pgb, true); // false no change for GB == 1
+        GroebnerBaseAbstract<BigRational> popgb = new GBProxy<BigRational>(ogb, opgb);
+        List<GenPolynomial<BigRational>> gb;
+        long t;
+        t = System.currentTimeMillis();
+        gb = popgb.GB(cp);
+        t = System.currentTimeMillis() - t;
+        //System.out.println("gb = " + gb);
+        System.out.println("time(proxy-optimized-fraction-free-gb) = " + t);
+        t = System.currentTimeMillis();
+        gb = popgb.GB(cp);
+        t = System.currentTimeMillis() - t;
+        //System.out.println("gb = " + gb);
+        System.out.println("time(proxy-optimized-fraction-free-gb) = " + t);
+
+        PolynomialList<BigRational> pl = new PolynomialList<BigRational>(pring, gb);
+        Ideal<BigRational> id = new Ideal<BigRational>(pl, true);
+        System.out.println("cp = " + cp);
+        System.out.println("id = " + id);
+
+        Dimension dim = id.dimension();
+        System.out.println("dim = " + dim);
+        popgb.terminate();
+    }
+
+
+    /**
+     * Example Pappus, optimized and parallel and fraction free.
+     */
+    public static void example17() {
+        List<GenPolynomial<BigRational>> cp = getExample();
+        BigRational br = new BigRational();
+        GenPolynomialRing<BigRational> pring = cp.get(0).ring;
+
+        GroebnerBaseAbstract<BigRational> sgb = GBFactory.getImplementation(br, GBFactory.Algo.ffgb);
+        GroebnerBaseAbstract<BigRational> pgb = new GroebnerBaseParallel<BigRational>();
+        GroebnerBaseAbstract<BigRational> ppgb = new GBProxy<BigRational>(sgb, pgb);
+        GroebnerBaseAbstract<BigRational> ogb = new GBOptimized<BigRational>(ppgb, true); // false no change for GB == 1
+        List<GenPolynomial<BigRational>> gb;
+        long t;
+        t = System.currentTimeMillis();
+        gb = ogb.GB(cp);
+        t = System.currentTimeMillis() - t;
+        //System.out.println("gb = " + gb);
+        System.out.println("time(optimized-proxy-fraction-free-gb) = " + t);
+        t = System.currentTimeMillis();
+        gb = ogb.GB(cp);
+        t = System.currentTimeMillis() - t;
+        //System.out.println("gb = " + gb);
+        System.out.println("time(optimized-proxy-fraction-free-gb) = " + t);
+
+        PolynomialList<BigRational> pl = new PolynomialList<BigRational>(pring, gb);
+        Ideal<BigRational> id = new Ideal<BigRational>(pl, true);
+        System.out.println("cp = " + cp);
+        System.out.println("id = " + id);
+
+        Dimension dim = id.dimension();
+        System.out.println("dim = " + dim);
+        ogb.terminate();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/ExtensionFieldBuilder.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/ExtensionFieldBuilder.java
@@ -1,0 +1,262 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.io.StringReader;
+import java.util.List;
+
+import edu.jas.arith.Rational;
+import edu.jas.arith.PrimeInteger;
+import edu.jas.poly.AlgebraicNumberRing;
+import edu.jas.poly.Complex;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.GenPolynomialTokenizer;
+import edu.jas.poly.TermOrder;
+import edu.jas.root.ComplexAlgebraicRing;
+import edu.jas.root.Interval;
+import edu.jas.root.RealAlgebraicRing;
+import edu.jas.root.Rectangle;
+import edu.jas.root.RootUtil;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.ufd.QuotientRing;
+import edu.jas.ufd.PolyUfdUtil;
+import edu.jas.vector.GenMatrixRing;
+
+
+/**
+ * Builder for extension field towers.
+ * @author Heinz Kredel
+ */
+public class ExtensionFieldBuilder implements Serializable {
+
+
+    /**
+     * The current factory.
+     */
+    public final RingFactory factory; // must be a raw type
+
+
+    /**
+     * Constructor not for use.
+     */
+    protected ExtensionFieldBuilder() {
+        throw new IllegalArgumentException("do not use this constructor");
+    }
+
+
+    /**
+     * Constructor.
+     * @param base the base field.
+     */
+    public ExtensionFieldBuilder(RingFactory base) {
+        factory = base;
+    }
+
+
+    /**
+     * Build the field tower. TODO: optimize field tower for faster
+     * computation.
+     */
+    public RingFactory build() {
+        return factory;
+    }
+
+
+    /**
+     * Set base field.
+     * @param base the base field for the extensions.
+     */
+    public static ExtensionFieldBuilder baseField(RingFactory base) {
+        return new ExtensionFieldBuilder(base);
+    }
+
+
+    /**
+     * Transcendent field extension.
+     * @param vars names for the transcendent generators.
+     */
+    @SuppressWarnings("unchecked")
+    public ExtensionFieldBuilder transcendentExtension(String vars) {
+        String[] variables = GenPolynomialTokenizer.variableList(vars);
+        GenPolynomialRing pfac = new GenPolynomialRing(factory, variables);
+        QuotientRing qfac = new QuotientRing(pfac);
+        RingFactory base = (RingFactory) qfac;
+        return new ExtensionFieldBuilder(base);
+    }
+
+
+    /**
+     * Polynomial ring extension.
+     * @param vars names for the polynomial ring generators.
+     */
+    @SuppressWarnings("unchecked")
+    public ExtensionFieldBuilder polynomialExtension(String vars) {
+        String[] variables = GenPolynomialTokenizer.variableList(vars);
+        GenPolynomialRing pfac = new GenPolynomialRing(factory, variables);
+        RingFactory base = (RingFactory) pfac;
+        return new ExtensionFieldBuilder(base);
+    }
+
+
+    /**
+     * Matrix ring extension.
+     * @param n dimension of n x n matrix.
+     */
+    @SuppressWarnings("unchecked")
+    public ExtensionFieldBuilder matrixExtension(int n) {
+        GenMatrixRing mfac = new GenMatrixRing(factory, n, n);
+        RingFactory base = (RingFactory) mfac;
+        return new ExtensionFieldBuilder(base);
+    }
+
+
+    /**
+     * Finite field extension.
+     * Construct a finite field with q = p**n elements, where
+     * p is the characteristic of the base field.
+     * @param n exponent.
+     */
+    @SuppressWarnings("unchecked")
+    public ExtensionFieldBuilder finiteFieldExtension(int n) {
+        java.math.BigInteger p = factory.characteristic();
+        if (p.signum() != 1) {
+            throw new IllegalArgumentException("characteristic not finite");
+        }
+        if (!PrimeInteger.isPrime(p)) { //??
+            throw new IllegalArgumentException("characteristic not prime");
+        }
+        RingFactory base = (RingFactory) PolyUfdUtil.algebraicNumberField(factory,n);
+        return new ExtensionFieldBuilder(base);
+    }
+
+
+    /**
+     * Algebraic field extension.
+     * @param var name(s) for the algebraic generator(s).
+     * @param expr generating expresion, a univariate or multivariate polynomial
+     *            in vars.
+     */
+    @SuppressWarnings("unchecked")
+    public ExtensionFieldBuilder algebraicExtension(String var, String expr) {
+        String[] variables = GenPolynomialTokenizer.variableList(var);
+        if (variables.length < 1) {
+            variables = GenPolynomialTokenizer.expressionVariables(expr);
+            if (variables.length < 1) {
+                throw new IllegalArgumentException("no variables in '" + var + "' and '" + expr + "'");
+            }
+        }
+        GenPolynomialRing pfac = new GenPolynomialRing(factory, variables);
+        if (variables.length == 1) { // simple extension
+            GenPolynomial gen = pfac.parse(expr);
+            AlgebraicNumberRing afac = new AlgebraicNumberRing(gen);
+            RingFactory base = (RingFactory) afac;
+            return new ExtensionFieldBuilder(base);
+        }
+        GenPolynomialTokenizer pt = new GenPolynomialTokenizer(pfac, new StringReader(expr));
+        List<GenPolynomial> gen = null;
+        try {
+            gen = pt.nextPolynomialList();
+        } catch (IOException e) { // should not happen
+            throw new IllegalArgumentException(e);
+        }
+        Ideal agen = new Ideal(pfac, gen);
+        if (agen.isONE()) {
+            throw new IllegalArgumentException("ideal is 1: " + expr);
+        }
+        if (agen.isZERO()) { // transcendent extension
+            QuotientRing qfac = new QuotientRing(pfac);
+            RingFactory base = (RingFactory) qfac;
+            return new ExtensionFieldBuilder(base);
+        }
+        // check if agen is prime?
+        ResidueRing afac = new ResidueRing(agen);
+        RingFactory base = (RingFactory) afac;
+        return new ExtensionFieldBuilder(base);
+    }
+
+
+    /**
+     * Real algebraic field extension.
+     * @param var name for the algebraic generator.
+     * @param expr generating expresion, a univariate polynomial in var.
+     * @param root isolating interval for a real root.
+     */
+    @SuppressWarnings("unchecked")
+    public ExtensionFieldBuilder realAlgebraicExtension(String var, String expr, String root) {
+        String[] variables = new String[] { var };
+        RingElem one = (RingElem) factory.getONE();
+        if (!(one instanceof Rational)) {
+            throw new IllegalArgumentException("base field not instance of Rational");
+        }
+        TermOrder to = new TermOrder(TermOrder.INVLEX);
+        GenPolynomialRing pfac = new GenPolynomialRing(factory, to, variables);
+        GenPolynomial gen = pfac.parse(expr);
+        RingFactory cf = pfac.coFac;
+        Interval iv = RootUtil.parseInterval(cf, root);
+        //System.out.println("iv = " + iv);
+        RealAlgebraicRing rfac = new RealAlgebraicRing(gen, iv);
+        RingFactory base = (RingFactory) rfac;
+        return new ExtensionFieldBuilder(base);
+    }
+
+
+    /**
+     * Complex algebraic field extension.
+     * @param var name for the algebraic generator.
+     * @param expr generating expresion, a univariate polynomial in var.
+     * @param root isolating rectangle for a complex root.
+     */
+    @SuppressWarnings("unchecked")
+    public ExtensionFieldBuilder complexAlgebraicExtension(String var, String expr, String root) {
+        String[] variables = new String[] { var };
+        RingElem one = (RingElem) factory.getONE();
+        if (!(one instanceof Complex)) {
+            throw new IllegalArgumentException("base field not instance of Complex");
+        }
+        GenPolynomialRing pfac = new GenPolynomialRing(factory, variables);
+        //System.out.println("pfac = " + pfac);
+        GenPolynomial gen = pfac.parse(expr);
+        //System.out.println("gen  = " + gen);
+        RingFactory cf = pfac.coFac;
+        Rectangle rt = RootUtil.parseRectangle(cf, root);
+        //System.out.println("rt = " + rt);
+        ComplexAlgebraicRing rfac = new ComplexAlgebraicRing(gen, rt);
+        RingFactory base = (RingFactory) rfac;
+        return new ExtensionFieldBuilder(base);
+    }
+
+
+    /**
+     * String representation of the ideal.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer s = new StringBuffer(" ");
+        s.append(factory.toString());
+        s.append(" ");
+        return s.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    public String toScript() {
+        // Python case
+        StringBuffer s = new StringBuffer(" ");
+        s.append(factory.toScript());
+        s.append(" ");
+        return s.toString();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/FactorAlgebraicPrim.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/FactorAlgebraicPrim.java
@@ -1,0 +1,183 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.AlgebraicNumberRing;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.poly.TermOrder;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.ufd.FactorAbsolute;
+import edu.jas.ufd.FactorAbstract;
+import edu.jas.ufd.PolyUfdUtil;
+import edu.jas.ufd.Squarefree;
+import edu.jas.ufd.SquarefreeFactory;
+
+
+/**
+ * Algebraic number coefficients factorization algorithms. This class
+ * implements factorization methods for polynomials over algebraic
+ * numbers over rational numbers or over (prime) modular integers. The
+ * algorithm uses zero dimensional ideal prime decomposition.
+ * @author Heinz Kredel
+ * @param <C> coefficient type
+ */
+
+public class FactorAlgebraicPrim<C extends GcdRingElem<C>> extends FactorAbsolute<AlgebraicNumber<C>> {
+
+
+    //FactorAbstract<AlgebraicNumber<C>>
+
+
+    private static final Logger logger = LogManager.getLogger(FactorAlgebraicPrim.class);
+
+
+    //private static final boolean debug = logger.isInfoEnabled();
+
+
+    /**
+     * Factorization engine for base coefficients.
+     */
+    public final FactorAbstract<C> factorCoeff;
+
+
+    /**
+     * No argument constructor. <b>Note:</b> can't use this constructor.
+     */
+    protected FactorAlgebraicPrim() {
+        throw new IllegalArgumentException("don't use this constructor");
+    }
+
+
+    /**
+     * Constructor.
+     * @param fac algebraic number factory.
+     */
+    public FactorAlgebraicPrim(AlgebraicNumberRing<C> fac) {
+        this(fac, FactorFactory.<C> getImplementation(fac.ring.coFac));
+    }
+
+
+    /**
+     * Constructor.
+     * @param fac algebraic number factory.
+     * @param factorCoeff factorization engine for polynomials over base
+     *            coefficients.
+     */
+    public FactorAlgebraicPrim(AlgebraicNumberRing<C> fac, FactorAbstract<C> factorCoeff) {
+        super(fac);
+        this.factorCoeff = factorCoeff;
+    }
+
+
+    /**
+     * GenPolynomial base factorization of a squarefree polynomial.
+     * @param P squarefree GenPolynomial&lt;AlgebraicNumber&lt;C&gt;&gt;.
+     * @return [p_1,...,p_k] with P = prod_{i=1, ..., k} p_i.
+     */
+    @Override
+    public List<GenPolynomial<AlgebraicNumber<C>>> baseFactorsSquarefree(GenPolynomial<AlgebraicNumber<C>> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P == null");
+        }
+        List<GenPolynomial<AlgebraicNumber<C>>> factors = new ArrayList<GenPolynomial<AlgebraicNumber<C>>>();
+        if (P.isZERO()) {
+            return factors;
+        }
+        if (P.isONE()) {
+            factors.add(P);
+            return factors;
+        }
+        GenPolynomialRing<AlgebraicNumber<C>> pfac = P.ring; // Q(alpha)[x]
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException("only for univariate polynomials");
+        }
+        AlgebraicNumberRing<C> afac = (AlgebraicNumberRing<C>) pfac.coFac;
+
+        AlgebraicNumber<C> ldcf = P.leadingBaseCoefficient();
+        if (!ldcf.isONE()) {
+            P = P.monic();
+            factors.add(pfac.getONE().multiply(ldcf));
+        }
+        //System.out.println("\nP = " + P);
+        if (logger.isDebugEnabled()) {
+            Squarefree<AlgebraicNumber<C>> sqengine = SquarefreeFactory
+                            .<AlgebraicNumber<C>> getImplementation(afac);
+            if (!sqengine.isSquarefree(P)) {
+                throw new RuntimeException("P not squarefree: " + sqengine.squarefreeFactors(P));
+            }
+            GenPolynomial<C> modu = afac.modul;
+            if (!factorCoeff.isIrreducible(modu)) {
+                throw new RuntimeException("modul not irreducible: " + factorCoeff.factors(modu));
+            }
+            System.out.println("P squarefree and modul irreducible via ideal decomposition");
+            //GreatestCommonDivisor<AlgebraicNumber<C>> aengine //= GCDFactory.<AlgebraicNumber<C>> getProxy(afac);
+            //  = new GreatestCommonDivisorSimple<AlgebraicNumber<C>>( /*cfac.coFac*/ );
+        }
+        GenPolynomial<C> agen = afac.modul;
+        GenPolynomialRing<C> cfac = afac.ring;
+        GenPolynomialRing<GenPolynomial<C>> rfac = new GenPolynomialRing<GenPolynomial<C>>(cfac, pfac);
+        TermOrder to = new TermOrder(TermOrder.INVLEX);
+        String[] vars = new String[2];
+        vars[0] = cfac.getVars()[0];
+        vars[1] = rfac.getVars()[0];
+        GenPolynomialRing<C> dfac = new GenPolynomialRing<C>(cfac.coFac, to, vars);
+        // transform minimal polynomial to bi-variate polynomial
+        GenPolynomial<C> Ad = agen.extend(dfac, 0, 0L);
+        // transform to bi-variate polynomial 
+        GenPolynomial<GenPolynomial<C>> Pc = PolyUtil.<C> fromAlgebraicCoefficients(rfac, P); 
+        //System.out.println("Pc = " + Pc.toScript());
+        GenPolynomial<C> Pd = PolyUtil.<C> distribute(dfac, Pc);
+        //System.out.println("Ad = " + Ad.toScript());
+        //System.out.println("Pd = " + Pd.toScript());
+
+        List<GenPolynomial<C>> id = new ArrayList<GenPolynomial<C>>(2);
+        id.add(Ad);
+        id.add(Pd);
+        Ideal<C> I = new Ideal<C>(dfac, id);
+        List<IdealWithUniv<C>> Iul = I.zeroDimPrimeDecomposition();
+        //System.out.println("prime decomp = " + Iul);
+        if (Iul.size() == 1) {
+            factors.add(P);
+            return factors;
+        }
+        GenPolynomial<AlgebraicNumber<C>> f = pfac.getONE();
+        for (IdealWithUniv<C> Iu : Iul) {
+            List<GenPolynomial<C>> pl = Iu.ideal.getList();
+            GenPolynomial<C> ag = PolyUtil.<C> selectWithVariable(pl, 1);
+            GenPolynomial<C> pg = PolyUtil.<C> selectWithVariable(pl, 0);
+            //System.out.println("ag = " + ag.toScript());
+            //System.out.println("pg = " + pg.toScript());
+            if (ag.equals(Ad)) {
+                //System.out.println("found factor --------------------");
+                GenPolynomial<GenPolynomial<C>> pgr = PolyUtil.<C> recursive(rfac, pg);
+                GenPolynomial<AlgebraicNumber<C>> pga = PolyUtil.<C> convertRecursiveToAlgebraicCoefficients(
+                                pfac, pgr);
+                //System.out.println("pga = " + pga.toScript());
+                f = f.multiply(pga);
+                factors.add(pga);
+            } else {
+                logger.warn("algebraic number mismatch: ag = " + ag + ", expected Ad = " + Ad);
+            }
+        }
+        f = f.subtract(P);
+        //System.out.println("f = " + f.toScript());
+        if (!f.isZERO()) {
+            throw new RuntimeException("no factorization: " + f + ", factors = " + factors);
+        }
+        return factors;
+        //return new edu.jas.ufd.FactorAlgebraic<C>(afac).baseFactorsSquarefree(P);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/FactorFactory.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/FactorFactory.java
@@ -1,0 +1,215 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.arith.Rational;
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.AlgebraicNumberRing;
+import edu.jas.poly.Complex;
+import edu.jas.poly.ComplexRing;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.root.RealAlgebraicNumber;
+import edu.jas.root.RealAlgebraicRing;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.ufd.FactorAbstract;
+import edu.jas.ufd.FactorAlgebraic;
+import edu.jas.ufd.FactorComplex;
+import edu.jas.ufd.FactorQuotient;
+import edu.jas.ufd.Quotient;
+import edu.jas.ufd.QuotientRing;
+import edu.jas.ufdroot.FactorRealAlgebraic;
+
+
+/**
+ * Factorization algorithms factory. Select appropriate factorization engine
+ * based on the coefficient types.
+ * <p>
+ * <b>Usage:</b> To create objects that implement the <code>Factorization</code>
+ * interface use the <code>FactorFactory</code>. It will select an appropriate
+ * implementation based on the types of polynomial coefficients C. To obtain an
+ * implementation use <code>getImplementation()</code>, it returns an object of
+ * a class which extends the <code>FactorAbstract</code> class which implements
+ * the <code>Factorization</code> interface.
+ * 
+ * <pre>
+ * Factorization&lt;CT&gt; engine;
+ * engine = FactorFactory.&lt;CT&gt; getImplementation(cofac);
+ * c = engine.factors(a);
+ * </pre>
+ * <p>
+ * For example, if the coefficient type is BigInteger, the usage looks like
+ * 
+ * <pre>
+ * BigInteger cofac = new BigInteger();
+ * Factorization&lt;BigInteger&gt; engine;
+ * engine = FactorFactory.getImplementation(cofac);
+ * Sm = engine.factors(poly);
+ * </pre>
+ * 
+ * @author Heinz Kredel
+ *
+ * @see edu.jas.ufd.Factorization#factors(edu.jas.poly.GenPolynomial P)
+ * @see edu.jas.ufd.FactorFactory#getImplementation(edu.jas.structure.RingFactory
+ *      P)
+ */
+
+public class FactorFactory extends edu.jas.ufd.FactorFactory {
+
+
+    private static final Logger logger = LogManager.getLogger(FactorFactory.class);
+
+
+    /**
+     * Protected factory constructor.
+     */
+    protected FactorFactory() {
+    }
+
+
+    /**
+     * Determine suitable implementation of factorization algorithms, case
+     * AlgebraicNumber&lt;C&gt;.
+     * @param fac AlgebraicNumberRing&lt;C&gt;.
+     * @param <C> coefficient type, e.g. BigRational, ModInteger.
+     * @return factorization algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C>> FactorAbstract<AlgebraicNumber<C>> getImplementation(
+                    AlgebraicNumberRing<C> fac) {
+        return new FactorAlgebraic<C>(fac, FactorFactory.<C> getImplementation(fac.ring.coFac));
+    }
+
+
+    /**
+     * Determine suitable implementation of factorization algorithms, case
+     * Complex&lt;C&gt;.
+     * @param fac ComplexRing&lt;C&gt;.
+     * @param <C> coefficient type, e.g. BigRational, ModInteger.
+     * @return factorization algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C>> FactorAbstract<Complex<C>> getImplementation(
+                    ComplexRing<C> fac) {
+        return new FactorComplex<C>(fac);
+    }
+
+
+    /**
+     * Determine suitable implementation of factorization algorithms, case
+     * Quotient&lt;C&gt;.
+     * @param fac QuotientRing&lt;C&gt;.
+     * @param <C> coefficient type, e.g. BigRational, ModInteger.
+     * @return factorization algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C>> FactorAbstract<Quotient<C>> getImplementation(
+                    QuotientRing<C> fac) {
+        return new FactorQuotient<C>(fac, FactorFactory.<C> getImplementation(fac.ring.coFac));
+    }
+
+
+    /**
+     * Determine suitable implementation of factorization algorithms, case
+     * recursive GenPolynomial&lt;C&gt;. Use <code>recursiveFactors()</code>.
+     * @param fac GenPolynomialRing&lt;C&gt;.
+     * @param <C> coefficient type, e.g. BigRational, ModInteger.
+     * @return factorization algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C>> FactorAbstract<C> getImplementation(GenPolynomialRing<C> fac) {
+        return getImplementation(fac.coFac);
+    }
+
+
+    /**
+     * Determine suitable implementation of factorization algorithms, case
+     * RealAlgebraicNumber&lt;C&gt;.
+     * @param fac RealAlgebraicRing&lt;C&gt;.
+     * @param <C> coefficient type, e.g. BigRational.
+     * @return factorization algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C> & Rational> FactorAbstract<RealAlgebraicNumber<C>> getImplementation(
+                    RealAlgebraicRing<C> fac) {
+        return new FactorRealAlgebraic<C>(fac,
+                        FactorFactory.<AlgebraicNumber<C>> getImplementation(fac.algebraic));
+    }
+
+
+    /**
+     * Determine suitable implementation of factorization algorithms, case
+     * RealAlgebraicNumber&lt;C&gt;.
+     * @param fac RealAlgebraicRing&lt;C&gt;.
+     * @param <C> coefficient type, e.g. BigRational.
+     * @return factorization algorithm implementation.
+     */
+    @SuppressWarnings("unchecked")
+    public static <C extends GcdRingElem<C> & Rational> FactorAbstract<edu.jas.application.RealAlgebraicNumber<C>> getImplementation(
+                    edu.jas.application.RealAlgebraicRing<C> fac) {
+        edu.jas.root.RealAlgebraicRing<C> rar = (edu.jas.root.RealAlgebraicRing<C>) (Object) fac.realRing;
+        return new FactorRealReal<C>(fac,
+                        FactorFactory.<edu.jas.root.RealAlgebraicNumber<C>> getImplementation(rar));
+    }
+
+
+    /**
+     * Determine suitable implementation of factorization algorithms, other
+     * cases.
+     * @param <C> coefficient type
+     * @param fac RingFactory&lt;C&gt;.
+     * @return factorization algorithm implementation.
+     */
+    @SuppressWarnings("unchecked")
+    public static <C extends GcdRingElem<C>> FactorAbstract<C> getImplementation(RingFactory<C> fac) {
+        logger.info("app factor factory = " + fac.getClass().getName());
+        //System.out.println("fac_o = " + fac.getClass().getName());
+        FactorAbstract/*raw type<C>*/ ufd = null;
+        edu.jas.application.RealAlgebraicRing rrfac = null;
+        RealAlgebraicRing rfac = null;
+        AlgebraicNumberRing afac = null;
+        ComplexRing cfac = null;
+        QuotientRing qfac = null;
+        GenPolynomialRing pfac = null;
+        Object ofac = fac;
+        if (ofac instanceof edu.jas.application.RealAlgebraicRing) {
+            //System.out.println("rrfac_o = " + ofac);
+            rrfac = (edu.jas.application.RealAlgebraicRing) ofac;
+            //ofac = rrfac.realRing;
+            ufd = new FactorRealReal/*raw <C>*/(rrfac,
+                            FactorFactory.<edu.jas.root.RealAlgebraicNumber> getImplementation(
+                                            rrfac.realRing));
+        } else if (ofac instanceof edu.jas.root.RealAlgebraicRing) {
+            //System.out.println("rfac_o = " + ofac);
+            rfac = (edu.jas.root.RealAlgebraicRing) ofac;
+            //ofac = rfac.algebraic;
+            ufd = new FactorRealAlgebraic/*raw <C>*/(rfac,
+                            FactorFactory.<AlgebraicNumber<C>> getImplementation(rfac.algebraic));
+        } else if (ofac instanceof ComplexRing) {
+            cfac = (ComplexRing<C>) ofac;
+            afac = cfac.algebraicRing();
+            ufd = new FactorComplex(cfac, FactorFactory.<C> getImplementation(afac));
+        } else if (ofac instanceof AlgebraicNumberRing) {
+            //System.out.println("afac_o = " + ofac);
+            afac = (AlgebraicNumberRing) ofac;
+            //ofac = afac.ring.coFac;
+            ufd = new FactorAlgebraic/*raw <C>*/(afac, FactorFactory.<C> getImplementation(afac.ring.coFac));
+        } else if (ofac instanceof QuotientRing) {
+            //System.out.println("qfac_o = " + ofac);
+            qfac = (QuotientRing) ofac;
+            ufd = new FactorQuotient/*raw <C>*/(qfac, FactorFactory.<C> getImplementation(qfac.ring.coFac));
+        } else if (ofac instanceof GenPolynomialRing) {
+            //System.out.println("qfac_o = " + ofac);
+            pfac = (GenPolynomialRing) ofac;
+            ufd = getImplementation(pfac.coFac);
+        } else {
+            //System.out.println("no fac = " + fac.getClass().getName());
+            ufd = edu.jas.ufd.FactorFactory.getImplementation(fac);
+            //return (FactorAbstract<C>) ufd;
+        }
+        //logger.info("implementation = " + ufd);
+        return (FactorAbstract<C>) ufd;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/FactorRealReal.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/FactorRealReal.java
@@ -1,0 +1,140 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.arith.Rational;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.ufd.FactorAbstract;
+
+
+/**
+ * Real algebraic number coefficients factorization algorithms. This class
+ * implements factorization methods for polynomials over bi-variate real
+ * algebraic numbers from package
+ * 
+ * <pre>
+ * edu.jas.application
+ * </pre>
+ * 
+ * .
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class FactorRealReal<C extends GcdRingElem<C> & Rational>
+                extends FactorAbstract<RealAlgebraicNumber<C>> {
+
+
+    // TODO: check if is absolute possible? and what does it mean? 
+    // absolute not possible since factorization over reals leads to factors of degree 2
+    //FactorAbsolute<AlgebraicNumber<C>>
+    //FactorAbstract<AlgebraicNumber<C>>
+
+
+    private static final Logger logger = LogManager.getLogger(FactorRealReal.class);
+
+
+    private static final boolean debug = logger.isInfoEnabled();
+
+
+    /**
+     * Factorization engine for base coefficients.
+     */
+    public final FactorAbstract<edu.jas.root.RealAlgebraicNumber<C>> factorAlgebraic;
+
+
+    /**
+     * No argument constructor. <b>Note:</b> can't use this constructor.
+     */
+    protected FactorRealReal() {
+        throw new IllegalArgumentException("don't use this constructor");
+    }
+
+
+    /**
+     * Constructor.
+     * @param fac algebraic number factory.
+     */
+    @SuppressWarnings("unchecked")
+    public FactorRealReal(RealAlgebraicRing<C> fac) {
+        // ignore recursion, as it is handled in FactorRealAlgebraic:
+        this(fac, FactorFactory.<edu.jas.root.RealAlgebraicNumber<C>> getImplementation(
+                        (edu.jas.root.RealAlgebraicRing<C>) (Object) fac.realRing));
+    }
+
+
+    /**
+     * Constructor.
+     * @param fac algebraic number factory.
+     * @param factorAlgebraic factorization engine for polynomials over base
+     *            coefficients.
+     */
+    public FactorRealReal(RealAlgebraicRing<C> fac,
+                    FactorAbstract<edu.jas.root.RealAlgebraicNumber<C>> factorAlgebraic) {
+        super(fac);
+        this.factorAlgebraic = factorAlgebraic;
+    }
+
+
+    /**
+     * GenPolynomial base factorization of a squarefree polynomial.
+     * @param P squarefree GenPolynomial&lt;RealAlgebraicNumber&lt;C&gt;&gt;.
+     * @return [p_1,...,p_k] with P = prod_{i=1, ..., k} p_i.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public List<GenPolynomial<RealAlgebraicNumber<C>>> baseFactorsSquarefree(
+                    GenPolynomial<RealAlgebraicNumber<C>> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P == null");
+        }
+        List<GenPolynomial<RealAlgebraicNumber<C>>> factors = new ArrayList<GenPolynomial<RealAlgebraicNumber<C>>>();
+        if (P.isZERO()) {
+            return factors;
+        }
+        if (P.isONE()) {
+            factors.add(P);
+            return factors;
+        }
+        GenPolynomialRing<RealAlgebraicNumber<C>> pfac = P.ring; // Q(alpha)[x]
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException("only for univariate polynomials");
+        }
+        RealAlgebraicRing<C> rere = (RealAlgebraicRing<C>) pfac.coFac;
+        edu.jas.root.RealAlgebraicRing<C> rfac = (edu.jas.root.RealAlgebraicRing<C>) (Object) rere.realRing;
+
+        RealAlgebraicNumber<C> ldcf = P.leadingBaseCoefficient();
+        if (!ldcf.isONE()) {
+            P = P.monic();
+            factors.add(pfac.getONE().multiply(ldcf));
+        }
+        //System.out.println("\nP = " + P);
+        GenPolynomialRing<edu.jas.root.RealAlgebraicNumber<C>> arfac = new GenPolynomialRing<edu.jas.root.RealAlgebraicNumber<C>>(
+                        rfac, pfac);
+        GenPolynomial<edu.jas.root.RealAlgebraicNumber<C>> A = PolyUtilApp
+                        .<C> realAlgFromRealCoefficients(arfac, P);
+        // factor A:
+        List<GenPolynomial<edu.jas.root.RealAlgebraicNumber<C>>> afactors = factorAlgebraic
+                        .baseFactorsSquarefree(A);
+        for (GenPolynomial<edu.jas.root.RealAlgebraicNumber<C>> a : afactors) {
+            GenPolynomial<RealAlgebraicNumber<C>> p = PolyUtilApp.<C> realFromRealAlgCoefficients(pfac, a);
+            factors.add(p);
+        }
+        if (debug) {
+            logger.info("rafactors = " + factors);
+        }
+        return factors;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/GBAlgorithmBuilder.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/GBAlgorithmBuilder.java
@@ -1,0 +1,575 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.Serializable;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.arith.BigInteger;
+import edu.jas.arith.BigRational;
+import edu.jas.gb.GBOptimized;
+import edu.jas.gb.GBProxy;
+import edu.jas.gb.GroebnerBaseAbstract;
+import edu.jas.gb.GroebnerBaseArriSigSeqIter;
+import edu.jas.gb.GroebnerBaseF5zSigSeqIter;
+import edu.jas.gb.GroebnerBaseGGVSigSeqIter;
+import edu.jas.gb.GroebnerBaseParIter;
+import edu.jas.gb.GroebnerBaseParallel;
+import edu.jas.gb.GroebnerBaseSeqIter;
+import edu.jas.gb.OrderedMinPairlist;
+import edu.jas.gb.OrderedPairlist;
+import edu.jas.gb.OrderedSyzPairlist;
+import edu.jas.gb.PairList;
+import edu.jas.gbufd.GBFactory;
+import edu.jas.gbufd.GroebnerBaseFGLM;
+import edu.jas.gbufd.GroebnerBasePseudoParallel;
+import edu.jas.gbufd.GroebnerBaseQuotient;
+import edu.jas.gbufd.GroebnerBaseRational;
+import edu.jas.gbufd.GroebnerBaseWalk;
+import edu.jas.kern.ComputerThreads;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.ufd.Quotient;
+import edu.jas.ufd.QuotientRing;
+
+
+/**
+ * Builder for commutative Gr&ouml;bner bases algorithm implementations.
+ * <p>
+ * <b>Usage:</b> To create objects that implement the <code>GroebnerBase</code>
+ * interface one can use the <code>GBFactory</code> or this
+ * <code>GBAlgorithmBuilder</code>. This class will select and compose an
+ * appropriate implementation based on the types of polynomial coefficients C
+ * and the desired properties. To build an implementation start with the static
+ * method <code>polynomialRing()</code> to define the polynomial ring. Then
+ * continue to construct the algorithm with the methods
+ * <ul>
+ * <li><code>optimize()</code> or <code>optimize(boolean)</code> for term order
+ * (variable order) optimization (true for return of permuted polynomials),</li>
+ * <li><code>normalPairlist()</code> (default), <code>syzygyPairlist()</code> or
+ * <code>simplePairlist()</code> for pair-list selection strategies,</li>
+ * <li><code>fractionFree()</code> for clearing denominators and computing with
+ * pseudo reduction,</li>
+ * <li><code>graded()</code> for using the FGLM algorithm to first compute a
+ * Gr&ouml;bner base with respect to a graded term order and then constructing a
+ * Gr&ouml;bner base wrt. a lexicographical term order,</li>
+ * <li><code>walk()</code> for using the Gr&ouml;bner walk algorithm to first
+ * compute a Gr&ouml;bner base with respect to a graded term order and then
+ * constructing a Gr&ouml;bner base wrt. a lexicographical term order,</li>
+ * <li><code>iterated()</code> for using the iterative GB algorithm to compute a
+ * Gr&ouml;bner base adding one polynomial after another,</li>
+ * <li><code>F5()</code>, <code>GGV()</code> and <code>Arri()</code> for using
+ * the respective iterative signature based GB algorithm (over field
+ * coefficients) to compute a Gr&ouml;bner base adding one polynomial after
+ * another,</li>
+ * <li><code>parallel()</code> additionaly compute a Gr&ouml;bner base over a
+ * field or integral domain in parallel,</li>
+ * <li><code>euclideanDomain()</code> for computing a e-Gr&ouml;bner base,</li>
+ * <li><code>domainAlgorithm(Algo)</code> for computing a d- or e-Gr&ouml;bner
+ * base,</li>
+ * </ul>
+ * <p>
+ * Finally call the method <code>build()</code> to obtain an implementaton of
+ * class <code>GroebnerBaseAbstract</code>. For example
+ * 
+ * <pre>
+ * GenPolynomialRing&lt;C&gt; pf = new GenPolynomialRing&lt;C&gt;(cofac, vars);
+ * GroebnerBaseAbstract&lt;C&gt; engine;
+ * engine = GBAlgorithmBuilder.&lt;C&gt; polynomialRing(pf).fractionFree().parallel().optimize().build();
+ * c = engine.GB(A);
+ * </pre>
+ * <p>
+ * For example, if the coefficient type is BigRational, the usage looks like
+ * 
+ * <pre>
+ * GenPolynomialRing&lt;BigRational&gt; pf = new GenPolynomialRing&lt;BigRational&gt;(cofac, vars);
+ * GroebnerBaseAbstract&lt;BigRational&gt; engine;
+ * engine = GBAlgorithmBuilder.&lt;BigRational&gt; polynomialRing(pf).fractionFree().parallel().optimize().build();
+ * c = engine.GB(A);
+ * </pre>
+ * 
+ * <b>Note:</b> Not all combinations are meanigful
+ * 
+ * @author Heinz Kredel
+ *
+ * @see edu.jas.gb.GroebnerBase
+ * @see edu.jas.gbufd.GBFactory
+ */
+
+public class GBAlgorithmBuilder<C extends GcdRingElem<C>> implements Serializable {
+
+
+    private static final Logger logger = LogManager.getLogger(GBAlgorithmBuilder.class);
+
+
+    /**
+     * The current GB algorithm implementation.
+     */
+    private GroebnerBaseAbstract<C> algo;
+
+
+    /**
+     * The current polynomial ring.
+     */
+    public final GenPolynomialRing<C> ring;
+
+
+    /**
+     * Requested pairlist strategy.
+     */
+    public final PairList<C> strategy;
+
+
+    /**
+     * Constructor not for use.
+     */
+    protected GBAlgorithmBuilder() {
+        throw new IllegalArgumentException("do not use this constructor");
+    }
+
+
+    /**
+     * Constructor.
+     * @param ring the polynomial ring.
+     */
+    public GBAlgorithmBuilder(GenPolynomialRing<C> ring) {
+        this(ring, null);
+    }
+
+
+    /**
+     * Constructor.
+     * @param ring the polynomial ring.
+     * @param algo already determined algorithm.
+     */
+    public GBAlgorithmBuilder(GenPolynomialRing<C> ring, GroebnerBaseAbstract<C> algo) {
+        this(ring, algo, null);
+    }
+
+
+    /**
+     * Constructor.
+     * @param ring the polynomial ring.
+     * @param algo already determined algorithm.
+     * @param strategy pairlist strategy.
+     */
+    public GBAlgorithmBuilder(GenPolynomialRing<C> ring, GroebnerBaseAbstract<C> algo, PairList<C> strategy) {
+        if (ring == null) {
+            throw new IllegalArgumentException("ring may not be null");
+        }
+        this.ring = ring;
+        if (strategy == null) {
+            strategy = new OrderedPairlist<C>();
+        } else {
+            if (algo == null) { // or overwrite?
+                algo = GBFactory.<C> getImplementation(ring.coFac, strategy);
+            }
+        }
+        this.algo = algo; // null accepted
+        this.strategy = strategy;
+    }
+
+
+    /**
+     * Build the GB algorithm implementaton.
+     * @return GB algorithm implementaton as GroebnerBaseAbstract object.
+     */
+    public GroebnerBaseAbstract<C> build() {
+        if (algo == null) {
+            if (strategy == null) { // should not happen
+                algo = GBFactory.<C> getImplementation(ring.coFac);
+            } else {
+                algo = GBFactory.<C> getImplementation(ring.coFac, strategy);
+            }
+        }
+        return algo;
+    }
+
+
+    /**
+     * Define polynomial ring.
+     * @param fac the commutative polynomial ring.
+     * @return GBAlgorithmBuilder object.
+     */
+    public static <C extends GcdRingElem<C>> GBAlgorithmBuilder<C> polynomialRing(GenPolynomialRing<C> fac) {
+        return new GBAlgorithmBuilder<C>(fac);
+    }
+
+
+    /**
+     * Select syzygy critical pair-list strategy. Gebauer and M&ouml;ller
+     * algorithm.
+     * @return GBAlgorithmBuilder object.
+     */
+    public GBAlgorithmBuilder<C> syzygyPairlist() {
+        return new GBAlgorithmBuilder<C>(ring, algo, new OrderedSyzPairlist<C>());
+    }
+
+
+    /**
+     * Select normal critical pair-list strategy. Buchberger, Winkler and Kredel
+     * algorithm.
+     * @return GBAlgorithmBuilder object.
+     */
+    public GBAlgorithmBuilder<C> normalPairlist() {
+        return new GBAlgorithmBuilder<C>(ring, algo, new OrderedPairlist<C>());
+    }
+
+
+    /**
+     * Select simple critical pair-list strategy. Original Buchberger algorithm.
+     * @return GBAlgorithmBuilder object.
+     */
+    public GBAlgorithmBuilder<C> simplePairlist() {
+        return new GBAlgorithmBuilder<C>(ring, algo, new OrderedMinPairlist<C>());
+    }
+
+
+    /**
+     * Request term order optimization. Call optimize(true) for return of
+     * permuted polynomials.
+     * @return GBAlgorithmBuilder object.
+     */
+    public GBAlgorithmBuilder<C> optimize() {
+        return optimize(true);
+    }
+
+
+    /**
+     * Request term order optimization.
+     * @param rP true for return of permuted polynomials, false for inverse
+     *            permuted polynomials and new GB computation.
+     * @return GBAlgorithmBuilder object.
+     */
+    public GBAlgorithmBuilder<C> optimize(boolean rP) {
+        if (algo == null) {
+            algo = GBFactory.<C> getImplementation(ring.coFac, strategy);
+        }
+        GroebnerBaseAbstract<C> bb = new GBOptimized<C>(algo, rP);
+        return new GBAlgorithmBuilder<C>(ring, bb, strategy);
+    }
+
+
+    /**
+     * Request fraction free algorithm. For BigRational and Quotient
+     * coefficients denominators are cleared and pseudo reduction is used.
+     * @return GBAlgorithmBuilder object.
+     */
+    @SuppressWarnings({ "cast", "unchecked" })
+    public GBAlgorithmBuilder<C> fractionFree() {
+        if (algo != null) {
+            logger.warn("selected algorithm ignored: " + algo + ", use fractionFree before");
+        }
+        if (((Object) ring.coFac) instanceof BigRational) {
+            BigRational cf = (BigRational) (Object) ring.coFac;
+            PairList<BigRational> sty = (PairList) strategy;
+            GroebnerBaseAbstract<BigRational> bb = GBFactory.getImplementation(cf, GBFactory.Algo.ffgb, sty);
+            GroebnerBaseAbstract<C> cbb = (GroebnerBaseAbstract<C>) (GroebnerBaseAbstract) bb;
+            return new GBAlgorithmBuilder<C>(ring, cbb, strategy);
+        }
+        if (((Object) ring.coFac) instanceof QuotientRing) {
+            QuotientRing<C> cf = (QuotientRing<C>) (Object) ring.coFac;
+            PairList<Quotient<C>> sty = (PairList) strategy;
+            GroebnerBaseAbstract<Quotient<C>> bb = GBFactory.<C> getImplementation(cf, GBFactory.Algo.ffgb,
+                            sty);
+            GroebnerBaseAbstract<C> cbb = (GroebnerBaseAbstract<C>) (GroebnerBaseAbstract) bb;
+            return new GBAlgorithmBuilder<C>(ring, cbb, strategy);
+        }
+        logger.warn("no fraction free algorithm implemented for " + ring);
+        return this;
+    }
+
+
+    /**
+     * Request e-GB algorithm.
+     * @return GBAlgorithmBuilder object.
+     */
+    public GBAlgorithmBuilder<C> euclideanDomain() {
+        return domainAlgorithm(GBFactory.Algo.egb);
+    }
+
+
+    /**
+     * Request d-, e- or i-GB algorithm.
+     * @param a algorithm from GBFactory.Algo.
+     * @return GBAlgorithmBuilder object.
+     */
+    @SuppressWarnings({ "cast", "unchecked" })
+    public GBAlgorithmBuilder<C> domainAlgorithm(GBFactory.Algo a) {
+        if (strategy != null) {
+            logger.warn("strategy " + strategy + " ignored for algorithm " + a);
+        }
+        if (((Object) ring.coFac) instanceof BigInteger) {
+            BigInteger cf = (BigInteger) (Object) ring.coFac;
+            GroebnerBaseAbstract<BigInteger> bb = GBFactory.getImplementation(cf, a);
+            GroebnerBaseAbstract<C> cbb = (GroebnerBaseAbstract<C>) (GroebnerBaseAbstract) bb;
+            return new GBAlgorithmBuilder<C>(ring, cbb);
+        }
+        if (((Object) ring.coFac) instanceof GenPolynomial) {
+            GenPolynomialRing<C> cf = (GenPolynomialRing) (Object) ring.coFac;
+            GroebnerBaseAbstract<GenPolynomial<C>> bb = GBFactory.<C> getImplementation(cf, a);
+            GroebnerBaseAbstract<C> cbb = (GroebnerBaseAbstract<C>) (GroebnerBaseAbstract) bb;
+            return new GBAlgorithmBuilder<C>(ring, cbb);
+        }
+        logger.warn("no domain algorithm implemented for " + ring);
+        return this;
+    }
+
+
+    /**
+     * Request parallel algorithm. Additionaly run a parallel algorithm via
+     * GBProxy.
+     * @return GBAlgorithmBuilder object.
+     */
+    @SuppressWarnings("unchecked")
+    public GBAlgorithmBuilder<C> parallel() {
+        return parallel(ComputerThreads.N_CPUS);
+    }
+
+
+    /**
+     * Request parallel algorithm. Additionaly run a parallel algorithm via
+     * GBProxy.
+     * @param threads number of threads requested.
+     * @return GBAlgorithmBuilder object.
+     */
+    @SuppressWarnings({ "cast", "unchecked" })
+    public GBAlgorithmBuilder<C> parallel(int threads) {
+        if (ComputerThreads.NO_THREADS) {
+            logger.warn("parallel algorithms disabled");
+            return this;
+        }
+        if (algo == null) {
+            algo = GBFactory.<C> getImplementation(ring.coFac, strategy);
+        }
+        if (algo instanceof GroebnerBaseSeqIter) { // iterative requested
+            GroebnerBaseAbstract<C> bb;
+            bb = (GroebnerBaseAbstract) new GroebnerBaseParIter<C>(threads, strategy);
+            GroebnerBaseAbstract<C> pbb = new GBProxy<C>(algo, bb);
+            return new GBAlgorithmBuilder<C>(ring, pbb, strategy);
+        } else if (((RingFactory) ring.coFac) instanceof BigRational) {
+            GroebnerBaseAbstract<C> bb;
+            if (algo instanceof GroebnerBaseRational) { // fraction free requested
+                PairList<BigInteger> pli;
+                if (strategy instanceof OrderedMinPairlist) {
+                    pli = new OrderedMinPairlist<BigInteger>();
+                } else if (strategy instanceof OrderedSyzPairlist) {
+                    pli = new OrderedSyzPairlist<BigInteger>();
+                } else {
+                    pli = new OrderedPairlist<BigInteger>();
+                }
+                bb = (GroebnerBaseAbstract) new GroebnerBaseRational<BigRational>(threads, pli);
+            } else {
+                bb = (GroebnerBaseAbstract) new GroebnerBaseParallel<C>(threads, strategy);
+            }
+            GroebnerBaseAbstract<C> pbb = new GBProxy<C>(algo, bb);
+            return new GBAlgorithmBuilder<C>(ring, pbb, strategy);
+        } else if (((RingFactory) ring.coFac) instanceof QuotientRing) {
+            GroebnerBaseAbstract<C> bb;
+            if (algo instanceof GroebnerBaseQuotient) { // fraction free requested
+                PairList<GenPolynomial<C>> pli;
+                if (strategy instanceof OrderedMinPairlist) {
+                    pli = new OrderedMinPairlist<GenPolynomial<C>>();
+                } else if (strategy instanceof OrderedSyzPairlist) {
+                    pli = new OrderedSyzPairlist<GenPolynomial<C>>();
+                } else {
+                    pli = new OrderedPairlist<GenPolynomial<C>>();
+                }
+                QuotientRing<C> fac = (QuotientRing) ring.coFac;
+                bb = (GroebnerBaseAbstract) new GroebnerBaseQuotient<C>(threads, fac, pli); // pl not possible
+            } else {
+                bb = (GroebnerBaseAbstract) new GroebnerBaseParallel<C>(threads, strategy);
+            }
+            GroebnerBaseAbstract<C> pbb = new GBProxy<C>(algo, bb);
+            return new GBAlgorithmBuilder<C>(ring, pbb);
+        } else if (ring.coFac.isField()) {
+            GroebnerBaseAbstract<C> bb = new GroebnerBaseParallel<C>(threads, strategy);
+            GroebnerBaseAbstract<C> pbb = new GBProxy<C>(algo, bb);
+            return new GBAlgorithmBuilder<C>(ring, pbb, strategy);
+        } else if (ring.coFac.getONE() instanceof GcdRingElem) {
+            GroebnerBaseAbstract<C> bb = new GroebnerBasePseudoParallel<C>(threads, ring.coFac, strategy);
+            GroebnerBaseAbstract<C> pbb = new GBProxy<C>(algo, bb);
+            return new GBAlgorithmBuilder<C>(ring, pbb, strategy);
+        }
+        logger.warn("no parallel algorithm implemented for " + ring);
+        return this;
+    }
+
+
+    /**
+     * Request FGLM algorithm.
+     * @return GBAlgorithmBuilder object.
+     */
+    @SuppressWarnings("unchecked")
+    public GBAlgorithmBuilder<C> graded() {
+        if (ring.coFac.isField()) {
+            GroebnerBaseAbstract<C> bb;
+            if (algo == null) {
+                bb = new GroebnerBaseFGLM<C>();
+            } else {
+                bb = new GroebnerBaseFGLM<C>(algo);
+            }
+            return new GBAlgorithmBuilder<C>(ring, bb, strategy);
+        }
+        logger.warn("no FGLM algorithm implemented for " + ring);
+        return this;
+    }
+
+
+    /**
+     * Request Groebner walk algorithm.
+     * @return GBAlgorithmBuilder object.
+     */
+    @SuppressWarnings("unchecked")
+    public GBAlgorithmBuilder<C> walk() {
+        if (ring.coFac.isField()) {
+            GroebnerBaseAbstract<C> bb;
+            if (algo == null) {
+                bb = new GroebnerBaseWalk<C>();
+            } else {
+                bb = new GroebnerBaseWalk<C>(algo);
+            }
+            return new GBAlgorithmBuilder<C>(ring, bb, strategy);
+        }
+        logger.warn("no Groebner walk algorithm implemented for " + ring);
+        return this;
+    }
+
+
+    /**
+     * Request iterated GB algorithm.
+     * @return GBAlgorithmBuilder object.
+     */
+    @SuppressWarnings("unchecked")
+    public GBAlgorithmBuilder<C> iterated() {
+        if (ring.coFac.isField()) {
+            GroebnerBaseAbstract<C> bb;
+            bb = new GroebnerBaseSeqIter<C>(strategy);
+            // if (algo instanceof GBProxy) ... assemble parallel todo
+            if (algo != null) {
+                logger.warn("algorithm " + algo + " ignored for " + bb);
+            }
+            return new GBAlgorithmBuilder<C>(ring, bb, strategy);
+        }
+        logger.warn("no iterated GB algorithm implemented for " + ring);
+        return this;
+    }
+
+
+    /**
+     * Request iterated F5 signature based GB algorithm.
+     * @return GBAlgorithmBuilder object.
+     */
+    @SuppressWarnings("unchecked")
+    public GBAlgorithmBuilder<C> F5() {
+        if (ring.coFac.isField()) {
+            GroebnerBaseAbstract<C> bb;
+            bb = new GroebnerBaseF5zSigSeqIter<C>();
+            // if (algo instanceof GBProxy) ... assemble parallel todo
+            if (algo != null) {
+                logger.warn("algorithm " + algo + " ignored for " + bb);
+            }
+            if (strategy != null) {
+                logger.warn("strategy " + strategy + " ignored for " + bb);
+            }
+            return new GBAlgorithmBuilder<C>(ring, bb, strategy);
+        }
+        logger.warn("no iterated F5 GB algorithm implemented for " + ring);
+        return this;
+    }
+
+
+    /**
+     * Request iterated GGV signature based GB algorithm.
+     * @return GBAlgorithmBuilder object.
+     */
+    @SuppressWarnings("unchecked")
+    public GBAlgorithmBuilder<C> GGV() {
+        if (ring.coFac.isField()) {
+            GroebnerBaseAbstract<C> bb;
+            bb = new GroebnerBaseGGVSigSeqIter<C>();
+            // if (algo instanceof GBProxy) ... assemble parallel todo
+            if (algo != null) {
+                logger.warn("algorithm " + algo + " ignored for " + bb);
+            }
+            if (strategy != null) {
+                logger.warn("strategy " + strategy + " ignored for " + bb);
+            }
+            return new GBAlgorithmBuilder<C>(ring, bb, strategy);
+        }
+        logger.warn("no iterated GGV GB algorithm implemented for " + ring);
+        return this;
+    }
+
+
+    /**
+     * Request iterated Arri signature based GB algorithm.
+     * @return GBAlgorithmBuilder object.
+     */
+    @SuppressWarnings("unchecked")
+    public GBAlgorithmBuilder<C> Arri() {
+        if (ring.coFac.isField()) {
+            GroebnerBaseAbstract<C> bb;
+            bb = new GroebnerBaseArriSigSeqIter<C>();
+            // if (algo instanceof GBProxy) ... assemble parallel todo
+            if (algo != null) {
+                logger.warn("algorithm " + algo + " ignored for " + bb);
+            }
+            if (strategy != null) {
+                logger.warn("strategy " + strategy + " ignored for " + bb);
+            }
+            return new GBAlgorithmBuilder<C>(ring, bb, strategy);
+        }
+        logger.warn("no iterated Arri GB algorithm implemented for " + ring);
+        return this;
+    }
+
+
+    /**
+     * String representation of the GB algorithm implementation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer s = new StringBuffer(" ");
+        if (algo != null) {
+            s.append(algo.toString());
+            s.append(" for ");
+        }
+        s.append(ring.toString());
+        if (strategy != null) {
+            s.append(" strategy=");
+            s.append(strategy.toString());
+        }
+        return s.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    public String toScript() {
+        // Python case
+        StringBuffer s = new StringBuffer(" ");
+        if (algo != null) {
+            s.append(algo.toString()); // nonsense
+            s.append(" ");
+        }
+        s.append(ring.toScript());
+        if (strategy != null) {
+            s.append(",strategy=");
+            s.append(strategy.toString());
+        }
+        return s.toString();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/GroebnerSystem.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/GroebnerSystem.java
@@ -1,0 +1,280 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.PolynomialList;
+import edu.jas.poly.OrderedPolynomialList;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Container for a Groebner system. 
+ * It contains a list of colored systems and a
+ * list of parametric polynomials representing the 
+ * corresponding comprehensive Groebner base.
+ * @param <C> coefficient type
+ */
+public class GroebnerSystem<C extends GcdRingElem<C>> {
+
+
+    private static final Logger logger = LogManager.getLogger(GroebnerSystem.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * List of colored systems.
+     */
+    public final List<ColoredSystem<C>> list;
+
+
+    /**
+     * List of conditions for this Groebner system.
+     */
+    protected List<Condition<C>> conds;
+
+
+    /**
+     * Comprehensive Groebner base for this Groebner system.
+     */
+    protected PolynomialList<GenPolynomial<C>> cgb;
+
+
+    /**
+     * Constructor for a Groebner system.
+     * @param S a list of colored systems.
+     */
+    public GroebnerSystem(List<ColoredSystem<C>> S) {
+        this.list = S;
+        this.conds = null;
+        this.cgb = null;
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer("GroebnerSystem: \n");
+        boolean first = true;
+        for (ColoredSystem<C> cs : list) {
+            if ( first ) {
+               first = false;
+            } else {
+               sb.append("\n");
+            }
+            sb.append( cs.toString() );
+        }
+        sb.append("Conditions:\n");
+        first = true;
+        for ( Condition<C> cond : getConditions() ) {
+            if ( first ) {
+                first = false;
+            } else {
+                sb.append("\n");
+            }
+            sb.append( cond.toString() );
+        }
+        sb.append("\n");
+        if ( cgb == null ) {
+           sb.append("Comprehensive Groebner Base not jet computed\n");
+        } else {
+           sb.append("Comprehensive Groebner Base:\n");
+           first = true;
+           for ( GenPolynomial<GenPolynomial<C>> p : getCGB() ) {
+               if ( first ) {
+                  first = false;
+               } else {
+                  sb.append(",\n");
+               }
+               sb.append( p.toString() );
+           }
+           sb.append("\n");
+        }
+        return sb.toString();
+    }
+
+
+    /**
+     * Get the Script representation.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    public String toScript() {
+        StringBuffer sb = new StringBuffer("GroebnerSystem: \n");
+        boolean first = true;
+        for (ColoredSystem<C> cs : list) {
+            if ( first ) {
+               first = false;
+            } else {
+               sb.append("\n");
+            }
+            sb.append( cs.toScript() );
+        }
+        sb.append("Conditions:\n");
+        first = true;
+        for ( Condition<C> cond : getConditions() ) {
+            if ( first ) {
+                first = false;
+            } else {
+                sb.append("\n");
+            }
+            sb.append( cond.toScript() );
+        }
+        sb.append("\n");
+        if ( cgb == null ) {
+           sb.append("Comprehensive Groebner Base not jet computed\n");
+        } else {
+           sb.append("Comprehensive Groebner Base:\n");
+           first = true;
+           for ( GenPolynomial<GenPolynomial<C>> p : getCGB() ) {
+               if ( first ) {
+                  first = false;
+               } else {
+                  sb.append(",\n");
+               }
+               sb.append( p.toScript() );
+           }
+           sb.append("\n");
+        }
+        return sb.toString();
+    }
+
+
+    /**
+     * Is this Groebner system equal to other.
+     * @param c other Groebner system.
+     * @return true, if this is equal to other, else false.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object c) {
+        GroebnerSystem<C> cs = null;
+        try {
+            cs = (GroebnerSystem<C>) c;
+        } catch (ClassCastException e) {
+            return false;
+        }
+        if (cs == null) {
+            return false;
+        }
+        boolean t = list.equals(cs.list);
+        return t;
+    }
+
+
+    /**
+     * Hash code for this colored system.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = list.hashCode();
+        return h;
+    }
+
+
+    /**
+     * Check invariants. Check if all colored systems are determined and 
+     * all invariants are met.
+     * @return true, if all invariants are met, else false.
+     */
+    public boolean checkInvariant() {
+        for (ColoredSystem<C> s : list) {
+            if (!s.checkInvariant()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Is each colored system completely determined.
+     * @return true, if each ColoredSystem is determined, else false.
+     */
+    public boolean isDetermined() {
+        for (ColoredSystem<C> s : list) {
+            if (!s.isDetermined()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Get list of conditions determining this Groebner system. 
+     * @return list of determining conditions.
+     */
+    public List<Condition<C>> getConditions() {
+        if ( conds != null ) {
+           return conds;
+        }
+        List<Condition<C>> cd = new ArrayList<Condition<C>>( list.size() );
+        for (ColoredSystem<C> cs : list) {
+            cd.add(cs.condition);
+        }
+        conds = cd;
+        return conds;
+    }
+
+
+    /**
+     * Get comprehensive Groebner base. 
+     * @return the comprehensive Groebner base for this Groebner system.
+     */
+    public List<GenPolynomial<GenPolynomial<C>>> getCGB() {
+        if ( cgb != null ) {
+           return cgb.list;
+        }
+        // assure conditions are collected
+        List<Condition<C>> unused = getConditions();
+        if ( unused.isEmpty() ) { // use for findbugs
+            logger.info("unused is empty");
+        }
+        //System.out.println("unused ");
+        // combine for CGB
+        Set<GenPolynomial<GenPolynomial<C>>> Gs 
+           = new HashSet<GenPolynomial<GenPolynomial<C>>>();
+        for (ColoredSystem<C> cs : list) {
+            if (debug) {
+                if (!cs.isDetermined()) {
+                    System.out.println("not determined, cs = " + cs);
+                }
+                if (!cs.checkInvariant()) {
+                    System.out.println("not invariant, cs = " + cs);
+                }
+            }
+            for (ColorPolynomial<C> p : cs.list) {
+                GenPolynomial<GenPolynomial<C>> f = p.getPolynomial();
+                Gs.add(f);
+            }
+        }
+        List<GenPolynomial<GenPolynomial<C>>> G 
+            = new ArrayList<GenPolynomial<GenPolynomial<C>>>(Gs);
+        GenPolynomialRing<GenPolynomial<C>> ring = null;
+        if ( G.size() > 0 ) {
+           ring = G.get(0).ring;
+        }
+        cgb = new OrderedPolynomialList<GenPolynomial<C>>(ring,G);
+        return G;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/Ideal.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/Ideal.java
@@ -1,0 +1,3200 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedMap;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.gb.ExtendedGB;
+import edu.jas.gb.GroebnerBaseAbstract;
+import edu.jas.gb.Reduction;
+import edu.jas.gbufd.GBFactory;
+import edu.jas.gbufd.GroebnerBasePartial;
+import edu.jas.gbufd.PolyGBUtil;
+import edu.jas.gbufd.SyzygyAbstract;
+import edu.jas.gbufd.SyzygySeq;
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.AlgebraicNumberRing;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.OptimizedPolynomialList;
+import edu.jas.poly.PolyUtil;
+import edu.jas.poly.PolynomialList;
+import edu.jas.poly.TermOrder;
+import edu.jas.poly.TermOrderOptimization;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.NotInvertibleException;
+import edu.jas.structure.RingFactory;
+import edu.jas.ufd.FactorAbstract;
+import edu.jas.ufd.GCDFactory;
+import edu.jas.ufd.GreatestCommonDivisor;
+import edu.jas.ufd.PolyUfdUtil;
+import edu.jas.ufd.Quotient;
+import edu.jas.ufd.QuotientRing;
+import edu.jas.ufd.SquarefreeAbstract;
+import edu.jas.ufd.SquarefreeFactory;
+
+
+/**
+ * Ideal implements some methods for ideal arithmetic, for example intersection,
+ * quotient and zero and positive dimensional ideal decomposition.
+ * @author Heinz Kredel
+ */
+public class Ideal<C extends GcdRingElem<C>> implements Comparable<Ideal<C>>, Serializable {
+
+
+    private static final Logger logger = LogManager.getLogger(Ideal.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * The data structure is a PolynomialList.
+     */
+    protected PolynomialList<C> list;
+
+
+    /**
+     * Indicator if list is a Groebner Base.
+     */
+    protected boolean isGB;
+
+
+    /**
+     * Indicator if test has been performed if this is a Groebner Base.
+     */
+    protected boolean testGB;
+
+
+    /**
+     * Indicator if list has optimized term order.
+     */
+    protected boolean isTopt;
+
+
+    /**
+     * Groebner base engine.
+     */
+    protected final GroebnerBaseAbstract<C> bb;
+
+
+    /**
+     * Reduction engine.
+     */
+    protected final Reduction<C> red;
+
+
+    /**
+     * Squarefree decomposition engine.
+     */
+    protected final SquarefreeAbstract<C> engine;
+
+
+    /**
+     * Constructor.
+     * @param ring polynomial ring
+     */
+    public Ideal(GenPolynomialRing<C> ring) {
+        this(ring, new ArrayList<GenPolynomial<C>>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param ring polynomial ring
+     * @param F list of polynomials
+     */
+    public Ideal(GenPolynomialRing<C> ring, List<GenPolynomial<C>> F) {
+        this(new PolynomialList<C>(ring, F));
+    }
+
+
+    /**
+     * Constructor.
+     * @param ring polynomial ring
+     * @param F list of polynomials
+     * @param gb true if F is known to be a Groebner Base, else false
+     */
+    public Ideal(GenPolynomialRing<C> ring, List<GenPolynomial<C>> F, boolean gb) {
+        this(new PolynomialList<C>(ring, F), gb);
+    }
+
+
+    /**
+     * Constructor.
+     * @param ring polynomial ring
+     * @param F list of polynomials
+     * @param gb true if F is known to be a Groebner Base, else false
+     * @param topt true if term order is optimized, else false
+     */
+    public Ideal(GenPolynomialRing<C> ring, List<GenPolynomial<C>> F, boolean gb, boolean topt) {
+        this(new PolynomialList<C>(ring, F), gb, topt);
+    }
+
+
+    /**
+     * Constructor.
+     * @param list polynomial list
+     */
+    public Ideal(PolynomialList<C> list) {
+        this(list, false);
+    }
+
+
+    /**
+     * Constructor.
+     * @param list polynomial list
+     * @param bb Groebner Base engine
+     * @param red Reduction engine
+     */
+    public Ideal(PolynomialList<C> list, GroebnerBaseAbstract<C> bb, Reduction<C> red) {
+        this(list, false, bb, red);
+    }
+
+
+    /**
+     * Constructor.
+     * @param list polynomial list
+     * @param gb true if list is known to be a Groebner Base, else false
+     */
+    public Ideal(PolynomialList<C> list, boolean gb) {
+        //this(list, gb, new GroebnerBaseSeqIter<C>(new OrderedSyzPairlist<C>()), new ReductionSeq<C>() );
+        //this(list, gb, new GroebnerBaseSeq<C>(new OrderedSyzPairlist<C>()), new ReductionSeq<C>() );
+        this(list, gb, GBFactory.getImplementation(list.ring.coFac));
+    }
+
+
+    /**
+     * Constructor.
+     * @param list polynomial list
+     * @param gb true if list is known to be a Groebner Base, else false
+     * @param topt true if term order is optimized, else false
+     */
+    public Ideal(PolynomialList<C> list, boolean gb, boolean topt) {
+        //this(list, gb, topt, new GroebnerBaseSeqIter<C>(new OrderedSyzPairlist<C>()), new ReductionSeq<C>());
+        this(list, gb, topt, GBFactory.getImplementation(list.ring.coFac));
+    }
+
+
+    /**
+     * Constructor.
+     * @param list polynomial list
+     * @param gb true if list is known to be a Groebner Base, else false
+     * @param bb Groebner Base engine
+     * @param red Reduction engine
+     */
+    public Ideal(PolynomialList<C> list, boolean gb, GroebnerBaseAbstract<C> bb, Reduction<C> red) {
+        this(list, gb, false, bb, red);
+    }
+
+
+    /**
+     * Constructor.
+     * @param list polynomial list
+     * @param gb true if list is known to be a Groebner Base, else false
+     * @param bb Groebner Base engine
+     */
+    public Ideal(PolynomialList<C> list, boolean gb, GroebnerBaseAbstract<C> bb) {
+        this(list, gb, false, bb, bb.red);
+    }
+
+
+    /**
+     * Constructor.
+     * @param list polynomial list
+     * @param gb true if list is known to be a Groebner Base, else false
+     * @param topt true if term order is optimized, else false
+     * @param bb Groebner Base engine
+     */
+    public Ideal(PolynomialList<C> list, boolean gb, boolean topt, GroebnerBaseAbstract<C> bb) {
+        this(list, gb, topt, bb, bb.red);
+    }
+
+
+    /**
+     * Constructor.
+     * @param list polynomial list
+     * @param gb true if list is known to be a Groebner Base, else false
+     * @param topt true if term order is optimized, else false
+     * @param bb Groebner Base engine
+     * @param red Reduction engine
+     */
+    public Ideal(PolynomialList<C> list, boolean gb, boolean topt, GroebnerBaseAbstract<C> bb,
+                    Reduction<C> red) {
+        if (list == null || list.list == null) {
+            throw new IllegalArgumentException("list and list.list may not be null");
+        }
+        this.list = list;
+        this.isGB = gb;
+        this.isTopt = topt;
+        this.testGB = (gb ? true : false); // ??
+        this.bb = bb;
+        this.red = red;
+        this.engine = SquarefreeFactory.<C> getImplementation(list.ring.coFac);
+    }
+
+
+    /**
+     * Clone this.
+     * @return a copy of this.
+     */
+    public Ideal<C> copy() {
+        return new Ideal<C>(list.copy(), isGB, isTopt, bb, red);
+    }
+
+
+    /**
+     * Get the List of GenPolynomials.
+     * @return list.list
+     */
+    public List<GenPolynomial<C>> getList() {
+        return list.list;
+    }
+
+
+    /**
+     * Get the GenPolynomialRing.
+     * @return list.ring
+     */
+    public GenPolynomialRing<C> getRing() {
+        return list.ring;
+    }
+
+
+    /**
+     * Get the zero ideal.
+     * @return ideal(0)
+     */
+    public Ideal<C> getZERO() {
+        List<GenPolynomial<C>> z = new ArrayList<GenPolynomial<C>>(0);
+        PolynomialList<C> pl = new PolynomialList<C>(getRing(), z);
+        return new Ideal<C>(pl, true, isTopt, bb, red);
+    }
+
+
+    /**
+     * Get the one ideal.
+     * @return ideal(1)
+     */
+    public Ideal<C> getONE() {
+        List<GenPolynomial<C>> one = new ArrayList<GenPolynomial<C>>(1);
+        one.add(list.ring.getONE());
+        PolynomialList<C> pl = new PolynomialList<C>(getRing(), one);
+        return new Ideal<C>(pl, true, isTopt, bb, red);
+    }
+
+
+    /**
+     * String representation of the ideal.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return list.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    public String toScript() {
+        // Python case
+        return list.toScript();
+    }
+
+
+    /**
+     * Comparison with any other object. Note: If both ideals are not Groebner
+     * Bases, then false may be returned even the ideals are equal.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (!(b instanceof Ideal)) {
+            logger.warn("equals no Ideal");
+            return false;
+        }
+        Ideal<C> B = null;
+        try {
+            B = (Ideal<C>) b;
+        } catch (ClassCastException ignored) {
+            return false;
+        }
+        //if ( isGB && B.isGB ) {
+        //   return list.equals( B.list ); requires also monic polys
+        //} else { // compute GBs ?
+        return this.contains(B) && B.contains(this);
+        //}
+    }
+
+
+    /**
+     * Ideal list comparison.
+     * @param L other Ideal.
+     * @return compareTo() of polynomial lists.
+     */
+    public int compareTo(Ideal<C> L) {
+        return list.compareTo(L.list);
+    }
+
+
+    /**
+     * Hash code for this ideal.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = list.hashCode();
+        if (isGB) {
+            h = h << 1;
+        }
+        if (testGB) {
+            h += 1;
+        }
+        return h;
+    }
+
+
+    /**
+     * Test if ZERO ideal.
+     * @return true, if this is the 0 ideal, else false
+     */
+    public boolean isZERO() {
+        return list.isZERO();
+    }
+
+
+    /**
+     * Test if ONE is contained in the ideal. To test for a proper ideal use
+     * <code>! id.isONE()</code>.
+     * @return true, if this is the 1 ideal, else false
+     */
+    public boolean isONE() {
+        return list.isONE();
+    }
+
+
+    /**
+     * Optimize the term order.
+     */
+    public void doToptimize() {
+        if (isTopt) {
+            return;
+        }
+        list = TermOrderOptimization.<C> optimizeTermOrder(list);
+        isTopt = true;
+        if (isGB) {
+            isGB = false;
+            doGB();
+        }
+        return;
+    }
+
+
+    /**
+     * Test if this is a Groebner base.
+     * @return true, if this is a Groebner base, else false
+     */
+    public boolean isGB() {
+        if (testGB) {
+            return isGB;
+        }
+        logger.warn("isGB computing");
+        isGB = bb.isGB(getList());
+        testGB = true;
+        return isGB;
+    }
+
+
+    /**
+     * Do Groebner Base. compute the Groebner Base for this ideal.
+     */
+    @SuppressWarnings("unchecked")
+    public void doGB() {
+        if (isGB && testGB) {
+            return;
+        }
+        //logger.warn("GB computing");
+        List<GenPolynomial<C>> G = getList();
+        logger.info("GB computing = " + G);
+        G = bb.GB(G);
+        if (isTopt) {
+            List<Integer> perm = ((OptimizedPolynomialList<C>) list).perm;
+            list = new OptimizedPolynomialList<C>(perm, getRing(), G);
+        } else {
+            list = new PolynomialList<C>(getRing(), G);
+        }
+        isGB = true;
+        testGB = true;
+        return;
+    }
+
+
+    /**
+     * Groebner Base. Get a Groebner Base for this ideal.
+     * @return GB(this)
+     */
+    public Ideal<C> GB() {
+        if (isGB) {
+            return this;
+        }
+        doGB();
+        return this;
+    }
+
+
+    /**
+     * Ideal containment. Test if B is contained in this ideal. Note: this is
+     * eventually modified to become a Groebner Base.
+     * @param B ideal
+     * @return true, if B is contained in this, else false
+     */
+    public boolean contains(Ideal<C> B) {
+        if (B == null || B.isZERO()) {
+            return true;
+        }
+        return contains(B.getList());
+    }
+
+
+    /**
+     * Ideal containment. Test if b is contained in this ideal. Note: this is
+     * eventually modified to become a Groebner Base.
+     * @param b polynomial
+     * @return true, if b is contained in this, else false
+     */
+    public boolean contains(GenPolynomial<C> b) {
+        if (b == null || b.isZERO()) {
+            return true;
+        }
+        if (this.isONE()) {
+            return true;
+        }
+        if (this.isZERO()) {
+            return false;
+        }
+        if (!isGB) {
+            doGB();
+        }
+        GenPolynomial<C> z;
+        z = red.normalform(getList(), b);
+        if (z == null || z.isZERO()) {
+            return true;
+        }
+        return false;
+    }
+
+
+    /**
+     * Ideal containment. Test if each b in B is contained in this ideal. Note:
+     * this is eventually modified to become a Groebner Base.
+     * @param B list of polynomials
+     * @return true, if each b in B is contained in this, else false
+     */
+    public boolean contains(List<GenPolynomial<C>> B) {
+        if (B == null || B.size() == 0) {
+            return true;
+        }
+        if (this.isONE()) {
+            return true;
+        }
+        if (!isGB) {
+            doGB();
+        }
+        for (GenPolynomial<C> b : B) {
+            if (b == null) {
+                continue;
+            }
+            GenPolynomial<C> z = red.normalform(getList(), b);
+            if (!z.isZERO()) {
+                //System.out.println("contains nf(b) != 0: " + b);
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Summation. Generators for the sum of ideals. Note: if both ideals are
+     * Groebner bases, a Groebner base is returned.
+     * @param B ideal
+     * @return ideal(this+B)
+     */
+    public Ideal<C> sum(Ideal<C> B) {
+        if (B == null || B.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return B;
+        }
+        int s = getList().size() + B.getList().size();
+        List<GenPolynomial<C>> c;
+        c = new ArrayList<GenPolynomial<C>>(s);
+        c.addAll(getList());
+        c.addAll(B.getList());
+        Ideal<C> I = new Ideal<C>(getRing(), c, false);
+        if (isGB && B.isGB) {
+            I.doGB();
+        }
+        return I;
+    }
+
+
+    /**
+     * Summation. Generators for the sum of ideal and a polynomial. Note: if
+     * this ideal is a Groebner base, a Groebner base is returned.
+     * @param b polynomial
+     * @return ideal(this+{b})
+     */
+    public Ideal<C> sum(GenPolynomial<C> b) {
+        if (b == null || b.isZERO()) {
+            return this;
+        }
+        int s = getList().size() + 1;
+        List<GenPolynomial<C>> c;
+        c = new ArrayList<GenPolynomial<C>>(s);
+        c.addAll(getList());
+        c.add(b);
+        Ideal<C> I = new Ideal<C>(getRing(), c, false);
+        if (isGB) {
+            I.doGB();
+        }
+        return I;
+    }
+
+
+    /**
+     * Summation. Generators for the sum of this ideal and a list of
+     * polynomials. Note: if this ideal is a Groebner base, a Groebner base is
+     * returned.
+     * @param L list of polynomials
+     * @return ideal(this+L)
+     */
+    public Ideal<C> sum(List<GenPolynomial<C>> L) {
+        if (L == null || L.isEmpty()) {
+            return this;
+        }
+        int s = getList().size() + L.size();
+        List<GenPolynomial<C>> c = new ArrayList<GenPolynomial<C>>(s);
+        c.addAll(getList());
+        c.addAll(L);
+        Ideal<C> I = new Ideal<C>(getRing(), c, false);
+        if (isGB) {
+            I.doGB();
+        }
+        return I;
+    }
+
+
+    /**
+     * Product. Generators for the product of ideals. Note: if both ideals are
+     * Groebner bases, a Groebner base is returned.
+     * @param B ideal
+     * @return ideal(this*B)
+     */
+    public Ideal<C> product(Ideal<C> B) {
+        if (B == null || B.isZERO()) {
+            return B;
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        int s = getList().size() * B.getList().size();
+        List<GenPolynomial<C>> c;
+        c = new ArrayList<GenPolynomial<C>>(s);
+        for (GenPolynomial<C> p : getList()) {
+            for (GenPolynomial<C> q : B.getList()) {
+                q = p.multiply(q);
+                c.add(q);
+            }
+        }
+        Ideal<C> I = new Ideal<C>(getRing(), c, false);
+        if (isGB && B.isGB) {
+            I.doGB();
+        }
+        return I;
+    }
+
+
+    /**
+     * Product. Generators for the product this ideal by a polynomial. Note: if
+     * this ideal is a Groebner base, a Groebner base is returned.
+     * @param b polynomial
+     * @return ideal(this*b)
+     */
+    public Ideal<C> product(GenPolynomial<C> b) {
+        if (b == null || b.isZERO()) {
+            return getZERO();
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        List<GenPolynomial<C>> c;
+        c = new ArrayList<GenPolynomial<C>>(getList().size());
+        for (GenPolynomial<C> p : getList()) {
+            GenPolynomial<C> q = p.multiply(b);
+            c.add(q);
+        }
+        Ideal<C> I = new Ideal<C>(getRing(), c, false);
+        if (isGB) {
+            I.doGB();
+        }
+        return I;
+    }
+
+
+    /**
+     * Intersection. Generators for the intersection of ideals. Using an
+     * iterative algorithm.
+     * @param Bl list of ideals
+     * @return ideal(cap_i B_i), a Groebner base
+     */
+    public Ideal<C> intersect(List<Ideal<C>> Bl) {
+        if (Bl == null || Bl.size() == 0) {
+            return getZERO();
+        }
+        Ideal<C> I = null;
+        for (Ideal<C> B : Bl) {
+            if (I == null) {
+                I = B;
+                continue;
+            }
+            if (I.isONE()) {
+                return I;
+            }
+            I = I.intersect(B);
+        }
+        return I;
+    }
+
+
+    /**
+     * Intersection. Generators for the intersection of ideals.
+     * @param B ideal
+     * @return ideal(this \cap B), a Groebner base
+     */
+    public Ideal<C> intersect(Ideal<C> B) {
+        if (B == null || B.isZERO()) { // (0)
+            return B;
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        List<GenPolynomial<C>> c = PolyGBUtil.<C> intersect(getRing(), getList(), B.getList());
+        Ideal<C> I = new Ideal<C>(getRing(), c, true);
+        return I;
+    }
+
+
+    /**
+     * Intersection. Generators for the intersection of a ideal with a
+     * polynomial ring. The polynomial ring of this ideal must be a contraction
+     * of R and the TermOrder must be an elimination order.
+     * @param R polynomial ring
+     * @return ideal(this \cap R)
+     */
+    public Ideal<C> intersect(GenPolynomialRing<C> R) {
+        if (R == null) {
+            throw new IllegalArgumentException("R may not be null");
+        }
+        List<GenPolynomial<C>> H = PolyUtil.<C> intersect(R, getList());
+        return new Ideal<C>(R, H, isGB, isTopt);
+    }
+
+
+    /**
+     * Eliminate. Generators for the intersection of a ideal with a polynomial
+     * ring. The polynomial rings must have variable names.
+     * @param R polynomial ring
+     * @return ideal(this \cap R)
+     */
+    public Ideal<C> eliminate(GenPolynomialRing<C> R) {
+        if (R == null) {
+            throw new IllegalArgumentException("R may not be null");
+        }
+        if (list.ring.equals(R)) {
+            return this;
+        }
+        String[] ename = R.getVars();
+        Ideal<C> I = eliminate(ename);
+        return I.intersect(R);
+    }
+
+
+    /**
+     * Eliminate. Preparation of generators for the intersection of a ideal with
+     * a polynomial ring.
+     * @param ename variables for the elimination ring.
+     * @return ideal(this) in K[ename,{vars \ ename}])
+     */
+    public Ideal<C> eliminate(String... ename) {
+        //System.out.println("ename = " + Arrays.toString(ename));
+        if (ename == null) {
+            throw new IllegalArgumentException("ename may not be null");
+        }
+        String[] aname = getRing().getVars();
+        //System.out.println("aname = " + Arrays.toString(aname));
+        if (aname == null) {
+            throw new IllegalArgumentException("aname may not be null");
+        }
+
+        GroebnerBasePartial<C> bbp = new GroebnerBasePartial<C>(bb, null);
+        String[] rname = GroebnerBasePartial.remainingVars(aname, ename);
+        //System.out.println("rname = " + Arrays.toString(rname));
+        PolynomialList<C> Pl = null;
+        if (rname.length == 0) {
+            if (Arrays.deepEquals(aname, ename)) {
+                return this;
+            }
+            Pl = bbp.partialGB(getList(), ename); // normal GB
+        } else {
+            Pl = bbp.elimPartialGB(getList(), rname, ename); // reversed!
+        }
+        //System.out.println("Pl = " + Pl);
+        if (debug) {
+            logger.debug("elimination GB = " + Pl);
+        }
+        Ideal<C> I = new Ideal<C>(Pl, true);
+        return I;
+    }
+
+
+    /**
+     * Quotient. Generators for the ideal quotient.
+     * @param h polynomial
+     * @return ideal(this : h), a Groebner base
+     */
+    public Ideal<C> quotient(GenPolynomial<C> h) {
+        if (h == null) { // == (0)
+            return this;
+        }
+        if (h.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        List<GenPolynomial<C>> H;
+        H = new ArrayList<GenPolynomial<C>>(1);
+        H.add(h);
+        Ideal<C> Hi = new Ideal<C>(getRing(), H, true);
+
+        Ideal<C> I = this.intersect(Hi);
+
+        List<GenPolynomial<C>> Q;
+        Q = new ArrayList<GenPolynomial<C>>(I.getList().size());
+        for (GenPolynomial<C> q : I.getList()) {
+            q = q.divide(h); // remainder == 0
+            Q.add(q);
+        }
+        return new Ideal<C>(getRing(), Q, true /*false?*/);
+    }
+
+
+    /**
+     * Quotient. Generators for the ideal quotient.
+     * @param H ideal
+     * @return ideal(this : H), a Groebner base
+     */
+    public Ideal<C> quotient(Ideal<C> H) {
+        if (H == null) { // == (0)
+            return this;
+        }
+        if (H.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        Ideal<C> Q = null;
+        for (GenPolynomial<C> h : H.getList()) {
+            Ideal<C> Hi = this.quotient(h);
+            if (Q == null) {
+                Q = Hi;
+            } else {
+                Q = Q.intersect(Hi);
+            }
+        }
+        return Q;
+    }
+
+
+    /**
+     * Infinite quotient. Generators for the infinite ideal quotient.
+     * @param h polynomial
+     * @return ideal(this : h<sup>s</sup>), a Groebner base
+     */
+    public Ideal<C> infiniteQuotientRab(GenPolynomial<C> h) {
+        if (h == null || h.isZERO()) { // == (0)
+            return getONE();
+        }
+        if (h.isONE()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        Ideal<C> I = this.GB(); // should be already
+        List<GenPolynomial<C>> a = I.getList();
+        List<GenPolynomial<C>> c;
+        c = new ArrayList<GenPolynomial<C>>(a.size() + 1);
+
+        GenPolynomialRing<C> tfac = getRing().extend(1);
+        // term order is also adjusted
+        for (GenPolynomial<C> p : a) {
+            p = p.extend(tfac, 0, 0L); // p
+            c.add(p);
+        }
+        GenPolynomial<C> q = h.extend(tfac, 0, 1L);
+        GenPolynomial<C> r = tfac.getONE(); // h.extend( tfac, 0, 0L );
+        GenPolynomial<C> hs = q.subtract(r); // 1 - t*h // (1-t)*h
+        c.add(hs);
+        logger.warn("infiniteQuotientRab computing GB ");
+        List<GenPolynomial<C>> g = bb.GB(c);
+        if (debug) {
+            logger.info("infiniteQuotientRab    = " + tfac + ", c = " + c);
+            logger.info("infiniteQuotientRab GB = " + g);
+        }
+        Ideal<C> E = new Ideal<C>(tfac, g, true);
+        Ideal<C> Is = E.intersect(getRing());
+        return Is;
+    }
+
+
+    /**
+     * Infinite quotient exponent.
+     * @param h polynomial
+     * @param Q quotient this : h^\infinity
+     * @return s with Q = this : h<sup>s</sup>
+     */
+    public int infiniteQuotientExponent(GenPolynomial<C> h, Ideal<C> Q) {
+        int s = 0;
+        if (h == null) { // == 0
+            return s;
+        }
+        if (h.isZERO() || h.isONE()) {
+            return s;
+        }
+        if (this.isZERO() || this.isONE()) {
+            return s;
+        }
+        //see below: if (this.contains(Q)) {
+        //    return s;
+        //}
+        GenPolynomial<C> p = getRing().getONE();
+        for (GenPolynomial<C> q : Q.getList()) {
+            if (this.contains(q)) {
+                continue;
+            }
+            //System.out.println("q = " + q + ", p = " + p + ", s = " + s);
+            GenPolynomial<C> qp = q.multiply(p);
+            while (!this.contains(qp)) {
+                p = p.multiply(h);
+                s++;
+                qp = q.multiply(p);
+            }
+        }
+        return s;
+    }
+
+
+    /**
+     * Infinite quotient. Generators for the infinite ideal quotient.
+     * @param h polynomial
+     * @return ideal(this : h<sup>s</sup>), a Groebner base
+     */
+    public Ideal<C> infiniteQuotient(GenPolynomial<C> h) {
+        if (h == null) { // == (0)
+            return this;
+        }
+        if (h.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        int s = 0;
+        Ideal<C> I = this.GB(); // should be already
+        GenPolynomial<C> hs = h;
+        Ideal<C> Is = I;
+
+        boolean eq = false;
+        while (!eq) {
+            Is = I.quotient(hs);
+            Is = Is.GB(); // should be already
+            logger.info("infiniteQuotient s = " + s);
+            eq = Is.contains(I); // I.contains(Is) always
+            if (!eq) {
+                I = Is;
+                s++;
+                // hs = hs.multiply( h );
+            }
+        }
+        return Is;
+    }
+
+
+    /**
+     * Radical membership test.
+     * @param h polynomial
+     * @return true if h is contained in the radical of ideal(this), else false.
+     */
+    public boolean isRadicalMember(GenPolynomial<C> h) {
+        if (h == null) { // == (0)
+            return true;
+        }
+        if (h.isZERO()) {
+            return true;
+        }
+        if (this.isZERO()) {
+            return true;
+        }
+        Ideal<C> x = infiniteQuotientRab(h);
+        if (debug) {
+            logger.debug("infiniteQuotientRab = " + x);
+        }
+        return x.isONE();
+    }
+
+
+    /**
+     * Infinite quotient. Generators for the infinite ideal quotient.
+     * @param h polynomial
+     * @return ideal(this : h<sup>s</sup>), a Groebner base
+     */
+    public Ideal<C> infiniteQuotientOld(GenPolynomial<C> h) {
+        if (h == null) { // == (0)
+            return this;
+        }
+        if (h.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        int s = 0;
+        Ideal<C> I = this.GB(); // should be already
+        GenPolynomial<C> hs = h;
+
+        boolean eq = false;
+        while (!eq) {
+            Ideal<C> Is = I.quotient(hs);
+            Is = Is.GB(); // should be already
+            logger.debug("infiniteQuotient s = " + s);
+            eq = Is.contains(I); // I.contains(Is) always
+            if (!eq) {
+                I = Is;
+                s++;
+                hs = hs.multiply(h);
+            }
+        }
+        return I;
+    }
+
+
+    /**
+     * Infinite Quotient. Generators for the ideal infinite quotient.
+     * @param H ideal
+     * @return ideal(this : H<sup>s</sup>), a Groebner base
+     */
+    public Ideal<C> infiniteQuotient(Ideal<C> H) {
+        if (H == null) { // == (0)
+            return this;
+        }
+        if (H.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        Ideal<C> Q = null;
+        for (GenPolynomial<C> h : H.getList()) {
+            Ideal<C> Hi = this.infiniteQuotient(h);
+            if (Q == null) {
+                Q = Hi;
+            } else {
+                Q = Q.intersect(Hi);
+            }
+        }
+        return Q;
+    }
+
+
+    /**
+     * Infinite Quotient. Generators for the ideal infinite quotient.
+     * @param H ideal
+     * @return ideal(this : H<sup>s</sup>), a Groebner base
+     */
+    public Ideal<C> infiniteQuotientRab(Ideal<C> H) {
+        if (H == null) { // == (0)
+            return this;
+        }
+        if (H.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        Ideal<C> Q = null;
+        for (GenPolynomial<C> h : H.getList()) {
+            Ideal<C> Hi = this.infiniteQuotientRab(h);
+            if (Q == null) {
+                Q = Hi;
+            } else {
+                Q = Q.intersect(Hi);
+            }
+        }
+        return Q;
+    }
+
+
+    /**
+     * Power. Generators for the power of this ideal. Note: if this ideal is a
+     * Groebner base, a Groebner base is returned.
+     * @param d integer
+     * @return ideal(this^d)
+     */
+    public Ideal<C> power(int d) {
+        if (d <= 0) {
+            return getONE();
+        }
+        if (this.isZERO() || this.isONE()) {
+            return this;
+        }
+        Ideal<C> c = this;
+        for (int i = 1; i < d; i++) {
+            c = c.product(this);
+        }
+        return c;
+    }
+
+
+    /**
+     * Normalform for element.
+     * @param h polynomial
+     * @return normalform of h with respect to this
+     */
+    public GenPolynomial<C> normalform(GenPolynomial<C> h) {
+        if (h == null) {
+            return h;
+        }
+        if (h.isZERO()) {
+            return h;
+        }
+        if (this.isZERO()) {
+            return h;
+        }
+        GenPolynomial<C> r;
+        r = red.normalform(list.list, h);
+        return r;
+    }
+
+
+    /**
+     * Normalform for list of elements.
+     * @param L polynomial list
+     * @return list of normalforms of the elements of L with respect to this
+     */
+    public List<GenPolynomial<C>> normalform(List<GenPolynomial<C>> L) {
+        if (L == null) {
+            return L;
+        }
+        if (L.size() == 0) {
+            return L;
+        }
+        if (this.isZERO()) {
+            return L;
+        }
+        List<GenPolynomial<C>> M = new ArrayList<GenPolynomial<C>>(L.size());
+        for (GenPolynomial<C> h : L) {
+            GenPolynomial<C> r = normalform(h);
+            if (r != null && !r.isZERO()) {
+                M.add(r);
+            }
+        }
+        return M;
+    }
+
+
+    /**
+     * Annihilator for element modulo this ideal.
+     * @param h polynomial
+     * @return annihilator of h with respect to this
+     */
+    public Ideal<C> annihilator(GenPolynomial<C> h) {
+        if (h == null || h.isZERO()) {
+            return getZERO();
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        doGB();
+        List<GenPolynomial<C>> F = new ArrayList<GenPolynomial<C>>(1 + getList().size());
+        F.add(h);
+        F.addAll(getList());
+        //System.out.println("F = " + F);
+        SyzygyAbstract<C> syz = new SyzygySeq<C>(getRing().coFac);
+        List<List<GenPolynomial<C>>> S = syz.zeroRelationsArbitrary(F);
+        //System.out.println("S = " + S);
+        List<GenPolynomial<C>> gen = new ArrayList<GenPolynomial<C>>(S.size());
+        for (List<GenPolynomial<C>> rel : S) {
+            if (rel == null || rel.isEmpty()) {
+                continue;
+            }
+            GenPolynomial<C> p = rel.get(0);
+            if (p == null || p.isZERO()) {
+                continue;
+            }
+            gen.add(p);
+        }
+        Ideal<C> ann = new Ideal<C>(getRing(), gen);
+        //System.out.println("ann = " + ann);
+        return ann;
+    }
+
+
+    /**
+     * Test for annihilator of element modulo this ideal.
+     * @param h polynomial
+     * @param A ideal
+     * @return true, if A is the annihilator of h with respect to this
+     */
+    public boolean isAnnihilator(GenPolynomial<C> h, Ideal<C> A) {
+        Ideal<C> B = A.product(h);
+        return contains(B);
+    }
+
+
+    /**
+     * Annihilator for ideal modulo this ideal.
+     * @param H ideal
+     * @return annihilator of H with respect to this
+     */
+    public Ideal<C> annihilator(Ideal<C> H) {
+        if (H == null || H.isZERO()) {
+            return getZERO();
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        Ideal<C> ann = null;
+        for (GenPolynomial<C> h : H.getList()) {
+            Ideal<C> Hi = this.annihilator(h);
+            if (ann == null) {
+                ann = Hi;
+            } else {
+                ann = ann.intersect(Hi);
+            }
+        }
+        return ann;
+    }
+
+
+    /**
+     * Test for annihilator of ideal modulo this ideal.
+     * @param H ideal
+     * @param A ideal
+     * @return true, if A is the annihilator of H with respect to this
+     */
+    public boolean isAnnihilator(Ideal<C> H, Ideal<C> A) {
+        Ideal<C> B = A.product(H);
+        return contains(B);
+    }
+
+
+    /**
+     * Inverse for element modulo this ideal.
+     * @param h polynomial
+     * @return inverse of h with respect to this, if defined
+     */
+    public GenPolynomial<C> inverse(GenPolynomial<C> h) {
+        if (h == null || h.isZERO()) {
+            throw new NotInvertibleException("zero not invertible");
+        }
+        if (this.isZERO()) {
+            throw new NotInvertibleException("zero ideal");
+        }
+        if (h.isUnit()) {
+            return h.inverse();
+        }
+        doGB();
+        List<GenPolynomial<C>> F = new ArrayList<GenPolynomial<C>>(1 + list.list.size());
+        F.add(h);
+        F.addAll(list.list);
+        //System.out.println("F = " + F);
+        ExtendedGB<C> x = bb.extGB(F);
+        List<GenPolynomial<C>> G = x.G;
+        //System.out.println("G = " + G);
+        GenPolynomial<C> one = null;
+        int i = -1;
+        for (GenPolynomial<C> p : G) {
+            i++;
+            if (p == null) {
+                continue;
+            }
+            if (p.isUnit()) {
+                one = p;
+                break;
+            }
+        }
+        if (one == null) {
+            throw new NotInvertibleException(" h = " + h);
+        }
+        List<GenPolynomial<C>> row = x.G2F.get(i); // != -1
+        GenPolynomial<C> g = row.get(0);
+        if (g == null || g.isZERO()) {
+            throw new NotInvertibleException(" h = " + h);
+        }
+        // adjust g to get g*h == 1
+        GenPolynomial<C> f = g.multiply(h);
+        GenPolynomial<C> k = red.normalform(list.list, f);
+        if (!k.isONE()) {
+            C lbc = k.leadingBaseCoefficient();
+            lbc = lbc.inverse();
+            g = g.multiply(lbc);
+        }
+        if (debug) {
+            //logger.info("inv G = " + G);
+            //logger.info("inv G2F = " + x.G2F);
+            //logger.info("inv row "+i+" = " + row);
+            //logger.info("inv h = " + h);
+            //logger.info("inv g = " + g);
+            //logger.info("inv f = " + f);
+            f = g.multiply(h);
+            k = red.normalform(list.list, f);
+            logger.debug("inv k = " + k);
+            if (!k.isUnit()) {
+                throw new NotInvertibleException(" k = " + k);
+            }
+        }
+        return g;
+    }
+
+
+    /**
+     * Test if element is a unit modulo this ideal.
+     * @param h polynomial
+     * @return true if h is a unit with respect to this, else false
+     */
+    public boolean isUnit(GenPolynomial<C> h) {
+        if (h == null || h.isZERO()) {
+            return false;
+        }
+        if (this.isZERO()) {
+            return false;
+        }
+        List<GenPolynomial<C>> F = new ArrayList<GenPolynomial<C>>(1 + list.list.size());
+        F.add(h);
+        F.addAll(list.list);
+        List<GenPolynomial<C>> G = bb.GB(F);
+        for (GenPolynomial<C> p : G) {
+            if (p == null) {
+                continue;
+            }
+            if (p.isUnit()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    /**
+     * Radical approximation. Squarefree generators for the ideal.
+     * @return squarefree(this), a Groebner base
+     */
+    public Ideal<C> squarefree() {
+        if (this.isZERO()) {
+            return this;
+        }
+        Ideal<C> R = this;
+        Ideal<C> Rp = null;
+        List<GenPolynomial<C>> li, ri;
+        while (true) {
+            li = R.getList();
+            ri = new ArrayList<GenPolynomial<C>>(li); //.size() );
+            for (GenPolynomial<C> h : li) {
+                GenPolynomial<C> r = engine.squarefreePart(h);
+                ri.add(r);
+            }
+            Rp = new Ideal<C>(R.getRing(), ri, false);
+            Rp.doGB();
+            if (R.equals(Rp)) {
+                break;
+            }
+            R = Rp;
+        }
+        return R;
+    }
+
+
+    /**
+     * Ideal common zero test.
+     * @return -1, 0 or 1 if dimension(this) &eq; -1, 0 or &ge; 1.
+     */
+    public int commonZeroTest() {
+        if (this.isZERO()) {
+            return 1;
+        }
+        if (!isGB) {
+            doGB();
+        }
+        if (this.isONE()) {
+            return -1;
+        }
+        return bb.commonZeroTest(getList());
+    }
+
+
+    /**
+     * Test if this ideal is maximal.
+     * @return true, if this is maximal and not one, else false.
+     */
+    public boolean isMaximal() {
+        if (commonZeroTest() != 0) {
+            return false;
+        }
+        for (Long d : univariateDegrees()) {
+            if (d > 1L) {
+                // todo: test if univariate irreducible and no multiple polynomials
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Univariate head term degrees.
+     * @return a list of the degrees of univariate head terms.
+     */
+    public List<Long> univariateDegrees() {
+        List<Long> ud = new ArrayList<Long>();
+        if (this.isZERO()) {
+            return ud;
+        }
+        if (!isGB) {
+            doGB();
+        }
+        if (this.isONE()) {
+            return ud;
+        }
+        return bb.univariateDegrees(getList());
+    }
+
+
+    /**
+     * Ideal dimension.
+     * @return a dimension container (dim,maxIndep,list(maxIndep),vars).
+     */
+    public Dimension dimension() {
+        int t = commonZeroTest();
+        Set<Integer> S = new HashSet<Integer>();
+        Set<Set<Integer>> M = new HashSet<Set<Integer>>();
+        if (t <= 0) {
+            return new Dimension(t, S, M, this.list.ring.getVars());
+        }
+        int d = 0;
+        Set<Integer> U = new HashSet<Integer>();
+        for (int i = 0; i < this.list.ring.nvar; i++) {
+            U.add(i);
+        }
+        M = dimension(S, U, M);
+        for (Set<Integer> m : M) {
+            int dp = m.size();
+            if (dp > d) {
+                d = dp;
+                S = m;
+            }
+        }
+        return new Dimension(d, S, M, this.list.ring.getVars());
+    }
+
+
+    /**
+     * Ideal dimension.
+     * @param S is a set of independent variables.
+     * @param U is a set of variables of unknown status.
+     * @param M is a list of maximal sets of independent variables.
+     * @return a list of maximal sets of independent variables, eventually
+     *         containing S.
+     */
+    protected Set<Set<Integer>> dimension(Set<Integer> S, Set<Integer> U, Set<Set<Integer>> M) {
+        Set<Set<Integer>> MP = M;
+        Set<Integer> UP = new HashSet<Integer>(U);
+        for (Integer j : U) {
+            UP.remove(j);
+            Set<Integer> SP = new HashSet<Integer>(S);
+            SP.add(j);
+            if (!containsHT(SP, getList())) {
+                MP = dimension(SP, UP, MP);
+            }
+        }
+        boolean contained = false;
+        for (Set<Integer> m : MP) {
+            if (m.containsAll(S)) {
+                contained = true;
+                break;
+            }
+        }
+        if (!contained) {
+            MP.add(S);
+        }
+        return MP;
+    }
+
+
+    /**
+     * Ideal head term containment test.
+     * @param G list of polynomials.
+     * @param H index set.
+     * @return true, if the vaiables of the head terms of each polynomial in G
+     *         are contained in H, else false.
+     */
+    protected boolean containsHT(Set<Integer> H, List<GenPolynomial<C>> G) {
+        Set<Integer> S = null;
+        for (GenPolynomial<C> p : G) {
+            if (p == null) {
+                continue;
+            }
+            ExpVector e = p.leadingExpVector();
+            if (e == null) {
+                continue;
+            }
+            int[] v = e.dependencyOnVariables();
+            if (v == null) {
+                continue;
+            }
+            //System.out.println("v = " + Arrays.toString(v));
+            if (S == null) { // revert indices
+                S = new HashSet<Integer>(H.size());
+                int r = e.length() - 1;
+                for (Integer i : H) {
+                    S.add(r - i);
+                }
+            }
+            if (contains(v, S)) { // v \subset S
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    /**
+     * Set containment. is v \subset H.
+     * @param v index array.
+     * @param H index set.
+     * @return true, if each element of v is contained in H, else false .
+     */
+    protected boolean contains(int[] v, Set<Integer> H) {
+        for (int i = 0; i < v.length; i++) {
+            if (!H.contains(v[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Construct univariate polynomials of minimal degree in all variables in
+     * zero dimensional ideal(G).
+     * @return list of univariate polynomial of minimal degree in each variable
+     *         in ideal(G)
+     */
+    public List<GenPolynomial<C>> constructUnivariate() {
+        List<GenPolynomial<C>> univs = new ArrayList<GenPolynomial<C>>();
+        for (int i = list.ring.nvar - 1; i >= 0; i--) {
+            GenPolynomial<C> u = constructUnivariate(i);
+            univs.add(u);
+        }
+        return univs;
+    }
+
+
+    /**
+     * Construct univariate polynomial of minimal degree in variable i in zero
+     * dimensional ideal(G).
+     * @param i variable index.
+     * @return univariate polynomial of minimal degree in variable i in ideal(G)
+     */
+    public GenPolynomial<C> constructUnivariate(int i) {
+        doGB();
+        return bb.constructUnivariate(i, getList());
+    }
+
+
+    /**
+     * Zero dimensional radical decompostition. See Seidenbergs lemma 92, and
+     * BWK lemma 8.13.
+     * @return intersection of radical ideals G_i with ideal(this) subseteq
+     *         cap_i( ideal(G_i) )
+     */
+    public List<IdealWithUniv<C>> zeroDimRadicalDecomposition() {
+        List<IdealWithUniv<C>> dec = new ArrayList<IdealWithUniv<C>>();
+        if (this.isZERO()) {
+            return dec;
+        }
+        IdealWithUniv<C> iwu = new IdealWithUniv<C>(this, new ArrayList<GenPolynomial<C>>());
+        dec.add(iwu);
+        if (this.isONE()) {
+            return dec;
+        }
+        if (list.ring.coFac.characteristic().signum() > 0 && !list.ring.coFac.isFinite()) {
+            logger.warn("must use prime decomposition for char p and infinite coefficient rings, found "
+                            + list.ring.coFac.toScript());
+            return zeroDimPrimeDecomposition();
+        }
+        for (int i = list.ring.nvar - 1; i >= 0; i--) {
+            List<IdealWithUniv<C>> part = new ArrayList<IdealWithUniv<C>>();
+            for (IdealWithUniv<C> id : dec) {
+                //System.out.println("id = " + id + ", i = " + i);
+                GenPolynomial<C> u = id.ideal.constructUnivariate(i);
+                SortedMap<GenPolynomial<C>, Long> facs = engine.baseSquarefreeFactors(u);
+                if (facs == null || facs.size() == 0
+                                || (facs.size() == 1 && facs.get(facs.firstKey()) == 1L)) {
+                    List<GenPolynomial<C>> iup = new ArrayList<GenPolynomial<C>>();
+                    iup.addAll(id.upolys);
+                    iup.add(u);
+                    IdealWithUniv<C> Ipu = new IdealWithUniv<C>(id.ideal, iup);
+                    part.add(Ipu);
+                    continue; // irreducible
+                }
+                if (logger.isInfoEnabled()) {
+                    logger.info("squarefree facs = " + facs);
+                }
+                GenPolynomialRing<C> mfac = id.ideal.list.ring;
+                int j = mfac.nvar - 1 - i;
+                for (GenPolynomial<C> p : facs.keySet()) {
+                    // make p multivariate
+                    GenPolynomial<C> pm = p.extendUnivariate(mfac, j);
+                    // mfac.parse( p.toString() );
+                    //stem.out.println("pm = " + pm);
+                    Ideal<C> Ip = id.ideal.sum(pm);
+                    List<GenPolynomial<C>> iup = new ArrayList<GenPolynomial<C>>();
+                    iup.addAll(id.upolys);
+                    iup.add(p);
+                    IdealWithUniv<C> Ipu = new IdealWithUniv<C>(Ip, iup);
+                    if (debug) {
+                        logger.info("ideal with squarefree facs = " + Ipu);
+                    }
+                    part.add(Ipu);
+                }
+            }
+            dec = part;
+            //part = new ArrayList<IdealWithUniv<C>>();
+        }
+        return dec;
+    }
+
+
+    /**
+     * Test for Zero dimensional radical. See Seidenbergs lemma 92, and BWK
+     * lemma 8.13.
+     * @return true if this is an zero dimensional radical ideal, else false
+     */
+    public boolean isZeroDimRadical() {
+        if (this.isZERO()) {
+            return false;
+        }
+        if (this.isONE()) {
+            return false; // not 0-dim
+        }
+        if (list.ring.coFac.characteristic().signum() > 0 && !list.ring.coFac.isFinite()) {
+            logger.warn("radical only for char 0 or finite coefficient rings, but found "
+                            + list.ring.coFac.toScript());
+        }
+        for (int i = list.ring.nvar - 1; i >= 0; i--) {
+            GenPolynomial<C> u = constructUnivariate(i);
+            boolean t = engine.isSquarefree(u);
+            if (!t) {
+                System.out.println("not squarefree " + engine.squarefreePart(u) + ", " + u);
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Zero dimensional ideal irreducible decompostition. See algorithm DIRGZD
+     * of BGK 1986 and also PREDEC of the Gr&ouml;bner bases book 1993.
+     * @return intersection H, of ideals G_i with ideal(this) subseteq cap_i(
+     *         ideal(G_i) ) and each ideal G_i has only irreducible minimal
+     *         univariate polynomials and the G_i are pairwise co-prime.
+     */
+    public List<IdealWithUniv<C>> zeroDimDecomposition() {
+        List<IdealWithUniv<C>> dec = new ArrayList<IdealWithUniv<C>>();
+        if (this.isZERO()) {
+            return dec;
+        }
+        IdealWithUniv<C> iwu = new IdealWithUniv<C>(this, new ArrayList<GenPolynomial<C>>());
+        dec.add(iwu);
+        if (this.isONE()) {
+            return dec;
+        }
+        FactorAbstract<C> ufd = FactorFactory.<C> getImplementation(list.ring.coFac);
+        for (int i = list.ring.nvar - 1; i >= 0; i--) {
+            List<IdealWithUniv<C>> part = new ArrayList<IdealWithUniv<C>>();
+            for (IdealWithUniv<C> id : dec) {
+                //System.out.println("id.ideal = " + id.ideal);
+                GenPolynomial<C> u = id.ideal.constructUnivariate(i);
+                SortedMap<GenPolynomial<C>, Long> facs = ufd.baseFactors(u);
+                if (facs.size() == 0 || (facs.size() == 1 && facs.get(facs.firstKey()) == 1L)) {
+                    List<GenPolynomial<C>> iup = new ArrayList<GenPolynomial<C>>();
+                    iup.addAll(id.upolys);
+                    iup.add(u);
+                    IdealWithUniv<C> Ipu = new IdealWithUniv<C>(id.ideal, iup);
+                    part.add(Ipu);
+                    continue; // irreducible
+                }
+                if (debug) {
+                    logger.info("irreducible facs = " + facs);
+                }
+                GenPolynomialRing<C> mfac = id.ideal.list.ring;
+                int j = mfac.nvar - 1 - i;
+                for (GenPolynomial<C> p : facs.keySet()) {
+                    // make p multivariate
+                    GenPolynomial<C> pm = p.extendUnivariate(mfac, j);
+                    // mfac.parse( p.toString() );
+                    //System.out.println("pm = " + pm);
+                    Ideal<C> Ip = id.ideal.sum(pm);
+                    List<GenPolynomial<C>> iup = new ArrayList<GenPolynomial<C>>();
+                    iup.addAll(id.upolys);
+                    iup.add(p);
+                    IdealWithUniv<C> Ipu = new IdealWithUniv<C>(Ip, iup);
+                    part.add(Ipu);
+                }
+            }
+            dec = part;
+            //part = new ArrayList<IdealWithUniv<C>>();
+        }
+        return dec;
+    }
+
+
+    /**
+     * Zero dimensional ideal irreducible decompostition extension. One step
+     * decomposition via a minimal univariate polynomial in the lowest variable,
+     * used after each normalPosition step.
+     * @param upol list of univariate polynomials
+     * @param og list of other generators for the ideal
+     * @return intersection of ideals G_i with ideal(this) subseteq cap_i(
+     *         ideal(G_i) ) and all minimal univariate polynomials of all G_i
+     *         are irreducible
+     */
+    public List<IdealWithUniv<C>> zeroDimDecompositionExtension(List<GenPolynomial<C>> upol,
+                    List<GenPolynomial<C>> og) {
+        if (upol == null || upol.size() + 1 != list.ring.nvar) {
+            throw new IllegalArgumentException("univariate polynomial list not correct " + upol);
+        }
+        List<IdealWithUniv<C>> dec = new ArrayList<IdealWithUniv<C>>();
+        if (this.isZERO()) {
+            return dec;
+        }
+        IdealWithUniv<C> iwu = new IdealWithUniv<C>(this, upol);
+        if (this.isONE()) {
+            dec.add(iwu);
+            return dec;
+        }
+        FactorAbstract<C> ufd = FactorFactory.<C> getImplementation(list.ring.coFac);
+        int i = list.ring.nvar - 1;
+        //IdealWithUniv<C> id = new IdealWithUniv<C>(this,upol);
+        GenPolynomial<C> u = this.constructUnivariate(i);
+        SortedMap<GenPolynomial<C>, Long> facs = ufd.baseFactors(u);
+        if (facs.size() == 1 && facs.get(facs.firstKey()) == 1L) {
+            List<GenPolynomial<C>> iup = new ArrayList<GenPolynomial<C>>();
+            iup.add(u); // new polynomial first
+            iup.addAll(upol);
+            IdealWithUniv<C> Ipu = new IdealWithUniv<C>(this, iup, og);
+            dec.add(Ipu);
+            return dec;
+        }
+        if (true) {
+            logger.info("irreducible facs = " + facs);
+        }
+        GenPolynomialRing<C> mfac = list.ring;
+        int j = mfac.nvar - 1 - i;
+        for (GenPolynomial<C> p : facs.keySet()) {
+            // make p multivariate
+            GenPolynomial<C> pm = p.extendUnivariate(mfac, j);
+            //System.out.println("pm = " + pm);
+            Ideal<C> Ip = this.sum(pm);
+            List<GenPolynomial<C>> iup = new ArrayList<GenPolynomial<C>>();
+            iup.add(p); // new polynomial first
+            iup.addAll(upol);
+            IdealWithUniv<C> Ipu = new IdealWithUniv<C>(Ip, iup, og);
+            dec.add(Ipu);
+        }
+        return dec;
+    }
+
+
+    /**
+     * Test for zero dimensional ideal decompostition.
+     * @param L intersection of ideals G_i with ideal(G) subseteq cap_i(
+     *            ideal(G_i) ) and all minimal univariate polynomials of all G_i
+     *            are irreducible
+     * @return true if L is a zero dimensional irreducible decomposition of
+     *         this, else false
+     */
+    public boolean isZeroDimDecomposition(List<IdealWithUniv<C>> L) {
+        if (L == null || L.size() == 0) {
+            if (this.isZERO()) {
+                return true;
+            }
+            return false;
+        }
+        // add lower variables if L contains ideals from field extensions
+        GenPolynomialRing<C> ofac = list.ring;
+        int r = ofac.nvar;
+        int rp = L.get(0).ideal.list.ring.nvar;
+        int d = rp - r;
+        //System.out.println("d = " + d);
+        Ideal<C> Id = this;
+        if (d > 0) {
+            GenPolynomialRing<C> nfac = ofac.extendLower(d);
+            //System.out.println("nfac = " + nfac);
+            List<GenPolynomial<C>> elist = new ArrayList<GenPolynomial<C>>(list.list.size());
+            for (GenPolynomial<C> p : getList()) {
+                //System.out.println("p = " + p);
+                GenPolynomial<C> q = p.extendLower(nfac, 0, 0L);
+                //System.out.println("q = "  + q);
+                elist.add(q);
+            }
+            Id = new Ideal<C>(nfac, elist, isGB, isTopt);
+        }
+        // test if this is contained in the intersection
+        for (IdealWithUniv<C> I : L) {
+            boolean t = I.ideal.contains(Id);
+            if (!t) {
+                System.out.println("not contained " + this + " in " + I.ideal);
+                return false;
+            }
+        }
+        // test if all univariate polynomials are contained in the respective ideal
+        //List<GenPolynomial<C>> upprod = new ArrayList<GenPolynomial<C>>(rp);
+        for (IdealWithUniv<C> I : L) {
+            GenPolynomialRing<C> mfac = I.ideal.list.ring;
+            int i = 0;
+            for (GenPolynomial<C> p : I.upolys) {
+                GenPolynomial<C> pm = p.extendUnivariate(mfac, i++);
+                //System.out.println("pm = " + pm + ", p = " + p);
+                boolean t = I.ideal.contains(pm);
+                if (!t) {
+                    System.out.println("not contained " + pm + " in " + I.ideal);
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Compute normal position for variables i and j.
+     * @param i first variable index
+     * @param j second variable index
+     * @param og other generators for the ideal
+     * @return this + (z - x_j - t x_i) in the ring C[z, x_1, ..., x_r]
+     */
+    public IdealWithUniv<C> normalPositionFor(int i, int j, List<GenPolynomial<C>> og) {
+        // extend variables by one
+        GenPolynomialRing<C> ofac = list.ring;
+        if (ofac.tord.getEvord() != TermOrder.INVLEX) {
+            throw new IllegalArgumentException("invalid term order for normalPosition " + ofac.tord);
+        }
+        if (ofac.characteristic().signum() == 0) {
+            return normalPositionForChar0(i, j, og);
+        }
+        return normalPositionForCharP(i, j, og);
+    }
+
+
+    /**
+     * Compute normal position for variables i and j, characteristic zero.
+     * @param i first variable index
+     * @param j second variable index
+     * @param og other generators for the ideal
+     * @return this + (z - x_j - t x_i) in the ring C[z, x_1, ..., x_r]
+     */
+    IdealWithUniv<C> normalPositionForChar0(int i, int j, List<GenPolynomial<C>> og) {
+        // extend variables by one
+        GenPolynomialRing<C> ofac = list.ring;
+        GenPolynomialRing<C> nfac = ofac.extendLower(1);
+        List<GenPolynomial<C>> elist = new ArrayList<GenPolynomial<C>>(list.list.size() + 1);
+        for (GenPolynomial<C> p : getList()) {
+            GenPolynomial<C> q = p.extendLower(nfac, 0, 0L);
+            //System.out.println("q = "  + q);
+            elist.add(q);
+        }
+        List<GenPolynomial<C>> ogen = new ArrayList<GenPolynomial<C>>();
+        if (og != null && og.size() > 0) {
+            for (GenPolynomial<C> p : og) {
+                GenPolynomial<C> q = p.extendLower(nfac, 0, 0L);
+                //System.out.println("q = "  + q);
+                ogen.add(q);
+            }
+        }
+        Ideal<C> I = new Ideal<C>(nfac, elist, true);
+        //System.out.println("I = "  + I);
+        int ip = list.ring.nvar - 1 - i;
+        int jp = list.ring.nvar - 1 - j;
+        GenPolynomial<C> xi = nfac.univariate(ip);
+        GenPolynomial<C> xj = nfac.univariate(jp);
+        GenPolynomial<C> z = nfac.univariate(nfac.nvar - 1);
+        // compute GBs until value of t is OK
+        Ideal<C> Ip;
+        GenPolynomial<C> zp;
+        int t = 0;
+        do {
+            t--;
+            // zp = z - ( xj - xi * t )
+            zp = z.subtract(xj.subtract(xi.multiply(nfac.fromInteger(t))));
+            zp = zp.monic();
+            Ip = I.sum(zp);
+            //System.out.println("Ip = " + Ip);
+            if (-t % 5 == 0) {
+                logger.info("normal position, t = " + t);
+            }
+        } while (!Ip.isNormalPositionFor(i + 1, j + 1));
+        if (debug) {
+            logger.info("normal position = " + Ip);
+        }
+        ogen.add(zp);
+        IdealWithUniv<C> Ips = new IdealWithUniv<C>(Ip, null, ogen);
+        return Ips;
+    }
+
+
+    /**
+     * Compute normal position for variables i and j, positive characteristic.
+     * @param i first variable index
+     * @param j second variable index
+     * @param og other generators for the ideal
+     * @return this + (z - x_j - t x_i) in the ring C[z, x_1, ..., x_r]
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    IdealWithUniv<C> normalPositionForCharP(int i, int j, List<GenPolynomial<C>> og) {
+        // extend variables by one
+        GenPolynomialRing<C> ofac = list.ring;
+        GenPolynomialRing<C> nfac = ofac.extendLower(1);
+        List<GenPolynomial<C>> elist = new ArrayList<GenPolynomial<C>>(list.list.size() + 1);
+        for (GenPolynomial<C> p : getList()) {
+            GenPolynomial<C> q = p.extendLower(nfac, 0, 0L);
+            //System.out.println("q = "  + q);
+            elist.add(q);
+        }
+        List<GenPolynomial<C>> ogen = new ArrayList<GenPolynomial<C>>();
+        if (og != null && og.size() > 0) {
+            for (GenPolynomial<C> p : og) {
+                GenPolynomial<C> q = p.extendLower(nfac, 0, 0L);
+                //System.out.println("q = "  + q);
+                ogen.add(q);
+            }
+        }
+        Ideal<C> I = new Ideal<C>(nfac, elist, true);
+        //System.out.println("I = "  + I);
+        int ip = list.ring.nvar - 1 - i;
+        int jp = list.ring.nvar - 1 - j;
+        GenPolynomial<C> xi = nfac.univariate(ip);
+        GenPolynomial<C> xj = nfac.univariate(jp);
+        GenPolynomial<C> z = nfac.univariate(nfac.nvar - 1);
+        // compute GBs until value of t is OK
+        Ideal<C> Ip;
+        GenPolynomial<C> zp;
+        AlgebraicNumberRing<C> afac = null;
+        Iterator<AlgebraicNumber<C>> aiter = null;
+        //String obr = "";
+        //String cbr = "";
+        int t = 0;
+        do {
+            t--;
+            // zp = z - ( xj - xi * t )
+            GenPolynomial<C> tn;
+            if (afac == null) {
+                tn = nfac.fromInteger(t);
+                if (tn.isZERO()) {
+                    RingFactory<C> fac = nfac.coFac;
+                    //int braces = 2;
+                    while (!(fac instanceof AlgebraicNumberRing)) {
+                        if (fac instanceof GenPolynomialRing) {
+                            GenPolynomialRing<C> pfac = (GenPolynomialRing<C>) (Object) fac;
+                            fac = pfac.coFac;
+                        } else if (fac instanceof QuotientRing) {
+                            QuotientRing<C> pfac = (QuotientRing<C>) (Object) fac;
+                            fac = pfac.ring.coFac;
+                        } else {
+                            throw new ArithmeticException(
+                                            "field elements exhausted, need algebraic extension of base ring");
+                        }
+                        //braces++;
+                    }
+                    //for (int ii = 0; ii < braces; ii++) {
+                    //    obr += "{ ";
+                    //    cbr += " }";
+                    //}
+                    afac = (AlgebraicNumberRing<C>) (Object) fac;
+                    logger.info("afac = " + afac.toScript());
+                    aiter = afac.iterator();
+                    AlgebraicNumber<C> an = aiter.next();
+                    for (int kk = 0; kk < afac.characteristic().intValueExact(); kk++) {
+                        an = aiter.next();
+                    }
+                    //System.out.println("an,iter = " + an);
+                    //tn = nfac.parse(obr + an.toString() + cbr);
+                    tn = nfac.parse(an.toString());
+                    //System.out.println("tn = " + tn);
+                    //if (false) {
+                    //    throw new RuntimeException("probe");
+                    //}
+                }
+            } else {
+                if (!aiter.hasNext()) {
+                    throw new ArithmeticException(
+                                    "field elements exhausted, normal position not reachable: !aiter.hasNext(): "
+                                                    + t);
+                }
+                AlgebraicNumber<C> an = aiter.next();
+                //System.out.println("an,iter = " + an);
+                //tn = nfac.parse(obr + an.toString() + cbr);
+                tn = nfac.parse(an.toString());
+                //System.out.println("tn = " + tn);
+            }
+            if (tn.isZERO()) {
+                throw new ArithmeticException(
+                                "field elements exhausted, normal position not reachable: tn == 0: " + t);
+            }
+            zp = z.subtract(xj.subtract(xi.multiply(tn)));
+            zp = zp.monic();
+            Ip = I.sum(zp);
+            //System.out.println("Ip = " + Ip);
+            if (-t % 4 == 0) {
+                logger.info("normal position, t = " + t);
+                logger.info("normal position, GB = " + Ip);
+                if (t < -550) {
+                    throw new ArithmeticException("normal position not reached in " + t + " steps");
+                }
+            }
+        } while (!Ip.isNormalPositionFor(i + 1, j + 1));
+        if (debug) {
+            logger.info("normal position = " + Ip);
+        }
+        ogen.add(zp);
+        IdealWithUniv<C> Ips = new IdealWithUniv<C>(Ip, null, ogen);
+        return Ips;
+    }
+
+
+    /**
+     * Test if this ideal is in normal position for variables i and j.
+     * @param i first variable index
+     * @param j second variable index
+     * @return true if this is in normal position with respect to i and j
+     */
+    public boolean isNormalPositionFor(int i, int j) {
+        // called in extended ring!
+        int ip = list.ring.nvar - 1 - i;
+        int jp = list.ring.nvar - 1 - j;
+        boolean iOK = false;
+        boolean jOK = false;
+        for (GenPolynomial<C> p : getList()) {
+            if (p.isZERO()) {
+                continue;
+            }
+            ExpVector e = p.leadingExpVector();
+            int[] dov = e.dependencyOnVariables();
+            //System.out.println("dov = " + Arrays.toString(dov));
+            if (dov.length == 0) {
+                throw new IllegalArgumentException("ideal dimension is not zero");
+            }
+            if (dov[0] == ip) {
+                if (e.totalDeg() != 1) {
+                    return false;
+                }
+                iOK = true;
+            } else if (dov[0] == jp) {
+                if (e.totalDeg() != 1) {
+                    return false;
+                }
+                jOK = true;
+            }
+            if (iOK && jOK) {
+                return true;
+            }
+        }
+        return iOK && jOK;
+    }
+
+
+    /**
+     * Normal position index, separate for polynomials with more than 2
+     * variables. See also
+     * <a href="http://krum.rz.uni-mannheim.de/mas/src/masring/DIPDEC0.mi.html"
+     * >mas.masring.DIPDEC0#DIGISR</a>
+     * @return (i,j) for non-normal variables
+     */
+    public int[] normalPositionIndex2Vars() {
+        int[] np = null;
+        int i = -1;
+        int j = -1;
+        for (GenPolynomial<C> p : getList()) {
+            if (p.isZERO()) {
+                continue;
+            }
+            ExpVector e = p.leadingExpVector();
+            int[] dov = e.dependencyOnVariables();
+            //System.out.println("dov_head = " + Arrays.toString(dov));
+            if (dov.length == 0) {
+                throw new IllegalArgumentException("ideal dimension is not zero " + p);
+            }
+            // search bi-variate head terms
+            if (dov.length >= 2) {
+                i = dov[0];
+                j = dov[1];
+                break;
+            }
+            int n = dov[0];
+            GenPolynomial<C> q = p.reductum();
+            if (q.isZERO()) {
+                continue;
+            }
+            e = q.degreeVector();
+            dov = e.dependencyOnVariables();
+            //System.out.println("dov_red  = " + Arrays.toString(dov));
+            int k = Arrays.binarySearch(dov, n);
+            int len = 2;
+            if (k >= 0) {
+                len = 3;
+            }
+            // search bi-variate reductas
+            if (dov.length >= len) {
+                switch (k) {
+                case 0:
+                    i = dov[1];
+                    j = dov[2];
+                    break;
+                case 1:
+                    i = dov[0];
+                    j = dov[2];
+                    break;
+                case 2:
+                    i = dov[0];
+                    j = dov[1];
+                    break;
+                default:
+                    i = dov[0];
+                    j = dov[1];
+                    break;
+                }
+                break;
+            }
+        }
+        if (i < 0 || j < 0) {
+            return np;
+        }
+        // adjust index
+        i = list.ring.nvar - 1 - i;
+        j = list.ring.nvar - 1 - j;
+        np = new int[] { j, i }; // reverse
+        logger.info("normalPositionIndex2Vars, np = " + Arrays.toString(np));
+        return np;
+    }
+
+
+    /**
+     * Normal position index, separate multiple univariate polynomials. See also
+     * <a href="http://krum.rz.uni-mannheim.de/mas/src/masring/DIPDEC0.mi.html">
+     * mas.masring.DIPDEC0#DIGISM</a>
+     * @return (i,j) for non-normal variables
+     */
+    public int[] normalPositionIndexUnivars() {
+        int[] np = null; //new int[] { -1, -1 };
+        int i = -1;
+        int j = -1;
+        // search multiple univariate polynomials with degree &gt;= 2
+        for (GenPolynomial<C> p : getList()) {
+            if (p.isZERO()) {
+                continue;
+            }
+            ExpVector e = p.degreeVector();
+            int[] dov = e.dependencyOnVariables();
+            long t = e.totalDeg(); // lt(p) would be enough
+            //System.out.println("dov_univ = " + Arrays.toString(dov) + ", e = " + e);
+            if (dov.length == 0) {
+                throw new IllegalArgumentException("ideal dimension is not zero");
+            }
+            if (dov.length == 1 && t >= 2L) {
+                if (i == -1) {
+                    i = dov[0];
+                } else if (j == -1) {
+                    j = dov[0];
+                    if (i > j) {
+                        int x = i;
+                        i = j;
+                        j = x;
+                    }
+                }
+            }
+            if (i >= 0 && j >= 0) {
+                break;
+            }
+        }
+        if (i < 0 || j < 0) {
+            // search polynomials with univariate head term and degree &gt;= 2
+            for (GenPolynomial<C> p : getList()) {
+                if (p.isZERO()) {
+                    continue;
+                }
+                ExpVector e = p.leadingExpVector();
+                long t = e.totalDeg();
+                if (t >= 2) {
+                    e = p.degreeVector();
+                    int[] dov = e.dependencyOnVariables();
+                    //System.out.println("dov_univ2 = " + Arrays.toString(dov) + " e = " + e);
+                    if (dov.length == 0) {
+                        throw new IllegalArgumentException("ideal dimension is not zero");
+                    }
+                    if (dov.length >= 2) {
+                        i = dov[0];
+                        j = dov[1];
+                    }
+                }
+                if (i >= 0 && j >= 0) {
+                    break;
+                }
+            }
+        }
+        if (i < 0 || j < 0) {
+            return np;
+        }
+        // adjust index
+        i = list.ring.nvar - 1 - i;
+        j = list.ring.nvar - 1 - j;
+        np = new int[] { j, i }; // reverse
+        logger.info("normalPositionIndexUnivars, np = " + Arrays.toString(np));
+        return np;
+    }
+
+
+    /**
+     * Zero dimensional ideal decompostition for real roots. See algorithm
+     * mas.masring.DIPDEC0#DINTSR.
+     * @return intersection of ideals G_i with ideal(this) subseteq cap_i(
+     *         ideal(G_i) ) and each G_i contains at most bi-variate polynomials
+     *         and all univariate minimal polynomials are irreducible
+     */
+    public List<IdealWithUniv<C>> zeroDimRootDecomposition() {
+        List<IdealWithUniv<C>> dec = zeroDimDecomposition();
+        if (this.isZERO()) {
+            return dec;
+        }
+        if (this.isONE()) {
+            return dec;
+        }
+        List<IdealWithUniv<C>> rdec = new ArrayList<IdealWithUniv<C>>();
+        while (dec.size() > 0) {
+            IdealWithUniv<C> id = dec.remove(0);
+            int[] ri = id.ideal.normalPositionIndex2Vars();
+            if (ri == null || ri.length != 2) {
+                rdec.add(id);
+            } else {
+                IdealWithUniv<C> I = id.ideal.normalPositionFor(ri[0], ri[1], id.others);
+                List<IdealWithUniv<C>> rd = I.ideal.zeroDimDecompositionExtension(id.upolys, I.others);
+                //System.out.println("r_rd = " + rd);
+                dec.addAll(rd);
+            }
+        }
+        return rdec;
+    }
+
+
+    /**
+     * Zero dimensional ideal prime decompostition. See algorithm
+     * mas.masring.DIPDEC0#DINTSS.
+     * @return intersection of ideals G_i with ideal(this) subseteq cap_i(
+     *         ideal(G_i) ) and each G_i is a prime ideal
+     */
+    public List<IdealWithUniv<C>> zeroDimPrimeDecomposition() {
+        List<IdealWithUniv<C>> pdec = zeroDimPrimeDecompositionFE();
+        List<IdealWithUniv<C>> dec = new ArrayList<IdealWithUniv<C>>();
+        if (pdec.size() == 1) { // already prime
+            IdealWithUniv<C> Ip = pdec.get(0);
+            int s = Ip.upolys.size() - getRing().nvar; // skip field ext univariate polys
+            List<GenPolynomial<C>> upol = Ip.upolys.subList(s, Ip.upolys.size());
+            Ip = new IdealWithUniv<C>(this, upol);
+            dec.add(Ip);
+            return dec;
+        }
+        for (IdealWithUniv<C> Ip : pdec) {
+            if (Ip.ideal.getRing().nvar == getRing().nvar) { // no field extension
+                dec.add(Ip);
+            } else { // remove field extension
+                // add other generators for performance
+                Ideal<C> Id = Ip.ideal;
+                if (Ip.others != null) {
+                    //System.out.println("adding Ip.others = " + Ip.others);
+                    List<GenPolynomial<C>> pp = new ArrayList<GenPolynomial<C>>();
+                    pp.addAll(Id.getList());
+                    pp.addAll(Ip.others);
+                    Id = new Ideal<C>(Id.getRing(), pp);
+                }
+                Ideal<C> Is = Id.eliminate(getRing());
+                //System.out.println("Is = " + Is);
+                int s = Ip.upolys.size() - getRing().nvar; // skip field ext univariate polys
+                List<GenPolynomial<C>> upol = Ip.upolys.subList(s, Ip.upolys.size());
+                IdealWithUniv<C> Iu = new IdealWithUniv<C>(Is, upol);
+                //,Ip.others); used above and must be ignored here 
+                dec.add(Iu);
+            }
+        }
+        return dec;
+    }
+
+
+    /**
+     * Zero dimensional ideal prime decompostition, with field extension. See
+     * algorithm mas.masring.DIPDEC0#DINTSS.
+     * @return intersection of ideals G_i with ideal(this) subseteq cap_i(
+     *         ideal(G_i) ) and each G_i is a prime ideal with eventually
+     *         containing field extension variables
+     */
+    public List<IdealWithUniv<C>> zeroDimPrimeDecompositionFE() {
+        List<IdealWithUniv<C>> dec = zeroDimRootDecomposition();
+        if (this.isZERO()) {
+            return dec;
+        }
+        if (this.isONE()) {
+            return dec;
+        }
+        List<IdealWithUniv<C>> rdec = new ArrayList<IdealWithUniv<C>>();
+        while (dec.size() > 0) {
+            IdealWithUniv<C> id = dec.remove(0);
+            int[] ri = id.ideal.normalPositionIndexUnivars();
+            if (ri == null || ri.length != 2) {
+                rdec.add(id);
+            } else {
+                IdealWithUniv<C> I = id.ideal.normalPositionFor(ri[0], ri[1], id.others);
+                List<IdealWithUniv<C>> rd = I.ideal.zeroDimDecompositionExtension(id.upolys, I.others);
+                //System.out.println("rd = " + rd);
+                dec.addAll(rd);
+            }
+        }
+        return rdec;
+    }
+
+
+    /**
+     * Zero dimensional ideal associated primary ideal. See algorithm
+     * mas.masring.DIPIDEAL#DIRLPI.
+     * @param P prime ideal associated to this
+     * @return primary ideal of this with respect to the associated pime ideal P
+     */
+    public Ideal<C> primaryIdeal(Ideal<C> P) {
+        Ideal<C> Qs = P;
+        Ideal<C> Q;
+        int e = 0;
+        do {
+            Q = Qs;
+            e++;
+            Qs = Q.product(P);
+        } while (Qs.contains(this));
+        boolean t;
+        Ideal<C> As;
+        do {
+            As = this.sum(Qs);
+            t = As.contains(Q);
+            if (!t) {
+                Q = Qs;
+                e++;
+                Qs = Q.product(P);
+            }
+        } while (!t);
+        logger.info("exponent = " + e);
+        return As;
+    }
+
+
+    /**
+     * Zero dimensional ideal primary decompostition.
+     * @return list of primary components of primary ideals G_i (pairwise
+     *         co-prime) with ideal(this) = cap_i( ideal(G_i) ) together with
+     *         the associated primes
+     */
+    public List<PrimaryComponent<C>> zeroDimPrimaryDecomposition() {
+        List<IdealWithUniv<C>> pdec = zeroDimPrimeDecomposition();
+        if (logger.isInfoEnabled()) {
+            logger.info("prim decomp = " + pdec);
+        }
+        return zeroDimPrimaryDecomposition(pdec);
+    }
+
+
+    /**
+     * Zero dimensional ideal elimination to original ring.
+     * @param pdec list of prime ideals G_i
+     * @return intersection of pairwise co-prime prime ideals G_i in the ring of
+     *         this with ideal(this) = cap_i( ideal(G_i) )
+     */
+    public List<IdealWithUniv<C>> zeroDimElimination(List<IdealWithUniv<C>> pdec) {
+        List<IdealWithUniv<C>> dec = new ArrayList<IdealWithUniv<C>>();
+        if (this.isZERO()) {
+            return dec;
+        }
+        if (this.isONE()) {
+            dec.add(pdec.get(0));
+            return dec;
+        }
+        List<IdealWithUniv<C>> qdec = new ArrayList<IdealWithUniv<C>>();
+        for (IdealWithUniv<C> Ip : pdec) {
+            //System.out.println("Ip = " + Ip);
+            List<GenPolynomial<C>> epol = new ArrayList<GenPolynomial<C>>();
+            epol.addAll(Ip.ideal.getList());
+            GenPolynomialRing<C> mfac = Ip.ideal.list.ring;
+            int j = 0;
+            // add univariate polynomials for performance
+            for (GenPolynomial<C> p : Ip.upolys) {
+                GenPolynomial<C> pm = p.extendUnivariate(mfac, j++);
+                if (j != 1) { // skip double
+                    epol.add(pm);
+                }
+            }
+            // add other generators for performance
+            if (Ip.others != null) {
+                epol.addAll(Ip.others);
+            }
+            Ideal<C> Ipp = new Ideal<C>(mfac, epol);
+            // logger.info("eliminate_1 = " + Ipp);
+            TermOrder to = null;
+            if (mfac.tord.getEvord() != TermOrder.IGRLEX) {
+                List<GenPolynomial<C>> epols = new ArrayList<GenPolynomial<C>>();
+                to = new TermOrder(TermOrder.IGRLEX);
+                GenPolynomialRing<C> smfac = new GenPolynomialRing<C>(mfac.coFac, mfac.nvar, to,
+                                mfac.getVars());
+                for (GenPolynomial<C> p : epol) {
+                    GenPolynomial<C> pm = smfac.copy(p);
+                    epols.add(pm.monic());
+                }
+                //epol = epols; 
+                Ipp = new Ideal<C>(smfac, epols);
+            }
+            epol = red.irreducibleSet(Ipp.getList());
+            Ipp = new Ideal<C>(Ipp.getRing(), epol);
+            if (logger.isInfoEnabled()) {
+                logger.info("eliminate = " + Ipp);
+            }
+            Ideal<C> Is = Ipp.eliminate(list.ring);
+            //System.out.println("Is = " + Is);
+            if (to != null && !Is.list.ring.equals(list.ring)) {
+                List<GenPolynomial<C>> epols = new ArrayList<GenPolynomial<C>>();
+                for (GenPolynomial<C> p : Is.getList()) {
+                    GenPolynomial<C> pm = list.ring.copy(p);
+                    epols.add(pm);
+                }
+                Is = new Ideal<C>(list.ring, epols);
+                //System.out.println("Is = " + Is);
+            }
+            int k = Ip.upolys.size() - list.ring.nvar;
+            List<GenPolynomial<C>> up = new ArrayList<GenPolynomial<C>>();
+            for (int i = 0; i < list.ring.nvar; i++) {
+                up.add(Ip.upolys.get(i + k));
+            }
+            IdealWithUniv<C> Ie = new IdealWithUniv<C>(Is, up);
+            qdec.add(Ie);
+        }
+        return qdec;
+    }
+
+
+    /**
+     * Zero dimensional ideal primary decompostition.
+     * @param pdec list of prime ideals G_i with no field extensions
+     * @return list of primary components of primary ideals G_i (pairwise
+     *         co-prime) with ideal(this) = cap_i( ideal(G_i) ) together with
+     *         the associated primes
+     */
+    public List<PrimaryComponent<C>> zeroDimPrimaryDecomposition(List<IdealWithUniv<C>> pdec) {
+        List<PrimaryComponent<C>> dec = new ArrayList<PrimaryComponent<C>>();
+        if (this.isZERO()) {
+            return dec;
+        }
+        if (this.isONE()) {
+            PrimaryComponent<C> pc = new PrimaryComponent<C>(pdec.get(0).ideal, pdec.get(0));
+            dec.add(pc);
+            return dec;
+        }
+        for (IdealWithUniv<C> Ip : pdec) {
+            Ideal<C> Qs = this.primaryIdeal(Ip.ideal);
+            PrimaryComponent<C> pc = new PrimaryComponent<C>(Qs, Ip);
+            dec.add(pc);
+        }
+        return dec;
+    }
+
+
+    /**
+     * Test for primary ideal decompostition.
+     * @param L list of primary components G_i
+     * @return true if ideal(this) == cap_i( ideal(G_i) )
+     */
+    public boolean isPrimaryDecomposition(List<PrimaryComponent<C>> L) {
+        // test if this is contained in the intersection
+        for (PrimaryComponent<C> I : L) {
+            boolean t = I.primary.contains(this);
+            if (!t) {
+                System.out.println("not contained " + this + " in " + I);
+                return false;
+            }
+        }
+        Ideal<C> isec = null;
+        for (PrimaryComponent<C> I : L) {
+            if (isec == null) {
+                isec = I.primary;
+            } else {
+                isec = isec.intersect(I.primary);
+            }
+        }
+        return this.contains(isec);
+    }
+
+
+    /**
+     * Ideal extension.
+     * @param vars list of variables for a polynomial ring for extension
+     * @return ideal G, with coefficients in QuotientRing(GenPolynomialRing
+     *         <C>(vars))
+     */
+    public IdealWithUniv<Quotient<C>> extension(String... vars) {
+        GenPolynomialRing<C> fac = getRing();
+        GenPolynomialRing<C> efac = new GenPolynomialRing<C>(fac.coFac, vars.length, fac.tord, vars);
+        IdealWithUniv<Quotient<C>> ext = extension(efac);
+        return ext;
+    }
+
+
+    /**
+     * Ideal extension.
+     * @param efac polynomial ring for extension
+     * @return ideal G, with coefficients in QuotientRing(efac)
+     */
+    public IdealWithUniv<Quotient<C>> extension(GenPolynomialRing<C> efac) {
+        QuotientRing<C> qfac = new QuotientRing<C>(efac);
+        IdealWithUniv<Quotient<C>> ext = extension(qfac);
+        return ext;
+    }
+
+
+    /**
+     * Ideal extension.
+     * @param qfac quotient polynomial ring for extension
+     * @return ideal G, with coefficients in qfac
+     */
+    public IdealWithUniv<Quotient<C>> extension(QuotientRing<C> qfac) {
+        GenPolynomialRing<C> fac = getRing();
+        GenPolynomialRing<C> efac = qfac.ring;
+        String[] rvars = GroebnerBasePartial.remainingVars(fac.getVars(), efac.getVars());
+        //System.out.println("rvars = " + Arrays.toString(rvars));
+
+        GroebnerBasePartial<C> bbp = new GroebnerBasePartial<C>();
+        //wrong: OptimizedPolynomialList<C> pgb = bbp.partialGB(getList(),rvars);
+        OptimizedPolynomialList<C> pgb = bbp.elimPartialGB(getList(), rvars, efac.getVars());
+        if (logger.isInfoEnabled()) {
+            logger.info("rvars = " + Arrays.toString(rvars));
+            logger.info("partialGB = " + pgb);
+        }
+
+        GenPolynomialRing<GenPolynomial<C>> rfac = new GenPolynomialRing<GenPolynomial<C>>(efac, rvars.length,
+                        fac.tord, rvars);
+        List<GenPolynomial<C>> plist = pgb.list;
+        List<GenPolynomial<GenPolynomial<C>>> rpgb = PolyUtil.<C> recursive(rfac, plist);
+        //System.out.println("rfac = " + rfac);
+        GenPolynomialRing<Quotient<C>> qpfac = new GenPolynomialRing<Quotient<C>>(qfac, rfac);
+        List<GenPolynomial<Quotient<C>>> qpgb = PolyUfdUtil.<C> quotientFromIntegralCoefficients(qpfac, rpgb);
+        //System.out.println("qpfac = " + qpfac);
+
+        // compute f 
+        GreatestCommonDivisor<C> ufd = GCDFactory.getImplementation(fac.coFac);
+        GenPolynomial<C> f = null; // qfac.ring.getONE();
+        for (GenPolynomial<GenPolynomial<C>> p : rpgb) {
+            if (f == null) {
+                f = p.leadingBaseCoefficient();
+            } else {
+                f = ufd.lcm(f, p.leadingBaseCoefficient());
+            }
+        }
+        //SquarefreeAbstract<C> sqf = SquarefreeFactory.getImplementation(fac.coFac);
+        //not required: f = sqf.squarefreePart(f);
+        GenPolynomial<GenPolynomial<C>> fp = rfac.getONE().multiply(f);
+        GenPolynomial<Quotient<C>> fq = PolyUfdUtil.<C> quotientFromIntegralCoefficients(qpfac, fp);
+        if (logger.isInfoEnabled()) {
+            logger.info("extension f = " + f);
+            logger.info("ext = " + qpgb);
+        }
+        List<GenPolynomial<Quotient<C>>> upols = new ArrayList<GenPolynomial<Quotient<C>>>(0);
+        List<GenPolynomial<Quotient<C>>> opols = new ArrayList<GenPolynomial<Quotient<C>>>(1);
+        opols.add(fq);
+
+        qpgb = PolyUtil.<Quotient<C>> monic(qpgb);
+        Ideal<Quotient<C>> ext = new Ideal<Quotient<C>>(qpfac, qpgb);
+        IdealWithUniv<Quotient<C>> extu = new IdealWithUniv<Quotient<C>>(ext, upols, opols);
+        return extu;
+    }
+
+
+    /**
+     * Ideal contraction and permutation.
+     * @param eideal extension ideal of this.
+     * @return contraction ideal of eideal in this polynomial ring
+     */
+    public IdealWithUniv<C> permContraction(IdealWithUniv<Quotient<C>> eideal) {
+        return Ideal.<C> permutation(getRing(), Ideal.<C> contraction(eideal));
+    }
+
+
+    /**
+     * Ideal contraction.
+     * @param eid extension ideal of this.
+     * @return contraction ideal of eid in distributed polynomial ring
+     */
+    public static <C extends GcdRingElem<C>> IdealWithUniv<C> contraction(IdealWithUniv<Quotient<C>> eid) {
+        Ideal<Quotient<C>> eideal = eid.ideal;
+        List<GenPolynomial<Quotient<C>>> qgb = eideal.getList();
+        QuotientRing<C> qfac = (QuotientRing<C>) eideal.getRing().coFac;
+        GenPolynomialRing<GenPolynomial<C>> rfac = new GenPolynomialRing<GenPolynomial<C>>(qfac.ring,
+                        eideal.getRing());
+        GenPolynomialRing<C> dfac = qfac.ring.extend(eideal.getRing().getVars());
+        TermOrder to = new TermOrder(qfac.ring.tord.getEvord());
+        dfac = new GenPolynomialRing<C>(dfac.coFac, dfac.nvar, to, dfac.getVars());
+        //System.out.println("qfac = " + qfac);
+        //System.out.println("rfac = " + rfac);
+        //System.out.println("dfac = " + dfac);
+        // convert polynomials
+        List<GenPolynomial<GenPolynomial<C>>> cgb = PolyUfdUtil.<C> integralFromQuotientCoefficients(rfac,
+                        qgb);
+        List<GenPolynomial<C>> dgb = PolyUtil.<C> distribute(dfac, cgb);
+        Ideal<C> cont = new Ideal<C>(dfac, dgb);
+        // convert other polynomials
+        List<GenPolynomial<C>> opols = new ArrayList<GenPolynomial<C>>();
+        if (eid.others != null && eid.others.size() > 0) {
+            List<GenPolynomial<GenPolynomial<C>>> orpol = PolyUfdUtil
+                            .<C> integralFromQuotientCoefficients(rfac, eid.others);
+            List<GenPolynomial<C>> opol = PolyUtil.<C> distribute(dfac, orpol);
+            opols.addAll(opol);
+        }
+        // convert univariate polynomials
+        List<GenPolynomial<C>> upols = new ArrayList<GenPolynomial<C>>(0);
+        int i = 0;
+        for (GenPolynomial<Quotient<C>> p : eid.upolys) {
+            GenPolynomial<Quotient<C>> pm = p.extendUnivariate(eideal.getRing(), i++);
+            //System.out.println("pm = " + pm + ", p = " + p);
+            GenPolynomial<GenPolynomial<C>> urpol = PolyUfdUtil.<C> integralFromQuotientCoefficients(rfac,
+                            pm);
+            GenPolynomial<C> upol = PolyUtil.<C> distribute(dfac, urpol);
+            upols.add(upol);
+            //System.out.println("upol = " + upol);
+        }
+        // compute f 
+        GreatestCommonDivisor<C> ufd = GCDFactory.getImplementation(qfac.ring.coFac);
+        GenPolynomial<C> f = null; // qfac.ring.getONE();
+        for (GenPolynomial<GenPolynomial<C>> p : cgb) {
+            if (f == null) {
+                f = p.leadingBaseCoefficient();
+            } else {
+                f = ufd.lcm(f, p.leadingBaseCoefficient());
+            }
+        }
+        GenPolynomial<GenPolynomial<C>> fp = rfac.getONE().multiply(f);
+        f = PolyUtil.<C> distribute(dfac, fp);
+        if (logger.isInfoEnabled()) {
+            logger.info("contraction f = " + f);
+            logger.info("cont = " + cont);
+        }
+        opols.add(f);
+        if (f.isONE()) {
+            IdealWithUniv<C> cf = new IdealWithUniv<C>(cont, upols, opols);
+            return cf;
+        }
+        // compute ideal quotient by f
+        Ideal<C> Q = cont.infiniteQuotientRab(f);
+        IdealWithUniv<C> Qu = new IdealWithUniv<C>(Q, upols, opols);
+        return Qu;
+    }
+
+
+    /**
+     * Ideal permutation.
+     * @param oring polynomial ring to which variables are back permuted.
+     * @param Cont ideal to be permuted
+     * @return permutation of cont in polynomial ring oring
+     */
+    public static <C extends GcdRingElem<C>> IdealWithUniv<C> permutation(GenPolynomialRing<C> oring,
+                    IdealWithUniv<C> Cont) {
+        Ideal<C> cont = Cont.ideal;
+        GenPolynomialRing<C> dfac = cont.getRing();
+        // (back) permutation of variables
+        String[] ovars = oring.getVars();
+        String[] dvars = dfac.getVars();
+        //System.out.println("ovars = " + Arrays.toString(ovars));
+        //System.out.println("dvars = " + Arrays.toString(dvars));
+        if (Arrays.deepEquals(ovars, dvars)) { // nothing to do
+            return Cont;
+        }
+        List<Integer> perm = GroebnerBasePartial.getPermutation(dvars, ovars);
+        //System.out.println("perm  = " + perm);
+        GenPolynomialRing<C> pfac = cont.getRing().permutation(perm);
+        if (logger.isInfoEnabled()) {
+            logger.info("pfac = " + pfac);
+        }
+        List<GenPolynomial<C>> ppolys = TermOrderOptimization.<C> permutation(perm, pfac, cont.getList());
+        //System.out.println("ppolys = " + ppolys);
+        cont = new Ideal<C>(pfac, ppolys);
+        if (logger.isDebugEnabled()) {
+            logger.info("perm cont = " + cont);
+        }
+        List<GenPolynomial<C>> opolys = TermOrderOptimization.<C> permutation(perm, pfac, Cont.others);
+        //System.out.println("opolys = " + opolys);
+        List<GenPolynomial<C>> upolys = TermOrderOptimization.<C> permutation(perm, pfac, Cont.upolys);
+        //System.out.println("opolys = " + opolys);
+        IdealWithUniv<C> Cu = new IdealWithUniv<C>(cont, upolys, opolys);
+        return Cu;
+    }
+
+
+    /**
+     * Ideal radical.
+     * @return the radical ideal of this
+     */
+    public Ideal<C> radical() {
+        List<IdealWithUniv<C>> rdec = radicalDecomposition();
+        List<Ideal<C>> dec = new ArrayList<Ideal<C>>(rdec.size());
+        for (IdealWithUniv<C> ru : rdec) {
+            dec.add(ru.ideal);
+        }
+        Ideal<C> R = intersect(dec);
+        return R;
+    }
+
+
+    /**
+     * Ideal radical decompostition.
+     * @return intersection of ideals G_i with radical(this) eq cap_i(
+     *         ideal(G_i) ) and each G_i is a radical ideal and the G_i are
+     *         pairwise co-prime
+     */
+    public List<IdealWithUniv<C>> radicalDecomposition() {
+        // check dimension
+        int z = commonZeroTest();
+        List<IdealWithUniv<C>> dec = new ArrayList<IdealWithUniv<C>>();
+        List<GenPolynomial<C>> ups = new ArrayList<GenPolynomial<C>>();
+        // dimension -1
+        if (z < 0) {
+            IdealWithUniv<C> id = new IdealWithUniv<C>(this, ups);
+            dec.add(id); // see GB book
+            return dec;
+        }
+        // dimension 0
+        if (z == 0) {
+            dec = zeroDimRadicalDecomposition();
+            return dec;
+        }
+        // dimension > 0
+        if (this.isZERO()) {
+            return dec;
+        }
+        if (list.ring.coFac.characteristic().signum() > 0 && !list.ring.coFac.isFinite()) {
+            // must not be the case at this point
+            logger.warn("must use prime decomposition for char p and infinite coefficient rings, found "
+                            + list.ring.coFac.toScript());
+            return primeDecomposition();
+        }
+        Dimension dim = dimension();
+        if (logger.isInfoEnabled()) {
+            logger.info("dimension = " + dim);
+        }
+
+        // a short maximal independent set with small variables
+        Set<Set<Integer>> M = dim.M;
+        Set<Integer> min = null;
+        for (Set<Integer> m : M) {
+            if (min == null) {
+                min = m;
+                continue;
+            }
+            if (m.size() < min.size()) {
+                min = m;
+            }
+        }
+        int ms = min.size();
+        Integer[] ia = new Integer[0];
+        int mx = min.toArray(ia)[ms - 1];
+        for (Set<Integer> m : M) {
+            if (m.size() == ms) {
+                int mxx = m.toArray(ia)[ms - 1];
+                if (mxx < mx) {
+                    min = m;
+                    mx = mxx;
+                }
+            }
+        }
+        //System.out.println("min = " + min);
+        String[] mvars = new String[min.size()];
+        int j = 0;
+        for (Integer i : min) {
+            mvars[j++] = dim.v[i];
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("extension for variables = " + Arrays.toString(mvars) + ", indexes = " + min);
+        }
+        // reduce to dimension zero
+        IdealWithUniv<Quotient<C>> Ext = extension(mvars);
+        if (logger.isInfoEnabled()) {
+            logger.info("extension = " + Ext);
+        }
+
+        List<IdealWithUniv<Quotient<C>>> edec = Ext.ideal.zeroDimRadicalDecomposition();
+        if (logger.isInfoEnabled()) {
+            logger.info("0-dim radical decomp = " + edec);
+        }
+        // remove field extensions are not required
+        // reconstruct dimension
+        for (IdealWithUniv<Quotient<C>> ep : edec) {
+            IdealWithUniv<C> cont = permContraction(ep);
+            //System.out.println("cont = " + cont);
+            dec.add(cont);
+        }
+        IdealWithUniv<C> extcont = permContraction(Ext);
+        //System.out.println("extcont = " + extcont);
+
+        // get f
+        List<GenPolynomial<C>> ql = extcont.others;
+        if (ql.size() == 0) { // should not happen
+            return dec;
+        }
+        GenPolynomial<C> fx = ql.get(0);
+        //System.out.println("cont(Ext) fx = " + fx + ", " + fx.ring);
+        if (fx.isONE()) {
+            return dec;
+        }
+        Ideal<C> T = sum(fx);
+        //System.out.println("T.rec = " + T.getList());
+        if (T.isONE()) {
+            logger.info("1 in ideal for " + fx);
+            return dec;
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("radical decomp ext-cont fx = " + fx);
+            logger.info("recursion radical decomp T = " + T);
+        }
+        // recursion:
+        List<IdealWithUniv<C>> Tdec = T.radicalDecomposition();
+        if (logger.isInfoEnabled()) {
+            logger.info("recursion radical decomp = " + Tdec);
+        }
+        dec.addAll(Tdec);
+        return dec;
+    }
+
+
+    /**
+     * Ideal irreducible decompostition.
+     * @return intersection of ideals G_i with ideal(this) subseteq cap_i(
+     *         ideal(G_i) ) and each G_i is an ideal with irreducible univariate
+     *         polynomials (after extension to a zero dimensional ideal) and the
+     *         G_i are pairwise co-prime
+     */
+    public List<IdealWithUniv<C>> decomposition() {
+        // check dimension
+        int z = commonZeroTest();
+        List<IdealWithUniv<C>> dec = new ArrayList<IdealWithUniv<C>>();
+        // dimension -1
+        if (z < 0) {
+            //List<GenPolynomial<C>> ups = new ArrayList<GenPolynomial<C>>();
+            //IdealWithUniv<C> id = new IdealWithUniv<C>(this, ups);
+            //dec.add(id); see GB book
+            return dec;
+        }
+        // dimension 0
+        if (z == 0) {
+            dec = zeroDimDecomposition();
+            return dec;
+        }
+        // dimension > 0
+        if (this.isZERO()) {
+            return dec;
+        }
+        Dimension dim = dimension();
+        if (logger.isInfoEnabled()) {
+            logger.info("dimension = " + dim);
+        }
+
+        // shortest maximal independent set
+        Set<Set<Integer>> M = dim.M;
+        Set<Integer> min = null;
+        for (Set<Integer> m : M) {
+            if (min == null) {
+                min = m;
+                continue;
+            }
+            if (m.size() < min.size()) {
+                min = m;
+            }
+        }
+        //System.out.println("min = " + min);
+        String[] mvars = new String[min.size()];
+        int j = 0;
+        for (Integer i : min) {
+            mvars[j++] = dim.v[i];
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("extension for variables = " + Arrays.toString(mvars));
+        }
+        // reduce to dimension zero
+        IdealWithUniv<Quotient<C>> Ext = extension(mvars);
+        if (logger.isInfoEnabled()) {
+            logger.info("extension = " + Ext);
+        }
+
+        List<IdealWithUniv<Quotient<C>>> edec = Ext.ideal.zeroDimDecomposition();
+        if (logger.isInfoEnabled()) {
+            logger.info("0-dim irred decomp = " + edec);
+        }
+        // remove field extensions are not required
+        // reconstruct dimension
+        for (IdealWithUniv<Quotient<C>> ep : edec) {
+            IdealWithUniv<C> cont = permContraction(ep);
+            //System.out.println("cont = " + cont);
+            dec.add(cont);
+        }
+        IdealWithUniv<C> extcont = permContraction(Ext);
+        //System.out.println("extcont = " + extcont);
+
+        // get f
+        List<GenPolynomial<C>> ql = extcont.others;
+        if (ql.size() == 0) { // should not happen
+            return dec;
+        }
+        GenPolynomial<C> fx = ql.get(0);
+        //System.out.println("cont(Ext) fx = " + fx + ", " + fx.ring);
+        if (fx.isONE()) {
+            return dec;
+        }
+        Ideal<C> T = sum(fx);
+        //System.out.println("T.rec = " + T.getList());
+        if (T.isONE()) {
+            logger.info("1 in ideal for " + fx);
+            return dec;
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("irred decomp ext-cont fx = " + fx);
+            logger.info("recursion irred decomp T = " + T);
+        }
+        // recursion:
+        List<IdealWithUniv<C>> Tdec = T.decomposition();
+        if (logger.isInfoEnabled()) {
+            logger.info("recursion irred decomposition = " + Tdec);
+        }
+        dec.addAll(Tdec);
+        return dec;
+    }
+
+
+    /**
+     * Ideal prime decompostition.
+     * @return intersection of ideals G_i with ideal(this) subseteq cap_i(
+     *         ideal(G_i) ) and each G_i is a prime ideal and the G_i are
+     *         pairwise co-prime
+     */
+    public List<IdealWithUniv<C>> primeDecomposition() {
+        // check dimension
+        int z = commonZeroTest();
+        List<IdealWithUniv<C>> dec = new ArrayList<IdealWithUniv<C>>();
+        // dimension -1
+        if (z < 0) {
+            //List<GenPolynomial<C>> ups = new ArrayList<GenPolynomial<C>>();
+            //IdealWithUniv<C> id = new IdealWithUniv<C>(this, ups);
+            //dec.add(id); see GB book
+            return dec;
+        }
+        // dimension 0
+        if (z == 0) {
+            dec = zeroDimPrimeDecomposition();
+            return dec;
+        }
+        // dimension > 0
+        if (this.isZERO()) {
+            return dec;
+        }
+        Dimension dim = dimension();
+        if (logger.isInfoEnabled()) {
+            logger.info("dimension = " + dim);
+        }
+
+        // shortest maximal independent set
+        Set<Set<Integer>> M = dim.M;
+        Set<Integer> min = null;
+        for (Set<Integer> m : M) {
+            if (min == null) {
+                min = m;
+                continue;
+            }
+            if (m.size() < min.size()) {
+                min = m;
+            }
+        }
+        //System.out.println("min = " + min);
+        String[] mvars = new String[min.size()];
+        int j = 0;
+        for (Integer i : min) {
+            mvars[j++] = dim.v[i];
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("extension for variables = " + Arrays.toString(mvars));
+        }
+        // reduce to dimension zero
+        IdealWithUniv<Quotient<C>> Ext = extension(mvars);
+        if (logger.isInfoEnabled()) {
+            logger.info("extension = " + Ext);
+        }
+        List<IdealWithUniv<Quotient<C>>> edec = Ext.ideal.zeroDimPrimeDecomposition();
+        if (logger.isInfoEnabled()) {
+            logger.info("0-dim prime decomp = " + edec);
+        }
+        // remove field extensions, already done
+        // reconstruct dimension
+        for (IdealWithUniv<Quotient<C>> ep : edec) {
+            IdealWithUniv<C> cont = permContraction(ep);
+            //System.out.println("cont = " + cont);
+            dec.add(cont);
+        }
+        // get f
+        IdealWithUniv<C> extcont = permContraction(Ext);
+        //System.out.println("extcont = " + extcont);
+        List<GenPolynomial<C>> ql = extcont.others;
+        if (ql.size() == 0) { // should not happen
+            return dec;
+        }
+        GenPolynomial<C> fx = ql.get(0);
+        //System.out.println("cont(Ext) fx = " + fx + ", " + fx.ring);
+        if (fx.isONE()) {
+            return dec;
+        }
+        // compute exponent not required
+        Ideal<C> T = sum(fx);
+        //System.out.println("T.rec = " + T.getList());
+        if (T.isONE()) {
+            logger.info("1 in ideal for " + fx);
+            return dec;
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("prime decomp ext-cont fx = " + fx);
+            logger.info("recursion prime decomp T = " + T);
+        }
+        // recursion:
+        List<IdealWithUniv<C>> Tdec = T.primeDecomposition();
+        if (logger.isInfoEnabled()) {
+            logger.info("recursion prime decomp = " + Tdec);
+        }
+        dec.addAll(Tdec);
+        return dec;
+    }
+
+
+    /**
+     * Test for ideal decompostition.
+     * @param L intersection of ideals G_i with ideal(G) eq cap_i(ideal(G_i) )
+     * @return true if L is a decomposition of this, else false
+     */
+    public boolean isDecomposition(List<IdealWithUniv<C>> L) {
+        if (L == null || L.size() == 0) {
+            if (this.isZERO()) {
+                return true;
+            }
+            return false;
+        }
+        GenPolynomialRing<C> ofac = list.ring;
+        int r = ofac.nvar;
+        int rp = L.get(0).ideal.list.ring.nvar;
+        int d = rp - r;
+        //System.out.println("d = " + d);
+        Ideal<C> Id = this;
+        if (d > 0) { // add lower variables
+            GenPolynomialRing<C> nfac = ofac.extendLower(d);
+            //System.out.println("nfac = " + nfac);
+            List<GenPolynomial<C>> elist = new ArrayList<GenPolynomial<C>>(list.list.size());
+            for (GenPolynomial<C> p : getList()) {
+                //System.out.println("p = " + p);
+                GenPolynomial<C> q = p.extendLower(nfac, 0, 0L);
+                //System.out.println("q = "  + q);
+                elist.add(q);
+            }
+            Id = new Ideal<C>(nfac, elist, isGB, isTopt);
+        }
+
+        // test if this is contained in the intersection
+        for (IdealWithUniv<C> I : L) {
+            boolean t = I.ideal.contains(Id);
+            if (!t) {
+                System.out.println("not contained " + this + " in " + I.ideal);
+                return false;
+            }
+        }
+        //         // test if all univariate polynomials are contained in the respective ideal
+        //         for (IdealWithUniv<C> I : L) {
+        //             GenPolynomialRing<C> mfac = I.ideal.list.ring;
+        //             int i = 0;
+        //             for (GenPolynomial<C> p : I.upolys) {
+        //                 GenPolynomial<C> pm = p.extendUnivariate(mfac, i++);
+        //                 //System.out.println("pm = " + pm + ", p = " + p);
+        //                 boolean t = I.ideal.contains(pm);
+        //                 if (!t) {
+        //                     System.out.println("not contained " + pm + " in " + I.ideal);
+        //                     return false;
+        //                 }
+        //             }
+        //         }
+        return true;
+    }
+
+
+    /**
+     * Ideal primary decompostition.
+     * @return list of primary components of primary ideals G_i (pairwise
+     *         co-prime) with ideal(this) = cap_i( ideal(G_i) ) together with
+     *         the associated primes
+     */
+    public List<PrimaryComponent<C>> primaryDecomposition() {
+        // check dimension
+        int z = commonZeroTest();
+        List<PrimaryComponent<C>> dec = new ArrayList<PrimaryComponent<C>>();
+        // dimension -1
+        if (z < 0) {
+            //List<GenPolynomial<C>> ups = new ArrayList<GenPolynomial<C>>();
+            //IdealWithUniv<C> id = new IdealWithUniv<C>(this, ups);
+            //PrimaryComponent<C> pc = new PrimaryComponent<C>(this, id);
+            //dec.add(pc); see GB book
+            return dec;
+        }
+        // dimension 0
+        if (z == 0) {
+            dec = zeroDimPrimaryDecomposition();
+            return dec;
+        }
+        // dimension > 0
+        if (this.isZERO()) {
+            return dec;
+        }
+        Dimension dim = dimension();
+        if (logger.isInfoEnabled()) {
+            logger.info("dimension = " + dim);
+        }
+
+        // shortest maximal independent set
+        Set<Set<Integer>> M = dim.M;
+        Set<Integer> min = null;
+        for (Set<Integer> m : M) {
+            if (min == null) {
+                min = m;
+                continue;
+            }
+            if (m.size() < min.size()) {
+                min = m;
+            }
+        }
+        //System.out.println("min = " + min);
+        String[] mvars = new String[min.size()];
+        int j = 0;
+        for (Integer i : min) {
+            mvars[j++] = dim.v[i];
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("extension for variables = " + Arrays.toString(mvars));
+        }
+        // reduce to dimension zero
+        IdealWithUniv<Quotient<C>> Ext = extension(mvars);
+        if (logger.isInfoEnabled()) {
+            logger.info("extension = " + Ext);
+        }
+
+        List<PrimaryComponent<Quotient<C>>> edec = Ext.ideal.zeroDimPrimaryDecomposition();
+        if (logger.isInfoEnabled()) {
+            logger.info("0-dim primary decomp = " + edec);
+        }
+        // remove field extensions, already done
+        // reconstruct dimension
+        List<GenPolynomial<Quotient<C>>> upq = new ArrayList<GenPolynomial<Quotient<C>>>();
+        for (PrimaryComponent<Quotient<C>> ep : edec) {
+            IdealWithUniv<Quotient<C>> epu = new IdealWithUniv<Quotient<C>>(ep.primary, upq);
+            IdealWithUniv<C> contq = permContraction(epu);
+            IdealWithUniv<C> contp = permContraction(ep.prime);
+            PrimaryComponent<C> pc = new PrimaryComponent<C>(contq.ideal, contp);
+            //System.out.println("pc = " + pc);
+            dec.add(pc);
+        }
+
+        // get f
+        IdealWithUniv<C> extcont = permContraction(Ext);
+        if (debug) {
+            logger.info("cont(Ext) = " + extcont);
+        }
+        List<GenPolynomial<C>> ql = extcont.others;
+        if (ql.size() == 0) { // should not happen
+            return dec;
+        }
+        GenPolynomial<C> fx = ql.get(0);
+        //System.out.println("cont(Ext) fx = " + fx + ", " + fx.ring);
+        if (fx.isONE()) {
+            return dec;
+        }
+        // compute exponent
+        int s = this.infiniteQuotientExponent(fx, extcont.ideal);
+        if (s == 0) {
+            logger.info("exponent is 0 ");
+            return dec;
+        }
+        if (s > 1) {
+            fx = fx.power(s);
+        }
+        if (debug) {
+            logger.info("exponent fx = " + s + ", fx^s = " + fx);
+        }
+
+        Ideal<C> T = sum(fx);
+        //System.out.println("T.rec = " + T.getList());
+        if (T.isONE()) {
+            logger.info("1 in ideal for " + fx);
+            return dec;
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("primmary decomp ext-cont fx = " + fx);
+            logger.info("recursion primary decomp T = " + T);
+        }
+        // recursion:
+        List<PrimaryComponent<C>> Tdec = T.primaryDecomposition();
+        if (logger.isInfoEnabled()) {
+            logger.info("recursion primary decomp = " + Tdec);
+        }
+        dec.addAll(Tdec);
+        return dec;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/IdealWithComplexAlgebraicRoots.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/IdealWithComplexAlgebraicRoots.java
@@ -1,0 +1,243 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.jas.arith.BigDecimal;
+import edu.jas.arith.Rational;
+import edu.jas.poly.Complex;
+import edu.jas.poly.ComplexRing;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+// import edu.jas.root.RealAlgebraicNumber;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Container for Ideals together with univariate polynomials and complex
+ * algebraic roots.
+ * @author Heinz Kredel
+ */
+public class IdealWithComplexAlgebraicRoots<D extends GcdRingElem<D> & Rational> extends IdealWithUniv<D> {
+
+
+    /**
+     * The list of complex algebraic roots.
+     */
+    public final List<List<Complex<RealAlgebraicNumber<D>>>> can;
+
+
+    /**
+     * The list of decimal approximations of the complex algebraic roots.
+     */
+    protected List<List<Complex<BigDecimal>>> droots = null;
+
+
+    /**
+     * Constructor not for use.
+     */
+    protected IdealWithComplexAlgebraicRoots() {
+        throw new IllegalArgumentException("do not use this constructor");
+    }
+
+
+    /**
+     * Constructor.
+     * @param id the ideal
+     * @param up the list of univariate polynomials
+     * @param cr the list of complex algebraic roots
+     */
+    public IdealWithComplexAlgebraicRoots(Ideal<D> id, List<GenPolynomial<D>> up,
+                    List<List<Complex<RealAlgebraicNumber<D>>>> cr) {
+        super(id, up);
+        can = cr;
+    }
+
+
+    /**
+     * Constructor.
+     * @param iu the ideal with univariate polynomials
+     * @param cr the list of real algebraic roots
+     */
+    public IdealWithComplexAlgebraicRoots(IdealWithUniv<D> iu,
+                    List<List<Complex<RealAlgebraicNumber<D>>>> cr) {
+        super(iu.ideal, iu.upolys);
+        can = cr;
+    }
+
+
+    /**
+     * String representation of the ideal.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer(super.toString() + "\ncomplex roots:\n");
+        sb.append("[");
+        boolean f1 = true;
+        for (List<Complex<RealAlgebraicNumber<D>>> lr : can) {
+            if (!f1) {
+                sb.append(", ");
+            } else {
+                f1 = false;
+            }
+            sb.append("[");
+            boolean f2 = true;
+            for (Complex<RealAlgebraicNumber<D>> rr : lr) {
+                if (!f2) {
+                    sb.append(", ");
+                } else {
+                    f2 = false;
+                }
+                sb.append(rr.ring.toScript());
+            }
+            sb.append("]");
+        }
+        sb.append("]");
+        if (droots != null) {
+            sb.append("\ndecimal complex root approximation:\n");
+            for (List<Complex<BigDecimal>> d : droots) {
+                sb.append(d.toString());
+                sb.append("\n");
+            }
+        }
+        return sb.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        return super.toScript() + ",  " + can.toString();
+    }
+
+
+    /**
+     * Get decimal approximation of the complex root tuples.
+     */
+    public synchronized List<List<Complex<BigDecimal>>> decimalApproximation() {
+        if (this.droots != null) {
+            return droots;
+        }
+        List<List<Complex<BigDecimal>>> rroots = new ArrayList<List<Complex<BigDecimal>>>();
+        ComplexRing<BigDecimal> cfac = new ComplexRing<BigDecimal>(new BigDecimal());
+        for (List<Complex<RealAlgebraicNumber<D>>> rri : this.can) {
+            List<Complex<BigDecimal>> r = new ArrayList<Complex<BigDecimal>>();
+            for (Complex<RealAlgebraicNumber<D>> rr : rri) {
+                BigDecimal dr = new BigDecimal(rr.getRe().magnitude());
+                BigDecimal di = new BigDecimal(rr.getIm().magnitude());
+                Complex<BigDecimal> d = new Complex<BigDecimal>(cfac, dr, di);
+                r.add(d);
+            }
+            rroots.add(r);
+        }
+        droots = rroots;
+        return rroots;
+    }
+
+
+    /**
+     * compute decimal approximation of the complex root tuples.
+     */
+    public void doDecimalApproximation() {
+        List<List<Complex<BigDecimal>>> unused = decimalApproximation();
+        if (unused.isEmpty()) { // use for findbugs
+            System.out.println("unused is empty");
+        }
+        return;
+    }
+
+
+    /**
+     * Is decimal approximation of the complex roots.
+     * @return true, if the decimal complex roots approximate the complex roots.
+     */
+    public synchronized boolean isDecimalApproximation() {
+        doDecimalApproximation();
+        if (droots == null || droots.size() == 0) {
+            return true;
+        }
+        if (upolys == null || upolys.size() == 0) {
+            return true;
+        }
+        Complex<BigDecimal> dd = droots.get(0).get(0);
+        ComplexRing<BigDecimal> dr = dd.ring;
+        Complex<BigDecimal> c = new Complex<BigDecimal>(dr,
+                        new BigDecimal("0.15").power(BigDecimal.DEFAULT_PRECISION / 2));
+        c = c.norm();
+        //System.out.println("eps: c = " + c);
+        Complex<BigDecimal> cc = new Complex<BigDecimal>(dr,
+                        new BigDecimal("0.1").power(BigDecimal.DEFAULT_PRECISION / 3));
+        cc = cc.norm();
+
+        ComplexRing<D> cr = new ComplexRing<D>(ideal.list.ring.coFac);
+        List<GenPolynomial<Complex<BigDecimal>>> upds = new ArrayList<GenPolynomial<Complex<BigDecimal>>>(
+                        upolys.size());
+        for (GenPolynomial<D> up : upolys) {
+            GenPolynomialRing<D> pfac = up.ring;
+            GenPolynomialRing<Complex<D>> cpfac = new GenPolynomialRing<Complex<D>>(cr, pfac);
+            GenPolynomialRing<Complex<BigDecimal>> dpfac = new GenPolynomialRing<Complex<BigDecimal>>(dr,
+                            cpfac);
+            GenPolynomial<Complex<D>> upc = PolyUtil.<D> complexFromAny(cpfac, up);
+            GenPolynomial<Complex<BigDecimal>> upd = PolyUtil.<D> complexDecimalFromRational(dpfac, upc);
+            //System.out.println("upd = " + upd);
+            upds.add(upd);
+        }
+        for (List<Complex<BigDecimal>> rr : droots) {
+            int i = 0;
+            for (GenPolynomial<Complex<BigDecimal>> upd : upds) {
+                Complex<BigDecimal> d = rr.get(i++);
+                Complex<BigDecimal> z = PolyUtil.<Complex<BigDecimal>> evaluateMain(dr, upd, d);
+                z = z.norm();
+                //System.out.println("z = " + z + ", d = " + d);
+                if (z.getRe().compareTo(c.getRe()) >= 0) {
+                    //System.out.println("no root: z = " + z + ", c = " + c);
+                    if (z.getRe().compareTo(cc.getRe()) >= 0) {
+                        System.out.println("no root: z = " + z + ", cc = " + cc);
+                        return false;
+                    }
+                }
+            }
+            //System.out.println();
+        }
+
+        GenPolynomialRing<D> pfac = ideal.list.ring;
+        cr = new ComplexRing<D>(pfac.coFac);
+        GenPolynomialRing<Complex<D>> cpfac = new GenPolynomialRing<Complex<D>>(cr, pfac);
+        GenPolynomialRing<Complex<BigDecimal>> dpfac = new GenPolynomialRing<Complex<BigDecimal>>(dr, cpfac);
+        List<GenPolynomial<D>> ips = ideal.list.list;
+        c = new Complex<BigDecimal>(dr, new BigDecimal("0.15").power(BigDecimal.DEFAULT_PRECISION / 2 - 1));
+        for (GenPolynomial<D> ip : ips) {
+            GenPolynomial<Complex<D>> ipc = PolyUtil.<D> complexFromAny(cpfac, ip);
+            GenPolynomial<Complex<BigDecimal>> ipd = PolyUtil.<D> complexDecimalFromRational(dpfac, ipc);
+            //System.out.println("ipd = " + ipd);
+            for (List<Complex<BigDecimal>> rr : droots) {
+                Complex<BigDecimal> z = PolyUtil.<Complex<BigDecimal>> evaluateAll(dr, ipd, rr);
+                z = z.norm();
+                //System.out.println("z = " + z + ", rr = " + rr);
+                if (z.getRe().compareTo(c.getRe()) >= 0) {
+                    //System.out.println("no root: z = " + z + ", c = " + c);
+                    if (z.getRe().compareTo(cc.getRe()) >= 0) {
+                        System.out.println("no root: z = " + z + ", cc = " + cc);
+                        System.out.println("ipd = " + ipd + ", rr = " + rr);
+                        return false;
+                    }
+                }
+            }
+            //System.out.println();
+        }
+        return true;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/IdealWithComplexRoots.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/IdealWithComplexRoots.java
@@ -1,0 +1,82 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.Serializable;
+import java.util.List;
+
+import edu.jas.arith.BigDecimal;
+import edu.jas.poly.Complex;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Container for Ideals together with univariate polynomials and complex roots.
+ * @author Heinz Kredel
+ */
+class IdealWithComplexRoots<C extends GcdRingElem<C>> extends IdealWithUniv<C> {
+
+
+    /**
+     * The list of complex roots.
+     */
+    public final List<List<Complex<BigDecimal>>> croots;
+
+
+    /**
+     * Constructor not for use.
+     */
+    protected IdealWithComplexRoots() {
+        throw new IllegalArgumentException("do not use this constructor");
+    }
+
+
+    /**
+     * Constructor.
+     * @param id the ideal
+     * @param up the list of univaraite polynomials
+     * @param cr the list of complex roots
+     */
+    public IdealWithComplexRoots(Ideal<C> id, List<GenPolynomial<C>> up, List<List<Complex<BigDecimal>>> cr) {
+        super(id, up);
+        croots = cr;
+    }
+
+
+    /**
+     * Constructor.
+     * @param iu the ideal with univariate polynomials
+     * @param cr the list of complex roots
+     */
+    public IdealWithComplexRoots(IdealWithUniv<C> iu, List<List<Complex<BigDecimal>>> cr) {
+        super(iu.ideal, iu.upolys);
+        croots = cr;
+    }
+
+
+    /**
+     * String representation of the ideal.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return super.toString() + "\ncomplex roots: " + croots.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        return super.toScript() + ",  " + croots.toString();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/IdealWithRealAlgebraicRoots.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/IdealWithRealAlgebraicRoots.java
@@ -1,0 +1,223 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.jas.arith.BigDecimal;
+import edu.jas.arith.Rational;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.root.RealAlgebraicNumber;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Container for Ideals together with univariate polynomials and real algebraic
+ * roots.
+ * @author Heinz Kredel
+ */
+public class IdealWithRealAlgebraicRoots<D extends GcdRingElem<D> & Rational> extends IdealWithUniv<D> {
+
+
+    /**
+     * The list of real algebraic roots.
+     */
+    public final List<List<RealAlgebraicNumber<D>>> ran;
+
+
+    /**
+     * The list of decimal approximations of the real algebraic roots.
+     */
+    protected List<List<BigDecimal>> droots = null;
+
+
+    /**
+     * Constructor not for use.
+     */
+    protected IdealWithRealAlgebraicRoots() {
+        throw new IllegalArgumentException("do not use this constructor");
+    }
+
+
+    /**
+     * Constructor.
+     * @param id the ideal
+     * @param up the list of univaraite polynomials
+     * @param rr the list of real algebraic roots
+     */
+    public IdealWithRealAlgebraicRoots(Ideal<D> id, List<GenPolynomial<D>> up,
+                    List<List<RealAlgebraicNumber<D>>> rr) {
+        super(id, up);
+        ran = rr;
+    }
+
+
+    /**
+     * Constructor.
+     * @param iu the ideal with univariate polynomials
+     * @param rr the list of real algebraic roots
+     */
+    public IdealWithRealAlgebraicRoots(IdealWithUniv<D> iu, List<List<RealAlgebraicNumber<D>>> rr) {
+        super(iu.ideal, iu.upolys);
+        ran = rr;
+    }
+
+
+    /**
+     * String representation of the ideal.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer(super.toString() + "\nreal roots:\n");
+        sb.append("[");
+        boolean f1 = true;
+        for (List<RealAlgebraicNumber<D>> lr : ran) {
+            if (!f1) {
+                sb.append(", ");
+            } else {
+                f1 = false;
+            }
+            sb.append("[");
+            boolean f2 = true;
+            for (RealAlgebraicNumber<D> rr : lr) {
+                if (!f2) {
+                    sb.append(", ");
+                } else {
+                    f2 = false;
+                }
+                sb.append(rr.ring.toScript());
+            }
+            sb.append("]");
+        }
+        sb.append("]");
+        if (droots != null) {
+            sb.append("\ndecimal real root approximation:\n");
+            for (List<BigDecimal> d : droots) {
+                sb.append(d.toString());
+                sb.append("\n");
+            }
+        }
+        return sb.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        return super.toScript() + ",  " + ran.toString();
+    }
+
+
+    /**
+     * Get decimal approximation of the real root tuples.
+     */
+    public synchronized List<List<BigDecimal>> decimalApproximation() {
+        if (this.droots != null) {
+            return droots;
+        }
+        List<List<BigDecimal>> rroots = new ArrayList<List<BigDecimal>>();
+        for (List<RealAlgebraicNumber<D>> rri : this.ran) {
+            List<BigDecimal> r = new ArrayList<BigDecimal>();
+            for (RealAlgebraicNumber<D> rr : rri) {
+                BigDecimal d = new BigDecimal(rr.magnitude());
+                r.add(d);
+            }
+            rroots.add(r);
+        }
+        droots = rroots;
+        return rroots;
+    }
+
+
+    /**
+     * compute decimal approximation of the real root tuples.
+     */
+    public void doDecimalApproximation() {
+        List<List<BigDecimal>> unused = decimalApproximation();
+        if (unused.isEmpty()) { // use for findbugs
+            System.out.println("unused is empty");
+        }
+        return;
+    }
+
+
+    /**
+     * Is decimal approximation of the real roots.
+     * @return true, if the decimal real roots approximate the real roots.
+     */
+    public synchronized boolean isDecimalApproximation() {
+        doDecimalApproximation();
+        if (droots == null || droots.size() == 0) {
+            return true;
+        }
+        if (upolys == null || upolys.size() == 0) {
+            return true;
+        }
+        BigDecimal dr = droots.get(0).get(0);
+        BigDecimal c = new BigDecimal("0.15").power(BigDecimal.DEFAULT_PRECISION / 2);
+        //System.out.println("eps: c = " + c);
+        List<GenPolynomial<BigDecimal>> upds = new ArrayList<GenPolynomial<BigDecimal>>(upolys.size());
+        for (GenPolynomial<D> up : upolys) {
+            GenPolynomialRing<D> pfac = up.ring;
+            GenPolynomialRing<BigDecimal> dpfac = new GenPolynomialRing<BigDecimal>(dr, pfac);
+            GenPolynomial<BigDecimal> upd = PolyUtil.<D> decimalFromRational(dpfac, up);
+            //System.out.println("upd = " + upd);
+            upds.add(upd);
+        }
+        for (List<BigDecimal> rr : droots) {
+            int i = 0;
+            for (GenPolynomial<BigDecimal> upd : upds) {
+                BigDecimal d = rr.get(i++);
+                BigDecimal z = PolyUtil.<BigDecimal> evaluateMain(dr, upd, d);
+                z = z.abs();
+                //System.out.println("z = " + z + ", d = " + d);
+                if (z.compareTo(c) >= 0) {
+                    //System.out.println("no root: z = " + z);
+                    BigDecimal cc = new BigDecimal("0.1").power(BigDecimal.DEFAULT_PRECISION / 3);
+                    if (z.compareTo(cc) >= 0) {
+                        System.out.println("no root: z = " + z + ", cc = " + cc);
+                        return false;
+                    }
+                }
+            }
+        }
+        GenPolynomialRing<D> pfac = ideal.list.ring;
+        GenPolynomialRing<BigDecimal> dpfac = new GenPolynomialRing<BigDecimal>(dr, pfac);
+        List<GenPolynomial<D>> ips = ideal.list.list;
+        //List<GenPolynomial<BigDecimal>> ipds = new ArrayList<GenPolynomial<BigDecimal>>(ips.size());
+        c = new BigDecimal("0.15").power(BigDecimal.DEFAULT_PRECISION / 2 - 1);
+        for (GenPolynomial<D> ip : ips) {
+            GenPolynomial<BigDecimal> ipd = PolyUtil.<D> decimalFromRational(dpfac, ip);
+            //System.out.println("ipd = " + ipd);
+            //ipds.add(ipd);
+            for (List<BigDecimal> rr : droots) {
+                BigDecimal z = PolyUtil.<BigDecimal> evaluateAll(dr, ipd, rr);
+                z = z.abs();
+                //System.out.println("z = " + z + ", rr = " + rr);
+                if (z.compareTo(c) >= 0) {
+                    //System.out.println("no root: z = " + z + ", c = " + c);
+                    BigDecimal cc = new BigDecimal("0.1").power(BigDecimal.DEFAULT_PRECISION / 3);
+                    if (z.compareTo(cc) >= 0) {
+                        System.out.println("no root: z = " + z + ", cc = " + cc);
+                        System.out.println("ipd = " + ipd + ", rr = " + rr);
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/IdealWithRealRoots.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/IdealWithRealRoots.java
@@ -1,0 +1,81 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.Serializable;
+import java.util.List;
+
+import edu.jas.arith.BigDecimal;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Container for Ideals together with univariate polynomials and real roots.
+ * @author Heinz Kredel
+ */
+public class IdealWithRealRoots<C extends GcdRingElem<C>> extends IdealWithUniv<C> {
+
+
+    /**
+     * The list of real roots.
+     */
+    public final List<List<BigDecimal>> rroots;
+
+
+    /**
+     * Constructor not for use.
+     */
+    protected IdealWithRealRoots() {
+        throw new IllegalArgumentException("do not use this constructor");
+    }
+
+
+    /**
+     * Constructor.
+     * @param id the ideal
+     * @param up the list of univaraite polynomials
+     * @param rr the list of real roots
+     */
+    public IdealWithRealRoots(Ideal<C> id, List<GenPolynomial<C>> up, List<List<BigDecimal>> rr) {
+        super(id, up);
+        rroots = rr;
+    }
+
+
+    /**
+     * Constructor.
+     * @param iu the ideal with univariate polynomials
+     * @param rr the list of real roots
+     */
+    public IdealWithRealRoots(IdealWithUniv<C> iu, List<List<BigDecimal>> rr) {
+        super(iu.ideal, iu.upolys);
+        rroots = rr;
+    }
+
+
+    /**
+     * String representation of the ideal.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return super.toString() + "\nreal roots: " + rroots.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        return super.toScript() + ",  " + rroots.toString();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/IdealWithUniv.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/IdealWithUniv.java
@@ -1,0 +1,111 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.Serializable;
+import java.util.List;
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Container for Ideals together with univariate polynomials.
+ * @author Heinz Kredel
+ */
+public class IdealWithUniv<C extends GcdRingElem<C>> implements Serializable {
+
+
+    /**
+     * The ideal.
+     */
+    public final Ideal<C> ideal;
+
+
+    /**
+     * The list of univariate polynomials. Contains polynomials from serveral
+     * rings, depending on the stage of the decomposition. 1) polynomials in a
+     * ring of one variable, 2) polynomials depending on only one variable but
+     * in a ring with multiple variables, 3) after contraction to a non-zero
+     * dimensional ring multivariate polynomials depending on one significant
+     * variable and multiple variables from the quotient coefficients.
+     */
+    public final List<GenPolynomial<C>> upolys;
+
+
+    /**
+     * A list of other useful polynomials. 1) field extension polynomials, 2)
+     * generators for infinite quotients.
+     */
+    public final List<GenPolynomial<C>> others;
+
+
+    /**
+     * Constructor not for use.
+     */
+    protected IdealWithUniv() {
+        throw new IllegalArgumentException("do not use this constructor");
+    }
+
+
+    /**
+     * Constructor.
+     * @param id the ideal
+     * @param up the list of univariate polynomials
+     */
+    protected IdealWithUniv(Ideal<C> id, List<GenPolynomial<C>> up) {
+        this(id, up, null);
+    }
+
+
+    /**
+     * Constructor.
+     * @param id the ideal
+     * @param up the list of univariate polynomials
+     * @param og the list of other polynomials
+     */
+    protected IdealWithUniv(Ideal<C> id, List<GenPolynomial<C>> up, List<GenPolynomial<C>> og) {
+        ideal = id;
+        upolys = up;
+        others = og;
+    }
+
+
+    /**
+     * String representation of the ideal.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        String s = ideal.toString();
+        if (upolys != null) {
+            s += "\nunivariate polynomials:\n" + upolys.toString();
+        }
+        if (others == null) {
+            return s;
+        }
+        return s + "\nother polynomials:\n" + others.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    public String toScript() {
+        // Python case
+        String s = ideal.toScript();
+        if (upolys != null) {
+            s += ", upolys=" + upolys.toString();
+        }
+        if (others == null) {
+            return s;
+        }
+        return s + ", others=" + others.toString();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/IntegerProgram.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/IntegerProgram.java
@@ -1,0 +1,480 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.Arrays;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.arith.BigInteger;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.ExpVectorLong;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialTokenizer;
+import edu.jas.poly.PolynomialList;
+import edu.jas.poly.TermOrder;
+
+
+/**
+ * Solution of Integer Programming problems using Groebner bases. Integer
+ * Program is in standard form -&gt; minimization of given Equation plus
+ * restrictions. See chapter 8 in Cox, Little, O'Shea "Using Algebraic 
+ * Geometry", 1998.
+ * @author Maximilian Nohr
+ */
+public class IntegerProgram implements java.io.Serializable {
+
+
+    private static final Logger logger = LogManager.getLogger(IntegerProgram.class);
+
+
+    private static boolean DEBUG = logger.isDebugEnabled(); //false;
+
+
+    private boolean negVars;
+
+
+    private boolean success;
+
+
+    /* 
+    Integer Program is in standard form -&gt; minimization of given 
+    Equation + restrictions
+    */
+    int n; // # of variables including slack variables
+
+
+    int m; // # of restrictions
+
+
+    long[] C; // List of Coefficients c_1...c_n of objective function
+
+
+    long[] B; // List of  b_1...b_m, restriction right hand side  
+
+
+    long[][] A; // m x n Matrix of a_{11}....a_{mn}, restriction matrix
+
+
+    long[] D; // Polynomial degrees 1...n
+
+
+    long[][] Aa; // restriction matrix a_{11}..a_{mn} after Laurent transformation
+
+
+    Ideal<BigInteger> I; //the Ideal
+
+
+    Ideal<BigInteger> GB; // the Groebner base for the ideal
+
+
+    TermOrder to; // the Term order for the GB
+
+
+    PolynomialList<BigInteger> F; // The Polynomials that generate the Ideal
+
+
+    GenPolynomial<BigInteger> S; // The Polynomial that is reduced for the Solution
+
+
+    /**
+     * Constructor. Use one instance for every new problem since solve() is not
+     * reentrant.
+     */
+    public IntegerProgram() {
+    }
+
+
+    /**
+     * Set DEBUG flag to parameter value.
+     * @param b
+     */
+    public void setDebug(boolean b) {
+        DEBUG = b;
+    }
+
+
+    /*
+     * Setup the Ideal corresponding to the Integer Program. 
+     */
+    @SuppressWarnings("unchecked")
+    private void createIdeal() {
+        Aa = A.clone();
+        negVars = negVarTest();
+        String[] w = new String[n];
+        String[] f = new String[n];
+        String[] z = new String[m];
+        String[] t = new String[n];
+        StringBuilder sb = new StringBuilder();
+        sb.append("Int(");
+
+        if (negVars) { //A or B has negative values
+            for (int i = 1; i <= n; i++) {
+                w[i - 1] = "w" + i;
+            }
+            for (int i = 1; i <= m; i++) {
+                z[i - 1] = "z" + i;
+            }
+            for (int i = 0; i < n; i++) {
+                StringBuffer h = new StringBuffer("");
+                long min = 0;
+                for (int j = 0; j < m; j++) {
+                    if (A[j][i] < min) {
+                        min = A[j][i];
+                    }
+                }
+                if (min < 0) {
+                    long e = -min;
+                    h.append("t^" + e + " * ");
+                    for (int j = 0; j < m; j++) {
+                        Aa[j][i] = A[j][i] + e;
+                        h.append(z[j] + "^" + Aa[j][i] + " * ");
+                    }
+                } else {
+                    for (int j = 0; j < m; j++) {
+                        if (A[j][i] != 0) {
+                            h.append(z[j] + "^" + A[j][i] + " * ");
+                        }
+                    }
+                }
+                f[i] = h.substring(0, h.length() - 3).toString();
+            }
+            setDeg();
+            setTO();
+            for (int i = 0; i < n; i++) {
+                t[i] = f[i] + " - " + w[i];
+            }
+            sb.append("t");
+            for (int i = 0; i < m; i++) {
+                sb.append(",").append(z[i]);
+            }
+            for (int i = 0; i < n; i++) {
+                sb.append(",").append(w[i]);
+            }
+            sb.append(") W ");
+            //sb.append(to.weightToString().substring(6, to.weightToString().length()));
+            sb.append(to.weightToString());
+            sb.append(" ( ( t");
+            for (int i = 0; i < m; i++) {
+                sb.append(" * ").append(z[i]);
+            }
+            sb.append(" - 1 )");
+            for (int i = 0; i < n; i++) {
+                sb.append(", (").append(t[i]).append(" )");
+            }
+            sb.append(") ");
+
+        } else { //if neither A nor B contain negative values
+            for (int i = 1; i <= n; i++) {
+                w[i - 1] = "w" + i;
+            }
+            for (int i = 1; i <= m; i++) {
+                z[i - 1] = "z" + i;
+            }
+            for (int i = 0; i < n; i++) {
+                StringBuffer h = new StringBuffer("");
+                for (int j = 0; j < m; j++) {
+                    if (A[j][i] != 0) {
+                        h.append(z[j] + "^" + A[j][i] + " * ");
+                    }
+                }
+                f[i] = h.substring(0, h.length() - 3).toString();
+            }
+            setDeg();
+            setTO();
+            for (int i = 0; i < n; i++) {
+                t[i] = f[i] + " - " + w[i];
+            }
+            sb.append(z[0]);
+            for (int i = 1; i < m; i++) {
+                sb.append(",").append(z[i]);
+            }
+            for (int i = 0; i < n; i++) {
+                sb.append(",").append(w[i]);
+            }
+            sb.append(") W ");
+            //sb.append(to.weightToString().substring(6, to.weightToString().length()));
+            sb.append(to.weightToString());
+            sb.append(" ( (").append(t[0]).append(")");
+            for (int i = 1; i < n; i++) {
+                sb.append(", (").append(t[i]).append(" )");
+            }
+            sb.append(") ");
+        }
+        if (DEBUG) {
+            logger.debug("list=" + sb.toString());
+        }
+
+        Reader source = new StringReader(sb.toString());
+        GenPolynomialTokenizer parser = new GenPolynomialTokenizer(source);
+        PolynomialList<BigInteger> F = null;
+
+        try {
+            F = (PolynomialList<BigInteger>) parser.nextPolynomialSet();
+        } catch (ClassCastException e) {
+            e.printStackTrace();
+            return;
+        } catch (IOException e) {
+            e.printStackTrace();
+            return;
+        }
+        if (DEBUG) {
+            logger.debug("F=" + F);
+        }
+        I = new Ideal<BigInteger>(F);
+        return;
+    }
+
+
+    /**
+     * @return true if the last calculation had a solution, else false
+     */
+    public boolean getSuccess() {
+        return success;
+    }
+
+
+    /**
+     * Solve Integer Program.
+     * @param A matrix of restrictions
+     * @param B restrictions right hand side
+     * @param C objective function
+     * @return solution s, such that s*C -&gt; minimal and A*s = B, or s = null
+     *         if no solution exists
+     */
+    public long[] solve(long[][] A, long[] B, long[] C) {
+        this.A = Arrays.copyOf(A, A.length);
+        this.B = Arrays.copyOf(B, B.length);
+        this.C = Arrays.copyOf(C, C.length);
+        this.n = A[0].length;
+        this.m = A.length;
+        D = new long[n];
+
+        createIdeal();
+        GB = I.GB();
+        return solve(B);
+    }
+
+
+    /**
+     * Solve Integer Program for new right hand side. Uses the GB (matrix A and
+     * C) from the last calculation.
+     * @param B restrictions right hand side
+     * @return solution s, such that s*C -&gt; minimal and A*s = B, or s = null
+     *         if no solution exists
+     */
+    public long[] solve(long[] B) {
+        long[] returnMe = new long[n];
+        if (B.length != m) {
+            System.out.println("ERROR: Dimensions don't match: " + B.length + " != " + m);
+            return returnMe;
+        }
+        long[] l;
+        this.B = Arrays.copyOf(B, B.length);
+        if (DEBUG) {
+            logger.debug("GB=" + GB);
+        }
+        if (negVars) {
+            l = new long[m + n + 1];
+            long min = findMin(B);
+            if (min < 0) {
+                long r = -min;
+                l[m + n] = r;
+                for (int i = 0; i < m; i++) {
+                    l[m + n - 1 - i] = B[i] + r;
+                }
+            } else {
+                for (int i = 0; i < m; i++) {
+                    l[m + n - 1 - i] = B[i];
+                }
+            }
+        } else {
+            l = new long[m + n];
+            for (int i = 0; i < m; i++) {
+                l[m + n - 1 - i] = B[i];
+            }
+        }
+        ExpVector e = new ExpVectorLong(l);
+        S = new GenPolynomial<BigInteger>(I.getRing(), e);
+        S = GB.normalform(S);
+
+        ExpVector E = S.exponentIterator().next();
+        for (int i = 0; i < n; i++) {
+            returnMe[n - 1 - i] = E.getVal(i);
+        }
+        success = true;
+        for (int i = n; i < n + m; i++) {
+            if (E.getVal(i) != 0) {
+                success = false;
+                break;
+            }
+        }
+        if (success) {
+            if (DEBUG) {
+                logger.debug("The solution is: " + Arrays.toString(returnMe));
+            }
+        } else {
+            logger.warn("The Problem does not have a feasible solution.");
+            returnMe = null;
+        }
+        return returnMe;
+    }
+
+
+    /*
+     * Set the degree.
+     */
+    private void setDeg() {
+        for (int j = 0; j < n; j++) {
+            for (int i = 0; i < m; i++) {
+                D[j] += Aa[i][j];
+            }
+        }
+    }
+
+
+    /*
+     * Set the term order.
+     */
+    private void setTO() {
+        int h;
+        if (negVars) {//if A and/or B contains negative values
+            h = m + n + 1;
+        } else {
+            h = m + n;
+        }
+        long[] u1 = new long[h];
+        long[] u2 = new long[h];
+        for (int i = 0; i < h - n; i++) { //m+1 because t needs another 1 
+            u1[h - 1 - i] = 1;
+        }
+        long[] h1 = new long[h]; // help vectors to construct u2 out of
+        long[] h2 = new long[h];
+        for (int i = h - n; i < h; i++) {
+            h1[i] = C[i - (h - n)];
+            h2[i] = D[i - (h - n)];
+        }
+        long min = h1[0];
+        for (int i = 0; i < h; i++) {
+            u2[h - 1 - i] = h1[i] + h2[i];
+            if (u2[h - 1 - i] < min) {
+                min = u2[h - 1 - i];
+            }
+        }
+        while (min < 0) {
+            min = u2[0];
+            for (int i = 0; i < h; i++) {
+                u2[h - 1 - i] += h2[i];
+                if (u2[h - 1 - i] < min) {
+                    min = u2[h - 1 - i];
+                }
+            }
+        }
+        long[][] wv = { u1, u2 };
+        to = new TermOrder(wv);
+    }
+
+
+    /*
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Function to minimize:\n");
+
+        char c = 'A'; // variables are named A, B, C, ...
+
+        boolean plus = false;
+        for (int i = 0; i < n; i++) {
+            if (C[i] != 0) {
+                if (C[i] < 0) {
+                    sb.append("(").append(C[i]).append(")");
+                    sb.append("*");
+                } else if (C[i] != 1) {
+                    sb.append(C[i]);
+                    sb.append("*");
+                }
+                sb.append(c);
+                sb.append(" + ");
+                plus = true;
+            }
+            c++;
+        }
+        if (plus) {
+            sb.delete(sb.lastIndexOf("+"), sb.length());
+        }
+        sb.append("\nunder the Restrictions:\n");
+        for (int i = 0; i < m; i++) {
+            c = 'A';
+            //System.out.println("A["+i+"] = " + Arrays.toString(A[i]));
+            plus = false;
+            for (int j = 0; j < n; j++) {
+                if (A[i][j] != 0) {
+                    if (A[i][j] < 0) {
+                        sb.append("(").append(A[i][j]).append(")");
+                        sb.append("*");
+                    } else if (A[i][j] != 1) {
+                        sb.append(A[i][j]);
+                        sb.append("*");
+                    } 
+                    sb.append(c);
+                    sb.append(" + ");
+                    plus = true;
+                }
+                c++;
+            }
+            if (plus) {
+                sb.delete(sb.lastIndexOf("+"), sb.length()); 
+            } else {
+                sb.append("0 ");
+            }
+            sb.append("= ").append(B[i]).append("\n");
+        }
+        return sb.toString();
+    }
+
+
+    /*
+     * Test for negative variables.
+     * @return true if negative variables appear
+     */
+    private boolean negVarTest() {
+        for (int i = 0; i < m; i++) {
+            if (B[i] < 0) {
+                return true;
+            }
+            for (int j = 0; j < n; j++) {
+                if (A[i][j] < 0) {
+                    return true;
+                }
+
+            }
+        }
+        return false;
+    }
+
+
+    /*
+     * Find minimal element.
+     * @param B vector of at least one element, B.length &gt;= 1 
+     * @return minimal element of B
+     */
+    private long findMin(long[] B) {
+        long min = B[0];
+        for (int i = 1; i < B.length; i++) {
+            if (B[i] < min) {
+                min = B[i];
+            }
+        }
+        return min;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/IntegerProgramExamples.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/IntegerProgramExamples.java
@@ -1,0 +1,284 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.util.Arrays;
+
+
+/**
+ * Examples for Integer Programming.
+ * @author Maximilian Nohr
+ */
+public class IntegerProgramExamples {
+
+
+    /**
+     * Execute all examples.
+     * @param args
+     */
+    public static void main(String[] args) {
+        example1();
+        example2();
+        example3();
+        example4();
+        example5();
+        example6();
+        example7();
+        example8();
+        // too big: example9();
+        // too big: example10();
+    }
+
+
+    /**
+     * Example p.360 CLOII
+     */
+    public static void example1() {
+        IntegerProgram IP = new IntegerProgram();
+
+        long t0 = System.currentTimeMillis();
+
+        //bsp. s.360 CLOII
+        long[][] A0 = { { 4, 5, 1, 0 }, { 2, 3, 0, 1 } };
+        long[] B0 = { 37, 20 };
+        long[] C0 = { -11, -15, 0, 0 };
+
+        long[] sol = IP.solve(A0, B0, C0);
+
+        long t1 = System.currentTimeMillis();
+        long t = t1 - t0;
+        System.out.println("\n" + IP);
+        System.out.println("The solution is: " + Arrays.toString(sol));
+        System.out.println("The computation needed " + t + " milliseconds.");
+
+
+        long[] BW = { 1, 2 }; //,3};
+
+        sol = IP.solve(BW);
+
+        int count = 0;
+        for (int i = 0; i < 5; i++) {
+            for (int j = 0; j < 5; j++) {
+                B0[0] = i;
+                B0[1] = j;
+
+                sol = IP.solve(A0, B0, C0);
+                if (IP.getSuccess()) {
+                    count++;
+                }
+            }
+        }
+        System.out.println(count + " times successful!");
+    }
+
+
+    /**
+     * Example p.374 CLOII 10a
+     */
+    public static void example2() {
+        IntegerProgram IP = new IntegerProgram();
+
+        long t0 = System.currentTimeMillis();
+
+        //bsp. s.374 CLOII 10a
+        long[][] A = { { 3, 2, 1, 1 }, { 4, 1, 1, 0 } };
+        long[] B = { 10, 5 };
+        long[] C = { 2, 3, 1, 5 };
+
+        long[] sol = IP.solve(A, B, C);
+
+        //10b
+        long[] Bb = { 20, 14 };
+        sol = IP.solve(Bb);
+
+        long t1 = System.currentTimeMillis();
+        long t = t1 - t0;
+        System.out.println("\n" + IP);
+        System.out.println("The solution is: " + Arrays.toString(sol));
+        System.out.println("The computation needed " + t + " milliseconds.");
+    }
+
+
+    /**
+     * Example p.372 CLOII
+     */
+    public static void example3() {
+        IntegerProgram IP = new IntegerProgram();
+
+        long t0 = System.currentTimeMillis();
+
+        //bsp. s.372 CLOII
+        long[][] A2 = { { 3, -2, 1, 0 }, { 4, 1, -1, -1 } };
+        long[] B2 = { -1, 5 };
+        long[] C2 = { 1, 1000, 1, 100 };
+
+        long[] sol = IP.solve(A2, B2, C2);
+
+        long t1 = System.currentTimeMillis();
+        long t = t1 - t0;
+        System.out.println("\n" + IP);
+        System.out.println("The solution is: " + Arrays.toString(sol));
+        System.out.println("The computation needed " + t + " milliseconds.");
+    }
+
+
+    public static void example4() {
+        IntegerProgram IP = new IntegerProgram();
+
+        long t0 = System.currentTimeMillis();
+
+        //bsp. s.374 10c
+        long[][] A3 = { { 3, 2, 1, 1, 0, 0 }, { 1, 2, 3, 0, 1, 0 }, { 2, 1, 1, 0, 0, 1 } };
+        long[] B3 = { 45, 21, 18 };
+        long[] C3 = { -3, -4, -2, 0, 0, 0 };
+
+        long[] sol = IP.solve(A3, B3, C3);
+
+        long t1 = System.currentTimeMillis();
+        long t = t1 - t0;
+        System.out.println("\n" + IP);
+        System.out.println("The solution is: " + Arrays.toString(sol));
+        System.out.println("The computation needed " + t + " milliseconds.");
+    }
+
+
+    /**
+     * Example p.138 AAECC-9
+     */
+    public static void example5() {
+        IntegerProgram IP = new IntegerProgram();
+
+        long t0 = System.currentTimeMillis();
+
+        //bsp. s.138 AAECC-9
+        long[][] A4 = { { 32, 45, -41, 22 }, { -82, -13, 33, -33 }, { 23, -21, 12, -12 } };
+        long[] B4 = { 214, 712, 331 }; //im Beispiel keine b genannt
+        long[] C4 = { 1, 1, 1, 1 };
+
+        long[] sol = IP.solve(A4, B4, C4);
+
+        long t1 = System.currentTimeMillis();
+        long t = t1 - t0;
+        System.out.println("\n" + IP);
+        System.out.println("The solution is: " + Arrays.toString(sol));
+        System.out.println("The computation needed " + t + " milliseconds.");
+    }
+
+
+    /**
+     * Example from M. Nohr
+     */
+    public static void example6() {
+        IntegerProgram IP = new IntegerProgram();
+
+        long t0 = System.currentTimeMillis();
+
+        //eigenes beispiel
+        //System.out.println("example from mnohr:");
+        long[][] A5 = { { 4, 3, 1, 0 }, { 3, 1, 0, 1 } };
+        long[] B5 = { 200, 100 };
+        long[] C5 = { -5, -4, 0, 0 };
+
+        long[] sol = IP.solve(A5, B5, C5);
+
+        long t1 = System.currentTimeMillis();
+        long t = t1 - t0;
+        System.out.println("\n" + IP);
+        System.out.println("The solution is: " + Arrays.toString(sol));
+        System.out.println("The computation needed " + t + " milliseconds.");
+    }
+
+
+    /**
+     * Example unsolvable
+     */
+    public static void example7() {
+        IntegerProgram IP = new IntegerProgram();
+
+        long t0 = System.currentTimeMillis();
+
+        long[][] A9 = { { 1, 1, 1, 1 }, { -1, -1, -1, -1 } };
+        long[] B9 = { 1, 1 };
+        long[] C9 = { 1, 1, 0, 0 };
+
+        long[] sol = IP.solve(A9, B9, C9);
+
+        long t1 = System.currentTimeMillis();
+        long t = t1 - t0;
+        System.out.println("\nunsolvable: " + IP);
+        System.out.println("The solution is: " + Arrays.toString(sol));
+        System.out.println("The computation needed " + t + " milliseconds.");
+    }
+
+
+    /**
+     * Example ?
+     */
+    public static void example8() {
+        IntegerProgram IP = new IntegerProgram();
+
+        long t0 = System.currentTimeMillis();
+
+        long[][] A8 = { { 4, 3, 1, 0 }, { 3, 1, 0, 1 } };
+        long[] B8 = { 200, 100 };
+        long[] C8 = { -5, -4, 0, 0 };
+
+        long[] sol = IP.solve(A8, B8, C8);
+
+        long t1 = System.currentTimeMillis();
+        long t = t1 - t0;
+        System.out.println("\n" + IP);
+        System.out.println("The solution is: " + Arrays.toString(sol));
+        System.out.println("The computation needed " + t + " milliseconds.");
+    }
+
+
+    /**
+     * Example p.137 AAECC-9, too many vars
+     */
+    public static void example9() {
+        IntegerProgram IP = new IntegerProgram();
+
+        long t0 = System.currentTimeMillis();
+
+        // bsp s.137 AAECC-9 auch too many vars
+        long[][] A7 = { { 2, 5, -3, 1, -2 }, { 1, 7, 2, 3, 1 }, { 4, -2, -1, -5, 3 } };
+        long[] B7 = { 214, 712, 331 };
+        long[] C7 = { 1, 1, 1, 1, 1 };
+
+        long[] sol = IP.solve(A7, B7, C7);
+
+        long t1 = System.currentTimeMillis();
+        long t = t1 - t0;
+        System.out.println("\n" + IP);
+        System.out.println("The solution is: " + Arrays.toString(sol));
+        System.out.println("The computation needed " + t + " milliseconds.");
+    }
+
+
+    /**
+     * Example, too big
+     */
+    public static void example10() {
+        IntegerProgram IP = new IntegerProgram();
+
+        long t0 = System.currentTimeMillis();
+        //too many variables
+        long[][] A6 = { { 5, 11, 23, -5, 4, -7, -4 }, { 1, -5, -14, 15, 7, -8, 10 },
+                { 3, 21, -12, 7, 9, 11, 8 } };
+        long[] B6 = { 23, 19, 31 };
+        long[] C6 = { 1, 1, 1, 1, 1, 1, 1 };
+
+        long[] sol = IP.solve(A6, B6, C6);
+
+        long t1 = System.currentTimeMillis();
+        long t = t1 - t0;
+        System.out.println("\n" + IP);
+        System.out.println("The solution is: " + Arrays.toString(sol));
+        System.out.println("The computation needed " + t + " milliseconds.");
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/Local.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/Local.java
@@ -1,0 +1,592 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.kern.PrettyPrint;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.QuotPair;
+
+
+/**
+ * Local ring element based on GenPolynomial with RingElem interface. Objects of
+ * this class are (nearly) immutable.
+ * @author Heinz Kredel
+ */
+// To be fixed?: Not jet working because of monic GBs.
+public class Local<C extends GcdRingElem<C>> 
+       implements RingElem<Local<C>>, QuotPair<GenPolynomial<C>> {
+
+
+    private static final Logger logger = LogManager.getLogger(Local.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Local class factory data structure.
+     */
+    public final LocalRing<C> ring;
+
+
+    /**
+     * Numerator part of the element data structure.
+     */
+    protected final GenPolynomial<C> num;
+
+
+    /**
+     * Denominator part of the element data structure.
+     */
+    protected final GenPolynomial<C> den;
+
+
+    /**
+     * Flag to remember if this local element is a unit. -1 is unknown, 1 is
+     * unit, 0 not a unit.
+     */
+    protected int isunit = -1; // initially unknown
+
+
+    /**
+     * The constructor creates a Local object from a ring factory.
+     * @param r ring factory.
+     */
+    public Local(LocalRing<C> r) {
+        this(r, r.ring.getZERO());
+    }
+
+
+    /**
+     * The constructor creates a Local object from a ring factory and a
+     * numerator polynomial. The denominator is assumed to be 1.
+     * @param r ring factory.
+     * @param n numerator polynomial.
+     */
+    public Local(LocalRing<C> r, GenPolynomial<C> n) {
+        this(r, n, r.ring.getONE(), true);
+    }
+
+
+    /**
+     * The constructor creates a Local object from a ring factory and a
+     * numerator and denominator polynomial.
+     * @param r ring factory.
+     * @param n numerator polynomial.
+     * @param d denominator polynomial.
+     */
+    public Local(LocalRing<C> r, GenPolynomial<C> n, GenPolynomial<C> d) {
+        this(r, n, d, false);
+    }
+
+
+    /**
+     * The constructor creates a Local object from a ring factory and a
+     * numerator and denominator polynomial.
+     * @param r ring factory.
+     * @param n numerator polynomial.
+     * @param d denominator polynomial.
+     * @param isred true if gcd(n,d) == 1, else false.
+     */
+    protected Local(LocalRing<C> r, GenPolynomial<C> n, GenPolynomial<C> d, boolean isred) {
+        if (d == null || d.isZERO()) {
+            throw new IllegalArgumentException("denominator may not be zero");
+        }
+        ring = r;
+        if (d.signum() < 0) {
+            n = n.negate();
+            d = d.negate();
+        }
+        if (isred) {
+            num = n;
+            den = d;
+            return;
+        }
+        GenPolynomial<C> p = ring.ideal.normalform(d);
+        if (p == null || p.isZERO()) {
+            throw new IllegalArgumentException("denominator may not be in ideal");
+        }
+        //d = p; cant do this
+        C lc = d.leadingBaseCoefficient();
+        if (!lc.isONE() && lc.isUnit()) {
+            lc = lc.inverse();
+            n = n.multiply(lc);
+            d = d.multiply(lc);
+        }
+        if (n.compareTo(d) == 0) {
+            num = ring.ring.getONE();
+            den = ring.ring.getONE();
+            return;
+        }
+        if (n.negate().compareTo(d) == 0) {
+            num = ring.ring.getONE().negate();
+            den = ring.ring.getONE();
+            return;
+        }
+        if (n.isZERO()) {
+            num = n;
+            den = ring.ring.getONE();
+            return;
+        }
+        // must reduce to lowest terms
+        //GenPolynomial<C> gcd = ring.ring.getONE();
+        GenPolynomial<C> gcd = ring.engine.gcd(n, d);
+        if (debug) {
+            logger.info("gcd = " + gcd);
+        }
+        if (gcd.isONE()) {
+            num = n;
+            den = d;
+        } else {
+            // d not in ideal --> gcd not in ideal 
+            //p = ring.ideal.normalform( gcd );
+            //if ( p == null || p.isZERO() ) { // find nonzero factor
+            //   num = n;
+            //   den = d;
+            //} else {
+            num = n.divide(gcd);
+            den = d.divide(gcd);
+            //}
+        }
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public LocalRing<C> factory() {
+        return ring;
+    }
+
+
+    /**
+     * Numerator.
+     * @see edu.jas.structure.QuotPair#numerator()
+     */
+    public GenPolynomial<C> numerator() {
+        return num;
+    }
+
+
+    /**
+     * Denominator.
+     * @see edu.jas.structure.QuotPair#denominator()
+     */
+    public GenPolynomial<C> denominator() {
+        return den;
+    }
+
+
+    /**
+     * Clone this.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public Local<C> copy() {
+        return new Local<C>(ring, num, den, true);
+    }
+
+
+    /**
+     * Is Local zero.
+     * @return If this is 0 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isZERO()
+     */
+    public boolean isZERO() {
+        return num.isZERO();
+    }
+
+
+    /**
+     * Is Local one.
+     * @return If this is 1 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isONE()
+     */
+    public boolean isONE() {
+        return num.equals(den);
+    }
+
+
+    /**
+     * Is Local unit.
+     * @return If this is a unit then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isUnit()
+     */
+    public boolean isUnit() {
+        if (isunit > 0) {
+            return true;
+        }
+        if (isunit == 0) {
+            return false;
+        }
+        // not jet known
+        if (num.isZERO()) {
+            isunit = 0;
+            return false;
+        }
+        GenPolynomial<C> p = ring.ideal.normalform(num);
+        boolean u = (p != null && !p.isZERO());
+        if (u) {
+            isunit = 1;
+        } else {
+            isunit = 0;
+        }
+        return (u);
+    }
+
+
+    /**
+     * Is Qoutient a constant.
+     * @return true, if this has constant numerator and denominator, else false.
+     */
+    public boolean isConstant() {
+        return num.isConstant() && den.isConstant();
+    }
+
+
+    /**
+     * Get the String representation as RingElem.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        if (PrettyPrint.isTrue()) {
+            String s = "{ " + num.toString(ring.ring.getVars());
+            if (den.isONE()) {
+                return s + " }";
+            }
+            return s + "| " + den.toString(ring.ring.getVars()) + " }";
+        }
+        return "Local[ " + num.toString() + " | " + den.toString() + " ]";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        if (den.isONE()) {
+            return num.toScript();
+        }
+        return num.toScript() + " / " + den.toScript();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python case
+        return factory().toScript();
+    }
+
+
+    /**
+     * Local comparison.
+     * @param b Local.
+     * @return sign(this-b).
+     */
+    @Override
+    public int compareTo(Local<C> b) {
+        if (b == null || b.isZERO()) {
+            return this.signum();
+        }
+        if (this.isZERO()) {
+            return -b.signum();
+        }
+        // assume sign(den,b.den) > 0
+        int s1 = num.signum();
+        int s2 = b.num.signum();
+        int t = (s1 - s2) / 2;
+        if (t != 0) {
+            System.out.println("compareTo: t = " + t);
+            return t;
+        }
+        if (den.compareTo(b.den) == 0) {
+            return num.compareTo(b.num);
+        }
+        GenPolynomial<C> r = num.multiply(b.den);
+        GenPolynomial<C> s = den.multiply(b.num);
+        return r.compareTo(s);
+        //GenPolynomial<C> x = r.subtract(s);
+        //return x.signum();
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean equals(Object b) {
+        if (!(b instanceof Local)) {
+            return false;
+        }
+        Local<C> a = null;
+        try {
+            a = (Local<C>) b;
+        } catch (ClassCastException e) {
+        }
+        if (a == null) {
+            return false;
+        }
+        return compareTo(a) == 0;
+    }
+
+
+    /**
+     * Hash code for this local.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = ring.hashCode();
+        h = 37 * h + num.hashCode();
+        h = 37 * h + den.hashCode();
+        return h;
+    }
+
+
+    /**
+     * Local absolute value.
+     * @return the absolute value of this.
+     * @see edu.jas.structure.RingElem#abs()
+     */
+    public Local<C> abs() {
+        return new Local<C>(ring, num.abs(), den, true);
+    }
+
+
+    /**
+     * Local summation.
+     * @param S Local.
+     * @return this+S.
+     */
+    public Local<C> sum(Local<C> S) {
+        if (S == null || S.isZERO()) {
+            return this;
+        }
+        GenPolynomial<C> n = num.multiply(S.den);
+        n = n.sum(den.multiply(S.num));
+        GenPolynomial<C> d = den.multiply(S.den);
+        return new Local<C>(ring, n, d, false);
+    }
+
+
+    /**
+     * Local negate.
+     * @return -this.
+     * @see edu.jas.structure.RingElem#negate()
+     */
+    public Local<C> negate() {
+        return new Local<C>(ring, num.negate(), den, true);
+    }
+
+
+    /**
+     * Local signum.
+     * @see edu.jas.structure.RingElem#signum()
+     * @return signum(this).
+     */
+    public int signum() {
+        return num.signum();
+    }
+
+
+    /**
+     * Local subtraction.
+     * @param S Local.
+     * @return this-S.
+     */
+    public Local<C> subtract(Local<C> S) {
+        if (S == null || S.isZERO()) {
+            return this;
+        }
+        GenPolynomial<C> n = num.multiply(S.den);
+        n = n.subtract(den.multiply(S.num));
+        GenPolynomial<C> d = den.multiply(S.den);
+        return new Local<C>(ring, n, d, false);
+    }
+
+
+    /**
+     * Local division.
+     * @param S Local.
+     * @return this/S.
+     */
+    public Local<C> divide(Local<C> S) {
+        return multiply(S.inverse());
+    }
+
+
+    /**
+     * Local inverse.
+     * @see edu.jas.structure.RingElem#inverse()
+     * @return S with S = 1/this if defined.
+     */
+    public Local<C> inverse() {
+        if (isONE()) {
+            return this;
+        }
+        if (isUnit()) {
+            return new Local<C>(ring, den, num, true);
+        }
+        throw new ArithmeticException("element not invertible " + this);
+    }
+
+
+    /**
+     * Local remainder.
+     * @param S Local.
+     * @return this - (this/S)*S.
+     */
+    public Local<C> remainder(Local<C> S) {
+        if (S.isUnit()) {
+            return ring.getZERO();
+        }
+        throw new UnsupportedOperationException("remainder not implemented" + S);
+    }
+
+
+    /**
+     * Local multiplication.
+     * @param S Local.
+     * @return this*S.
+     */
+    public Local<C> multiply(Local<C> S) {
+        if (S == null || S.isZERO()) {
+            return S;
+        }
+        if (num.isZERO()) {
+            return this;
+        }
+        if (S.isONE()) {
+            return this;
+        }
+        if (this.isONE()) {
+            return S;
+        }
+        GenPolynomial<C> n = num.multiply(S.num);
+        GenPolynomial<C> d = den.multiply(S.den);
+        return new Local<C>(ring, n, d, false);
+    }
+
+
+    /**
+     * Local multiplication by GenPolynomial.
+     * @param b GenPolynomial.
+     * @return this*b.
+     */
+    public Local<C> multiply(GenPolynomial<C> b) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        if (num.isZERO()) {
+            return this;
+        }
+        if (b.isONE()) {
+            return this;
+        }
+        GenPolynomial<C> n = num.multiply(b);
+        return new Local<C>(ring, n, den, false);
+    }
+
+
+    /**
+     * Local multiplication by coefficient.
+     * @param b coefficient.
+     * @return this*b.
+     */
+    public Local<C> multiply(C b) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        if (num.isZERO()) {
+            return this;
+        }
+        if (b.isONE()) {
+            return this;
+        }
+        GenPolynomial<C> n = num.multiply(b);
+        return new Local<C>(ring, n, den, false);
+    }
+
+
+    /**
+     * Local multiplication by exponent.
+     * @param e exponent vector.
+     * @return this*b.
+     */
+    public Local<C> multiply(ExpVector e) {
+        if (e == null || e.isZERO()) {
+            return this;
+        }
+        if (num.isZERO()) {
+            return this;
+        }
+        GenPolynomial<C> n = num.multiply(e);
+        return new Local<C>(ring, n, den, false);
+    }
+
+
+    /**
+     * Local monic.
+     * @return this with monic value part.
+     */
+    public Local<C> monic() {
+        if (num.isZERO()) {
+            return this;
+        }
+        return this;
+        // non sense:
+        //C lbc = num.leadingBaseCoefficient();
+        //lbc = lbc.inverse();
+        //GenPolynomial<C> n = num.multiply(lbc);
+        //GenPolynomial<C> d = den.multiply(lbc);
+        //return new Local<C>(ring, n, d, true);
+    }
+
+
+    /**
+     * Greatest common divisor.
+     * @param b other element.
+     * @return gcd(this,b).
+     */
+    public Local<C> gcd(Local<C> b) {
+        GenPolynomial<C> x = ring.engine.gcd(num, b.num);
+        GenPolynomial<C> y = ring.engine.gcd(den, b.den);
+        return new Local<C>(ring, x, y, true);
+    }
+
+
+    /**
+     * Extended greatest common divisor. <b>Note: </b>Not implemented, throws
+     * UnsupportedOperationException.
+     * @param b other element.
+     * @return [ gcd(this,b), c1, c2 ] with c1*this + c2*b = gcd(this,b).
+     */
+    public Local<C>[] egcd(Local<C> b) {
+        throw new UnsupportedOperationException("egcd not implemented " + this.getClass().getName());
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/LocalRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/LocalRing.java
@@ -1,0 +1,389 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.kern.StringUtil;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.ufd.GCDFactory;
+import edu.jas.ufd.GreatestCommonDivisor;
+import edu.jas.structure.QuotPairFactory;
+
+
+/**
+ * Local ring class based on GenPolynomial with RingElem interface. Objects of
+ * this class are effective immutable.
+ * @author Heinz Kredel
+ */
+public class LocalRing<C extends GcdRingElem<C>> 
+       implements RingFactory<Local<C>>, QuotPairFactory<GenPolynomial<C>,Local<C>>  {
+
+
+    private static final Logger logger = LogManager.getLogger(LocalRing.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Greatest common divisor engine for coefficient content and primitive
+     * parts.
+     */
+    protected final GreatestCommonDivisor<C> engine;
+
+
+    /**
+     * Polynomial ideal for localization.
+     */
+    public final Ideal<C> ideal;
+
+
+    /**
+     * Polynomial ring of the factory.
+     */
+    public final GenPolynomialRing<C> ring;
+
+
+    /**
+     * Indicator if this ring is a field.
+     */
+    protected int isField = -1; // initially unknown
+
+
+    /**
+     * The constructor creates a LocalRing object from an Ideal.
+     * @param i localization polynomial ideal.
+     */
+    public LocalRing(Ideal<C> i) {
+        if (i == null) {
+            throw new IllegalArgumentException("ideal may not be null");
+        }
+        ideal = i.GB(); // cheap if isGB
+        if (ideal.isONE()) {
+            throw new IllegalArgumentException("ideal may not be 1");
+        }
+        if (ideal.isMaximal()) {
+            isField = 1;
+        } else {
+            isField = 0;
+            logger.warn("ideal not maximal");
+            //throw new IllegalArgumentException("ideal must be maximal");
+        }
+        ring = ideal.list.ring;
+        //engine = GCDFactory.<C>getImplementation( ring.coFac );
+        engine = GCDFactory.<C> getProxy(ring.coFac);
+    }
+
+
+    /**
+     * Factory for base elements.
+     */
+    public GenPolynomialRing<C> pairFactory() {
+        return ring;
+    }
+
+
+    /**
+     * Create from numerator.
+     */
+    public Local<C> create(GenPolynomial<C> n) {
+        return new Local<C>(this, n);
+    }
+
+
+    /**
+     * Create from numerator, denominator pair.
+     */
+    public Local<C> create(GenPolynomial<C> n, GenPolynomial<C> d) {
+        return new Local<C>(this, n, d);
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite()
+     */
+    public boolean isFinite() {
+        return ring.isFinite() && ideal.bb.commonZeroTest(ideal.getList()) <= 0;
+    }
+
+
+    /**
+     * Copy Local element c.
+     * @param c
+     * @return a copy of c.
+     */
+    public Local<C> copy(Local<C> c) {
+        return new Local<C>(c.ring, c.num, c.den, true);
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as Local.
+     */
+    public Local<C> getZERO() {
+        return new Local<C>(this, ring.getZERO());
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as Local.
+     */
+    public Local<C> getONE() {
+        return new Local<C>(this, ring.getONE());
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     * @see edu.jas.structure.ElemFactory#generators()
+     */
+    public List<Local<C>> generators() {
+        List<GenPolynomial<C>> pgens = ring.generators();
+        List<Local<C>> gens = new ArrayList<Local<C>>(pgens.size());
+        GenPolynomial<C> one = ring.getONE();
+        for (GenPolynomial<C> p : pgens) {
+            Local<C> q = new Local<C>(this, p);
+            gens.add(q);
+            if (!p.isONE() && !ideal.contains(p)) { // q.isUnit()
+                q = new Local<C>(this, one, p);
+                gens.add(q);
+            }
+        }
+        return gens;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true if this ring is commutative, else false.
+     */
+    public boolean isCommutative() {
+        return ring.isCommutative();
+    }
+
+
+    /**
+     * Query if this ring is associative.
+     * @return true if this ring is associative, else false.
+     */
+    public boolean isAssociative() {
+        return ring.isAssociative();
+    }
+
+
+    /**
+     * Query if this ring is a field.
+     * @return false.
+     */
+    public boolean isField() {
+        if (isField > 0) {
+            return true;
+        }
+        if (isField == 0) {
+            return false;
+        }
+        // not reached
+        return false;
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic() {
+        return ring.characteristic();
+    }
+
+
+    /**
+     * Get a Local element from a BigInteger value.
+     * @param a BigInteger.
+     * @return a Local.
+     */
+    public Local<C> fromInteger(java.math.BigInteger a) {
+        return new Local<C>(this, ring.fromInteger(a));
+    }
+
+
+    /**
+     * Get a Local element from a long value.
+     * @param a long.
+     * @return a Local.
+     */
+    public Local<C> fromInteger(long a) {
+        return new Local<C>(this, ring.fromInteger(a));
+    }
+
+
+    /**
+     * Get the String representation as RingFactory.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "LocalRing[ " + ideal.toString() + " ]";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.ElemFactory#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        return "LC(" + ideal.list.toScript() + ")";
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    // not jet working
+    public boolean equals(Object b) {
+        if (!(b instanceof LocalRing)) {
+            return false;
+        }
+        LocalRing<C> a = null;
+        try {
+            a = (LocalRing<C>) b;
+        } catch (ClassCastException e) {
+        }
+        if (a == null) {
+            return false;
+        }
+        if (!ring.equals(a.ring)) {
+            return false;
+        }
+        return ideal.equals(a.ideal);
+    }
+
+
+    /**
+     * Hash code for this local ring.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = ideal.hashCode();
+        return h;
+    }
+
+
+    /**
+     * Local random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @return a random residue element.
+     */
+    public Local<C> random(int n) {
+        GenPolynomial<C> r = ring.random(n).monic();
+        r = ideal.normalform(r);
+        GenPolynomial<C> s;
+        do {
+            s = ring.random(n).monic();
+            s = ideal.normalform(s);
+        } while (s.isZERO());
+        return new Local<C>(this, r, s, false);
+    }
+
+
+    /**
+     * Generate a random residum polynomial.
+     * @param k bitsize of random coefficients.
+     * @param l number of terms.
+     * @param d maximal degree in each variable.
+     * @param q density of nozero exponents.
+     * @return a random residue polynomial.
+     */
+    public Local<C> random(int k, int l, int d, float q) {
+        GenPolynomial<C> r = ring.random(k, l, d, q).monic();
+        r = ideal.normalform(r);
+        GenPolynomial<C> s;
+        do {
+            s = ring.random(k, l, d, q).monic();
+            s = ideal.normalform(s);
+        } while (s.isZERO());
+        return new Local<C>(this, r, s, false);
+    }
+
+
+    /**
+     * Local random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @param rnd is a source for random bits.
+     * @return a random residue element.
+     */
+    public Local<C> random(int n, Random rnd) {
+        GenPolynomial<C> r = ring.random(n, rnd).monic();
+        r = ideal.normalform(r);
+        GenPolynomial<C> s;
+        do {
+            s = ring.random(n).monic();
+            s = ideal.normalform(s);
+        } while (s.isZERO());
+        return new Local<C>(this, r, s, false);
+    }
+
+
+    /**
+     * Parse Local from String.
+     * @param s String.
+     * @return Local from s.
+     */
+    public Local<C> parse(String s) {
+        int i = s.indexOf("{");
+        if (i >= 0) {
+            s = s.substring(i + 1);
+        }
+        i = s.lastIndexOf("}");
+        if (i >= 0) {
+            s = s.substring(0, i);
+        }
+        i = s.indexOf("|");
+        if (i < 0) {
+            GenPolynomial<C> n = ring.parse(s);
+            return new Local<C>(this, n);
+        }
+        String s1 = s.substring(0, i);
+        String s2 = s.substring(i + 1);
+        GenPolynomial<C> n = ring.parse(s1);
+        GenPolynomial<C> d = ring.parse(s2);
+        return new Local<C>(this, n, d);
+    }
+
+
+    /**
+     * Parse Local from Reader.
+     * @param r Reader.
+     * @return next Local from r.
+     */
+    public Local<C> parse(Reader r) {
+        String s = StringUtil.nextPairedString(r, '{', '}');
+        return parse(s);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/LocalSolvablePolynomial.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/LocalSolvablePolynomial.java
@@ -1,0 +1,688 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.RecSolvablePolynomial;
+import edu.jas.poly.TableRelation;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * LocalSolvablePolynomial generic recursive solvable polynomials implementing
+ * RingElem. n-variate ordered solvable polynomials over solvable polynomial
+ * coefficients. Objects of this class are intended to be immutable. The
+ * implementation is based on TreeMap respectively SortedMap from exponents to
+ * coefficients by extension of GenPolynomial.
+ * Will be deprecated use QLRSolvablePolynomial.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class LocalSolvablePolynomial<C extends GcdRingElem<C>> extends
+                GenSolvablePolynomial<SolvableLocal<C>> {
+
+
+    /**
+     * The factory for the recursive solvable polynomial ring. Hides super.ring.
+     */
+    public final LocalSolvablePolynomialRing<C> ring;
+
+
+    private static final Logger logger = LogManager.getLogger(LocalSolvablePolynomial.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor for zero LocalSolvablePolynomial.
+     * @param r solvable polynomial ring factory.
+     */
+    public LocalSolvablePolynomial(LocalSolvablePolynomialRing<C> r) {
+        super(r);
+        ring = r;
+    }
+
+
+    /**
+     * Constructor for LocalSolvablePolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param c coefficient polynomial.
+     * @param e exponent.
+     */
+    public LocalSolvablePolynomial(LocalSolvablePolynomialRing<C> r, SolvableLocal<C> c, ExpVector e) {
+        this(r);
+        if (c != null && !c.isZERO()) {
+            val.put(e, c);
+        }
+    }
+
+
+    /**
+     * Constructor for LocalSolvablePolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param c coefficient polynomial.
+     */
+    public LocalSolvablePolynomial(LocalSolvablePolynomialRing<C> r, SolvableLocal<C> c) {
+        this(r, c, r.evzero);
+    }
+
+
+    /**
+     * Constructor for LocalSolvablePolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param S solvable polynomial.
+     */
+    public LocalSolvablePolynomial(LocalSolvablePolynomialRing<C> r, GenSolvablePolynomial<SolvableLocal<C>> S) {
+        this(r, S.getMap());
+    }
+
+
+    /**
+     * Constructor for LocalSolvablePolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param v the SortedMap of some other (solvable) polynomial.
+     */
+    protected LocalSolvablePolynomial(LocalSolvablePolynomialRing<C> r,
+                    SortedMap<ExpVector, SolvableLocal<C>> v) {
+        this(r);
+        val.putAll(v); // assume no zero coefficients
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    @Override
+    public LocalSolvablePolynomialRing<C> factory() {
+        return ring;
+    }
+
+
+    /**
+     * Clone this LocalSolvablePolynomial.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public LocalSolvablePolynomial<C> copy() {
+        return new LocalSolvablePolynomial<C>(ring, this.val);
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object B) {
+        if (!(B instanceof LocalSolvablePolynomial)) {
+            return false;
+        }
+        return super.equals(B);
+    }
+
+
+    /**
+     * Hash code for this polynomial.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+
+    /**
+     * LocalSolvablePolynomial multiplication.
+     * @param Bp LocalSolvablePolynomial.
+     * @return this*Bp, where * denotes solvable multiplication.
+     */
+    // not @Override
+    public LocalSolvablePolynomial<C> multiply(LocalSolvablePolynomial<C> Bp) {
+        if (Bp == null || Bp.isZERO()) {
+            return ring.getZERO();
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        if (Bp.isONE()) {
+            return this;
+        }
+        if (this.isONE()) {
+            return Bp;
+        }
+        assert (ring.nvar == Bp.ring.nvar);
+        if (debug) {
+            logger.debug("ring = " + ring);
+        }
+        //System.out.println("this = " + this + ", Bp = " + Bp);
+        ExpVector Z = ring.evzero;
+        LocalSolvablePolynomial<C> Dp = ring.getZERO().copy();
+        LocalSolvablePolynomial<C> zero = ring.getZERO().copy();
+        SolvableLocal<C> one = ring.getONECoefficient();
+
+        //LocalSolvablePolynomial<C> C1 = null;
+        //LocalSolvablePolynomial<C> C2 = null;
+        Map<ExpVector, SolvableLocal<C>> A = val;
+        Map<ExpVector, SolvableLocal<C>> B = Bp.val;
+        Set<Map.Entry<ExpVector, SolvableLocal<C>>> Bk = B.entrySet();
+        for (Map.Entry<ExpVector, SolvableLocal<C>> y : A.entrySet()) {
+            SolvableLocal<C> a = y.getValue();
+            ExpVector e = y.getKey();
+            if (debug)
+                logger.info("e = " + e + ", a = " + a);
+            //int[] ep = e.dependencyOnVariables();
+            //int el1 = ring.nvar + 1;
+            //if (ep.length > 0) {
+            //    el1 = ep[0];
+            //}
+            //int el1s = ring.nvar + 1 - el1;
+            for (Map.Entry<ExpVector, SolvableLocal<C>> x : Bk) {
+                SolvableLocal<C> b = x.getValue();
+                ExpVector f = x.getKey();
+                if (debug)
+                    logger.info("f = " + f + ", b = " + b);
+                int[] fp = f.dependencyOnVariables();
+                int fl1 = 0;
+                if (fp.length > 0) {
+                    fl1 = fp[fp.length - 1];
+                }
+                int fl1s = ring.nvar + 1 - fl1;
+                // polynomial with coefficient multiplication 
+                LocalSolvablePolynomial<C> Cps = ring.getZERO().copy();
+                //LocalSolvablePolynomial<C> Cs;
+                LocalSolvablePolynomial<C> qp;
+                if (ring.polCoeff.coeffTable.isEmpty() || b.isConstant() || e.isZERO()) { // symmetric
+                    Cps = new LocalSolvablePolynomial<C>(ring, b, e);
+                    if (debug)
+                        logger.info("symmetric coeff: b = " + b + ", e = " + e);
+                } else { // unsymmetric
+                    if (debug)
+                        logger.info("unsymmetric coeff: b = " + b + ", e = " + e);
+                    // compute e * b as ( e * 1/b.den ) * b.num
+                    if (b.den.isONE()) { // recursion base
+                        // for (Map.Entry<ExpVector, C> z : b.num.getMap().entrySet()) {
+                        //     C c = z.getValue();
+                        //     SolvableLocal<C> cc = b.ring.getONE().multiply(c);
+                        //     ExpVector g = z.getKey();
+                        //     if (debug)
+                        //         logger.info("g = " + g + ", c = " + c);
+                        //     int[] gp = g.dependencyOnVariables();
+                        //     int gl1 = 0;
+                        //     if (gp.length > 0) {
+                        //         gl1 = gp[gp.length - 1];
+                        //     }
+                        //     int gl1s = b.ring.ring.nvar + 1 - gl1;
+                        //     if (debug) {
+                        //         logger.info("gl1s = " + gl1s);
+                        //     }
+                        //     // split e = e1 * e2, g = g1 * g2
+                        //     ExpVector e1 = e;
+                        //     ExpVector e2 = Z;
+                        //     if (!e.isZERO()) {
+                        //         e1 = e.subst(el1, 0);
+                        //         e2 = Z.subst(el1, e.getVal(el1));
+                        //     }
+                        //     ExpVector e4;
+                        //     ExpVector g1 = g;
+                        //     ExpVector g2 = Zc;
+                        //     if (!g.isZERO()) {
+                        //         g1 = g.subst(gl1, 0);
+                        //         g2 = Zc.subst(gl1, g.getVal(gl1));
+                        //     }
+                        //     if (debug)
+                        //         logger.info("coeff, e1 = " + e1 + ", e2 = " + e2);
+                        //     if (debug)
+                        //         logger.info("coeff, g1 = " + g1 + ", g2 = " + g2);
+                        //     TableRelation<GenPolynomial<C>> crel = ring.coeffTable.lookup(e2, g2);
+                        //     if (debug)
+                        //         logger.info("coeff, crel = " + crel.p);
+                        //     if (debug)
+                        //         logger.info("coeff, e  = " + e + " g, = " + g + ", crel = " + crel);
+                        //     Cs = ring.fromPolyCoefficients(crel.p); //LocalSolvablePolynomial<C>(ring, crel.p);
+                        //     // rest of multiplication and update relations
+                        //     if (crel.f != null) {
+                        //         SolvableLocal<C> c2 = b.ring.getONE().multiply(crel.f);
+                        //         C2 = new LocalSolvablePolynomial<C>(ring, c2, Z);
+                        //         Cs = Cs.multiply(C2);
+                        //         if (crel.e == null) {
+                        //             e4 = e2;
+                        //         } else {
+                        //             e4 = e2.subtract(crel.e);
+                        //         }
+                        //         ring.coeffTable.update(e4, g2, ring.toPolyCoefficients(Cs));
+                        //     }
+                        //     if (crel.e != null) { // process left part
+                        //         C1 = new LocalSolvablePolynomial<C>(ring, one, crel.e);
+                        //         Cs = C1.multiply(Cs);
+                        //         ring.coeffTable.update(e2, g2, ring.toPolyCoefficients(Cs));
+                        //     }
+                        //     if (!g1.isZERO()) { // process right part
+                        //         SolvableLocal<C> c2 = b.ring.getONE().multiply(g1);
+                        //         C2 = new LocalSolvablePolynomial<C>(ring, c2, Z);
+                        //         Cs = Cs.multiply(C2);
+                        //     }
+                        //     if (!e1.isZERO()) { // process left part
+                        //         C1 = new LocalSolvablePolynomial<C>(ring, one, e1);
+                        //         Cs = C1.multiply(Cs);
+                        //     }
+                        //     //System.out.println("e1*Cs*g1 = " + Cs);
+                        //     Cs = Cs.multiplyLeft(cc); // cc * Cs
+                        //     Cps = (LocalSolvablePolynomial<C>) Cps.sum(Cs);
+                        // } // end b.num loop 
+                        // recursive polynomial coefficient multiplication : e * b.num
+                        RecSolvablePolynomial<C> rsp1 = new RecSolvablePolynomial<C>(ring.polCoeff, e);
+                        RecSolvablePolynomial<C> rsp2 = new RecSolvablePolynomial<C>(ring.polCoeff, b.num);
+                        RecSolvablePolynomial<C> rsp3 = rsp1.multiply(rsp2);
+                        LocalSolvablePolynomial<C> rsp = ring.fromPolyCoefficients(rsp3);
+                        Cps = rsp;
+                        // if (rsp.compareTo(Cps) != 0) {
+                        //     logger.info("coeff-poly: Cps = " + Cps);
+                        //     logger.info("coeff-poly: rsp = " + rsp);
+                        //     //System.out.println("rsp.compareTo(Cps) != 0");
+                        //     //} else {
+                        //     //System.out.println("rsp.compareTo(Cps) == 0");
+                        // }
+                    } else { // b.den != 1
+                        if (debug)
+                            logger.info("coeff-num: Cps = " + Cps + ", num = " + b.num + ", den = " + b.den);
+                        Cps = new LocalSolvablePolynomial<C>(ring, b.ring.getONE(), e);
+
+                        // coefficient multiplication with 1/den: 
+                        LocalSolvablePolynomial<C> qv = Cps;
+                        SolvableLocal<C> qden = new SolvableLocal<C>(b.ring, b.den); // den/1
+                        //System.out.println("qv = " + qv + ", den = " + den);
+                        // recursion with den==1:
+                        LocalSolvablePolynomial<C> v = qv.multiply(qden);
+                        LocalSolvablePolynomial<C> vl = qv.multiplyLeft(qden);
+                        //System.out.println("v = " + v + ", vl = " + vl + ", qden = " + qden);
+                        LocalSolvablePolynomial<C> vr = (LocalSolvablePolynomial<C>) v.subtract(vl);
+                        SolvableLocal<C> qdeni = new SolvableLocal<C>(b.ring, b.ring.ring.getONE(), b.den);
+                        //System.out.println("vr = " + vr + ", qdeni = " + qdeni);
+                        // recursion with smaller head term:
+                        LocalSolvablePolynomial<C> rq = vr.multiply(qdeni);
+                        qp = (LocalSolvablePolynomial<C>) qv.subtract(rq);
+                        qp = qp.multiplyLeft(qdeni);
+                        //System.out.println("qp_i = " + qp);
+                        Cps = qp;
+
+                        if (!b.num.isONE()) {
+                            SolvableLocal<C> qnum = new SolvableLocal<C>(b.ring, b.num); // num/1
+                            // recursion with den == 1:
+                            Cps = Cps.multiply(qnum);
+                        }
+                    }
+                } // end coeff
+                if (debug)
+                    logger.info("coeff-den: Cps = " + Cps);
+                // polynomial multiplication 
+                LocalSolvablePolynomial<C> Dps = ring.getZERO().copy();
+                LocalSolvablePolynomial<C> Ds = null;
+                LocalSolvablePolynomial<C> D1, D2;
+                if (ring.table.isEmpty() || Cps.isConstant() || f.isZERO()) { // symmetric
+                    if (debug)
+                        logger.info("symmetric poly: b = " + b + ", e = " + e);
+                    ExpVector g = e.sum(f);
+                    if (Cps.isConstant()) {
+                        Ds = new LocalSolvablePolynomial<C>(ring, Cps.leadingBaseCoefficient(), g); // symmetric!
+                    } else {
+                        Ds = Cps.shift(f); // symmetric
+                    }
+                } else { // eventually unsymmetric
+                    if (debug)
+                        logger.info("unsymmetric poly: Cps = " + Cps + ", f = " + f);
+                    for (Map.Entry<ExpVector, SolvableLocal<C>> z : Cps.val.entrySet()) {
+                        // split g = g1 * g2, f = f1 * f2
+                        SolvableLocal<C> c = z.getValue();
+                        ExpVector g = z.getKey();
+                        if (debug)
+                            logger.info("g = " + g + ", c = " + c);
+                        int[] gp = g.dependencyOnVariables();
+                        int gl1 = ring.nvar + 1;
+                        if (gp.length > 0) {
+                            gl1 = gp[0];
+                        }
+                        int gl1s = ring.nvar + 1 - gl1;
+                        if (gl1s <= fl1s) { // symmetric
+                            ExpVector h = g.sum(f);
+                            if (debug)
+                                logger.info("disjoint poly: g = " + g + ", f = " + f + ", h = " + h);
+                            Ds = (LocalSolvablePolynomial<C>) zero.sum(one, h); // symmetric!
+                        } else {
+                            ExpVector g1 = g.subst(gl1, 0);
+                            ExpVector g2 = Z.subst(gl1, g.getVal(gl1)); // bug el1, gl1
+                            ExpVector g4;
+                            ExpVector f1 = f.subst(fl1, 0);
+                            ExpVector f2 = Z.subst(fl1, f.getVal(fl1));
+                            if (debug) {
+                                logger.info("poly, g1 = " + g1 + ", f1 = " + f1 + ", Dps = " + Dps);
+                                logger.info("poly, g2 = " + g2 + ", f2 = " + f2);
+                            }
+                            TableRelation<SolvableLocal<C>> rel = ring.table.lookup(g2, f2);
+                            if (debug)
+                                logger.info("poly, g  = " + g + ", f  = " + f + ", rel = " + rel);
+                            Ds = new LocalSolvablePolynomial<C>(ring, rel.p); //ring.copy(rel.p);
+                            if (rel.f != null) {
+                                D2 = new LocalSolvablePolynomial<C>(ring, one, rel.f);
+                                Ds = Ds.multiply(D2);
+                                if (rel.e == null) {
+                                    g4 = g2;
+                                } else {
+                                    g4 = g2.subtract(rel.e);
+                                }
+                                ring.table.update(g4, f2, Ds);
+                            }
+                            if (rel.e != null) {
+                                D1 = new LocalSolvablePolynomial<C>(ring, one, rel.e);
+                                Ds = D1.multiply(Ds);
+                                ring.table.update(g2, f2, Ds);
+                            }
+                            if (!f1.isZERO()) {
+                                D2 = new LocalSolvablePolynomial<C>(ring, one, f1);
+                                Ds = Ds.multiply(D2);
+                                //ring.table.update(?,f1,Ds)
+                            }
+                            if (!g1.isZERO()) {
+                                D1 = new LocalSolvablePolynomial<C>(ring, one, g1);
+                                Ds = D1.multiply(Ds);
+                                //ring.table.update(e1,?,Ds)
+                            }
+                        }
+                        Ds = Ds.multiplyLeft(c); // c * Ds
+                        Dps = (LocalSolvablePolynomial<C>) Dps.sum(Ds);
+                    } // end Dps loop
+                    Ds = Dps;
+                }
+                Ds = Ds.multiplyLeft(a); // multiply(a,b); // non-symmetric 
+                if (debug)
+                    logger.debug("Ds = " + Ds);
+                Dp = (LocalSolvablePolynomial<C>) Dp.sum(Ds);
+            } // end B loop
+        } // end A loop
+          //System.out.println("this * Bp = " + Dp);
+        return Dp;
+    }
+
+
+    /**
+     * LocalSolvablePolynomial left and right multiplication. Product with two
+     * polynomials.
+     * @param S LocalSolvablePolynomial.
+     * @param T LocalSolvablePolynomial.
+     * @return S*this*T.
+     */
+    // not @Override
+    public LocalSolvablePolynomial<C> multiply(LocalSolvablePolynomial<C> S, LocalSolvablePolynomial<C> T) {
+        if (S.isZERO() || T.isZERO() || this.isZERO()) {
+            return ring.getZERO();
+        }
+        if (S.isONE()) {
+            return multiply(T);
+        }
+        if (T.isONE()) {
+            return S.multiply(this);
+        }
+        return S.multiply(this).multiply(T);
+    }
+
+
+    /**
+     * LocalSolvablePolynomial multiplication. Product with coefficient ring
+     * element.
+     * @param b solvable coefficient.
+     * @return this*b, where * is coefficient multiplication.
+     */
+    @Override
+    public LocalSolvablePolynomial<C> multiply(SolvableLocal<C> b) {
+        LocalSolvablePolynomial<C> Cp = ring.getZERO().copy();
+        if (b == null || b.isZERO()) {
+            return Cp;
+        }
+        if (b.isONE()) {
+            return this;
+        }
+        Cp = new LocalSolvablePolynomial<C>(ring, b, ring.evzero);
+        return multiply(Cp);
+    }
+
+
+    /**
+     * LocalSolvablePolynomial left and right multiplication. Product with
+     * coefficient ring element.
+     * @param b coefficient polynomial.
+     * @param c coefficient polynomial.
+     * @return b*this*c, where * is coefficient multiplication.
+     */
+    @Override
+    public LocalSolvablePolynomial<C> multiply(SolvableLocal<C> b, SolvableLocal<C> c) {
+        LocalSolvablePolynomial<C> Cp = ring.getZERO().copy();
+        if (b == null || b.isZERO()) {
+            return Cp;
+        }
+        if (c == null || c.isZERO()) {
+            return Cp;
+        }
+        if (b.isONE() && c.isONE()) {
+            return this;
+        }
+        Cp = new LocalSolvablePolynomial<C>(ring, b, ring.evzero);
+        LocalSolvablePolynomial<C> Dp = new LocalSolvablePolynomial<C>(ring, c, ring.evzero);
+        return multiply(Cp, Dp);
+    }
+
+
+    /**
+     * LocalSolvablePolynomial multiplication. Product with exponent vector.
+     * @param e exponent.
+     * @return this * x<sup>e</sup>, where * denotes solvable multiplication.
+     */
+    @Override
+    public LocalSolvablePolynomial<C> multiply(ExpVector e) {
+        if (e == null || e.isZERO()) {
+            return this;
+        }
+        SolvableLocal<C> b = ring.getONECoefficient();
+        return multiply(b, e);
+    }
+
+
+    /**
+     * LocalSolvablePolynomial left and right multiplication. Product with
+     * exponent vector.
+     * @param e exponent.
+     * @param f exponent.
+     * @return x<sup>e</sup> * this * x<sup>f</sup>, where * denotes solvable
+     *         multiplication.
+     */
+    @Override
+    public LocalSolvablePolynomial<C> multiply(ExpVector e, ExpVector f) {
+        if (e == null || e.isZERO()) {
+            return this;
+        }
+        if (f == null || f.isZERO()) {
+            return this;
+        }
+        SolvableLocal<C> b = ring.getONECoefficient();
+        return multiply(b, e, b, f);
+    }
+
+
+    /**
+     * LocalSolvablePolynomial multiplication. Product with ring element and
+     * exponent vector.
+     * @param b coefficient polynomial.
+     * @param e exponent.
+     * @return this * b x<sup>e</sup>, where * denotes solvable multiplication.
+     */
+    @Override
+    public LocalSolvablePolynomial<C> multiply(SolvableLocal<C> b, ExpVector e) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        if (b.isONE() && e.isZERO()) {
+            return this;
+        }
+        LocalSolvablePolynomial<C> Cp = new LocalSolvablePolynomial<C>(ring, b, e);
+        return multiply(Cp);
+    }
+
+
+    /**
+     * LocalSolvablePolynomial left and right multiplication. Product with ring
+     * element and exponent vector.
+     * @param b coefficient polynomial.
+     * @param e exponent.
+     * @param c coefficient polynomial.
+     * @param f exponent.
+     * @return b x<sup>e</sup> * this * c x<sup>f</sup>, where * denotes
+     *         solvable multiplication.
+     */
+    @Override
+    public LocalSolvablePolynomial<C> multiply(SolvableLocal<C> b, ExpVector e, SolvableLocal<C> c,
+                    ExpVector f) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        if (c == null || c.isZERO()) {
+            return ring.getZERO();
+        }
+        if (b.isONE() && e.isZERO() && c.isONE() && f.isZERO()) {
+            return this;
+        }
+        LocalSolvablePolynomial<C> Cp = new LocalSolvablePolynomial<C>(ring, b, e);
+        LocalSolvablePolynomial<C> Dp = new LocalSolvablePolynomial<C>(ring, c, f);
+        return multiply(Cp, Dp);
+    }
+
+
+    /**
+     * LocalSolvablePolynomial multiplication. Left product with ring element
+     * and exponent vector.
+     * @param b coefficient polynomial.
+     * @param e exponent.
+     * @return b x<sup>e</sup> * this, where * denotes solvable multiplication.
+     */
+    @Override
+    public LocalSolvablePolynomial<C> multiplyLeft(SolvableLocal<C> b, ExpVector e) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        LocalSolvablePolynomial<C> Cp = new LocalSolvablePolynomial<C>(ring, b, e);
+        return Cp.multiply(this);
+    }
+
+
+    /**
+     * LocalSolvablePolynomial multiplication. Left product with exponent
+     * vector.
+     * @param e exponent.
+     * @return x<sup>e</sup> * this, where * denotes solvable multiplication.
+     */
+    @Override
+    public LocalSolvablePolynomial<C> multiplyLeft(ExpVector e) {
+        if (e == null || e.isZERO()) {
+            return this;
+        }
+        SolvableLocal<C> b = ring.getONECoefficient();
+        LocalSolvablePolynomial<C> Cp = new LocalSolvablePolynomial<C>(ring, b, e);
+        return Cp.multiply(this);
+    }
+
+
+    /**
+     * LocalSolvablePolynomial multiplication. Left product with coefficient
+     * ring element.
+     * @param b coefficient polynomial.
+     * @return b*this, where * is coefficient multiplication.
+     */
+    @Override
+    public LocalSolvablePolynomial<C> multiplyLeft(SolvableLocal<C> b) {
+        LocalSolvablePolynomial<C> Cp = ring.getZERO().copy();
+        if (b == null || b.isZERO()) {
+            return Cp;
+        }
+        Map<ExpVector, SolvableLocal<C>> Cm = Cp.val; //getMap();
+        Map<ExpVector, SolvableLocal<C>> Am = val;
+        SolvableLocal<C> c;
+        for (Map.Entry<ExpVector, SolvableLocal<C>> y : Am.entrySet()) {
+            ExpVector e = y.getKey();
+            SolvableLocal<C> a = y.getValue();
+            c = b.multiply(a);
+            if (!c.isZERO()) {
+                Cm.put(e, c);
+            }
+        }
+        return Cp;
+    }
+
+
+    /**
+     * LocalSolvablePolynomial multiplication. Left product with 'monomial'.
+     * @param m 'monomial'.
+     * @return m * this, where * denotes solvable multiplication.
+     */
+    @Override
+    public LocalSolvablePolynomial<C> multiplyLeft(Map.Entry<ExpVector, SolvableLocal<C>> m) {
+        if (m == null) {
+            return ring.getZERO();
+        }
+        return multiplyLeft(m.getValue(), m.getKey());
+    }
+
+
+    /**
+     * LocalSolvablePolynomial multiplication. Product with 'monomial'.
+     * @param m 'monomial'.
+     * @return this * m, where * denotes solvable multiplication.
+     */
+    @Override
+    public LocalSolvablePolynomial<C> multiply(Map.Entry<ExpVector, SolvableLocal<C>> m) {
+        if (m == null) {
+            return ring.getZERO();
+        }
+        return multiply(m.getValue(), m.getKey());
+    }
+
+
+    /**
+     * LocalSolvablePolynomial multiplication. Left product with coefficient
+     * ring element.
+     * @param f exponent vector.
+     * @return B*f, where * is commutative multiplication.
+     */
+    protected LocalSolvablePolynomial<C> shift(ExpVector f) {
+        LocalSolvablePolynomial<C> C = ring.getZERO().copy();
+        if (this.isZERO()) {
+            return C;
+        }
+        if (f == null || f.isZERO()) {
+            return this;
+        }
+        Map<ExpVector, SolvableLocal<C>> Cm = C.val;
+        Map<ExpVector, SolvableLocal<C>> Bm = this.val;
+        for (Map.Entry<ExpVector, SolvableLocal<C>> y : Bm.entrySet()) {
+            ExpVector e = y.getKey();
+            SolvableLocal<C> a = y.getValue();
+            ExpVector d = e.sum(f);
+            if (!a.isZERO()) {
+                Cm.put(d, a);
+            }
+        }
+        return C;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/LocalSolvablePolynomialRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/LocalSolvablePolynomialRing.java
@@ -1,0 +1,805 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.kern.PrettyPrint;
+import edu.jas.kern.Scripting;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.GenPolynomialTokenizer;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.GenSolvablePolynomialRing;
+import edu.jas.poly.RecSolvablePolynomial;
+import edu.jas.poly.RecSolvablePolynomialRing;
+import edu.jas.poly.RelationTable;
+import edu.jas.poly.TermOrder;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * LocalSolvablePolynomialRing generic recursive solvable polynomial factory
+ * implementing RingFactory and extending GenSolvablePolynomialRing factory.
+ * Factory for n-variate ordered solvable polynomials over solvable polynomial
+ * coefficients. The non-commutative multiplication relations are maintained in
+ * a relation table and the non-commutative multiplication relations between the
+ * coefficients and the main variables are maintained in a coefficient relation
+ * table. Almost immutable object, except variable names and relation table
+ * contents.
+ * @param <C> coefficient type.
+ * @author Heinz Kredel
+ * will be deprecated use QLRSolvablePolynomialRing
+ */
+
+public class LocalSolvablePolynomialRing<C extends GcdRingElem<C>> extends
+                GenSolvablePolynomialRing<SolvableLocal<C>> {
+
+
+    /*
+     * The solvable multiplication relations between variables and coefficients.
+     */
+    //public final RelationTable<GenPolynomial<C>> coeffTable;
+
+
+    /**
+     * Recursive solvable polynomial ring with polynomial coefficients.
+     */
+    public final RecSolvablePolynomialRing<C> polCoeff;
+
+
+    /**
+     * The constant polynomial 0 for this ring. Hides super ZERO.
+     */
+    public final LocalSolvablePolynomial<C> ZERO;
+
+
+    /**
+     * The constant polynomial 1 for this ring. Hides super ONE.
+     */
+    public final LocalSolvablePolynomial<C> ONE;
+
+
+    private static final Logger logger = LogManager.getLogger(LocalSolvablePolynomialRing.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * default term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     */
+    public LocalSolvablePolynomialRing(RingFactory<SolvableLocal<C>> cf, int n) {
+        this(cf, n, new TermOrder(), null, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * default term order.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param rt solvable multiplication relations.
+     */
+    public LocalSolvablePolynomialRing(RingFactory<SolvableLocal<C>> cf, int n,
+                    RelationTable<SolvableLocal<C>> rt) {
+        this(cf, n, new TermOrder(), null, rt);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     */
+    public LocalSolvablePolynomialRing(RingFactory<SolvableLocal<C>> cf, int n, TermOrder t) {
+        this(cf, n, t, null, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     * @param rt solvable multiplication relations.
+     */
+    public LocalSolvablePolynomialRing(RingFactory<SolvableLocal<C>> cf, int n, TermOrder t,
+                    RelationTable<SolvableLocal<C>> rt) {
+        this(cf, n, t, null, rt);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     * @param v names for the variables.
+     */
+    public LocalSolvablePolynomialRing(RingFactory<SolvableLocal<C>> cf, int n, TermOrder t, String[] v) {
+        this(cf, n, t, v, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param t a term order.
+     * @param v names for the variables.
+     */
+    public LocalSolvablePolynomialRing(RingFactory<SolvableLocal<C>> cf, TermOrder t, String[] v) {
+        this(cf, v.length, t, v, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * default term order.
+     * @param cf factory for coefficients of type C.
+     * @param v names for the variables.
+     */
+    public LocalSolvablePolynomialRing(RingFactory<SolvableLocal<C>> cf, String[] v) {
+        this(cf, v.length, new TermOrder(), v, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     * @param v names for the variables.
+     * @param rt solvable multiplication relations.
+     */
+    public LocalSolvablePolynomialRing(RingFactory<SolvableLocal<C>> cf, int n, TermOrder t, String[] v,
+                    RelationTable<SolvableLocal<C>> rt) {
+        super(cf, n, t, v, rt);
+        //if (rt == null) { // handled in super }
+        SolvableLocalRing<C> cfring = (SolvableLocalRing<C>) cf; // == coFac
+        polCoeff = new RecSolvablePolynomialRing<C>(cfring.ring, n, t, v);
+        if (table.size() > 0) { // TODO
+            ExpVector e = null;
+            ExpVector f = null;
+            GenSolvablePolynomial<GenPolynomial<C>> p = null;
+            polCoeff.table.update(e, f, p); // from rt
+        }
+        //coeffTable = polCoeff.coeffTable; //new RelationTable<GenPolynomial<C>>(polCoeff, true);
+        ZERO = new LocalSolvablePolynomial<C>(this);
+        SolvableLocal<C> coeff = coFac.getONE();
+        //evzero = ExpVector.create(nvar); // from super
+        ONE = new LocalSolvablePolynomial<C>(this, coeff, evzero);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the the
+     * same term order, number of variables and variable names as the given
+     * polynomial factory, only the coefficient factories differ and the
+     * solvable multiplication relations are <b>empty</b>.
+     * @param cf factory for coefficients of type C.
+     * @param o other solvable polynomial ring.
+     */
+    public LocalSolvablePolynomialRing(RingFactory<SolvableLocal<C>> cf, GenSolvablePolynomialRing o) {
+        this(cf, o.nvar, o.tord, o.getVars(), null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the the
+     * same term order, number of variables and variable names as the given
+     * polynomial factory, only the coefficient factories differ and the
+     * solvable multiplication relations are <b>empty</b>.
+     * @param cf factory for coefficients of type C.
+     * @param o other solvable polynomial ring.
+     */
+    public LocalSolvablePolynomialRing(RingFactory<SolvableLocal<C>> cf, LocalSolvablePolynomialRing o) {
+        this(cf, (GenSolvablePolynomialRing) o);
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        String res = super.toString();
+        if (PrettyPrint.isTrue()) {
+            //res += "\n" + table.toString(vars);
+            res += "\n" + polCoeff.coeffTable.toString(vars);
+        } else {
+            res += ", #rel = " + table.size() + " + " + polCoeff.coeffTable.size();
+        }
+        return res;
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        StringBuffer s = new StringBuffer();
+        switch (Scripting.getLang()) {
+        case Ruby:
+            s.append("SolvPolyRing.new(");
+            break;
+        case Python:
+        default:
+            s.append("SolvPolyRing(");
+        }
+        if (coFac instanceof RingElem) {
+            s.append(((RingElem<SolvableLocal<C>>) coFac).toScriptFactory());
+        } else {
+            s.append(coFac.toScript().trim());
+        }
+        s.append(",\"" + varsToString() + "\",");
+        String to = tord.toScript();
+        s.append(to);
+        if (table.size() > 0) {
+            String rel = table.toScript();
+            s.append(",rel=");
+            s.append(rel);
+        }
+        if (polCoeff.coeffTable.size() > 0) {
+            String rel = polCoeff.coeffTable.toScript();
+            s.append(",coeffrel=");
+            s.append(rel);
+        }
+        s.append(")");
+        return s.toString();
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object other) {
+        if (!(other instanceof LocalSolvablePolynomialRing)) {
+            return false;
+        }
+        LocalSolvablePolynomialRing<C> oring = null;
+        try {
+            oring = (LocalSolvablePolynomialRing<C>) other;
+        } catch (ClassCastException ignored) {
+        }
+        if (oring == null) {
+            return false;
+        }
+        // do a super.equals( )
+        if (!super.equals(other)) {
+            return false;
+        }
+        // check same base relations
+        //if ( ! table.equals(oring.table) ) { // done in super
+        //    return false;
+        //}
+        if (!polCoeff.coeffTable.equals(oring.polCoeff.coeffTable)) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Hash code for this polynomial ring.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = super.hashCode();
+        h = 37 * h + table.hashCode(); // may be different after some computations
+        h = 37 * h + polCoeff.coeffTable.hashCode(); // may be different
+        return h;
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as LocalSolvablePolynomial<C>.
+     */
+    @Override
+    public LocalSolvablePolynomial<C> getZERO() {
+        return ZERO;
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as LocalSolvablePolynomial<C>.
+     */
+    @Override
+    public LocalSolvablePolynomial<C> getONE() {
+        return ONE;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true if this ring is commutative, else false.
+     */
+    @Override
+    public boolean isCommutative() {
+        if (polCoeff.coeffTable.size() == 0) {
+            return super.isCommutative();
+        }
+        // check structure of relations?
+        return false;
+    }
+
+
+    /**
+     * Query if this ring is associative. Test if the relations between the mian
+     * variables and the coefficient generators define an associative solvable
+     * ring.
+     * @return true, if this ring is associative, else false.
+     */
+    @Override
+    public boolean isAssociative() {
+        if (!coFac.isAssociative()) {
+            return false;
+        }
+        LocalSolvablePolynomial<C> Xi, Xj, Xk, p, q;
+        List<GenPolynomial<SolvableLocal<C>>> gens = generators();
+        int ngen = gens.size();
+        for (int i = 0; i < ngen; i++) {
+            Xi = (LocalSolvablePolynomial<C>) gens.get(i);
+            for (int j = i + 1; j < ngen; j++) {
+                Xj = (LocalSolvablePolynomial<C>) gens.get(j);
+                for (int k = j + 1; k < ngen; k++) {
+                    Xk = (LocalSolvablePolynomial<C>) gens.get(k);
+                    try {
+                        p = Xk.multiply(Xj).multiply(Xi);
+                        q = Xk.multiply(Xj.multiply(Xi));
+                    } catch (IllegalArgumentException e) {
+                        //e.printStackTrace();
+                        continue;
+                    }
+                    if (p.compareTo(q) != 0) {
+                        if (logger.isInfoEnabled()) {
+                            logger.info("Xk = " + Xk + ", Xj = " + Xj + ", Xi = " + Xi);
+                            logger.info("p = ( Xk * Xj ) * Xi = " + p);
+                            logger.info("q = Xk * ( Xj * Xi ) = " + q);
+                            logger.info("q-p = " + p.subtract(q));
+                        }
+                        return false;
+                    }
+                }
+            }
+        }
+        return true; //coFac.isAssociative();
+    }
+
+
+    /**
+     * Get a (constant) LocalSolvablePolynomial&lt;C&gt; element from a long
+     * value.
+     * @param a long.
+     * @return a LocalSolvablePolynomial&lt;C&gt;.
+     */
+    @Override
+    public LocalSolvablePolynomial<C> fromInteger(long a) {
+        return new LocalSolvablePolynomial<C>(this, coFac.fromInteger(a), evzero);
+    }
+
+
+    /**
+     * Get a (constant) LocalSolvablePolynomial&lt;C&gt; element from a
+     * BigInteger value.
+     * @param a BigInteger.
+     * @return a LocalSolvablePolynomial&lt;C&gt;.
+     */
+    @Override
+    public LocalSolvablePolynomial<C> fromInteger(BigInteger a) {
+        return new LocalSolvablePolynomial<C>(this, coFac.fromInteger(a), evzero);
+    }
+
+
+    /**
+     * Random solvable polynomial. Generates a random solvable polynomial with k
+     * = 5, l = n, d = (nvar == 1) ? n : 3, q = (nvar == 1) ? 0.7 : 0.3.
+     * @param n number of terms.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    public LocalSolvablePolynomial<C> random(int n) {
+        return random(n, random);
+    }
+
+
+    /**
+     * Random solvable polynomial. Generates a random solvable polynomial with k
+     * = 5, l = n, d = (nvar == 1) ? n : 3, q = (nvar == 1) ? 0.7 : 0.3.
+     * @param n number of terms.
+     * @param rnd is a source for random bits.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    public LocalSolvablePolynomial<C> random(int n, Random rnd) {
+        if (nvar == 1) {
+            return random(5, n, n, 0.7f, rnd);
+        }
+        return random(5, n, 3, 0.3f, rnd);
+    }
+
+
+    /**
+     * Generate a random solvable polynomial.
+     * @param k bitsize of random coefficients.
+     * @param l number of terms.
+     * @param d maximal degree in each variable.
+     * @param q density of nozero exponents.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    public LocalSolvablePolynomial<C> random(int k, int l, int d, float q) {
+        return random(k, l, d, q, random);
+    }
+
+
+    /**
+     * Random solvable polynomial.
+     * @param k size of random coefficients.
+     * @param l number of terms.
+     * @param d maximal degree in each variable.
+     * @param q density of nozero exponents.
+     * @param rnd is a source for random bits.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    public LocalSolvablePolynomial<C> random(int k, int l, int d, float q, Random rnd) {
+        LocalSolvablePolynomial<C> r = getZERO(); // copy( ZERO ); 
+        ExpVector e;
+        SolvableLocal<C> a;
+        // add random coeffs and exponents
+        for (int i = 0; i < l; i++) {
+            e = ExpVector.random(nvar, d, q, rnd);
+            a = coFac.random(k, rnd);
+            r = (LocalSolvablePolynomial<C>) r.sum(a, e);
+            // somewhat inefficient but clean
+        }
+        return r;
+    }
+
+
+    /**
+     * Copy polynomial c.
+     * @param c
+     * @return a copy of c.
+     */
+    public LocalSolvablePolynomial<C> copy(LocalSolvablePolynomial<C> c) {
+        return new LocalSolvablePolynomial<C>(this, c.getMap());
+    }
+
+
+    /**
+     * Parse a solvable polynomial with the use of GenPolynomialTokenizer
+     * @param s String.
+     * @return LocalSolvablePolynomial from s.
+     */
+    @Override
+    public LocalSolvablePolynomial<C> parse(String s) {
+        return parse(new StringReader(s));
+    }
+
+
+    /**
+     * Parse a solvable polynomial with the use of GenPolynomialTokenizer
+     * @param r Reader.
+     * @return next LocalSolvablePolynomial from r.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public LocalSolvablePolynomial<C> parse(Reader r) {
+        GenPolynomialTokenizer pt = new GenPolynomialTokenizer(this, r);
+        LocalSolvablePolynomial<C> p = null;
+        try {
+            GenSolvablePolynomial<SolvableLocal<C>> s = pt.nextSolvablePolynomial();
+            p = new LocalSolvablePolynomial<C>(this, s);
+        } catch (IOException e) {
+            logger.error(e.toString() + " parse " + this);
+            p = ZERO;
+        }
+        return p;
+    }
+
+
+    /**
+     * Generate univariate solvable polynomial in a given variable.
+     * @param i the index of the variable.
+     * @return X_i as solvable univariate polynomial.
+     */
+    @Override
+    public LocalSolvablePolynomial<C> univariate(int i) {
+        return (LocalSolvablePolynomial<C>) super.univariate(i);
+    }
+
+
+    /**
+     * Generate univariate solvable polynomial in a given variable with given
+     * exponent.
+     * @param i the index of the variable.
+     * @param e the exponent of the variable.
+     * @return X_i^e as solvable univariate polynomial.
+     */
+    @Override
+    public LocalSolvablePolynomial<C> univariate(int i, long e) {
+        return (LocalSolvablePolynomial<C>) super.univariate(i, e);
+    }
+
+
+    /**
+     * Generate univariate solvable polynomial in a given variable with given
+     * exponent.
+     * @param modv number of module variables.
+     * @param i the index of the variable.
+     * @param e the exponent of the variable.
+     * @return X_i^e as solvable univariate polynomial.
+     */
+    @Override
+    public LocalSolvablePolynomial<C> univariate(int modv, int i, long e) {
+        return (LocalSolvablePolynomial<C>) super.univariate(modv, i, e);
+    }
+
+
+    /**
+     * Generate list of univariate polynomials in all variables.
+     * @return List(X_1,...,X_n) a list of univariate polynomials.
+     */
+    @Override
+    public List<LocalSolvablePolynomial<C>> univariateList() {
+        return univariateList(0, 1L);
+    }
+
+
+    /**
+     * Generate list of univariate polynomials in all variables.
+     * @param modv number of module variables.
+     * @return List(X_1,...,X_n) a list of univariate polynomials.
+     */
+    @Override
+    public List<LocalSolvablePolynomial<C>> univariateList(int modv) {
+        return univariateList(modv, 1L);
+    }
+
+
+    /**
+     * Generate list of univariate polynomials in all variables with given
+     * exponent.
+     * @param modv number of module variables.
+     * @param e the exponent of the variables.
+     * @return List(X_1^e,...,X_n^e) a list of univariate polynomials.
+     */
+    @Override
+    public List<LocalSolvablePolynomial<C>> univariateList(int modv, long e) {
+        List<LocalSolvablePolynomial<C>> pols = new ArrayList<LocalSolvablePolynomial<C>>(nvar);
+        int nm = nvar - modv;
+        for (int i = 0; i < nm; i++) {
+            LocalSolvablePolynomial<C> p = univariate(modv, nm - 1 - i, e);
+            pols.add(p);
+        }
+        return pols;
+    }
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by i.
+     * @param i number of variables to extend.
+     * @return extended solvable polynomial ring factory.
+     */
+    @Override
+    public LocalSolvablePolynomialRing<C> extend(int i) {
+        return extend(i,false);
+    }
+
+    
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by i.
+     * @param i number of variables to extend.
+     * @param top true for TOP term order, false for POT term order.
+     * @return extended solvable polynomial ring factory.
+     */
+    @Override
+    public LocalSolvablePolynomialRing<C> extend(int i, boolean top) {
+        GenPolynomialRing<SolvableLocal<C>> pfac = super.extend(i, top);
+        LocalSolvablePolynomialRing<C> spfac = new LocalSolvablePolynomialRing<C>(pfac.coFac, pfac.nvar,
+                        pfac.tord, pfac.getVars());
+        spfac.table.extend(this.table);
+        spfac.polCoeff.coeffTable.extend(this.polCoeff.coeffTable);
+        return spfac;
+    }
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by length(vn). New variables commute with the exiting
+     * variables.
+     * @param vn names for extended variables.
+     * @return extended polynomial ring factory.
+     */
+    @Override
+    public LocalSolvablePolynomialRing<C> extend(String[] vn) {
+        return extend(vn, false);
+    }
+
+    
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by length(vn). New variables commute with the exiting
+     * variables.
+     * @param vn names for extended variables.
+     * @param top true for TOP term order, false for POT term order.
+     * @return extended polynomial ring factory.
+     */
+    @Override
+    public LocalSolvablePolynomialRing<C> extend(String[] vn, boolean top) {
+        GenPolynomialRing<SolvableLocal<C>> pfac = super.extend(vn, top);
+        LocalSolvablePolynomialRing<C> spfac = new LocalSolvablePolynomialRing<C>(pfac.coFac, pfac.nvar,
+                        pfac.tord, pfac.getVars());
+        spfac.table.extend(this.table);
+        spfac.polCoeff.coeffTable.extend(this.polCoeff.coeffTable);
+        return spfac;
+    }
+
+ 
+    /**
+     * Contract variables. Used e.g. in module embedding. Contract number of
+     * variables by i.
+     * @param i number of variables to remove.
+     * @return contracted solvable polynomial ring factory.
+     */
+    @Override
+    public LocalSolvablePolynomialRing<C> contract(int i) {
+        GenPolynomialRing<SolvableLocal<C>> pfac = super.contract(i);
+        LocalSolvablePolynomialRing<C> spfac = new LocalSolvablePolynomialRing<C>(pfac.coFac, pfac.nvar,
+                        pfac.tord, pfac.getVars());
+        spfac.table.contract(this.table);
+        spfac.polCoeff.coeffTable.contract(this.polCoeff.coeffTable);
+        return spfac;
+    }
+
+
+    /**
+     * Reverse variables. Used e.g. in opposite rings.
+     * @return solvable polynomial ring factory with reversed variables.
+     */
+    @Override
+    public LocalSolvablePolynomialRing<C> reverse() {
+        return reverse(false);
+    }
+
+
+    /**
+     * Reverse variables. Used e.g. in opposite rings.
+     * @param partial true for partialy reversed term orders.
+     * @return solvable polynomial ring factory with reversed variables.
+     */
+    @Override
+    public LocalSolvablePolynomialRing<C> reverse(boolean partial) {
+        GenPolynomialRing<SolvableLocal<C>> pfac = super.reverse(partial);
+        LocalSolvablePolynomialRing<C> spfac = new LocalSolvablePolynomialRing<C>(pfac.coFac, pfac.nvar,
+                        pfac.tord, pfac.getVars());
+        spfac.partial = partial;
+        spfac.table.reverse(this.table);
+        spfac.polCoeff.coeffTable.reverse(this.polCoeff.coeffTable);
+        return spfac;
+    }
+
+
+    /**
+     * Rational function from integral polynomial coefficients. Represent as
+     * polynomial with type SolvableLocal<C> coefficients.
+     * @param A polynomial with integral polynomial coefficients to be
+     *            converted.
+     * @return polynomial with type SolvableLocal<C> coefficients.
+     */
+    public LocalSolvablePolynomial<C> fromPolyCoefficients(GenSolvablePolynomial<GenPolynomial<C>> A) {
+        LocalSolvablePolynomial<C> B = getZERO().copy();
+        if (A == null || A.isZERO()) {
+            return B;
+        }
+        RingFactory<SolvableLocal<C>> cfac = coFac;
+        SolvableLocalRing<C> qfac = (SolvableLocalRing<C>) cfac;
+        for (Map.Entry<ExpVector, GenPolynomial<C>> y : A.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            GenSolvablePolynomial<C> a = (GenSolvablePolynomial<C>) y.getValue();
+            SolvableLocal<C> p = new SolvableLocal<C>(qfac, a); // can not be zero
+            if (!p.isZERO()) {
+                //B = B.sum( p, e ); // inefficient
+                B.doPutToMap(e, p);
+            }
+        }
+        return B;
+    }
+
+
+    /**
+     * Integral function from rational polynomial coefficients. Represent as
+     * polynomial with type GenSolvablePolynomial<C> coefficients.
+     * @param A polynomial with rational polynomial coefficients to be
+     *            converted.
+     * @return polynomial with type GenSolvablePolynomial<C> coefficients.
+     */
+    public RecSolvablePolynomial<C> toPolyCoefficients(LocalSolvablePolynomial<C> A) {
+        RecSolvablePolynomial<C> B = polCoeff.getZERO().copy();
+        if (A == null || A.isZERO()) {
+            return B;
+        }
+        for (Map.Entry<ExpVector, SolvableLocal<C>> y : A.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            SolvableLocal<C> a = y.getValue();
+            if (!a.den.isONE()) {
+                throw new IllegalArgumentException("den != 1 not supported: " + a);
+            }
+            GenPolynomial<C> p = a.num; // can not be zero
+            if (!p.isZERO()) {
+                //B = B.sum( p, e ); // inefficient
+                B.doPutToMap(e, p);
+            }
+        }
+        return B;
+    }
+
+
+    /**
+     * Integral function from rational polynomial coefficients. Represent as
+     * polynomial with type GenSolvablePolynomial<C> coefficients.
+     * @param A polynomial with rational polynomial coefficients to be
+     *            converted.
+     * @return polynomial with type GenSolvablePolynomial<C> coefficients.
+     */
+    public RecSolvablePolynomial<C> toPolyCoefficients(GenPolynomial<SolvableLocal<C>> A) {
+        RecSolvablePolynomial<C> B = polCoeff.getZERO().copy();
+        if (A == null || A.isZERO()) {
+            return B;
+        }
+        for (Map.Entry<ExpVector, SolvableLocal<C>> y : A.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            SolvableLocal<C> a = y.getValue();
+            if (!a.den.isONE()) {
+                throw new IllegalArgumentException("den != 1 not supported: " + a);
+            }
+            GenPolynomial<C> p = a.num; // can not be zero
+            if (!p.isZERO()) {
+                //B = B.sum( p, e ); // inefficient
+                B.doPutToMap(e, p);
+            }
+        }
+        return B;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/OrderedCPairlist.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/OrderedCPairlist.java
@@ -1,0 +1,451 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.GenSolvablePolynomialRing;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Pair list management. Implemented for ColorPolynomials using TreeMap and
+ * BitSet.
+ * @author Heinz Kredel
+ */
+
+public class OrderedCPairlist<C extends GcdRingElem<C>> implements Serializable {
+
+
+    private static final Logger logger = LogManager.getLogger(OrderedCPairlist.class);
+
+
+    protected final GenPolynomialRing<GenPolynomial<C>> ring;
+
+
+    protected final List<ColorPolynomial<C>> P;
+
+
+    protected final SortedMap<ExpVector, LinkedList<CPair<C>>> pairlist;
+
+
+    protected final List<BitSet> red;
+
+
+    protected final CReductionSeq<C> reduction;
+
+
+    protected boolean oneInGB = false;
+
+
+    protected boolean useCriterion4 = false; // unused
+
+
+    protected int putCount;
+
+
+    protected int remCount;
+
+
+    protected final int moduleVars; // unused
+
+
+    /**
+     * Constructor for OrderedPairlist.
+     * @param r polynomial factory.
+     */
+    public OrderedCPairlist(GenPolynomialRing<GenPolynomial<C>> r) {
+        this(0, r);
+    }
+
+
+    /**
+     * Constructor for OrderedPairlist.
+     * @param m number of module variables.
+     * @param r polynomial factory.
+     */
+    public OrderedCPairlist(int m, GenPolynomialRing<GenPolynomial<C>> r) {
+        moduleVars = m;
+        ring = r;
+        P = new ArrayList<ColorPolynomial<C>>();
+        pairlist = new TreeMap<ExpVector, LinkedList<CPair<C>>>(ring.tord.getAscendComparator());
+        // pairlist = new TreeMap( to.getSugarComparator() );
+        red = new ArrayList<BitSet>();
+        putCount = 0;
+        remCount = 0;
+        if (ring instanceof GenSolvablePolynomialRing) {
+            useCriterion4 = false;
+        }
+        RingFactory<GenPolynomial<C>> rf = ring.coFac;
+        GenPolynomialRing<C> cf = (GenPolynomialRing<C>) rf;
+        reduction = new CReductionSeq<C>(cf.coFac);
+    }
+
+
+    /**
+     * Internal constructor for OrderedPairlist. Used to clone this pair list.
+     * @param m number of module variables.
+     * @param r polynomial factory.
+     * @param P list of color polynomials.
+     * @param pl critical pair list.
+     * @param red reduction matrix.
+     * @param cred color polynomial reduction engine.
+     * @param pc put count.
+     * @param rc remove count.
+     */
+    private OrderedCPairlist(int m, GenPolynomialRing<GenPolynomial<C>> r, List<ColorPolynomial<C>> P,
+                    SortedMap<ExpVector, LinkedList<CPair<C>>> pl, List<BitSet> red, CReductionSeq<C> cred,
+                    int pc, int rc) {
+        moduleVars = m;
+        this.ring = r;
+        this.P = P;
+        pairlist = pl;
+        this.red = red;
+        reduction = cred;
+        putCount = pc;
+        remCount = rc;
+    }
+
+
+    /**
+     * Clone this OrderedPairlist.
+     * @return a 2 level clone of this.
+     */
+    public synchronized OrderedCPairlist<C> copy() {
+        return new OrderedCPairlist<C>(moduleVars, ring, new ArrayList<ColorPolynomial<C>>(P),
+                        clonePairlist(), cloneBitSet(), reduction, putCount, remCount);
+    }
+
+
+    /**
+     * Clone this pairlist.
+     * @return a 2 level clone of this pairlist.
+     */
+    private SortedMap<ExpVector, LinkedList<CPair<C>>> clonePairlist() {
+        SortedMap<ExpVector, LinkedList<CPair<C>>> pl = new TreeMap<ExpVector, LinkedList<CPair<C>>>(
+                        ring.tord.getAscendComparator());
+        for (Map.Entry<ExpVector, LinkedList<CPair<C>>> m : pairlist.entrySet()) {
+            ExpVector e = m.getKey();
+            LinkedList<CPair<C>> l = m.getValue();
+            l = new LinkedList<CPair<C>>(l);
+            pl.put(e, l);
+        }
+        return pl;
+    }
+
+
+    /**
+     * Count remaining Pairs.
+     * @return number of pairs remaining in this pairlist.
+     */
+    public int pairCount() {
+        int c = 0;
+        for (Map.Entry<ExpVector, LinkedList<CPair<C>>> m : pairlist.entrySet()) {
+            LinkedList<CPair<C>> l = m.getValue();
+            c += l.size();
+        }
+        return c;
+    }
+
+
+    /**
+     * Clone this reduction BitSet.
+     * @return a 2 level clone of this reduction BitSet.
+     */
+    private List<BitSet> cloneBitSet() {
+        List<BitSet> r = new ArrayList<BitSet>(this.red.size());
+        for (BitSet b : red) {
+            BitSet n = (BitSet) b.clone();
+            r.add(n);
+        }
+        return r;
+    }
+
+
+    /**
+     * bitCount.
+     * @return number of bits set in this bitset.
+     */
+    public int bitCount() {
+        int c = 0;
+        for (BitSet b : red) {
+            c += b.cardinality();
+        }
+        return c;
+    }
+
+
+    /**
+     * toString.
+     * @return counters of this.
+     */
+    @Override
+    public String toString() {
+        int p = pairCount();
+        int b = bitCount();
+        if (p != b) {
+            return "OrderedCPairlist( pairCount=" + p + ", bitCount=" + b + ", putCount=" + putCount
+                            + ", remCount=" + remCount + " )";
+        }
+        return "OrderedCPairlist( pairCount=" + p + ", putCount=" + putCount + ", remCount=" + remCount
+                        + " )";
+    }
+
+
+    /**
+     * Equals.
+     * @param ob an Object.
+     * @return true if this is equal to o, else false.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object ob) {
+        OrderedCPairlist<C> c = null;
+        try {
+            c = (OrderedCPairlist<C>) ob;
+        } catch (ClassCastException e) {
+            return false;
+        }
+        if (c == null) {
+            return false;
+        }
+        boolean t = getList().equals(c.getList());
+        if (!t) {
+            return t;
+        }
+        t = pairCount() == c.pairCount();
+        if (!t) {
+            return t;
+        }
+        return true;
+    }
+
+
+    /**
+     * Hash code for this pair list.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = getList().hashCode();
+        h = h << 7;
+        h += pairCount(); // findbugs
+        return h;
+    }
+
+
+    /**
+     * Put one Polynomial to the pairlist and reduction matrix.
+     * @param p polynomial.
+     * @return the index of the added polynomial.
+     */
+    public synchronized int put(ColorPolynomial<C> p) {
+        putCount++;
+        if (oneInGB) {
+            return P.size() - 1;
+        }
+        ExpVector e = p.leadingExpVector();
+        // System.out.println("p = " + p);
+        int l = P.size();
+        for (int j = 0; j < l; j++) {
+            ColorPolynomial<C> pj = P.get(j);
+            // System.out.println("pj = " + pj);
+            ExpVector f = pj.leadingExpVector();
+            if (moduleVars > 0) {
+                if (e.invLexCompareTo(f, 0, moduleVars) != 0) {
+                    continue; // skip pair
+                }
+            }
+            // System.out.println("e = " + e + ", f = " + f);
+            ExpVector g = e.lcm(f); // EVLCM( e, f );
+            CPair<C> pair = new CPair<C>(pj, p, j, l);
+            // redi = (BitSet)red.get(j);
+            // /if ( j < l ) redi.set( l );
+            // System.out.println("bitset."+j+" = " + redi );
+
+            // multiple pairs under same keys -> list of pairs
+            LinkedList<CPair<C>> xl = pairlist.get(g);
+            if (xl == null) {
+                xl = new LinkedList<CPair<C>>();
+            }
+            // xl.addLast( pair ); // first or last ?
+            xl.addFirst(pair); // first or last ? better for d- e-GBs
+            pairlist.put(g, xl);
+        }
+        // System.out.println("pairlist.keys@put = " + pairlist.keySet() );
+        P.add(p);
+        BitSet redi = new BitSet();
+        redi.set(0, l); // jdk 1.4
+        red.add(redi);
+        return P.size() - 1;
+    }
+
+
+    /**
+     * Remove the next required pair from the pairlist and reduction matrix.
+     * Appy the criterions 3 and 4 to see if the S-polynomial is required.
+     * @return the next pair if one exists, otherwise null.
+     */
+    public synchronized CPair<C> removeNext() {
+        if (oneInGB) {
+            return null;
+        }
+        Iterator<Map.Entry<ExpVector, LinkedList<CPair<C>>>> ip = pairlist.entrySet().iterator();
+
+        CPair<C> pair = null;
+        boolean c = false;
+        int i, j;
+
+        while (!c && ip.hasNext()) {
+            Map.Entry<ExpVector, LinkedList<CPair<C>>> me = ip.next();
+            ExpVector g = me.getKey();
+            LinkedList<CPair<C>> xl = me.getValue();
+            if (logger.isInfoEnabled())
+                logger.info("g  = " + g);
+            pair = null;
+            while (!c && xl.size() > 0) {
+                pair = xl.removeFirst();
+                // xl is also modified in pairlist
+                i = pair.i;
+                j = pair.j;
+                // System.out.println("pair(" + j + "," +i+") ");
+                //if (useCriterion4) {
+                // c = reduction.criterion4( pair.pi, pair.pj, g );
+                //    c = true;
+                //}
+                c = true;
+                // System.out.println("c4 = " + c);
+                //if (c) {
+                // c = criterion3( i, j, g );
+                // System.out.println("c3 = " + c);
+                //}
+                red.get(j).clear(i); // set(i,false) jdk1.4
+            }
+            if (xl.size() == 0)
+                ip.remove();
+            // = pairlist.remove( g );
+        }
+        if (!c) {
+            pair = null;
+        } else {
+            remCount++; // count only real pairs
+        }
+        return pair;
+    }
+
+
+    /**
+     * Test if there is possibly a pair in the list.
+     * @return true if a next pair could exist, otherwise false.
+     */
+    public synchronized boolean hasNext() {
+        return pairlist.size() > 0;
+    }
+
+
+    /**
+     * Get the list of polynomials.
+     * @return the polynomial list.
+     */
+    public List<ColorPolynomial<C>> getList() {
+        return P;
+    }
+
+
+    /**
+     * Get the number of polynomials put to the pairlist.
+     * @return the number of calls to put.
+     */
+    public synchronized int putCount() {
+        return putCount;
+    }
+
+
+    /**
+     * Get the number of required pairs removed from the pairlist.
+     * @return the number of non null pairs delivered.
+     */
+    public synchronized int remCount() {
+        return remCount;
+    }
+
+
+    /**
+     * Put to ONE-Polynomial to the pairlist.
+     * @param one polynomial. (no more required)
+     * @return the index of the last polynomial.
+     */
+    public synchronized int putOne(ColorPolynomial<C> one) {
+        putCount++;
+        if (one == null) {
+            return P.size() - 1;
+        }
+        if (!one.isONE()) {
+            return P.size() - 1;
+        }
+        oneInGB = true;
+        pairlist.clear();
+        P.clear();
+        P.add(one);
+        red.clear();
+        return P.size() - 1;
+    }
+
+
+    /**
+     * GB criterium 3.
+     * @return true if the S-polynomial(i,j) is required.
+     */
+    public boolean criterion3(int i, int j, ExpVector eij) {
+        // assert i < j;
+        boolean s = red.get(j).get(i);
+        if (!s) {
+            logger.warn("c3.s false for " + j + " " + i);
+            return s;
+        }
+        // now s = true;
+        for (int k = 0; k < P.size(); k++) {
+            if (i != k && j != k) {
+                ColorPolynomial<C> A = P.get(k);
+                ExpVector ek = A.leadingExpVector();
+                boolean m = eij.multipleOf(ek); // EVMT(eij,ek);
+                if (m) {
+                    if (k < i) {
+                        // System.out.println("k < i "+k+" "+i);
+                        s = red.get(i).get(k) || red.get(j).get(k);
+                    } else if (i < k && k < j) {
+                        // System.out.println("i < k < j "+i+" "+k+" "+j);
+                        s = red.get(k).get(i) || red.get(j).get(k);
+                    } else if (j < k) {
+                        // System.out.println("j < k "+j+" "+k);
+                        s = red.get(k).get(i) || red.get(k).get(j);
+                    }
+                    // System.out.println("s."+k+" = " + s);
+                    if (!s) {
+                        return s;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/PolyUtilApp.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/PolyUtilApp.java
@@ -1,0 +1,1838 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.arith.BigDecimal;
+import edu.jas.arith.BigRational;
+import edu.jas.arith.Product;
+import edu.jas.arith.ProductRing;
+import edu.jas.arith.Rational;
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.AlgebraicNumberRing;
+import edu.jas.poly.Complex;
+import edu.jas.poly.ComplexRing;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.poly.PolynomialList;
+import edu.jas.poly.TermOrder;
+import edu.jas.root.ComplexRoots;
+import edu.jas.root.ComplexRootsAbstract;
+import edu.jas.root.ComplexRootsSturm;
+import edu.jas.root.Interval;
+import edu.jas.root.InvalidBoundaryException;
+import edu.jas.root.RealAlgebraicNumber;
+import edu.jas.root.RealAlgebraicRing;
+import edu.jas.root.RealRootTuple;
+import edu.jas.root.RealRootsAbstract;
+import edu.jas.root.RealRootsSturm;
+import edu.jas.root.Rectangle;
+import edu.jas.root.RootFactory;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.structure.UnaryFunctor;
+import edu.jas.util.ListUtil;
+
+
+/**
+ * Polynomial utilities for applications, for example conversion ExpVector to
+ * Product or zero dimensional ideal root computation.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+public class PolyUtilApp<C extends RingElem<C>> {
+
+
+    private static final Logger logger = LogManager.getLogger(PolyUtilApp.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Product representation.
+     * @param <C> coefficient type.
+     * @param pfac polynomial ring factory.
+     * @param L list of polynomials to be represented.
+     * @return Product represenation of L in the polynomial ring pfac.
+     */
+    public static <C extends GcdRingElem<C>> List<GenPolynomial<Product<Residue<C>>>> toProductRes(
+                    GenPolynomialRing<Product<Residue<C>>> pfac, List<GenPolynomial<GenPolynomial<C>>> L) {
+
+        List<GenPolynomial<Product<Residue<C>>>> list = new ArrayList<GenPolynomial<Product<Residue<C>>>>();
+        if (L == null || L.size() == 0) {
+            return list;
+        }
+        GenPolynomial<Product<Residue<C>>> b;
+        for (GenPolynomial<GenPolynomial<C>> a : L) {
+            b = toProductRes(pfac, a);
+            list.add(b);
+        }
+        return list;
+    }
+
+
+    /**
+     * Product representation.
+     * @param <C> coefficient type.
+     * @param pfac polynomial ring factory.
+     * @param A polynomial to be represented.
+     * @return Product represenation of A in the polynomial ring pfac.
+     */
+    public static <C extends GcdRingElem<C>> GenPolynomial<Product<Residue<C>>> toProductRes(
+                    GenPolynomialRing<Product<Residue<C>>> pfac, GenPolynomial<GenPolynomial<C>> A) {
+
+        GenPolynomial<Product<Residue<C>>> P = pfac.getZERO().copy();
+        if (A == null || A.isZERO()) {
+            return P;
+        }
+        RingFactory<Product<Residue<C>>> rpfac = pfac.coFac;
+        ProductRing<Residue<C>> fac = (ProductRing<Residue<C>>) rpfac;
+        Product<Residue<C>> p;
+        for (Map.Entry<ExpVector, GenPolynomial<C>> y : A.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            GenPolynomial<C> a = y.getValue();
+            p = toProductRes(fac, a);
+            if (!p.isZERO()) {
+                P.doPutToMap(e, p);
+            }
+        }
+        return P;
+    }
+
+
+    /**
+     * Product representation.
+     * @param <C> coefficient type.
+     * @param pfac product ring factory.
+     * @param c coefficient to be represented.
+     * @return Product represenation of c in the ring pfac.
+     */
+    public static <C extends GcdRingElem<C>> Product<Residue<C>> toProductRes(ProductRing<Residue<C>> pfac,
+                    GenPolynomial<C> c) {
+
+        SortedMap<Integer, Residue<C>> elem = new TreeMap<Integer, Residue<C>>();
+        for (int i = 0; i < pfac.length(); i++) {
+            RingFactory<Residue<C>> rfac = pfac.getFactory(i);
+            ResidueRing<C> fac = (ResidueRing<C>) rfac;
+            Residue<C> u = new Residue<C>(fac, c);
+            //fac.fromInteger( c.getVal() );
+            if (!u.isZERO()) {
+                elem.put(i, u);
+            }
+        }
+        return new Product<Residue<C>>(pfac, elem);
+    }
+
+
+    /**
+     * Product residue representation.
+     * @param <C> coefficient type.
+     * @param CS list of ColoredSystems from comprehensive GB system.
+     * @return Product residue represenation of CS.
+     */
+    public static <C extends GcdRingElem<C>> List<GenPolynomial<Product<Residue<C>>>> toProductRes(
+                    List<ColoredSystem<C>> CS) {
+
+        List<GenPolynomial<Product<Residue<C>>>> list = new ArrayList<GenPolynomial<Product<Residue<C>>>>();
+        if (CS == null || CS.isEmpty()) {
+            return list;
+        }
+        GenPolynomialRing<GenPolynomial<C>> pr = null;
+        List<RingFactory<Residue<C>>> rrl = new ArrayList<RingFactory<Residue<C>>>(CS.size());
+        for (ColoredSystem<C> cs : CS) {
+            Ideal<C> id = cs.condition.zero;
+            ResidueRing<C> r = new ResidueRing<C>(id);
+            if (!rrl.contains(r)) {
+                rrl.add(r);
+            }
+            if (pr == null) {
+                if (cs.list.size() > 0) {
+                    pr = cs.list.get(0).green.ring;
+                }
+            }
+        }
+        if (pr == null) {
+            throw new IllegalArgumentException("no polynomial ring found");
+        }
+        ProductRing<Residue<C>> pfac;
+        pfac = new ProductRing<Residue<C>>(rrl);
+        //System.out.println("pfac = " + pfac);
+        GenPolynomialRing<Product<Residue<C>>> rf = new GenPolynomialRing<Product<Residue<C>>>(pfac, pr.nvar,
+                        pr.tord, pr.getVars());
+        GroebnerSystem<C> gs = new GroebnerSystem<C>(CS);
+        List<GenPolynomial<GenPolynomial<C>>> F = gs.getCGB();
+        list = PolyUtilApp.<C> toProductRes(rf, F);
+        return list;
+    }
+
+
+    /**
+     * Residue coefficient representation.
+     * @param pfac polynomial ring factory.
+     * @param L list of polynomials to be represented.
+     * @return Represenation of L in the polynomial ring pfac.
+     */
+    public static <C extends GcdRingElem<C>> List<GenPolynomial<Residue<C>>> toResidue(
+                    GenPolynomialRing<Residue<C>> pfac, List<GenPolynomial<GenPolynomial<C>>> L) {
+        List<GenPolynomial<Residue<C>>> list = new ArrayList<GenPolynomial<Residue<C>>>();
+        if (L == null || L.size() == 0) {
+            return list;
+        }
+        GenPolynomial<Residue<C>> b;
+        for (GenPolynomial<GenPolynomial<C>> a : L) {
+            b = toResidue(pfac, a);
+            if (!b.isZERO()) {
+                list.add(b);
+            }
+        }
+        return list;
+    }
+
+
+    /**
+     * Residue coefficient representation.
+     * @param pfac polynomial ring factory.
+     * @param A polynomial to be represented.
+     * @return Represenation of A in the polynomial ring pfac.
+     */
+    public static <C extends GcdRingElem<C>> GenPolynomial<Residue<C>> toResidue(
+                    GenPolynomialRing<Residue<C>> pfac, GenPolynomial<GenPolynomial<C>> A) {
+        GenPolynomial<Residue<C>> P = pfac.getZERO().copy();
+        if (A == null || A.isZERO()) {
+            return P;
+        }
+        RingFactory<Residue<C>> rpfac = pfac.coFac;
+        ResidueRing<C> fac = (ResidueRing<C>) rpfac;
+        Residue<C> p;
+        for (Map.Entry<ExpVector, GenPolynomial<C>> y : A.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            GenPolynomial<C> a = y.getValue();
+            p = new Residue<C>(fac, a);
+            if (!p.isZERO()) {
+                P.doPutToMap(e, p);
+            }
+        }
+        return P;
+    }
+
+
+    /**
+     * Product slice.
+     * @param <C> coefficient type.
+     * @param L list of polynomials with product coefficients.
+     * @return Slices represenation of L.
+     */
+    public static <C extends GcdRingElem<C>> Map<Ideal<C>, PolynomialList<GenPolynomial<C>>> productSlice(
+                    PolynomialList<Product<Residue<C>>> L) {
+
+        Map<Ideal<C>, PolynomialList<GenPolynomial<C>>> map;
+        RingFactory<Product<Residue<C>>> fpr = L.ring.coFac;
+        ProductRing<Residue<C>> pr = (ProductRing<Residue<C>>) fpr;
+        int s = pr.length();
+        map = new TreeMap<Ideal<C>, PolynomialList<GenPolynomial<C>>>();
+        List<GenPolynomial<GenPolynomial<C>>> slist;
+
+        List<GenPolynomial<Product<Residue<C>>>> plist = L.list;
+        PolynomialList<GenPolynomial<C>> spl;
+
+        for (int i = 0; i < s; i++) {
+            RingFactory<Residue<C>> r = pr.getFactory(i);
+            ResidueRing<C> rr = (ResidueRing<C>) r;
+            Ideal<C> id = rr.ideal;
+            GenPolynomialRing<C> cof = rr.ring;
+            GenPolynomialRing<GenPolynomial<C>> pfc;
+            pfc = new GenPolynomialRing<GenPolynomial<C>>(cof, L.ring);
+            slist = fromProduct(pfc, plist, i);
+            spl = new PolynomialList<GenPolynomial<C>>(pfc, slist);
+            PolynomialList<GenPolynomial<C>> d = map.get(id);
+            if (d != null) {
+                throw new RuntimeException("ideal exists twice " + id);
+            }
+            map.put(id, spl);
+        }
+        return map;
+    }
+
+
+    /**
+     * Product slice at i.
+     * @param <C> coefficient type.
+     * @param L list of polynomials with product coeffients.
+     * @param i index of slice.
+     * @return Slice of of L at i.
+     */
+    public static <C extends GcdRingElem<C>> PolynomialList<GenPolynomial<C>> productSlice(
+                    PolynomialList<Product<Residue<C>>> L, int i) {
+
+        RingFactory<Product<Residue<C>>> fpr = L.ring.coFac;
+        ProductRing<Residue<C>> pr = (ProductRing<Residue<C>>) fpr;
+        List<GenPolynomial<GenPolynomial<C>>> slist;
+
+        List<GenPolynomial<Product<Residue<C>>>> plist = L.list;
+        PolynomialList<GenPolynomial<C>> spl;
+
+        RingFactory<Residue<C>> r = pr.getFactory(i);
+        ResidueRing<C> rr = (ResidueRing<C>) r;
+        GenPolynomialRing<C> cof = rr.ring;
+        GenPolynomialRing<GenPolynomial<C>> pfc;
+        pfc = new GenPolynomialRing<GenPolynomial<C>>(cof, L.ring);
+        slist = fromProduct(pfc, plist, i);
+        spl = new PolynomialList<GenPolynomial<C>>(pfc, slist);
+        return spl;
+    }
+
+
+    /**
+     * From product representation.
+     * @param <C> coefficient type.
+     * @param pfac polynomial ring factory.
+     * @param L list of polynomials to be converted from product representation.
+     * @param i index of product representation to be taken.
+     * @return Represenation of i-slice of L in the polynomial ring pfac.
+     */
+    public static <C extends GcdRingElem<C>> List<GenPolynomial<GenPolynomial<C>>> fromProduct(
+                    GenPolynomialRing<GenPolynomial<C>> pfac, List<GenPolynomial<Product<Residue<C>>>> L,
+                    int i) {
+
+        List<GenPolynomial<GenPolynomial<C>>> list = new ArrayList<GenPolynomial<GenPolynomial<C>>>();
+
+        if (L == null || L.size() == 0) {
+            return list;
+        }
+        GenPolynomial<GenPolynomial<C>> b;
+        for (GenPolynomial<Product<Residue<C>>> a : L) {
+            b = fromProduct(pfac, a, i);
+            if (!b.isZERO()) {
+                b = b.abs();
+                if (!list.contains(b)) {
+                    list.add(b);
+                }
+            }
+        }
+        return list;
+    }
+
+
+    /**
+     * From product representation.
+     * @param <C> coefficient type.
+     * @param pfac polynomial ring factory.
+     * @param P polynomial to be converted from product representation.
+     * @param i index of product representation to be taken.
+     * @return Represenation of i-slice of P in the polynomial ring pfac.
+     */
+    public static <C extends GcdRingElem<C>> GenPolynomial<GenPolynomial<C>> fromProduct(
+                    GenPolynomialRing<GenPolynomial<C>> pfac, GenPolynomial<Product<Residue<C>>> P, int i) {
+
+        GenPolynomial<GenPolynomial<C>> b = pfac.getZERO().copy();
+        if (P == null || P.isZERO()) {
+            return b;
+        }
+
+        for (Map.Entry<ExpVector, Product<Residue<C>>> y : P.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            Product<Residue<C>> a = y.getValue();
+            Residue<C> r = a.get(i);
+            if (r != null && !r.isZERO()) {
+                GenPolynomial<C> p = r.val;
+                if (!p.isZERO()) {
+                    b.doPutToMap(e, p);
+                }
+            }
+        }
+        return b;
+    }
+
+
+    /**
+     * Product slice to String.
+     * @param <C> coefficient type.
+     * @param L list of polynomials with to be represented.
+     * @return Product represenation of L in the polynomial ring pfac.
+     */
+    public static <C extends GcdRingElem<C>> String productSliceToString(
+                    Map<Ideal<C>, PolynomialList<GenPolynomial<C>>> L) {
+        //Set<GenPolynomial<GenPolynomial<C>>> sl = new TreeSet<GenPolynomial<GenPolynomial<C>>>();
+        PolynomialList<GenPolynomial<C>> pl = null;
+        StringBuffer sb = new StringBuffer(); //"\nproductSlice ----------------- begin");
+        for (Map.Entry<Ideal<C>, PolynomialList<GenPolynomial<C>>> en : L.entrySet()) {
+            sb.append("\n\ncondition == 0:\n");
+            sb.append(en.getKey().list.toScript());
+            pl = en.getValue(); //L.get(id);
+            //sl.addAll(pl.list);
+            sb.append("\ncorresponding ideal:\n");
+            sb.append(pl.toScript());
+        }
+        //List<GenPolynomial<GenPolynomial<C>>> sll 
+        //   = new ArrayList<GenPolynomial<GenPolynomial<C>>>( sl );
+        //pl = new PolynomialList<GenPolynomial<C>>(pl.ring,sll);
+        // sb.append("\nunion = " + pl.toString());
+        //sb.append("\nproductSlice ------------------------- end\n");
+        return sb.toString();
+    }
+
+
+    /**
+     * Product slice to String.
+     * @param <C> coefficient type.
+     * @param L list of polynomials with product coefficients.
+     * @return string represenation of slices of L.
+     */
+    public static <C extends GcdRingElem<C>> String productToString(PolynomialList<Product<Residue<C>>> L) {
+        Map<Ideal<C>, PolynomialList<GenPolynomial<C>>> M;
+        M = productSlice(L);
+        String s = productSliceToString(M);
+        return s;
+    }
+
+
+    /**
+     * Construct superset of complex roots for zero dimensional ideal(G).
+     * @param I zero dimensional ideal.
+     * @param eps desired precision.
+     * @return list of coordinates of complex roots for ideal(G)
+     */
+    public static <D extends GcdRingElem<D> & Rational> List<List<Complex<BigDecimal>>> complexRootTuples(
+                    Ideal<D> I, BigRational eps) {
+        List<GenPolynomial<D>> univs = I.constructUnivariate();
+        if (logger.isInfoEnabled()) {
+            logger.info("univs = " + univs);
+        }
+        return complexRoots(I, univs, eps);
+    }
+
+
+    /**
+     * Construct superset of complex roots for zero dimensional ideal(G).
+     * @param I zero dimensional ideal.
+     * @param univs list of univariate polynomials.
+     * @param eps desired precision.
+     * @return list of coordinates of complex roots for ideal(G)
+     */
+    public static <D extends GcdRingElem<D> & Rational> List<List<Complex<BigDecimal>>> complexRoots(
+                    Ideal<D> I, List<GenPolynomial<D>> univs, BigRational eps) {
+        List<List<Complex<BigDecimal>>> croots = new ArrayList<List<Complex<BigDecimal>>>();
+        RingFactory<D> cf = I.list.ring.coFac;
+        ComplexRing<D> cr = new ComplexRing<D>(cf);
+        ComplexRootsAbstract<D> cra = new ComplexRootsSturm<D>(cr);
+        List<GenPolynomial<Complex<D>>> cunivs = new ArrayList<GenPolynomial<Complex<D>>>();
+        for (GenPolynomial<D> p : univs) {
+            GenPolynomialRing<Complex<D>> pfac = new GenPolynomialRing<Complex<D>>(cr, p.ring);
+            //System.out.println("pfac = " + pfac.toScript());
+            GenPolynomial<Complex<D>> cp = PolyUtil.<D> toComplex(pfac, p);
+            cunivs.add(cp);
+            //System.out.println("cp = " + cp);
+        }
+        for (int i = 0; i < I.list.ring.nvar; i++) {
+            List<Complex<BigDecimal>> cri = cra.approximateRoots(cunivs.get(i), eps);
+            //System.out.println("cri = " + cri);
+            croots.add(cri);
+        }
+        croots = ListUtil.<Complex<BigDecimal>> tupleFromList(croots);
+        return croots;
+    }
+
+
+    /**
+     * Construct superset of complex roots for zero dimensional ideal(G).
+     * @param Il list of zero dimensional ideals with univariate polynomials.
+     * @param eps desired precision.
+     * @return list of coordinates of complex roots for ideal(cap_i(G_i))
+     */
+    public static <D extends GcdRingElem<D> & Rational> List<List<Complex<BigDecimal>>> complexRootTuples(
+                    List<IdealWithUniv<D>> Il, BigRational eps) {
+        List<List<Complex<BigDecimal>>> croots = new ArrayList<List<Complex<BigDecimal>>>();
+        for (IdealWithUniv<D> I : Il) {
+            List<List<Complex<BigDecimal>>> cr = complexRoots(I.ideal, I.upolys, eps);
+            croots.addAll(cr);
+        }
+        return croots;
+    }
+
+
+    /**
+     * Construct superset of complex roots for zero dimensional ideal(G).
+     * @param Il list of zero dimensional ideals with univariate polynomials.
+     * @param eps desired precision.
+     * @return list of ideals with coordinates of complex roots for
+     *         ideal(cap_i(G_i))
+     */
+    public static <D extends GcdRingElem<D> & Rational> List<IdealWithComplexRoots<D>> complexRoots(
+                    List<IdealWithUniv<D>> Il, BigRational eps) {
+        List<IdealWithComplexRoots<D>> Ic = new ArrayList<IdealWithComplexRoots<D>>(Il.size());
+        for (IdealWithUniv<D> I : Il) {
+            List<List<Complex<BigDecimal>>> cr = complexRoots(I.ideal, I.upolys, eps);
+            IdealWithComplexRoots<D> ic = new IdealWithComplexRoots<D>(I, cr);
+            Ic.add(ic);
+        }
+        return Ic;
+    }
+
+
+    /**
+     * Construct superset of complex roots for zero dimensional ideal(G).
+     * @param G list of polynomials of a of zero dimensional ideal.
+     * @param eps desired precision.
+     * @return list of ideals with coordinates of complex roots for ideal(G)
+     */
+    public static <D extends GcdRingElem<D> & Rational> List<IdealWithComplexRoots<D>> complexRoots(
+                    Ideal<D> G, BigRational eps) {
+        List<IdealWithUniv<D>> Il = G.zeroDimDecomposition();
+        return complexRoots(Il, eps);
+    }
+
+
+    /**
+     * Construct superset of real roots for zero dimensional ideal(G).
+     * @param I zero dimensional ideal.
+     * @param eps desired precision.
+     * @return list of coordinates of real roots for ideal(G)
+     */
+    public static <D extends GcdRingElem<D> & Rational> List<List<BigDecimal>> realRootTuples(Ideal<D> I,
+                    BigRational eps) {
+        List<GenPolynomial<D>> univs = I.constructUnivariate();
+        if (logger.isInfoEnabled()) {
+            logger.info("univs = " + univs);
+        }
+        return realRoots(I, univs, eps);
+    }
+
+
+    /**
+     * Construct superset of real roots for zero dimensional ideal(G).
+     * @param I zero dimensional ideal.
+     * @param univs list of univariate polynomials.
+     * @param eps desired precision.
+     * @return list of coordinates of real roots for ideal(G)
+     */
+    public static <D extends GcdRingElem<D> & Rational> List<List<BigDecimal>> realRoots(Ideal<D> I,
+                    List<GenPolynomial<D>> univs, BigRational eps) {
+        List<List<BigDecimal>> roots = new ArrayList<List<BigDecimal>>();
+        //RingFactory<D> cf = (RingFactory<D>) I.list.ring.coFac;
+        RealRootsAbstract<D> rra = new RealRootsSturm<D>();
+        for (int i = 0; i < I.list.ring.nvar; i++) {
+            List<BigDecimal> rri = rra.approximateRoots(univs.get(i), eps);
+            //System.out.println("rri = " + rri);
+            roots.add(rri);
+        }
+        //System.out.println("roots-1 = " + roots);
+        roots = ListUtil.<BigDecimal> tupleFromList(roots);
+        //System.out.println("roots-2 = " + roots);
+        return roots;
+    }
+
+
+    /**
+     * Construct superset of real roots for zero dimensional ideal(G).
+     * @param Il list of zero dimensional ideals with univariate polynomials.
+     * @param eps desired precision.
+     * @return list of coordinates of real roots for ideal(cap_i(G_i))
+     */
+    public static <D extends GcdRingElem<D> & Rational> List<List<BigDecimal>> realRootTuples(
+                    List<IdealWithUniv<D>> Il, BigRational eps) {
+        List<List<BigDecimal>> rroots = new ArrayList<List<BigDecimal>>();
+        for (IdealWithUniv<D> I : Il) {
+            List<List<BigDecimal>> rr = realRoots(I.ideal, I.upolys, eps);
+            rroots.addAll(rr);
+        }
+        return rroots;
+    }
+
+
+    /**
+     * Construct superset of real roots for zero dimensional ideal(G).
+     * @param Il list of zero dimensional ideals with univariate polynomials.
+     * @param eps desired precision.
+     * @return list of ideals with coordinates of real roots for
+     *         ideal(cap_i(G_i))
+     */
+    public static <D extends GcdRingElem<D> & Rational> List<IdealWithRealRoots<D>> realRoots(
+                    List<IdealWithUniv<D>> Il, BigRational eps) {
+        List<IdealWithRealRoots<D>> Ir = new ArrayList<IdealWithRealRoots<D>>(Il.size());
+        for (IdealWithUniv<D> I : Il) {
+            List<List<BigDecimal>> rr = realRoots(I.ideal, I.upolys, eps);
+            IdealWithRealRoots<D> ir = new IdealWithRealRoots<D>(I, rr);
+            Ir.add(ir);
+        }
+        return Ir;
+    }
+
+
+    /**
+     * Construct superset of real roots for zero dimensional ideal(G).
+     * @param G list of polynomials of a of zero dimensional ideal.
+     * @param eps desired precision.
+     * @return list of ideals with coordinates of real roots for ideal(G)
+     */
+    public static <D extends GcdRingElem<D> & Rational> List<IdealWithRealRoots<D>> realRoots(Ideal<D> G,
+                    BigRational eps) {
+        List<IdealWithUniv<D>> Il = G.zeroDimDecomposition();
+        return realRoots(Il, eps);
+    }
+
+
+    /**
+     * Test for real roots of zero dimensional ideal(L).
+     * @param L list of polynomials.
+     * @param roots list of real roots for ideal(G).
+     * @param eps desired precision.
+     * @return true if root is a list of coordinates of real roots for ideal(L)
+     */
+    public static boolean isRealRoots(List<GenPolynomial<BigDecimal>> L, List<List<BigDecimal>> roots,
+                    BigDecimal eps) {
+        if (L == null || L.size() == 0) {
+            return true;
+        }
+        // polynomials with decimal coefficients
+        BigDecimal dc = BigDecimal.ONE;
+        //GenPolynomialRing<BigDecimal> dfac = L.get(0).ring;
+        //System.out.println("dfac = " + dfac);
+        for (GenPolynomial<BigDecimal> dp : L) {
+            //System.out.println("dp = " + dp);
+            for (List<BigDecimal> r : roots) {
+                //System.out.println("r = " + r);
+                BigDecimal ev = PolyUtil.<BigDecimal> evaluateAll(dc, dp, r);
+                if (ev.abs().compareTo(eps) > 0) {
+                    System.out.println("ev = " + ev);
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Test for complex roots of zero dimensional ideal(L).
+     * @param L list of polynomials.
+     * @param roots list of real roots for ideal(G).
+     * @param eps desired precision.
+     * @return true if root is a list of coordinates of complex roots for
+     *         ideal(L)
+     */
+    public static boolean isComplexRoots(List<GenPolynomial<Complex<BigDecimal>>> L,
+                    List<List<Complex<BigDecimal>>> roots, BigDecimal eps) {
+        if (L == null || L.size() == 0) {
+            return true;
+        }
+        // polynomials with decimal coefficients
+        BigDecimal dc = BigDecimal.ONE;
+        ComplexRing<BigDecimal> dcc = new ComplexRing<BigDecimal>(dc);
+        //GenPolynomialRing<Complex<BigDecimal>> dfac = L.get(0).ring;
+        //System.out.println("dfac = " + dfac);
+        for (GenPolynomial<Complex<BigDecimal>> dp : L) {
+            //System.out.println("dp = " + dp);
+            for (List<Complex<BigDecimal>> r : roots) {
+                //System.out.println("r = " + r);
+                Complex<BigDecimal> ev = PolyUtil.<Complex<BigDecimal>> evaluateAll(dcc, dp, r);
+                if (ev.norm().getRe().compareTo(eps) > 0) {
+                    System.out.println("ev = " + ev);
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Construct real roots for zero dimensional ideal(G).
+     * @param I zero dimensional ideal with univariate irreducible polynomials
+     *            and bi-variate polynomials.
+     * @return real algebraic roots for ideal(G)
+     */
+    public static <D extends GcdRingElem<D> & Rational> IdealWithRealAlgebraicRoots<D> realAlgebraicRoots(
+                    IdealWithUniv<D> I) {
+        List<List<RealAlgebraicNumber<D>>> ran = new ArrayList<List<RealAlgebraicNumber<D>>>();
+        if (I == null) {
+            throw new IllegalArgumentException("null ideal not permitted");
+        }
+        if (I.ideal == null || I.upolys == null) {
+            throw new IllegalArgumentException("null ideal components not permitted " + I);
+        }
+        if (I.ideal.isZERO() || I.upolys.size() == 0) {
+            return new IdealWithRealAlgebraicRoots<D>(I, ran);
+        }
+        GenPolynomialRing<D> fac = I.ideal.list.ring;
+        // case i == 0:
+        GenPolynomial<D> p0 = I.upolys.get(0);
+        GenPolynomial<D> p0p = PolyUtil.<D> selectWithVariable(I.ideal.list.list, fac.nvar - 1);
+        if (p0p == null) {
+            throw new RuntimeException("no polynomial found in " + (fac.nvar - 1) + " of  " + I.ideal);
+        }
+        //System.out.println("p0  = " + p0);
+        if (logger.isInfoEnabled()) {
+            logger.info("p0p = " + p0p);
+        }
+        int[] dep0 = p0p.degreeVector().dependencyOnVariables();
+        //System.out.println("dep0 = " + Arrays.toString(dep0));
+        if (dep0.length != 1) {
+            throw new RuntimeException("wrong number of variables " + Arrays.toString(dep0));
+        }
+        List<RealAlgebraicNumber<D>> rra = RootFactory.<D> realAlgebraicNumbersIrred(p0);
+        if (logger.isInfoEnabled()) {
+            List<Interval<D>> il = new ArrayList<Interval<D>>();
+            for (RealAlgebraicNumber<D> rr : rra) {
+                il.add(rr.ring.getRoot());
+            }
+            logger.info("roots(p0) = " + il);
+        }
+        for (RealAlgebraicNumber<D> rr : rra) {
+            List<RealAlgebraicNumber<D>> rl = new ArrayList<RealAlgebraicNumber<D>>();
+            rl.add(rr);
+            ran.add(rl);
+        }
+        // case i > 0:
+        for (int i = 1; i < I.upolys.size(); i++) {
+            List<List<RealAlgebraicNumber<D>>> rn = new ArrayList<List<RealAlgebraicNumber<D>>>();
+            GenPolynomial<D> pi = I.upolys.get(i);
+            GenPolynomial<D> pip = PolyUtil.selectWithVariable(I.ideal.list.list, fac.nvar - 1 - i);
+            if (pip == null) {
+                throw new RuntimeException(
+                                "no polynomial found in " + (fac.nvar - 1 - i) + " of  " + I.ideal);
+            }
+            //System.out.println("i   = " + i);
+            //System.out.println("pi  = " + pi);
+            if (logger.isInfoEnabled()) {
+                logger.info("pi  = " + pi);
+                logger.info("pip = " + pip);
+            }
+            int[] depi = pip.degreeVector().dependencyOnVariables();
+            //System.out.println("depi = " + Arrays.toString(depi));
+            if (depi.length < 1 || depi.length > 2) {
+                throw new RuntimeException("wrong number of variables " + Arrays.toString(depi));
+            }
+            rra = RootFactory.<D> realAlgebraicNumbersIrred(pi);
+            if (logger.isInfoEnabled()) {
+                List<Interval<D>> il = new ArrayList<Interval<D>>();
+                for (RealAlgebraicNumber<D> rr : rra) {
+                    il.add(rr.ring.getRoot());
+                }
+                logger.info("roots(pi) = " + il);
+            }
+            if (depi.length == 1) {
+                // all combinations are roots of the ideal I
+                for (RealAlgebraicNumber<D> rr : rra) {
+                    //System.out.println("rr.ring = " + rr.ring);
+                    for (List<RealAlgebraicNumber<D>> rx : ran) {
+                        //System.out.println("rx = " + rx);
+                        List<RealAlgebraicNumber<D>> ry = new ArrayList<RealAlgebraicNumber<D>>();
+                        ry.addAll(rx);
+                        ry.add(rr);
+                        rn.add(ry);
+                    }
+                }
+            } else { // depi.length == 2
+                // select roots of the ideal I
+                GenPolynomial<D> pip2 = PolyUtil.<D> removeUnusedUpperVariables(pip);
+                //System.out.println("pip2 = " + pip2.ring);
+                GenPolynomialRing<D> ufac = pip2.ring.contract(1);
+                TermOrder to = new TermOrder(TermOrder.INVLEX);
+                GenPolynomialRing<GenPolynomial<D>> rfac = new GenPolynomialRing<GenPolynomial<D>>(ufac, 1,
+                                                                                                   to); // new vars
+                GenPolynomial<GenPolynomial<D>> pip2r = PolyUtil.<D> recursive(rfac, pip2);
+                int ix = fac.nvar - 1 - depi[depi.length - 1];
+                //System.out.println("ix = " + ix);
+                for (RealAlgebraicNumber<D> rr : rra) {
+                    //System.out.println("rr.ring = " + rr.ring);
+                    Interval<D> rroot = rr.ring.getRoot();
+                    GenPolynomial<D> pip2el = PolyUtil.<D> evaluateMainRecursive(ufac, pip2r, rroot.left);
+                    GenPolynomial<D> pip2er = PolyUtil.<D> evaluateMainRecursive(ufac, pip2r, rroot.right);
+                    GenPolynomialRing<D> upfac = I.upolys.get(ix).ring;
+                    GenPolynomial<D> pip2elc = convert(upfac, pip2el);
+                    GenPolynomial<D> pip2erc = convert(upfac, pip2er);
+                    //System.out.println("pip2elc = " + pip2elc);
+                    //System.out.println("pip2erc = " + pip2erc);
+                    for (List<RealAlgebraicNumber<D>> rx : ran) {
+                        //System.out.println("rx = " + rx);
+                        RealAlgebraicRing<D> rar = rx.get(ix).ring;
+                        //System.out.println("rar = " + rar.toScript());
+                        RealAlgebraicNumber<D> rel = new RealAlgebraicNumber<D>(rar, pip2elc);
+                        RealAlgebraicNumber<D> rer = new RealAlgebraicNumber<D>(rar, pip2erc);
+                        int sl = rel.signum();
+                        int sr = rer.signum();
+                        //System.out.println("sl = " + sl + ", sr = " + sr + ", sl*sr = " + (sl*sr));
+                        if (sl * sr <= 0) {
+                            //System.out.println("sl * sr <= 0: rar = " + rar.toScript());
+                            List<RealAlgebraicNumber<D>> ry = new ArrayList<RealAlgebraicNumber<D>>();
+                            ry.addAll(rx);
+                            ry.add(rr);
+                            rn.add(ry);
+                        }
+                    }
+                }
+            }
+            ran = rn;
+        }
+        if (logger.isInfoEnabled()) {
+            for (List<RealAlgebraicNumber<D>> rz : ran) {
+                List<Interval<D>> il = new ArrayList<Interval<D>>();
+                for (RealAlgebraicNumber<D> rr : rz) {
+                    il.add(rr.ring.getRoot());
+                }
+                logger.info("root-tuple = " + il);
+            }
+        }
+        IdealWithRealAlgebraicRoots<D> Ir = new IdealWithRealAlgebraicRoots<D>(I, ran);
+        return Ir;
+    }
+
+
+    /**
+     * Construct real roots for zero dimensional ideal(G).
+     * @param I list of zero dimensional ideal with univariate irreducible
+     *            polynomials and bi-variate polynomials.
+     * @return list of real algebraic roots for all ideal(I_i)
+     */
+    public static <D extends GcdRingElem<D> & Rational> List<IdealWithRealAlgebraicRoots<D>> realAlgebraicRoots(
+                    List<IdealWithUniv<D>> I) {
+        List<IdealWithRealAlgebraicRoots<D>> lir = new ArrayList<IdealWithRealAlgebraicRoots<D>>(I.size());
+        for (IdealWithUniv<D> iu : I) {
+            IdealWithRealAlgebraicRoots<D> iur = PolyUtilApp.<D> realAlgebraicRoots(iu);
+            //System.out.println("iur = " + iur);
+            lir.add(iur);
+        }
+        return lir;
+    }
+
+
+    /**
+     * Construct complex roots for zero dimensional ideal(G).
+     * @param I zero dimensional ideal with univariate irreducible polynomials
+     *            and bi-variate polynomials.
+     * @return complex algebraic roots for ideal(G) <b>Note:</b> implementation
+     *         contains errors, do not use.
+     */
+    public static <D extends GcdRingElem<D> & Rational> IdealWithComplexAlgebraicRoots<D> complexAlgebraicRootsWrong( // Wrong
+                    IdealWithUniv<D> I) {
+        List<List<Complex<edu.jas.application.RealAlgebraicNumber<D>>>> can;
+        can = new ArrayList<List<Complex<edu.jas.application.RealAlgebraicNumber<D>>>>();
+        if (I == null) {
+            throw new IllegalArgumentException("null ideal not permitted");
+        }
+        if (I.ideal == null || I.upolys == null) {
+            throw new IllegalArgumentException("null ideal components not permitted " + I);
+        }
+        if (I.ideal.isZERO() || I.upolys.size() == 0) {
+            return new IdealWithComplexAlgebraicRoots<D>(I, can);
+        }
+        GenPolynomialRing<D> fac = I.ideal.list.ring;
+        if (fac.nvar == 0) {
+            return new IdealWithComplexAlgebraicRoots<D>(I, can);
+        }
+        if (fac.nvar != I.upolys.size()) {
+            throw new IllegalArgumentException("ideal not zero dimnsional: " + I);
+        }
+        // case i == 0:
+        GenPolynomial<D> p0 = I.upolys.get(0);
+        GenPolynomial<D> p0p = PolyUtil.<D> selectWithVariable(I.ideal.list.list, fac.nvar - 1);
+        if (p0p == null) {
+            throw new RuntimeException("no polynomial found in " + (fac.nvar - 1) + " of  " + I.ideal);
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("p0  = " + p0);
+            logger.info("p0p = " + p0p);
+        }
+        int[] dep0 = p0p.degreeVector().dependencyOnVariables();
+        //System.out.println("dep0 = " + Arrays.toString(dep0));
+        if (dep0.length != 1) {
+            throw new RuntimeException("wrong number of variables " + Arrays.toString(dep0));
+        }
+        RingFactory<D> cfac = p0.ring.coFac;
+        ComplexRing<D> ccfac = new ComplexRing<D>(cfac);
+        GenPolynomialRing<Complex<D>> facc = new GenPolynomialRing<Complex<D>>(ccfac, p0.ring);
+        GenPolynomial<Complex<D>> p0c = PolyUtil.<D> complexFromAny(facc, p0);
+        List<Complex<edu.jas.application.RealAlgebraicNumber<D>>> cra;
+        cra = edu.jas.application.RootFactoryApp.<D> complexAlgebraicNumbersSquarefree(p0c);
+        logger.info("#roots(p0c) = " + cra.size());
+        if (debug) {
+            boolean t = edu.jas.application.RootFactoryApp.<D> isRoot(p0c, cra);
+            if (!t) {
+                throw new RuntimeException("no roots of " + p0c);
+            }
+        }
+        for (Complex<edu.jas.application.RealAlgebraicNumber<D>> cr : cra) {
+            List<Complex<edu.jas.application.RealAlgebraicNumber<D>>> cl;
+            cl = new ArrayList<Complex<edu.jas.application.RealAlgebraicNumber<D>>>();
+            cl.add(cr);
+            can.add(cl);
+        }
+        if (fac.nvar == 1) {
+            return new IdealWithComplexAlgebraicRoots<D>(I, can);
+        }
+        // case i > 0:
+        for (int i = 1; i < I.upolys.size(); i++) {
+            List<List<Complex<edu.jas.application.RealAlgebraicNumber<D>>>> cn;
+            cn = new ArrayList<List<Complex<edu.jas.application.RealAlgebraicNumber<D>>>>();
+            GenPolynomial<D> pi = I.upolys.get(i);
+            GenPolynomial<D> pip = PolyUtil.selectWithVariable(I.ideal.list.list, fac.nvar - 1 - i);
+            if (pip == null) {
+                throw new RuntimeException(
+                                "no polynomial found in " + (fac.nvar - 1 - i) + " of  " + I.ideal);
+            }
+            if (logger.isInfoEnabled()) {
+                logger.info("pi(" + i + ") = " + pi);
+                logger.info("pip  = " + pip);
+            }
+            facc = new GenPolynomialRing<Complex<D>>(ccfac, pi.ring);
+            GenPolynomial<Complex<D>> pic = PolyUtil.<D> complexFromAny(facc, pi);
+            int[] depi = pip.degreeVector().dependencyOnVariables();
+            //System.out.println("depi = " + Arrays.toString(depi));
+            if (depi.length < 1 || depi.length > 2) {
+                throw new RuntimeException(
+                                "wrong number of variables " + Arrays.toString(depi) + " for " + pip);
+            }
+            cra = edu.jas.application.RootFactoryApp.<D> complexAlgebraicNumbersSquarefree(pic);
+            logger.info("#roots(pic) = " + cra.size());
+            if (debug) {
+                boolean t = edu.jas.application.RootFactoryApp.<D> isRoot(pic, cra);
+                if (!t) {
+                    throw new RuntimeException("no roots of " + pic);
+                }
+            }
+            if (depi.length == 1) {
+                // all combinations are roots of the ideal I
+                for (Complex<edu.jas.application.RealAlgebraicNumber<D>> cr : cra) {
+                    //System.out.println("cr.ring = " + cr.ring);
+                    for (List<Complex<edu.jas.application.RealAlgebraicNumber<D>>> cx : can) {
+                        //System.out.println("cx = " + cx);
+                        List<Complex<edu.jas.application.RealAlgebraicNumber<D>>> cy;
+                        cy = new ArrayList<Complex<edu.jas.application.RealAlgebraicNumber<D>>>();
+                        cy.addAll(cx);
+                        cy.add(cr);
+                        cn.add(cy);
+                    }
+                }
+            } else { // depi.length == 2
+                // select roots of the ideal I
+                GenPolynomial<D> pip2 = PolyUtil.<D> removeUnusedUpperVariables(pip);
+                GenPolynomialRing<GenPolynomial<D>> rfac = pip2.ring.recursive(1);
+                GenPolynomialRing<D> ufac = pip2.ring.contract(1);
+                GenPolynomialRing<Complex<D>> ucfac = new GenPolynomialRing<Complex<D>>(ccfac, ufac);
+                GenPolynomialRing<Complex<D>> c2fac = new GenPolynomialRing<Complex<D>>(ccfac, pip2.ring);
+                GenPolynomial<Complex<D>> pip2c = PolyUtil.<D> complexFromAny(c2fac, pip2);
+                //System.out.println("pip2c = " + pip2c);
+                GenPolynomialRing<GenPolynomial<Complex<D>>> rcfac;
+                rcfac = new GenPolynomialRing<GenPolynomial<Complex<D>>>(ucfac, rfac);
+                GenPolynomial<GenPolynomial<Complex<D>>> pip2cr = PolyUtil.<Complex<D>> recursive(rcfac,
+                                pip2c);
+                //System.out.println("pip2cr = " + pip2cr);
+
+                int ix = fac.nvar - 1 - depi[depi.length - 1];
+                //System.out.println("ix = " + ix);
+                for (Complex<edu.jas.application.RealAlgebraicNumber<D>> cr : cra) {
+                    System.out.println("cr = " + toString(cr)); // <----------------------------------
+                    edu.jas.application.RealAlgebraicRing<D> cring = (edu.jas.application.RealAlgebraicRing<D>) cr.ring.ring;
+                    RealRootTuple<D> rroot = cring.getRoot();
+                    List<RealAlgebraicNumber<D>> rlist = rroot.tuple;
+                    Interval<D> vr = rlist.get(0).ring.getRoot();
+                    Interval<D> vi = rlist.get(1).ring.getRoot();
+                    logger.info("vr = " + vr + ", vi = " + vi);
+                    if (vr.length().isZERO()) {
+                        D e = vr.left.factory().parse("1/2");
+                        D m = vr.left; //middle();
+                        vr = new Interval<D>(m.subtract(e), m.sum(e));
+                        logger.info("|vr| == 0: " + vr);
+                    }
+                    if (vi.length().isZERO()) {
+                        D e = vi.left.factory().parse("1/2");
+                        D m = vi.left; //middle();
+                        vi = new Interval<D>(m.subtract(e), m.sum(e));
+                        logger.info("|vi| == 0: " + vi);
+                    }
+                    Complex<D> sw = new Complex<D>(ccfac, vr.left, vi.left);
+                    Complex<D> ne = new Complex<D>(ccfac, vr.right, vi.right);
+                    logger.info("sw   = " + toString1(sw) + ", ne   = " + toString1(ne));
+                    GenPolynomial<Complex<D>> pip2cesw, pip2cene;
+                    pip2cesw = PolyUtil.<Complex<D>> evaluateMainRecursive(ucfac, pip2cr, sw);
+                    pip2cene = PolyUtil.<Complex<D>> evaluateMainRecursive(ucfac, pip2cr, ne);
+                    GenPolynomialRing<D> upfac = I.upolys.get(ix).ring;
+                    GenPolynomialRing<Complex<D>> upcfac = new GenPolynomialRing<Complex<D>>(ccfac, upfac);
+                    //System.out.println("upfac = " + upfac);
+                    //System.out.println("upcfac = " + upcfac);
+                    GenPolynomial<Complex<D>> pip2eswc = convertComplexComplex(upcfac, pip2cesw);
+                    GenPolynomial<Complex<D>> pip2enec = convertComplexComplex(upcfac, pip2cene);
+                    //System.out.println("pip2eswc = " + pip2eswc);
+                    //System.out.println("pip2enec = " + pip2enec);
+                    for (List<Complex<edu.jas.application.RealAlgebraicNumber<D>>> cx : can) {
+                        //System.out.println("cxi = " + toString(cx.get(ix)));
+                        Complex<edu.jas.application.RealAlgebraicNumber<D>> cax = cx.get(ix);
+                        ComplexRing<edu.jas.application.RealAlgebraicNumber<D>> car = cax.ring;
+                        edu.jas.application.RealAlgebraicRing<D> rar = (edu.jas.application.RealAlgebraicRing<D>) car.ring;
+                        //System.out.println("car = " + car);
+                        //System.out.println("rar = " + rar);
+                        TermOrder to = new TermOrder(TermOrder.INVLEX);
+                        String vvr = rar.algebraic.ring.getVars()[0];
+                        String vvi = rar.algebraic.ring.getVars()[1];
+                        String[] vars = new String[] { vvr, vvi };
+                        GenPolynomialRing<Complex<D>> tfac = new GenPolynomialRing<Complex<D>>(ccfac, to,
+                                        vars);
+                        GenPolynomial<Complex<D>> t = tfac.univariate(1, 1L)
+                                        .sum(tfac.univariate(0, 1L).multiply(ccfac.getIMAG()));
+                        //System.out.println("t  = " + t); // t = x + i y
+                        GenPolynomialRing<D> rtfac = new GenPolynomialRing<D>(cfac, tfac);
+                        GenPolynomial<Complex<D>> su;
+                        GenPolynomial<D> re, im;
+                        su = PolyUtil.<Complex<D>> substituteUnivariate(pip2eswc, t);
+                        //su = su.monic(); not here
+                        re = PolyUtil.<D> realPartFromComplex(rtfac, su);
+                        im = PolyUtil.<D> imaginaryPartFromComplex(rtfac, su);
+                        //System.out.println("re = " + re);
+                        //System.out.println("im = " + im);
+                        edu.jas.application.RealAlgebraicNumber<D> resw, imsw, rene, imne;
+                        resw = new edu.jas.application.RealAlgebraicNumber<D>(rar, re);
+                        //System.out.println("resw = " + resw);
+                        int sswr = resw.signum();
+                        imsw = new edu.jas.application.RealAlgebraicNumber<D>(rar, im);
+                        //System.out.println("imsw = " + imsw);
+                        int sswi = imsw.signum();
+                        su = PolyUtil.<Complex<D>> substituteUnivariate(pip2enec, t);
+                        //su = su.monic(); not here
+                        re = PolyUtil.<D> realPartFromComplex(rtfac, su);
+                        im = PolyUtil.<D> imaginaryPartFromComplex(rtfac, su);
+                        //System.out.println("re = " + re);
+                        //System.out.println("im = " + im);
+                        rene = new edu.jas.application.RealAlgebraicNumber<D>(rar, re);
+                        //System.out.println("rene = " + rene);
+                        int sner = rene.signum();
+                        imne = new edu.jas.application.RealAlgebraicNumber<D>(rar, im);
+                        //System.out.println("imne = " + imne);
+                        int snei = imne.signum();
+                        //System.out.println("sswr = " + sswr + ", sswi = " + sswi);
+                        //System.out.println("sner = " + sner + ", snei = " + snei);
+                        if ((sswr * sner <= 0 && sswi * snei <= 0)) { // wrong !
+                            logger.info("   hit, cxi = " + toString(cx.get(ix)) + ", cr = " + toString(cr));
+                            List<Complex<edu.jas.application.RealAlgebraicNumber<D>>> cy;
+                            cy = new ArrayList<Complex<edu.jas.application.RealAlgebraicNumber<D>>>();
+                            cy.addAll(cx);
+                            cy.add(cr);
+                            cn.add(cy);
+                        } else {
+                            logger.info("no hit, cxi = " + toString(cx.get(ix)) + ", cr = " + toString(cr));
+                        }
+                    }
+                }
+            }
+            can = cn;
+        }
+        IdealWithComplexAlgebraicRoots<D> Ic = new IdealWithComplexAlgebraicRoots<D>(I, can);
+        return Ic;
+    }
+
+
+    /**
+     * Construct complex roots for zero dimensional ideal(G).
+     * @param I zero dimensional ideal with univariate irreducible polynomials
+     *            and bi-variate polynomials.
+     * @return complex algebraic roots for ideal(G) <b>Note:</b> not jet
+     *         completed oin all cases.
+     */
+    public static <D extends GcdRingElem<D> & Rational> IdealWithComplexAlgebraicRoots<D> complexAlgebraicRoots(
+                    IdealWithUniv<D> I) {
+        List<List<Complex<edu.jas.application.RealAlgebraicNumber<D>>>> can;
+        can = new ArrayList<List<Complex<edu.jas.application.RealAlgebraicNumber<D>>>>();
+        if (I == null) {
+            throw new IllegalArgumentException("null ideal not permitted");
+        }
+        if (I.ideal == null || I.upolys == null) {
+            throw new IllegalArgumentException("null ideal components not permitted " + I);
+        }
+        if (I.ideal.isZERO() || I.upolys.size() == 0) {
+            return new IdealWithComplexAlgebraicRoots<D>(I, can);
+        }
+        GenPolynomialRing<D> fac = I.ideal.list.ring;
+        if (fac.nvar == 0) {
+            return new IdealWithComplexAlgebraicRoots<D>(I, can);
+        }
+        if (fac.nvar != I.upolys.size()) {
+            throw new IllegalArgumentException("ideal not zero dimnsional: " + I);
+        }
+        // case i == 0:
+        GenPolynomial<D> p0 = I.upolys.get(0);
+        GenPolynomial<D> p0p = PolyUtil.<D> selectWithVariable(I.ideal.list.list, fac.nvar - 1);
+        if (p0p == null) {
+            throw new RuntimeException("no polynomial found in " + (fac.nvar - 1) + " of  " + I.ideal);
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("p0  = " + p0);
+            logger.info("p0p = " + p0p);
+        }
+        int[] dep0 = p0p.degreeVector().dependencyOnVariables();
+        //System.out.println("dep0 = " + Arrays.toString(dep0));
+        if (dep0.length != 1) {
+            throw new RuntimeException("wrong number of variables " + Arrays.toString(dep0));
+        }
+        RingFactory<D> cfac = p0.ring.coFac;
+        ComplexRing<D> ccfac = new ComplexRing<D>(cfac);
+        GenPolynomialRing<Complex<D>> facc = new GenPolynomialRing<Complex<D>>(ccfac, p0.ring);
+        GenPolynomial<Complex<D>> p0c = PolyUtil.<D> complexFromAny(facc, p0);
+        List<Complex<edu.jas.application.RealAlgebraicNumber<D>>> cra;
+        cra = edu.jas.application.RootFactoryApp.<D> complexAlgebraicNumbersSquarefree(p0c);
+        logger.info("#roots(p0c) = " + cra.size());
+        for (Complex<edu.jas.application.RealAlgebraicNumber<D>> cr : cra) {
+            List<Complex<edu.jas.application.RealAlgebraicNumber<D>>> cl;
+            cl = new ArrayList<Complex<edu.jas.application.RealAlgebraicNumber<D>>>();
+            cl.add(cr);
+            can.add(cl);
+        }
+        if (fac.nvar == 1) {
+            return new IdealWithComplexAlgebraicRoots<D>(I, can);
+        }
+        // case i > 0:
+        for (int i = 1; i < I.upolys.size(); i++) {
+            List<List<Complex<edu.jas.application.RealAlgebraicNumber<D>>>> cn;
+            cn = new ArrayList<List<Complex<edu.jas.application.RealAlgebraicNumber<D>>>>();
+            GenPolynomial<D> pi = I.upolys.get(i);
+            GenPolynomial<D> pip = PolyUtil.selectWithVariable(I.ideal.list.list, fac.nvar - 1 - i);
+            if (pip == null) {
+                throw new RuntimeException(
+                                "no polynomial found in " + (fac.nvar - 1 - i) + " of  " + I.ideal);
+            }
+            if (logger.isInfoEnabled()) {
+                logger.info("pi(" + i + ") = " + pi);
+                logger.info("pip  = " + pip);
+            }
+            facc = new GenPolynomialRing<Complex<D>>(ccfac, pi.ring);
+            GenPolynomial<Complex<D>> pic = PolyUtil.<D> complexFromAny(facc, pi);
+            int[] depi = pip.degreeVector().dependencyOnVariables();
+            //System.out.println("depi = " + Arrays.toString(depi));
+            if (depi.length < 1 || depi.length > 2) {
+                throw new RuntimeException(
+                                "wrong number of variables " + Arrays.toString(depi) + " for " + pip);
+            }
+            cra = edu.jas.application.RootFactoryApp.<D> complexAlgebraicNumbersSquarefree(pic);
+            logger.info("#roots(pic) = " + cra.size());
+            if (depi.length == 1) {
+                // all combinations are roots of the ideal I
+                for (Complex<edu.jas.application.RealAlgebraicNumber<D>> cr : cra) {
+                    //System.out.println("cr.ring = " + cr.ring);
+                    for (List<Complex<edu.jas.application.RealAlgebraicNumber<D>>> cx : can) {
+                        //System.out.println("cx = " + cx);
+                        List<Complex<edu.jas.application.RealAlgebraicNumber<D>>> cy;
+                        cy = new ArrayList<Complex<edu.jas.application.RealAlgebraicNumber<D>>>();
+                        cy.addAll(cx);
+                        cy.add(cr);
+                        cn.add(cy);
+                    }
+                }
+            } else { // depi.length == 2
+                // select roots of the ideal I
+                GenPolynomial<D> pip2 = PolyUtil.<D> removeUnusedUpperVariables(pip);
+                pip2 = PolyUtil.<D> removeUnusedLowerVariables(pip2);
+                pip2 = PolyUtil.<D> removeUnusedMiddleVariables(pip2);
+                GenPolynomialRing<GenPolynomial<D>> rfac = pip2.ring.recursive(1);
+                GenPolynomialRing<D> ufac = pip2.ring.contract(1);
+                GenPolynomialRing<Complex<D>> ucfac = new GenPolynomialRing<Complex<D>>(ccfac, ufac);
+                GenPolynomialRing<Complex<D>> c2fac = new GenPolynomialRing<Complex<D>>(ccfac, pip2.ring);
+                GenPolynomial<Complex<D>> pip2c = PolyUtil.<D> complexFromAny(c2fac, pip2);
+                GenPolynomialRing<GenPolynomial<Complex<D>>> rcfac;
+                rcfac = new GenPolynomialRing<GenPolynomial<Complex<D>>>(ucfac, rfac);
+                GenPolynomial<GenPolynomial<Complex<D>>> pip2cr = PolyUtil.<Complex<D>> recursive(rcfac,
+                                pip2c);
+                //System.out.println("pip2cr = " + pip2cr);
+                int ix = fac.nvar - 1 - depi[depi.length - 1];
+                //System.out.println("ix = " + ix);
+                for (Complex<edu.jas.application.RealAlgebraicNumber<D>> cr : cra) {
+                    //System.out.println("cr = " + toString(cr)); 
+                    edu.jas.application.RealAlgebraicRing<D> cring = (edu.jas.application.RealAlgebraicRing<D>) cr.ring.ring;
+                    RealRootTuple<D> rroot = cring.getRoot();
+                    List<RealAlgebraicNumber<D>> rlist = rroot.tuple;
+                    //System.out.println("rlist = " + rlist);
+                    Interval<D> vr = rlist.get(0).ring.getRoot();
+                    Interval<D> vi = rlist.get(1).ring.getRoot();
+                    //logger.info("vr = " + vr + ", vi = " + vi);
+                    edu.jas.application.RealAlgebraicNumber<D> vrl, vil, vrr, vir;
+                    vrl = new edu.jas.application.RealAlgebraicNumber<D>(cring, vr.left);
+                    vil = new edu.jas.application.RealAlgebraicNumber<D>(cring, vi.left);
+                    vrr = new edu.jas.application.RealAlgebraicNumber<D>(cring, vr.right);
+                    vir = new edu.jas.application.RealAlgebraicNumber<D>(cring, vi.right);
+                    ComplexRing<edu.jas.application.RealAlgebraicNumber<D>> crr;
+                    crr = new ComplexRing<edu.jas.application.RealAlgebraicNumber<D>>(cring);
+                    Complex<edu.jas.application.RealAlgebraicNumber<D>> csw, cne;
+                    csw = new Complex<edu.jas.application.RealAlgebraicNumber<D>>(crr, vrl, vil);
+                    cne = new Complex<edu.jas.application.RealAlgebraicNumber<D>>(crr, vrr, vir);
+                    //logger.info("csw  = " + toString(csw)   + ", cne  = " + toString(cne));
+                    Rectangle<edu.jas.application.RealAlgebraicNumber<D>> rec;
+                    rec = new Rectangle<edu.jas.application.RealAlgebraicNumber<D>>(csw, cne);
+                    //System.out.println("rec = " + rec);
+                    for (List<Complex<edu.jas.application.RealAlgebraicNumber<D>>> cx : can) {
+                        Complex<edu.jas.application.RealAlgebraicNumber<D>> cax = cx.get(ix);
+                        //System.out.println("cax = " + toString(cax));
+                        ComplexRing<edu.jas.application.RealAlgebraicNumber<D>> car = cax.ring;
+                        //System.out.println("car = " + car);
+                        GenPolynomialRing<Complex<edu.jas.application.RealAlgebraicNumber<D>>> pcrfac;
+                        pcrfac = new GenPolynomialRing<Complex<edu.jas.application.RealAlgebraicNumber<D>>>(
+                                        car, rcfac);
+                        GenPolynomial<Complex<edu.jas.application.RealAlgebraicNumber<D>>> pcr;
+                        pcr = evaluateToComplexRealCoefficients(pcrfac, pip2cr, cax);
+                        //System.out.println("pcr = " + pcr);
+                        ComplexRoots<edu.jas.application.RealAlgebraicNumber<D>> rengine;
+                        rengine = new ComplexRootsSturm<edu.jas.application.RealAlgebraicNumber<D>>(car);
+                        long nr = 0;
+                        try {
+                            nr = rengine.complexRootCount(rec, pcr);
+                            //logger.info("rootCount = " + nr);
+                        } catch (InvalidBoundaryException e) {
+                            e.printStackTrace();
+                        }
+                        if (nr == 1) { // one root
+                            logger.info("   hit, cxi = " + toString(cx.get(ix)) + ", cr = " + toString(cr));
+                            List<Complex<edu.jas.application.RealAlgebraicNumber<D>>> cy;
+                            cy = new ArrayList<Complex<edu.jas.application.RealAlgebraicNumber<D>>>();
+                            cy.addAll(cx);
+                            cy.add(cr);
+                            cn.add(cy);
+                        } else if (nr > 1) {
+                            logger.error("to many roots, cxi = " + toString(cx.get(ix)) + ", cr = "
+                                            + toString(cr));
+                        } else { // no root
+                            logger.info("no hit, cxi = " + toString(cx.get(ix)) + ", cr = " + toString(cr));
+                        }
+                    }
+                }
+            }
+            can = cn;
+        }
+        IdealWithComplexAlgebraicRoots<D> Ic = new IdealWithComplexAlgebraicRoots<D>(I, can);
+        return Ic;
+    }
+
+
+    /**
+     * String representation of a deximal approximation of a complex number.
+     * @param c compelx number.
+     * @return String representation of c
+     */
+    public static <D extends GcdRingElem<D> & Rational> String toString(
+                    Complex<edu.jas.application.RealAlgebraicNumber<D>> c) {
+        edu.jas.application.RealAlgebraicNumber<D> re = c.getRe();
+        edu.jas.application.RealAlgebraicNumber<D> im = c.getIm();
+        String s = re.decimalMagnitude().toString();
+        if (!im.isZERO()) {
+            s = s + "i" + im.decimalMagnitude();
+        }
+        return s;
+    }
+
+
+    /**
+     * String representation of a deximal approximation of a complex number.
+     * @param c compelx number.
+     * @return String representation of c
+     */
+    public static <D extends GcdRingElem<D> & Rational> String toString1(Complex<D> c) {
+        D re = c.getRe();
+        D im = c.getIm();
+        String s = new BigDecimal(re.getRational()).toString();
+        if (!im.isZERO()) {
+            s = s + "i" + new BigDecimal(im.getRational());
+        }
+        return s;
+    }
+
+
+    /**
+     * Construct complex roots for zero dimensional ideal(G).
+     * @param I list of zero dimensional ideal with univariate irreducible
+     *            polynomials and bi-variate polynomials.
+     * @return list of complex algebraic roots for ideal(G)
+     */
+    public static <D extends GcdRingElem<D> & Rational> List<IdealWithComplexAlgebraicRoots<D>> complexAlgebraicRoots(
+                    List<IdealWithUniv<D>> I) {
+        List<IdealWithComplexAlgebraicRoots<D>> lic = new ArrayList<IdealWithComplexAlgebraicRoots<D>>();
+        for (IdealWithUniv<D> iu : I) {
+            IdealWithComplexAlgebraicRoots<D> iuc = PolyUtilApp.<D> complexAlgebraicRoots(iu);
+            //System.out.println("iuc = " + iuc);
+            lic.add(iuc);
+        }
+        return lic;
+    }
+
+
+    /**
+     * Construct exact set of complex roots for zero dimensional ideal(G).
+     * @param I zero dimensional ideal.
+     * @return list of coordinates of complex roots for ideal(G)
+     */
+    public static <D extends GcdRingElem<D> & Rational> List<IdealWithComplexAlgebraicRoots<D>> complexAlgebraicRoots(
+                    Ideal<D> I) {
+        List<IdealWithUniv<D>> Ir = I.zeroDimRootDecomposition();
+        //System.out.println("Ir = " + Ir);
+        List<IdealWithComplexAlgebraicRoots<D>> roots = PolyUtilApp.<D> complexAlgebraicRoots(Ir);
+        return roots;
+    }
+
+
+    /*
+     * Convert to a polynomial in given ring.
+     * @param fac result polynomial ring.
+     * @param p polynomial.
+     * @return polynomial in ring fac <b>Note: </b> if p can not be represented
+     *         in fac then the results are unpredictable.
+     */
+    static <C extends RingElem<C>> GenPolynomial<C> convert(GenPolynomialRing<C> fac, GenPolynomial<C> p) {
+        if (fac.equals(p.factory())) {
+            return p;
+        }
+        GenPolynomial<C> q = fac.parse(p.toString());
+        if (!q.toString().equals(p.toString())) {
+            throw new RuntimeException("convert(" + p + ") = " + q);
+        }
+        return q;
+    }
+
+
+    /*
+     * Convert to a polynomial in given ring.
+     * @param fac result polynomial ring.
+     * @param p polynomial.
+     * @return polynomial in ring fac <b>Note: </b> if p can not be represented
+     *         in fac then the results are unpredictable.
+     */
+    static <C extends RingElem<C>> GenPolynomial<Complex<C>> convertComplex(GenPolynomialRing<Complex<C>> fac,
+                    GenPolynomial<C> p) {
+        GenPolynomial<Complex<C>> q = fac.parse(p.toString());
+        if (!q.toString().equals(p.toString())) {
+            throw new RuntimeException("convert(" + p + ") = " + q);
+        }
+        return q;
+    }
+
+
+    /*
+     * Convert to a polynomial in given ring.
+     * @param fac result polynomial ring.
+     * @param p complex polynomial.
+     * @return polynomial in ring fac <b>Note: </b> if p can not be represented
+     *         in fac then the results are unpredictable.
+     */
+    static <C extends RingElem<C>> GenPolynomial<Complex<C>> convertComplexComplex(
+                    GenPolynomialRing<Complex<C>> fac, GenPolynomial<Complex<C>> p) {
+        if (fac.equals(p.factory())) {
+            return p;
+        }
+        GenPolynomial<Complex<C>> q = fac.parse(p.toString());
+        if (!q.toString().equals(p.toString())) {
+            throw new RuntimeException("convert(" + p + ") = " + q);
+        }
+        return q;
+    }
+
+
+    /**
+     * Construct exact set of real roots for zero dimensional ideal(G).
+     * @param I zero dimensional ideal.
+     * @return list of coordinates of real roots for ideal(G)
+     */
+    public static <D extends GcdRingElem<D> & Rational> List<IdealWithRealAlgebraicRoots<D>> realAlgebraicRoots(
+                    Ideal<D> I) {
+        List<IdealWithUniv<D>> Ir = I.zeroDimRootDecomposition();
+        //System.out.println("Ir = " + Ir);
+        List<IdealWithRealAlgebraicRoots<D>> roots = PolyUtilApp.<D> realAlgebraicRoots(Ir);
+        return roots;
+    }
+
+
+    /**
+     * Construct primitive element for double field extension.
+     * @param a algebraic number ring with squarefree monic minimal polynomial
+     * @param b algebraic number ring with squarefree monic minimal polynomial
+     * @return primitive element container with algebraic number ring c, with
+     *         Q(c) = Q(a,b)
+     */
+    public static <C extends GcdRingElem<C>> PrimitiveElement<C> primitiveElement(AlgebraicNumberRing<C> a,
+                    AlgebraicNumberRing<C> b) {
+        GenPolynomial<C> ap = a.modul;
+        GenPolynomial<C> bp = b.modul;
+
+        // setup bivariate polynomial ring
+        String[] cv = new String[2];
+        cv[0] = ap.ring.getVars()[0];
+        cv[1] = bp.ring.getVars()[0];
+        TermOrder to = new TermOrder(TermOrder.INVLEX);
+        GenPolynomialRing<C> cfac = new GenPolynomialRing<C>(ap.ring.coFac, 2, to, cv);
+        GenPolynomial<C> as = ap.extendUnivariate(cfac, 0);
+        GenPolynomial<C> bs = bp.extendUnivariate(cfac, 1);
+        List<GenPolynomial<C>> L = new ArrayList<GenPolynomial<C>>(2);
+        L.add(as);
+        L.add(bs);
+        List<GenPolynomial<C>> Op = new ArrayList<GenPolynomial<C>>();
+
+        Ideal<C> id = new Ideal<C>(cfac, L);
+        //System.out.println("id = " + id);
+        IdealWithUniv<C> iu = id.normalPositionFor(0, 1, Op);
+        //System.out.println("iu = " + iu);
+
+        // extract result polynomials
+        List<GenPolynomial<C>> Np = iu.ideal.getList();
+        //System.out.println("Np = " + Np);
+        as = PolyUtil.<C> selectWithVariable(Np, 1);
+        bs = PolyUtil.<C> selectWithVariable(Np, 0);
+        GenPolynomial<C> cs = PolyUtil.<C> selectWithVariable(Np, 2);
+        //System.out.println("as = " + as);
+        //System.out.println("bs = " + bs);
+        //System.out.println("cs = " + cs);
+        String[] ev = new String[] { cs.ring.getVars()[0] };
+        GenPolynomialRing<C> efac = new GenPolynomialRing<C>(ap.ring.coFac, 1, to, ev);
+        //System.out.println("efac = " + efac);
+        cs = cs.contractCoeff(efac);
+        //System.out.println("cs = " + cs);
+        as = as.reductum().contractCoeff(efac);
+        as = as.negate();
+        //System.out.println("as = " + as);
+        bs = bs.reductum().contractCoeff(efac);
+        bs = bs.negate();
+        //System.out.println("bs = " + bs);
+        AlgebraicNumberRing<C> c = new AlgebraicNumberRing<C>(cs);
+        AlgebraicNumber<C> ab = new AlgebraicNumber<C>(c, as);
+        AlgebraicNumber<C> bb = new AlgebraicNumber<C>(c, bs);
+        PrimitiveElement<C> pe = new PrimitiveElement<C>(c, ab, bb, a, b);
+        if (logger.isInfoEnabled()) {
+            logger.info("primitive element = " + c);
+        }
+        return pe;
+    }
+
+
+    /**
+     * Convert to primitive element ring.
+     * @param cfac primitive element ring.
+     * @param A algebraic number representing the generating element of a in the
+     *            new ring.
+     * @param a algebraic number to convert.
+     * @return a converted to the primitive element ring
+     */
+    public static <C extends GcdRingElem<C>> AlgebraicNumber<C> convertToPrimitiveElem(
+                    AlgebraicNumberRing<C> cfac, AlgebraicNumber<C> A, AlgebraicNumber<C> a) {
+        GenPolynomialRing<C> aufac = a.ring.ring;
+        GenPolynomialRing<AlgebraicNumber<C>> ar = new GenPolynomialRing<AlgebraicNumber<C>>(cfac, aufac);
+        GenPolynomial<AlgebraicNumber<C>> aps = PolyUtil.<C> convertToAlgebraicCoefficients(ar, a.val);
+        AlgebraicNumber<C> ac = PolyUtil.<AlgebraicNumber<C>> evaluateMain(cfac, aps, A);
+        return ac;
+    }
+
+
+    /**
+     * Convert coefficients to primitive element ring.
+     * @param cfac primitive element ring.
+     * @param A algebraic number representing the generating element of a in the
+     *            new ring.
+     * @param a polynomial with coefficients algebraic number to convert.
+     * @return a with coefficients converted to the primitive element ring
+     */
+    public static <C extends GcdRingElem<C>> GenPolynomial<AlgebraicNumber<C>> convertToPrimitiveElem(
+                    AlgebraicNumberRing<C> cfac, AlgebraicNumber<C> A, GenPolynomial<AlgebraicNumber<C>> a) {
+        GenPolynomialRing<AlgebraicNumber<C>> cr = new GenPolynomialRing<AlgebraicNumber<C>>(cfac, a.ring);
+        return PolyUtil.<AlgebraicNumber<C>, AlgebraicNumber<C>> map(cr, a, new CoeffConvertAlg<C>(cfac, A));
+    }
+
+
+    /**
+     * Convert to primitive element ring.
+     * @param cfac primitive element ring.
+     * @param A algebraic number representing the generating element of a in the
+     *            new ring.
+     * @param a recursive algebraic number to convert.
+     * @return a converted to the primitive element ring
+     */
+    public static <C extends GcdRingElem<C>> AlgebraicNumber<C> convertToPrimitiveElem(
+                    AlgebraicNumberRing<C> cfac, AlgebraicNumber<C> A, AlgebraicNumber<C> B,
+                    AlgebraicNumber<AlgebraicNumber<C>> a) {
+        GenPolynomial<AlgebraicNumber<C>> aps = PolyUtilApp.<C> convertToPrimitiveElem(cfac, A, a.val);
+        AlgebraicNumber<C> ac = PolyUtil.<AlgebraicNumber<C>> evaluateMain(cfac, aps, B);
+        return ac;
+    }
+
+
+    /**
+     * Construct primitive element for double field extension.
+     * @param b algebraic number ring with squarefree monic minimal polynomial
+     *            over Q(a)
+     * @return primitive element container with algebraic number ring c, with
+     *         Q(c) = Q(a)(b)
+     */
+    public static <C extends GcdRingElem<C>> PrimitiveElement<C> primitiveElement(
+                    AlgebraicNumberRing<AlgebraicNumber<C>> b) {
+        GenPolynomial<AlgebraicNumber<C>> bp = b.modul;
+        AlgebraicNumberRing<C> a = (AlgebraicNumberRing<C>) b.ring.coFac;
+        GenPolynomial<C> ap = a.modul;
+
+        // setup bivariate polynomial ring
+        String[] cv = new String[2];
+        cv[0] = ap.ring.getVars()[0];
+        cv[1] = bp.ring.getVars()[0];
+        TermOrder to = new TermOrder(TermOrder.INVLEX);
+        GenPolynomialRing<C> cfac = new GenPolynomialRing<C>(ap.ring.coFac, 2, to, cv);
+        GenPolynomialRing<GenPolynomial<C>> rfac = new GenPolynomialRing<GenPolynomial<C>>(a.ring, 1,
+                        bp.ring.getVars());
+        GenPolynomial<C> as = ap.extendUnivariate(cfac, 0);
+        GenPolynomial<GenPolynomial<C>> bss = PolyUtil.<C> fromAlgebraicCoefficients(rfac, bp);
+        GenPolynomial<C> bs = PolyUtil.<C> distribute(cfac, bss);
+        List<GenPolynomial<C>> L = new ArrayList<GenPolynomial<C>>(2);
+        L.add(as);
+        L.add(bs);
+        List<GenPolynomial<C>> Op = new ArrayList<GenPolynomial<C>>();
+
+        Ideal<C> id = new Ideal<C>(cfac, L);
+        //System.out.println("id = " + id);
+        IdealWithUniv<C> iu = id.normalPositionFor(0, 1, Op);
+        //System.out.println("iu = " + iu);
+
+        // extract result polynomials
+        List<GenPolynomial<C>> Np = iu.ideal.getList();
+        as = PolyUtil.<C> selectWithVariable(Np, 1);
+        bs = PolyUtil.<C> selectWithVariable(Np, 0);
+        GenPolynomial<C> cs = PolyUtil.<C> selectWithVariable(Np, 2);
+        //System.out.println("as = " + as);
+        //System.out.println("bs = " + bs);
+        //System.out.println("cs = " + cs);
+        String[] ev = new String[] { cs.ring.getVars()[0] };
+        GenPolynomialRing<C> efac = new GenPolynomialRing<C>(ap.ring.coFac, 1, to, ev);
+        // System.out.println("efac = " + efac);
+        cs = cs.contractCoeff(efac);
+        // System.out.println("cs = " + cs);
+        as = as.reductum().contractCoeff(efac);
+        as = as.negate();
+        // System.out.println("as = " + as);
+        bs = bs.reductum().contractCoeff(efac);
+        bs = bs.negate();
+        //System.out.println("bs = " + bs);
+        AlgebraicNumberRing<C> c = new AlgebraicNumberRing<C>(cs);
+        AlgebraicNumber<C> ab = new AlgebraicNumber<C>(c, as);
+        AlgebraicNumber<C> bb = new AlgebraicNumber<C>(c, bs);
+        PrimitiveElement<C> pe = new PrimitiveElement<C>(c, ab, bb); // missing ,a,b);
+        if (logger.isInfoEnabled()) {
+            logger.info("primitive element = " + pe);
+        }
+        return pe;
+    }
+
+
+    /**
+     * Convert to primitive element ring.
+     * @param cfac primitive element ring.
+     * @param A algebraic number representing the generating element of a in the
+     *            new ring.
+     * @param a polynomial with recursive algebraic number coefficients to
+     *            convert.
+     * @return a converted to the primitive element ring
+     */
+    public static <C extends GcdRingElem<C>> GenPolynomial<AlgebraicNumber<C>> convertToPrimitiveElem(
+                    AlgebraicNumberRing<C> cfac, AlgebraicNumber<C> A, AlgebraicNumber<C> B,
+                    GenPolynomial<AlgebraicNumber<AlgebraicNumber<C>>> a) {
+        GenPolynomialRing<AlgebraicNumber<C>> cr = new GenPolynomialRing<AlgebraicNumber<C>>(cfac, a.ring);
+        return PolyUtil.<AlgebraicNumber<AlgebraicNumber<C>>, AlgebraicNumber<C>> map(cr, a,
+                        new CoeffRecConvertAlg<C>(cfac, A, B));
+    }
+
+
+    /**
+     * Convert to RealAlgebraicNumber coefficients. Represent as polynomial with
+     * RealAlgebraicNumber<C> coefficients from package
+     * <code>edu.jas.root.</code>
+     * @param afac result polynomial factory.
+     * @param A polynomial with RealAlgebraicNumber&lt;C&gt; coefficients to be
+     *            converted.
+     * @return polynomial with RealAlgebraicNumber&lt;C&gt; coefficients.
+     */
+    public static <C extends GcdRingElem<C> & Rational> GenPolynomial<edu.jas.root.RealAlgebraicNumber<C>> realAlgFromRealCoefficients(
+                    GenPolynomialRing<edu.jas.root.RealAlgebraicNumber<C>> afac,
+                    GenPolynomial<edu.jas.application.RealAlgebraicNumber<C>> A) {
+        edu.jas.root.RealAlgebraicRing<C> cfac = (edu.jas.root.RealAlgebraicRing<C>) afac.coFac;
+        return PolyUtil.<edu.jas.application.RealAlgebraicNumber<C>, edu.jas.root.RealAlgebraicNumber<C>> map(
+                        afac, A, new ReAlgFromRealCoeff<C>(cfac));
+    }
+
+
+    /**
+     * Convert to RealAlgebraicNumber coefficients. Represent as polynomial with
+     * RealAlgebraicNumber<C> coefficients from package
+     * 
+     * <pre>
+     * edu.jas.application
+     * </pre>
+     * 
+     * .
+     * @param rfac result polynomial factory.
+     * @param A polynomial with RealAlgebraicNumber&lt;C&gt; coefficients to be
+     *            converted.
+     * @return polynomial with RealAlgebraicNumber&lt;C&gt; coefficients.
+     */
+    public static <C extends GcdRingElem<C> & Rational> GenPolynomial<edu.jas.application.RealAlgebraicNumber<C>> realFromRealAlgCoefficients(
+                    GenPolynomialRing<edu.jas.application.RealAlgebraicNumber<C>> rfac,
+                    GenPolynomial<edu.jas.root.RealAlgebraicNumber<C>> A) {
+        edu.jas.application.RealAlgebraicRing<C> cfac = (edu.jas.application.RealAlgebraicRing<C>) rfac.coFac;
+        return PolyUtil.<edu.jas.root.RealAlgebraicNumber<C>, edu.jas.application.RealAlgebraicNumber<C>> map(
+                        rfac, A, new RealFromReAlgCoeff<C>(cfac));
+    }
+
+
+    /**
+     * Convert to Complex&lt;RealAlgebraicNumber&gt; coefficients. Represent as
+     * polynomial with Complex&lt;RealAlgebraicNumber&gt; coefficients, C is
+     * e.g. BigRational.
+     * @param pfac result polynomial factory.
+     * @param A polynomial with Complex coefficients to be converted.
+     * @return polynomial with Complex&lt;RealAlgebraicNumber&gt; coefficients.
+     */
+    public static <C extends GcdRingElem<C> & Rational> GenPolynomial<Complex<edu.jas.application.RealAlgebraicNumber<C>>> convertToComplexRealCoefficients(
+                    GenPolynomialRing<Complex<edu.jas.application.RealAlgebraicNumber<C>>> pfac,
+                    GenPolynomial<Complex<C>> A) {
+        ComplexRing<edu.jas.application.RealAlgebraicNumber<C>> afac;
+        afac = (ComplexRing<edu.jas.application.RealAlgebraicNumber<C>>) pfac.coFac;
+        return PolyUtil.<Complex<C>, Complex<edu.jas.application.RealAlgebraicNumber<C>>> map(pfac, A,
+                        new CoeffToComplexReal<C>(afac));
+    }
+
+
+    /**
+     * Evaluate to Complex&lt;RealAlgebraicNumber&gt; coefficients. Represent as
+     * polynomial with Complex&lt;RealAlgebraicNumber&gt; coefficients, C is
+     * e.g. BigRational.
+     * @param pfac result polynomial factory.
+     * @param A = A(x,Y) a recursive polynomial with
+     *            GenPolynomial&lt;Complex&gt; coefficients to be converted.
+     * @param r Complex&lt;RealAlgebraicNumber&gt; to be evaluated at.
+     * @return A(r,Y), a polynomial with Complex&lt;RealAlgebraicNumber&gt;
+     *         coefficients.
+     */
+    public static <C extends GcdRingElem<C> & Rational> GenPolynomial<Complex<edu.jas.application.RealAlgebraicNumber<C>>> evaluateToComplexRealCoefficients(
+                    GenPolynomialRing<Complex<edu.jas.application.RealAlgebraicNumber<C>>> pfac,
+                    GenPolynomial<GenPolynomial<Complex<C>>> A,
+                    Complex<edu.jas.application.RealAlgebraicNumber<C>> r) {
+        return PolyUtil.<GenPolynomial<Complex<C>>, Complex<edu.jas.application.RealAlgebraicNumber<C>>> map(
+                        pfac, A, new EvaluateToComplexReal<C>(pfac, r));
+    }
+
+
+}
+
+
+/**
+ * Coefficient to convert algebriac functor.
+ */
+class CoeffConvertAlg<C extends GcdRingElem<C>>
+                implements UnaryFunctor<AlgebraicNumber<C>, AlgebraicNumber<C>> {
+
+
+    final protected AlgebraicNumberRing<C> afac;
+
+
+    final protected AlgebraicNumber<C> A;
+
+
+    public CoeffConvertAlg(AlgebraicNumberRing<C> fac, AlgebraicNumber<C> a) {
+        if (fac == null || a == null) {
+            throw new IllegalArgumentException("fac and a must not be null");
+        }
+        afac = fac;
+        A = a;
+    }
+
+
+    public AlgebraicNumber<C> eval(AlgebraicNumber<C> c) {
+        if (c == null) {
+            return afac.getZERO();
+        }
+        return PolyUtilApp.<C> convertToPrimitiveElem(afac, A, c);
+    }
+}
+
+
+/**
+ * Coefficient recursive to convert algebriac functor.
+ */
+class CoeffRecConvertAlg<C extends GcdRingElem<C>>
+                implements UnaryFunctor<AlgebraicNumber<AlgebraicNumber<C>>, AlgebraicNumber<C>> {
+
+
+    final protected AlgebraicNumberRing<C> afac;
+
+
+    final protected AlgebraicNumber<C> A;
+
+
+    final protected AlgebraicNumber<C> B;
+
+
+    public CoeffRecConvertAlg(AlgebraicNumberRing<C> fac, AlgebraicNumber<C> a, AlgebraicNumber<C> b) {
+        if (fac == null || a == null || b == null) {
+            throw new IllegalArgumentException("fac, a and b must not be null");
+        }
+        afac = fac;
+        A = a;
+        B = b;
+    }
+
+
+    public AlgebraicNumber<C> eval(AlgebraicNumber<AlgebraicNumber<C>> c) {
+        if (c == null) {
+            return afac.getZERO();
+        }
+        return PolyUtilApp.<C> convertToPrimitiveElem(afac, A, B, c);
+    }
+}
+
+
+/**
+ * Coefficient to real algebriac from real algebraic functor.
+ */
+class ReAlgFromRealCoeff<C extends GcdRingElem<C> & Rational> implements
+                UnaryFunctor<edu.jas.application.RealAlgebraicNumber<C>, edu.jas.root.RealAlgebraicNumber<C>> {
+
+
+    final protected edu.jas.root.RealAlgebraicRing<C> afac;
+
+
+    public ReAlgFromRealCoeff(edu.jas.root.RealAlgebraicRing<C> fac) {
+        if (fac == null) {
+            throw new IllegalArgumentException("fac must not be null");
+        }
+        afac = fac;
+    }
+
+
+    @SuppressWarnings("unchecked")
+    public edu.jas.root.RealAlgebraicNumber<C> eval(edu.jas.application.RealAlgebraicNumber<C> c) {
+        if (c == null) {
+            return afac.getZERO();
+        }
+        return (edu.jas.root.RealAlgebraicNumber<C>) (Object) c.number; // force ignore recursion
+    }
+}
+
+
+/**
+ * Coefficient to real algebriac from algebraic functor.
+ */
+class RealFromReAlgCoeff<C extends GcdRingElem<C> & Rational> implements
+                UnaryFunctor<edu.jas.root.RealAlgebraicNumber<C>, edu.jas.application.RealAlgebraicNumber<C>> {
+
+
+    final protected edu.jas.application.RealAlgebraicRing<C> rfac;
+
+
+    public RealFromReAlgCoeff(edu.jas.application.RealAlgebraicRing<C> fac) {
+        if (fac == null) {
+            throw new IllegalArgumentException("fac must not be null");
+        }
+        rfac = fac;
+    }
+
+
+    @SuppressWarnings("unchecked")
+    public edu.jas.application.RealAlgebraicNumber<C> eval(edu.jas.root.RealAlgebraicNumber<C> c) {
+        if (c == null) {
+            return rfac.getZERO();
+        }
+        edu.jas.root.RealAlgebraicNumber<edu.jas.root.RealAlgebraicNumber<C>> rrc = (edu.jas.root.RealAlgebraicNumber<edu.jas.root.RealAlgebraicNumber<C>>) (Object) c; // force resurrect recursion
+        return new edu.jas.application.RealAlgebraicNumber<C>(rfac, rrc);
+    }
+}
+
+
+/**
+ * Coefficient to complex real algebriac functor.
+ */
+class CoeffToComplexReal<C extends GcdRingElem<C> & Rational>
+                implements UnaryFunctor<Complex<C>, Complex<edu.jas.application.RealAlgebraicNumber<C>>> {
+
+
+    final protected ComplexRing<edu.jas.application.RealAlgebraicNumber<C>> cfac;
+
+
+    final edu.jas.application.RealAlgebraicRing<C> afac;
+
+
+    final GenPolynomialRing<C> pfac;
+
+
+    public CoeffToComplexReal(ComplexRing<edu.jas.application.RealAlgebraicNumber<C>> fac) {
+        if (fac == null) {
+            throw new IllegalArgumentException("fac must not be null");
+        }
+        cfac = fac;
+        afac = (edu.jas.application.RealAlgebraicRing<C>) cfac.ring;
+        pfac = afac.univs.ideal.getRing();
+    }
+
+
+    public Complex<edu.jas.application.RealAlgebraicNumber<C>> eval(Complex<C> c) {
+        if (c == null) {
+            return cfac.getZERO();
+        }
+        GenPolynomial<C> pr, pi;
+        pr = new GenPolynomial<C>(pfac, c.getRe());
+        pi = new GenPolynomial<C>(pfac, c.getIm());
+        //System.out.println("pr = " + pr);
+        //System.out.println("pi = " + pi);
+        edu.jas.application.RealAlgebraicNumber<C> re, im;
+        re = new edu.jas.application.RealAlgebraicNumber<C>(afac, pr);
+        im = new edu.jas.application.RealAlgebraicNumber<C>(afac, pi);
+        //System.out.println("re = " + re);
+        //System.out.println("im = " + im);
+        return new Complex<edu.jas.application.RealAlgebraicNumber<C>>(cfac, re, im);
+    }
+}
+
+
+/**
+ * Polynomial coefficient to complex real algebriac evaluation functor.
+ */
+class EvaluateToComplexReal<C extends GcdRingElem<C> & Rational> implements
+                UnaryFunctor<GenPolynomial<Complex<C>>, Complex<edu.jas.application.RealAlgebraicNumber<C>>> {
+
+
+    final protected GenPolynomialRing<Complex<edu.jas.application.RealAlgebraicNumber<C>>> pfac;
+
+
+    final protected ComplexRing<edu.jas.application.RealAlgebraicNumber<C>> cfac;
+
+
+    final protected Complex<edu.jas.application.RealAlgebraicNumber<C>> root;
+
+
+    public EvaluateToComplexReal(GenPolynomialRing<Complex<edu.jas.application.RealAlgebraicNumber<C>>> fac,
+                    Complex<edu.jas.application.RealAlgebraicNumber<C>> r) {
+        if (fac == null) {
+            throw new IllegalArgumentException("fac must not be null");
+        }
+        if (r == null) {
+            throw new IllegalArgumentException("r must not be null");
+        }
+        pfac = fac;
+        cfac = (ComplexRing<edu.jas.application.RealAlgebraicNumber<C>>) fac.coFac;
+        root = r;
+        //System.out.println("cfac  = " + cfac);
+        //System.out.println("root  = " + root);
+    }
+
+
+    public Complex<edu.jas.application.RealAlgebraicNumber<C>> eval(GenPolynomial<Complex<C>> c) {
+        if (c == null) {
+            return cfac.getZERO();
+        }
+        //System.out.println("c  = " + c);
+        GenPolynomial<Complex<edu.jas.application.RealAlgebraicNumber<C>>> cp;
+        cp = PolyUtilApp.<C> convertToComplexRealCoefficients(pfac, c);
+        Complex<edu.jas.application.RealAlgebraicNumber<C>> cr;
+        cr = PolyUtil.<Complex<edu.jas.application.RealAlgebraicNumber<C>>> evaluateMain(cfac, cp, root);
+        return cr;
+    }
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/PrimaryComponent.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/PrimaryComponent.java
@@ -1,0 +1,115 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.Serializable;
+
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Container for primary components of ideals.
+ * @author Heinz Kredel
+ */
+public class PrimaryComponent<C extends GcdRingElem<C>> implements Serializable {
+
+
+    /**
+     * The primary ideal.
+     */
+    public final Ideal<C> primary;
+
+
+    /**
+     * The associated prime ideal.
+     */
+    public final IdealWithUniv<C> prime;
+
+
+    /**
+     * The exponent of prime for primary.
+     */
+    protected int exponent;
+
+
+    /**
+     * Constructor not for use.
+     */
+    protected PrimaryComponent() {
+        throw new IllegalArgumentException("do not use this constructor");
+    }
+
+
+    /**
+     * Constructor.
+     * @param q the primary ideal
+     * @param p the prime ideal.
+     */
+    protected PrimaryComponent(Ideal<C> q, IdealWithUniv<C> p) {
+        this(q, p, -1);
+    }
+
+
+    /**
+     * Constructor.
+     * @param q the primary ideal
+     * @param p the prime ideal.
+     * @param e the exponent of p for q.
+     */
+    protected PrimaryComponent(Ideal<C> q, IdealWithUniv<C> p, int e) {
+        primary = q;
+        prime = p;
+        exponent = e;
+    }
+
+
+    /**
+     * Get exponent.
+     * @return exponent.
+     */
+    public int getExponent() {
+        return exponent;
+    }
+
+
+    /**
+     * Set exponent.
+     * @param e the exponent.
+     */
+    public void setExponent(int e) {
+        exponent = e;
+    }
+
+
+    /**
+     * String representation of the ideal.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        String s = "\nprimary:\n" + primary.toString() + "\nprime:\n" + prime.toString();
+        if (exponent < 0) {
+            return s;
+        }
+        return s + "\nexponent:\n" + exponent;
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    public String toScript() {
+        // Python case
+        String s = primary.toScript() + ",  " + prime.toString();
+        if (exponent < 0) {
+            return s;
+        }
+        return s + ", " + exponent;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/PrimitiveElement.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/PrimitiveElement.java
@@ -1,0 +1,127 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.Serializable;
+
+import edu.jas.structure.GcdRingElem;
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.AlgebraicNumberRing;
+
+
+/**
+ * Container for primitive elements.
+ * @author Heinz Kredel
+ */
+public class PrimitiveElement<C extends GcdRingElem<C>> implements Serializable {
+
+
+    /**
+     * The primitive element.
+     */
+    public final AlgebraicNumberRing<C> primitiveElem;
+
+
+    /**
+     * The representation of the first algebraic element in the new ring.
+     */
+    public final AlgebraicNumber<C> A;
+
+
+    /**
+     * The representation of the second algebraic element in the new ring.
+     */
+    public final AlgebraicNumber<C> B;
+
+
+    /**
+     * The first original algebraic ring.
+     */
+    public final AlgebraicNumberRing<C> Aring;
+
+
+    /**
+     * The second original algebraic ring.
+     */
+    public final AlgebraicNumberRing<C> Bring;
+
+
+    /**
+     * Constructor not for use.
+     */
+    protected PrimitiveElement() {
+        throw new IllegalArgumentException("do not use this constructor");
+    }
+
+
+    /**
+     * Constructor.
+     * @param pe the primitive element
+     * @param A the first element.
+     * @param B the second element.
+     */
+    protected PrimitiveElement(AlgebraicNumberRing<C> pe, AlgebraicNumber<C> A, AlgebraicNumber<C> B) {
+        this(pe, A, B, null, null);
+    }
+
+
+    /**
+     * Constructor.
+     * @param pe the primitive element
+     * @param A the first element.
+     * @param B the second element.
+     */
+    protected PrimitiveElement(AlgebraicNumberRing<C> pe, AlgebraicNumber<C> A, AlgebraicNumber<C> B,
+                               AlgebraicNumberRing<C> ar, AlgebraicNumberRing<C> br ) {
+        primitiveElem = pe;
+        this.A = A;
+        this.B = B;
+        this.Aring = ar;
+        this.Bring = br;
+    }
+
+
+    /**
+     * String representation of the primitive element.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer s = new StringBuffer("PrimitiveElement[");
+        s.append(primitiveElem.toString());
+        s.append(", " + A.toString());
+        s.append(", " + B.toString());
+        if (Aring != null) {
+            s.append(", " + Aring.toString());
+        }
+        if (Bring != null) {
+            s.append(", " + Bring.toString());
+        }
+        return s + "]";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    public String toScript() {
+        // Python case
+        StringBuffer s = new StringBuffer("PrimitiveElement(");
+        s.append(primitiveElem.toScript());
+        s.append(", " + A.toScript());
+        s.append(", " + B.toScript());
+        if (Aring != null) {
+            s.append(", " + Aring.toScript());
+        }
+        if (Bring != null) {
+            s.append(", " + Bring.toScript());
+        }
+        return s + ")";
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/RealAlgebraicNumber.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/RealAlgebraicNumber.java
@@ -1,0 +1,435 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import edu.jas.arith.BigDecimal;
+import edu.jas.arith.BigRational;
+import edu.jas.arith.Rational;
+import edu.jas.kern.PrettyPrint;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.NotInvertibleException;
+
+
+/**
+ * Complex algebraic number class based on bi-variate real algebraic numbers.
+ * Objects of this class are immutable. Bi-variate ideal implementation is in
+ * version 3614 2011-04-28 09:20:34Z.
+ * @author Heinz Kredel
+ */
+
+public class RealAlgebraicNumber<C extends GcdRingElem<C> & Rational> implements
+                GcdRingElem<RealAlgebraicNumber<C>>, Rational {
+
+
+    /*
+     * Representing Residue, unused.
+     */
+    //private Residue<C> numberRes;
+
+
+    /**
+     * Representing recursive RealAlgebraicNumber.
+     */
+    public final edu.jas.root.RealAlgebraicNumber<edu.jas.root.RealAlgebraicNumber<C>> number;
+
+
+    /**
+     * Ring part of the data structure.
+     */
+    public final RealAlgebraicRing<C> ring;
+
+
+    /**
+     * The constructor creates a zero RealAlgebraicNumber.
+     * @param r ring RealAlgebraicRing<C>.
+     */
+    public RealAlgebraicNumber(RealAlgebraicRing<C> r) {
+        this(r, r.realRing.getZERO());
+    }
+
+
+    /**
+     * The constructor creates a RealAlgebraicNumber object from a GenPolynomial
+     * value.
+     * @param r ring RealAlgebraicRing<C>.
+     * @param a value element <C>.
+     */
+    public RealAlgebraicNumber(RealAlgebraicRing<C> r, C a) {
+        this(r, r.realRing.parse(a.toString()));
+    }
+
+
+    /**
+     * The constructor creates a RealAlgebraicNumber object from a GenPolynomial
+     * value.
+     * @param r ring RealAlgebraicRing<C>.
+     * @param a value GenPolynomial<C>.
+     */
+    public RealAlgebraicNumber(RealAlgebraicRing<C> r, GenPolynomial<C> a) {
+        this(r, r.realRing.parse(a.toString()));
+    }
+
+
+    /**
+     * The constructor creates a RealAlgebraicNumber object from a recursive
+     * real algebraic value.
+     * @param r ring RealAlgebraicRing<C>.
+     * @param a recursive real algebraic number.
+     */
+    public RealAlgebraicNumber(RealAlgebraicRing<C> r,
+                    edu.jas.root.RealAlgebraicNumber<edu.jas.root.RealAlgebraicNumber<C>> a) {
+        number = a;
+        ring = r;
+        //number = ring.realRing.parse(number.val.toString()); // convert?
+        //System.out.println("number = " + number);
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public RealAlgebraicRing<C> factory() {
+        return ring;
+    }
+
+
+    /**
+     * Clone this.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public RealAlgebraicNumber<C> copy() {
+        return new RealAlgebraicNumber<C>(ring, number);
+    }
+
+
+    /**
+     * Return a BigRational approximation of this Element.
+     * @return a BigRational approximation of this.
+     * @see edu.jas.arith.Rational#getRational()
+     */
+    @Override
+    public BigRational getRational() {
+        return magnitude();
+    }
+
+
+    /**
+     * Is RealAlgebraicNumber zero.
+     * @return If this is 0 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isZERO()
+     */
+    public boolean isZERO() {
+        return number.isZERO();
+    }
+
+
+    /**
+     * Is RealAlgebraicNumber one.
+     * @return If this is 1 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isONE()
+     */
+    public boolean isONE() {
+        return number.isONE();
+    }
+
+
+    /**
+     * Is RealAlgebraicNumber unit.
+     * @return If this is a unit then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isUnit()
+     */
+    public boolean isUnit() {
+        return number.isUnit();
+    }
+
+
+    /**
+     * Is RealAlgebraicNumber a root of unity.
+     * @return true if |this**i| == 1, for some 0 &lt; i &le; deg(modul), else false.
+     */
+    public boolean isRootOfUnity() {
+        return number.isRootOfUnity();
+    }
+
+
+    /**
+     * Get the String representation as RingElem.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        if (PrettyPrint.isTrue()) {
+            return "{ " + number.toString() + " }";
+        }
+        return "Complex" + number.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        return number.toScript();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python case
+        return factory().toScript();
+    }
+
+
+    /**
+     * RealAlgebraicNumber comparison.
+     * @param b RealAlgebraicNumber.
+     * @return sign(this-b).
+     */
+    @Override
+    public int compareTo(RealAlgebraicNumber<C> b) {
+        int s = 0;
+        if (number.ring != b.number.ring) {
+            s = (number.ring.equals(b.number.ring) ? 0 : 1);
+            System.out.println("s_mod = " + s);
+        }
+        if (s != 0) {
+            return s;
+        }
+        s = number.compareTo(b.number);
+        //System.out.println("s_real = " + s);
+        return s;
+    }
+
+
+    /**
+     * RealAlgebraicNumber comparison.
+     * @param b AlgebraicNumber.
+     * @return polynomial sign(this-b).
+     */
+    public int compareTo(edu.jas.root.RealAlgebraicNumber<edu.jas.root.RealAlgebraicNumber<C>> b) {
+        int s = number.compareTo(b);
+        //System.out.println("s_algeb = " + s);
+        return s;
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (!(b instanceof RealAlgebraicNumber)) {
+            return false;
+        }
+        RealAlgebraicNumber<C> a = null;
+        try {
+            a = (RealAlgebraicNumber<C>) b;
+        } catch (ClassCastException e) {
+        }
+        if (a == null) {
+            return false;
+        }
+        if (!ring.equals(a.ring)) {
+            return false;
+        }
+        return number.equals(a.number);
+    }
+
+
+    /**
+     * Hash code for this RealAlgebraicNumber.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return 37 * number.hashCode() + ring.hashCode();
+    }
+
+
+    /**
+     * RealAlgebraicNumber absolute value.
+     * @return the absolute value of this.
+     * @see edu.jas.structure.RingElem#abs()
+     */
+    public RealAlgebraicNumber<C> abs() {
+        if (this.signum() < 0) {
+            return new RealAlgebraicNumber<C>(ring, number.negate());
+        }
+        return this;
+    }
+
+
+    /**
+     * RealAlgebraicNumber summation.
+     * @param S RealAlgebraicNumber.
+     * @return this+S.
+     */
+    public RealAlgebraicNumber<C> sum(RealAlgebraicNumber<C> S) {
+        return new RealAlgebraicNumber<C>(ring, number.sum(S.number));
+    }
+
+
+    /**
+     * RealAlgebraicNumber summation.
+     * @param c recursive real algebraic number.
+     * @return this+c.
+     */
+    public RealAlgebraicNumber<C> sum(edu.jas.root.RealAlgebraicNumber<edu.jas.root.RealAlgebraicNumber<C>> c) {
+        return new RealAlgebraicNumber<C>(ring, number.sum(c));
+    }
+
+
+    /**
+     * RealAlgebraicNumber negate.
+     * @return -this.
+     * @see edu.jas.structure.RingElem#negate()
+     */
+    public RealAlgebraicNumber<C> negate() {
+        return new RealAlgebraicNumber<C>(ring, number.negate());
+    }
+
+
+    /**
+     * RealAlgebraicNumber subtraction.
+     * @param S RealAlgebraicNumber.
+     * @return this-S.
+     */
+    public RealAlgebraicNumber<C> subtract(RealAlgebraicNumber<C> S) {
+        return new RealAlgebraicNumber<C>(ring, number.subtract(S.number));
+    }
+
+
+    /**
+     * RealAlgebraicNumber division.
+     * @param S RealAlgebraicNumber.
+     * @return this/S.
+     */
+    public RealAlgebraicNumber<C> divide(RealAlgebraicNumber<C> S) {
+        return multiply(S.inverse());
+    }
+
+
+    /**
+     * RealAlgebraicNumber inverse.
+     * @see edu.jas.structure.RingElem#inverse()
+     * @throws NotInvertibleException if the element is not invertible.
+     * @return S with S = 1/this if defined.
+     */
+    public RealAlgebraicNumber<C> inverse() {
+        return new RealAlgebraicNumber<C>(ring, number.inverse());
+    }
+
+
+    /**
+     * RealAlgebraicNumber remainder.
+     * @param S RealAlgebraicNumber.
+     * @return this - (this/S)*S.
+     */
+    public RealAlgebraicNumber<C> remainder(RealAlgebraicNumber<C> S) {
+        return new RealAlgebraicNumber<C>(ring, number.remainder(S.number));
+    }
+
+
+    /**
+     * RealAlgebraicNumber multiplication.
+     * @param S RealAlgebraicNumber.
+     * @return this*S.
+     */
+    public RealAlgebraicNumber<C> multiply(RealAlgebraicNumber<C> S) {
+        return new RealAlgebraicNumber<C>(ring, number.multiply(S.number));
+    }
+
+
+    /**
+     * RealAlgebraicNumber multiplication.
+     * @param c recursive real algebraic number.
+     * @return this*c.
+     */
+    public RealAlgebraicNumber<C> multiply(
+                    edu.jas.root.RealAlgebraicNumber<edu.jas.root.RealAlgebraicNumber<C>> c) {
+        return new RealAlgebraicNumber<C>(ring, number.multiply(c));
+    }
+
+
+    /**
+     * RealAlgebraicNumber monic.
+     * @return this with monic value part.
+     */
+    public RealAlgebraicNumber<C> monic() {
+        return new RealAlgebraicNumber<C>(ring, number.monic());
+    }
+
+
+    /**
+     * RealAlgebraicNumber greatest common divisor.
+     * @param S RealAlgebraicNumber.
+     * @return gcd(this,S).
+     */
+    public RealAlgebraicNumber<C> gcd(RealAlgebraicNumber<C> S) {
+        return new RealAlgebraicNumber<C>(ring, number.gcd(S.number));
+    }
+
+
+    /**
+     * RealAlgebraicNumber extended greatest common divisor.
+     * @param S RealAlgebraicNumber.
+     * @return [ gcd(this,S), a, b ] with a*this + b*S = gcd(this,S).
+     */
+    @SuppressWarnings("unchecked")
+    public RealAlgebraicNumber<C>[] egcd(RealAlgebraicNumber<C> S) {
+        edu.jas.root.RealAlgebraicNumber<edu.jas.root.RealAlgebraicNumber<C>>[] aret = number.egcd(S.number);
+        RealAlgebraicNumber<C>[] ret = new RealAlgebraicNumber[3];
+        ret[0] = new RealAlgebraicNumber<C>(ring, aret[0]);
+        ret[1] = new RealAlgebraicNumber<C>(ring, aret[1]);
+        ret[2] = new RealAlgebraicNumber<C>(ring, aret[2]);
+        return ret;
+    }
+
+
+    /**
+     * RealAlgebraicNumber signum.
+     * @see edu.jas.structure.RingElem#signum()
+     * @return signum(this).
+     */
+    public int signum() {
+        return number.signum();
+    }
+
+
+    /**
+     * RealAlgebraicNumber magnitude.
+     * @return |this| as rational number.
+     */
+    public BigRational magnitude() {
+        return number.magnitude();
+    }
+
+
+    /**
+     * RealAlgebraicNumber decimal magnitude.
+     * @return |this| as big decimal.
+     */
+    public BigDecimal decimalMagnitude() {
+        BigRational cr = magnitude();
+        return new BigDecimal(cr);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/RealAlgebraicRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/RealAlgebraicRing.java
@@ -1,0 +1,422 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.arith.BigRational;
+import edu.jas.arith.Rational;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.root.Interval;
+import edu.jas.root.PolyUtilRoot;
+import edu.jas.root.RealRootTuple;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Real algebraic number factory class based on bi-variate real algebraic
+ * numbers. Objects of this class are immutable with the exception of the
+ * isolating intervals. Bi-variate ideal implementation is in version 3614
+ * 2011-04-28 09:20:34Z.
+ * @author Heinz Kredel
+ */
+
+public class RealAlgebraicRing<C extends GcdRingElem<C> & Rational>
+                implements RingFactory<RealAlgebraicNumber<C>> {
+
+
+    /**
+     * Representing ideal with univariate polynomials IdealWithUniv.
+     */
+    /*package*/final IdealWithUniv<C> univs;
+
+
+    /**
+     * Representing ResidueRing.
+     */
+    /*package*/final ResidueRing<C> algebraic;
+
+
+    /**
+     * Isolating intervals for the real algebraic roots of the real and
+     * imaginary part. <b>Note: </b> intervals may shrink eventually.
+     */
+    /*package*/RealRootTuple<C> root;
+
+
+    /**
+     * Recursive real root ring.
+     */
+    public final edu.jas.root.RealAlgebraicRing<edu.jas.root.RealAlgebraicNumber<C>> realRing;
+
+
+    /**
+     * Epsilon of the isolating rectangle for a complex root.
+     */
+    protected BigRational eps;
+
+
+    /**
+     * Precision of the isolating rectangle for a complex root.
+     */
+    public final int PRECISION = 9; //BigDecimal.DEFAULT_PRECISION;
+
+
+    private static final Logger logger = LogManager.getLogger(RealAlgebraicRing.class);
+
+
+    /**
+     * The constructor creates a RealAlgebraicNumber factory object from a
+     * IdealWithUniv, ResidueRing and a root tuple.
+     * @param m module IdealWithUniv&lt;C&gt;.
+     * @param a module ResidueRing&lt;C&gt;.
+     * @param r isolating rectangle for a complex root.
+     */
+    public RealAlgebraicRing(IdealWithUniv<C> m, ResidueRing<C> a, RealRootTuple<C> r) {
+        univs = m;
+        algebraic = a;
+        root = r;
+        if (algebraic.characteristic().signum() > 0) {
+            throw new IllegalArgumentException("characteristic not zero");
+        }
+        if (root.tuple.size() != 2) {
+            throw new IllegalArgumentException("wrong tuple size: " + root.tuple.size());
+        }
+        eps = BigRational.ONE;
+        edu.jas.root.RealAlgebraicRing<C> rfac1 = root.tuple.get(0).factory();
+        edu.jas.root.RealAlgebraicRing<C> rfac2 = root.tuple.get(1).factory();
+        GenPolynomial<C> p0 = PolyUtil.<C> selectWithVariable(univs.ideal.list.list, 0);
+        if (p0 == null) {
+            throw new RuntimeException("no polynomial found in " + (0) + " of  " + univs.ideal);
+        }
+        //System.out.println("realRing, pol = " + p0.toScript());
+        GenPolynomialRing<C> pfac = p0.ring;
+        GenPolynomialRing<GenPolynomial<C>> prfac = pfac.recursive(1);
+        //System.out.println("prfac = " + prfac);
+        GenPolynomial<GenPolynomial<C>> p0r = PolyUtil.<C> recursive(prfac, p0);
+        GenPolynomialRing<edu.jas.root.RealAlgebraicNumber<C>> parfac = new GenPolynomialRing<edu.jas.root.RealAlgebraicNumber<C>>(
+                        rfac1, prfac);
+        GenPolynomial<edu.jas.root.RealAlgebraicNumber<C>> p0ar = PolyUtilRoot
+                        .<C> convertRecursiveToAlgebraicCoefficients(parfac, p0r);
+        Interval<C> r2 = rfac2.getRoot();
+        edu.jas.root.RealAlgebraicNumber<C> rleft = rfac1.getZERO().sum(r2.left);
+        edu.jas.root.RealAlgebraicNumber<C> rright = rfac1.getZERO().sum(r2.right);
+        Interval<edu.jas.root.RealAlgebraicNumber<C>> r2r = new Interval<edu.jas.root.RealAlgebraicNumber<C>>(
+                        rleft, rright);
+        edu.jas.root.RealAlgebraicRing<edu.jas.root.RealAlgebraicNumber<C>> rr = new edu.jas.root.RealAlgebraicRing<edu.jas.root.RealAlgebraicNumber<C>>(
+                        p0ar, r2r);
+        logger.info("realRing = " + rr);
+        realRing = rr;
+    }
+
+
+    /**
+     * The constructor creates a RealAlgebraicNumber factory object from a
+     * IdealWithUniv and a root tuple.
+     * @param m module IdealWithUniv&lt;C&gt;.
+     * @param root isolating rectangle for a complex root.
+     */
+    public RealAlgebraicRing(IdealWithUniv<C> m, RealRootTuple<C> root) {
+        this(m, new ResidueRing<C>(m.ideal), root);
+    }
+
+
+    /**
+     * The constructor creates a RealAlgebraicNumber factory object from a
+     * IdealWithUniv and a root tuple.
+     * @param m module IdealWithUniv&lt;C&gt;.
+     * @param root isolating rectangle for a complex root.
+     * @param isField indicator if m is maximal.
+     */
+    public RealAlgebraicRing(IdealWithUniv<C> m, RealRootTuple<C> root, boolean isField) {
+        this(m, new ResidueRing<C>(m.ideal, isField), root);
+    }
+
+
+    /**
+     * Set a refined rectangle for the complex root. <b>Note: </b> rectangle may
+     * shrink eventually.
+     * @param v rectangle.
+     */
+    public synchronized void setRoot(RealRootTuple<C> v) {
+        assert root.contains(v) : "root contains v";
+        this.root = v;
+    }
+
+
+    /**
+     * Get rectangle for the complex root.
+     * @return v rectangle.
+     */
+    public synchronized RealRootTuple<C> getRoot() {
+        return this.root;
+    }
+
+
+    /**
+     * Get epsilon.
+     * @return epsilon.
+     */
+    public synchronized BigRational getEps() {
+        return this.eps;
+    }
+
+
+    /**
+     * Set a new epsilon.
+     * @param e epsilon.
+     */
+    public synchronized void setEps(C e) {
+        setEps(e.getRational());
+    }
+
+
+    /**
+     * Set a new epsilon.
+     * @param e epsilon.
+     */
+    public synchronized void setEps(BigRational e) {
+        this.eps = e;
+    }
+
+
+    /**
+     * Refine root.
+     * @param e epsilon.
+     */
+    public synchronized void refineRoot(BigRational e) {
+        setEps(e);
+        root.refineRoot(this.eps);
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite()
+     */
+    public boolean isFinite() {
+        return realRing.isFinite();
+    }
+
+
+    /**
+     * Copy RealAlgebraicNumber element c.
+     * @param c
+     * @return a copy of c.
+     */
+    public RealAlgebraicNumber<C> copy(RealAlgebraicNumber<C> c) {
+        return new RealAlgebraicNumber<C>(this, c.number);
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as RealAlgebraicNumber.
+     */
+    public RealAlgebraicNumber<C> getZERO() {
+        return new RealAlgebraicNumber<C>(this, realRing.getZERO());
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as RealAlgebraicNumber.
+     */
+    public RealAlgebraicNumber<C> getONE() {
+        return new RealAlgebraicNumber<C>(this, realRing.getONE());
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     * @see edu.jas.structure.ElemFactory#generators()
+     */
+    public List<RealAlgebraicNumber<C>> generators() {
+        List<edu.jas.root.RealAlgebraicNumber<edu.jas.root.RealAlgebraicNumber<C>>> agens = realRing
+                        .generators();
+        List<RealAlgebraicNumber<C>> gens = new ArrayList<RealAlgebraicNumber<C>>(agens.size());
+        for (edu.jas.root.RealAlgebraicNumber<edu.jas.root.RealAlgebraicNumber<C>> a : agens) {
+            gens.add(getZERO().sum(a));
+        }
+        return gens;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true if this ring is commutative, else false.
+     */
+    public boolean isCommutative() {
+        return realRing.isCommutative();
+    }
+
+
+    /**
+     * Query if this ring is associative.
+     * @return true if this ring is associative, else false.
+     */
+    public boolean isAssociative() {
+        return realRing.isAssociative();
+    }
+
+
+    /**
+     * Query if this ring is a field.
+     * @return true if algebraic is prime, else false.
+     */
+    public boolean isField() {
+        return realRing.isField();
+    }
+
+
+    /**
+     * Assert that this ring is a field.
+     * @param isField true if this ring is a field, else false.
+     */
+    public void setField(boolean isField) {
+        realRing.setField(isField);
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic() {
+        return realRing.characteristic();
+    }
+
+
+    /**
+     * Get a RealAlgebraicNumber element from a BigInteger value.
+     * @param a BigInteger.
+     * @return a RealAlgebraicNumber.
+     */
+    public RealAlgebraicNumber<C> fromInteger(java.math.BigInteger a) {
+        return new RealAlgebraicNumber<C>(this, realRing.fromInteger(a));
+    }
+
+
+    /**
+     * Get a RealAlgebraicNumber element from a long value.
+     * @param a long.
+     * @return a RealAlgebraicNumber.
+     */
+    public RealAlgebraicNumber<C> fromInteger(long a) {
+        return new RealAlgebraicNumber<C>(this, realRing.fromInteger(a));
+    }
+
+
+    /**
+     * Get the String representation as RingFactory.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public synchronized String toString() {
+        return "RealAlgebraicRing[ " + realRing.toString() + " in " + root + " | isField="
+                        + realRing.isField() + ", algebraic.ideal=" + algebraic.ideal.toString() + " ]";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.ElemFactory#toScript()
+     */
+    @Override
+    public synchronized String toScript() {
+        // Python case
+        return "RealRecN( " + realRing.toScript() + ", " + root.toScript()
+        //+ ", " + realRing.isField() 
+        //+ ", " + realRing.ring.toScript() 
+                        + " )";
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public synchronized boolean equals(Object b) {
+        if (!(b instanceof RealAlgebraicRing)) {
+            return false;
+        }
+        RealAlgebraicRing<C> a = null;
+        try {
+            a = (RealAlgebraicRing<C>) b;
+        } catch (ClassCastException e) {
+        }
+        if (a == null) {
+            return false;
+        }
+        return realRing.equals(a.realRing) && root.equals(a.getRoot());
+    }
+
+
+    /**
+     * Hash code for this RealAlgebraicNumber.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public synchronized int hashCode() {
+        return 37 * realRing.hashCode() + root.hashCode();
+    }
+
+
+    /**
+     * RealAlgebraicNumber random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @return a random integer mod modul.
+     */
+    public RealAlgebraicNumber<C> random(int n) {
+        return new RealAlgebraicNumber<C>(this, realRing.random(n));
+    }
+
+
+    /**
+     * RealAlgebraicNumber random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @param rnd is a source for random bits.
+     * @return a random integer mod modul.
+     */
+    public RealAlgebraicNumber<C> random(int n, Random rnd) {
+        return new RealAlgebraicNumber<C>(this, realRing.random(n, rnd));
+    }
+
+
+    /**
+     * Parse RealAlgebraicNumber from String.
+     * @param s String.
+     * @return RealAlgebraicNumber from s.
+     */
+    public RealAlgebraicNumber<C> parse(String s) {
+        return new RealAlgebraicNumber<C>(this, realRing.parse(s));
+    }
+
+
+    /**
+     * Parse RealAlgebraicNumber from Reader.
+     * @param r Reader.
+     * @return next RealAlgebraicNumber from r.
+     */
+    public RealAlgebraicNumber<C> parse(Reader r) {
+        return new RealAlgebraicNumber<C>(this, realRing.parse(r));
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/Residue.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/Residue.java
@@ -1,0 +1,398 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import edu.jas.kern.PrettyPrint;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Residue ring element based on GenPolynomial with RingElem interface. Objects
+ * of this class are (nearly) immutable.
+ * @author Heinz Kredel
+ */
+public class Residue<C extends GcdRingElem<C>> implements GcdRingElem<Residue<C>> {
+
+
+    /**
+     * Residue class factory data structure.
+     */
+    public final ResidueRing<C> ring;
+
+
+    /**
+     * Value part of the element data structure.
+     */
+    public final GenPolynomial<C> val;
+
+
+    /**
+     * Flag to remember if this residue element is a unit. -1 is unknown, 1 is
+     * unit, 0 not a unit.
+     */
+    protected int isunit = -1; // initially unknown
+
+
+    /**
+     * The constructor creates a Residue object from a ring factory.
+     * @param r residue ring factory.
+     */
+    public Residue(ResidueRing<C> r) {
+        this(r, r.ring.getZERO(), 0);
+    }
+
+
+    /**
+     * The constructor creates a Residue object from a ring factory and a
+     * polynomial.
+     * @param r residue ring factory.
+     * @param a polynomial.
+     */
+    public Residue(ResidueRing<C> r, GenPolynomial<C> a) {
+        this(r, a, -1);
+    }
+
+
+    /**
+     * The constructor creates a Residue object from a ring factory, a
+     * polynomial and an indicator if a is a unit.
+     * @param r residue ring factory.
+     * @param a polynomial.
+     * @param u isunit indicator, -1, 0, 1.
+     */
+    public Residue(ResidueRing<C> r, GenPolynomial<C> a, int u) {
+        ring = r;
+        val = ring.ideal.normalform(a); //.monic() no go
+        if ( u == 0 || u == 1 ) {
+            isunit = u;
+            return;
+        }
+        if (val.isZERO()) {
+            isunit = 0;
+            return;
+        }
+        if (ring.isField()) {
+            isunit = 1;
+            return;
+        }
+        if ( val.isUnit() ) {
+           isunit = 1;
+           //} else { // not possible
+           //isunit = 0;
+        }
+        isunit = -1;
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public ResidueRing<C> factory() {
+        return ring;
+    }
+
+
+    /**
+     * Clone this.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public Residue<C> copy() {
+        return new Residue<C>(ring, val, isunit);
+    }
+
+
+    /**
+     * Is Residue zero.
+     * @return If this is 0 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isZERO()
+     */
+    public boolean isZERO() {
+        return val.isZERO();
+    }
+
+
+    /**
+     * Is Residue one.
+     * @return If this is 1 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isONE()
+     */
+    public boolean isONE() {
+        return val.isONE();
+    }
+
+
+    /**
+     * Is Residue unit.
+     * @return If this is a unit then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isUnit()
+     */
+    public boolean isUnit() {
+        if (isunit > 0) {
+            return true;
+        }
+        if (isunit == 0) {
+            return false;
+        }
+        // not jet known
+        boolean u = ring.ideal.isUnit(val);
+        if (u) {
+            isunit = 1;
+        } else {
+            isunit = 0;
+        }
+        return (u);
+    }
+
+
+    /**
+     * Is Residue a constant.
+     * @return true if this.val is a constant polynomial, else false.
+     */
+    public boolean isConstant() {
+        return val.isConstant();
+    }
+
+
+    /**
+     * Get the String representation as RingElem.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        if (PrettyPrint.isTrue()) {
+            return val.toString(ring.ring.getVars());
+        }
+        return "Residue[ " + val.toString() + " mod " + ring.toString() + " ]";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        return val.toScript();
+        //         return "PolyResidue( " + val.toScript() 
+        //                         + ", " + ring.toScript() + " )";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python case
+        return factory().toScript();
+    }
+
+
+    /**
+     * Residue comparison.
+     * @param b Residue.
+     * @return sign(this-b), 0 means that this and b are equivalent in this
+     *         residue class ring.
+     */
+    @Override
+    public int compareTo(Residue<C> b) {
+        GenPolynomial<C> v = b.val;
+        if (!ring.equals(b.ring)) {
+            v = ring.ideal.normalform(v);
+        }
+        return val.compareTo(v);
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     * @return true means that this and b are equivalent in this residue class
+     *         ring.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (!(b instanceof Residue)) {
+            return false;
+        }
+        Residue<C> a = null;
+        try {
+            a = (Residue<C>) b;
+        } catch (ClassCastException e) {
+        }
+        if (a == null) {
+            return false;
+        }
+        return compareTo(a) == 0;
+    }
+
+
+    /**
+     * Hash code for this residue.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = ring.hashCode();
+        h = 37 * h + val.hashCode();
+        return h;
+    }
+
+
+    /**
+     * Residue absolute value.
+     * @return the absolute value of this.
+     * @see edu.jas.structure.RingElem#abs()
+     */
+    public Residue<C> abs() {
+        return new Residue<C>(ring, val.abs(), isunit);
+    }
+
+
+    /**
+     * Residue summation.
+     * @param S Residue.
+     * @return this+S.
+     */
+    public Residue<C> sum(Residue<C> S) {
+        return new Residue<C>(ring, val.sum(S.val));
+    }
+
+
+    /**
+     * Residue negate.
+     * @return -this.
+     * @see edu.jas.structure.RingElem#negate()
+     */
+    public Residue<C> negate() {
+        return new Residue<C>(ring, val.negate(), isunit);
+    }
+
+
+    /**
+     * Residue signum.
+     * @see edu.jas.structure.RingElem#signum()
+     * @return signum(this).
+     */
+    public int signum() {
+        return val.signum();
+    }
+
+
+    /**
+     * Residue subtraction.
+     * @param S Residue.
+     * @return this-S.
+     */
+    public Residue<C> subtract(Residue<C> S) {
+        return new Residue<C>(ring, val.subtract(S.val));
+    }
+
+
+    /**
+     * Residue division.
+     * @param S Residue.
+     * @return this/S.
+     */
+    public Residue<C> divide(Residue<C> S) {
+        if (ring.isField()) {
+            return multiply(S.inverse());
+        }
+        GenPolynomial<C> x = PolyUtil.<C> basePseudoDivide(val, S.val);
+        return new Residue<C>(ring, x);
+    }
+
+
+    /**
+     * Residue inverse.
+     * @see edu.jas.structure.RingElem#inverse()
+     * @return S with S = 1/this if defined.
+     */
+    public Residue<C> inverse() {
+        GenPolynomial<C> x = ring.ideal.inverse(val);
+        return new Residue<C>(ring, x, 1);
+    }
+
+
+    /**
+     * Residue remainder.
+     * @param S Residue.
+     * @return this - (this/S)*S.
+     */
+    public Residue<C> remainder(Residue<C> S) {
+        //GenPolynomial<C> x = val.remainder( S.val );
+        GenPolynomial<C> x = PolyUtil.<C> baseSparsePseudoRemainder(val, S.val);
+        return new Residue<C>(ring, x);
+    }
+
+
+    /**
+     * Residue multiplication.
+     * @param S Residue.
+     * @return this*S.
+     */
+    public Residue<C> multiply(Residue<C> S) {
+        GenPolynomial<C> x = val.multiply(S.val);
+        int i = -1;
+        if (isunit == 1 && S.isunit == 1) {
+            i = 1;
+        } else if (isunit == 0 || S.isunit == 0) {
+            i = 0;
+        }
+        return new Residue<C>(ring, x, i);
+    }
+
+
+    /**
+     * Residue monic.
+     * @return this with monic value part.
+     */
+    public Residue<C> monic() {
+        return new Residue<C>(ring, val.monic(), isunit);
+    }
+
+
+    /**
+     * Greatest common divisor.
+     * @param b other element.
+     * @return gcd(this,b).
+     */
+    public Residue<C> gcd(Residue<C> b) {
+        GenPolynomial<C> x = ring.engine.gcd(val, b.val);
+        int i = -1; // gcd might become a unit
+        if (x.isONE()) {
+            i = 1;
+        } else {
+            System.out.println("Residue gcd = " + x);
+        }
+        if (isunit == 1 && b.isunit == 1) {
+            i = 1;
+        }
+        return new Residue<C>(ring, x, i);
+    }
+
+
+    /**
+     * Extended greatest common divisor. <b>Note: </b>Not implemented, throws
+     * UnsupportedOperationException.
+     * @param b other element.
+     * @return [ gcd(this,b), c1, c2 ] with c1*this + c2*b = gcd(this,b).
+     */
+    public Residue<C>[] egcd(Residue<C> b) {
+        throw new UnsupportedOperationException("egcd not implemented");
+    }
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/ResidueRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/ResidueRing.java
@@ -1,0 +1,376 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.ufd.GCDFactory;
+import edu.jas.ufd.GreatestCommonDivisor;
+
+
+/**
+ * Residue ring factory based on GenPolynomial with RingFactory interface.
+ * Objects of this class are immutable.
+ * @author Heinz Kredel
+ */
+public class ResidueRing<C extends GcdRingElem<C>> implements RingFactory<Residue<C>> {
+
+
+    private static final Logger logger = LogManager.getLogger(ResidueRing.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled(); 
+
+
+    /**
+     * Greatest common divisor engine for coefficient content and primitive
+     * parts.
+     */
+    protected final GreatestCommonDivisor<C> engine;
+
+
+    /**
+     * Polynomial ideal for the reduction.
+     */
+    public final Ideal<C> ideal;
+
+
+    /**
+     * Polynomial ring of the factory. Shortcut to ideal.list.ring.
+     */
+    public final GenPolynomialRing<C> ring;
+
+
+    /**
+     * Indicator if this ring is a field.
+     */
+    protected int isField = -1; // initially unknown
+
+
+    /**
+     * The constructor creates a ResidueRing object from an Ideal.
+     * @param i polynomial ideal.
+     */
+    public ResidueRing(Ideal<C> i) {
+        this(i, false);
+    }
+
+
+    /**
+     * The constructor creates a ResidueRing object from an Ideal.
+     * @param i polynomial ideal.
+     * @param isMaximal true, if ideal is maxmal.
+     */
+    public ResidueRing(Ideal<C> i, boolean isMaximal) {
+        ideal = i.GB(); // cheap if isGB
+        ring = ideal.list.ring;
+        //engine = GCDFactory.<C>getImplementation( ring.coFac );
+        engine = GCDFactory.<C> getProxy(ring.coFac);
+        if (isMaximal) {
+            isField = 1;
+            return;
+        }
+        //System.out.println("rr engine = " + engine.getClass().getName());
+        //System.out.println("rr ring   = " + ring.getClass().getName());
+        //System.out.println("rr cofac  = " + ring.coFac.getClass().getName());
+        if (ideal.isONE()) {
+            logger.warn("ideal is one, so all residues are 0");
+        }
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite()
+     */
+    public boolean isFinite() {
+        return ideal.commonZeroTest() <= 0 && ring.coFac.isFinite();
+    }
+
+
+    /**
+     * Copy Residue element c.
+     * @param c
+     * @return a copy of c.
+     */
+    public Residue<C> copy(Residue<C> c) {
+        //System.out.println("rr copy in    = " + c.val);
+        if (c == null) { // where does this happen?
+            return getZERO(); // or null?
+        }
+        Residue<C> r = new Residue<C>(this, c.val);
+        //System.out.println("rr copy out   = " + r.val);
+        //System.out.println("rr copy ideal = " + ideal.list.list);
+        return r; //new Residue<C>( c.ring, c.val );
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as Residue.
+     */
+    public Residue<C> getZERO() {
+        return new Residue<C>(this, ring.getZERO());
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as Residue.
+     */
+    public Residue<C> getONE() {
+        Residue<C> one = new Residue<C>(this, ring.getONE());
+        if (one.isZERO()) {
+            logger.warn("ideal is one, so all residues are 0");
+        }
+        return one;
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     * @see edu.jas.structure.ElemFactory#generators()
+     */
+    public List<Residue<C>> generators() {
+        List<GenPolynomial<C>> pgens = ring.generators();
+        List<Residue<C>> gens = new ArrayList<Residue<C>>(pgens.size());
+        SortedSet<Residue<C>> sgens = new TreeSet<Residue<C>>();
+        List<GenPolynomial<C>> rgens = new ArrayList<GenPolynomial<C>>(pgens.size());
+        Ideal<C> gi = new Ideal<C>(ring, rgens);
+        ResidueRing<C> gr = new ResidueRing<C>(gi);
+        for (GenPolynomial<C> p : pgens) {
+            Residue<C> r = new Residue<C>(this, p);
+            if (r.isZERO()) {
+                continue;
+            }
+            if (!r.isONE() && r.val.isConstant()) {
+                continue;
+            }
+            // avoid duplicate generators
+            Residue<C> x = new Residue<C>(gr, r.val);
+            if (x.isZERO()) {
+                continue;
+            }
+            if (!x.isONE() && x.val.isConstant()) {
+                continue;
+            }
+            r = new Residue<C>(this, x.val);
+            if (r.isZERO()) {
+                continue;
+            }
+            r = r.monic();
+            if (!r.isONE() && !r.val.isConstant()) {
+                rgens.add(r.val);
+                //System.out.println("rgens = " + rgens);
+                gi = new Ideal<C>(ring, rgens);
+                gr = new ResidueRing<C>(gi);
+            }
+            sgens.add(r);
+        }
+        gens.addAll(sgens);
+        return gens;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true if this ring is commutative, else false.
+     */
+    public boolean isCommutative() {
+        return ring.isCommutative();
+    }
+
+
+    /**
+     * Query if this ring is associative.
+     * @return true if this ring is associative, else false.
+     */
+    public boolean isAssociative() {
+        return ring.isAssociative();
+    }
+
+
+    /**
+     * Query if this ring is a field.
+     * @return false.
+     */
+    public boolean isField() {
+        if (isField > 0) {
+            return true;
+        }
+        if (isField == 0) {
+            return false;
+        }
+        if (ideal.isMaximal()) {
+            isField = 1;
+            return true;
+        }
+        return false;
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic() {
+        return ring.characteristic();
+    }
+
+
+    /**
+     * Get a Residue element from a BigInteger value.
+     * @param a BigInteger.
+     * @return a Residue.
+     */
+    public Residue<C> fromInteger(java.math.BigInteger a) {
+        return new Residue<C>(this, ring.fromInteger(a));
+    }
+
+
+    /**
+     * Get a Residue element from a long value.
+     * @param a long.
+     * @return a Residue.
+     */
+    public Residue<C> fromInteger(long a) {
+        return new Residue<C>(this, ring.fromInteger(a));
+    }
+
+
+    /**
+     * Get the String representation as RingFactory.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "ResidueRing[ " + ideal.toString() + " ]";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.ElemFactory#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        return "RC(" + ideal.list.toScript() + ")";
+        //return "RC(" + ideal.toScript() + "," + ring.toScript()  + ")";
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (!(b instanceof ResidueRing)) {
+            return false;
+        }
+        ResidueRing<C> a = null;
+        try {
+            a = (ResidueRing<C>) b;
+        } catch (ClassCastException e) {
+        }
+        if (a == null) {
+            return false;
+        }
+        if (!ring.equals(a.ring)) {
+            return false;
+        }
+        return ideal.equals(a.ideal);
+    }
+
+
+    /**
+     * Hash code for this residue ring.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = ideal.hashCode();
+        return h;
+    }
+
+
+    /**
+     * Residue random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @return a random residue element.
+     */
+    public Residue<C> random(int n) {
+        GenPolynomial<C> x = ring.random(n).monic();
+        return new Residue<C>(this, x);
+    }
+
+
+    /**
+     * Generate a random residum polynomial.
+     * @param k bitsize of random coefficients.
+     * @param l number of terms.
+     * @param d maximal degree in each variable.
+     * @param q density of nozero exponents.
+     * @return a random residue polynomial.
+     */
+    public Residue<C> random(int k, int l, int d, float q) {
+        GenPolynomial<C> x = ring.random(k, l, d, q).monic();
+        return new Residue<C>(this, x);
+    }
+
+
+    /**
+     * Residue random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @param rnd is a source for random bits.
+     * @return a random residue element.
+     */
+    public Residue<C> random(int n, Random rnd) {
+        GenPolynomial<C> x = ring.random(n, rnd).monic();
+        return new Residue<C>(this, x);
+    }
+
+
+    /**
+     * Parse Residue from String.
+     * @param s String.
+     * @return Residue from s.
+     */
+    public Residue<C> parse(String s) {
+        GenPolynomial<C> x = ring.parse(s);
+        return new Residue<C>(this, x);
+    }
+
+
+    /**
+     * Parse Residue from Reader.
+     * @param r Reader.
+     * @return next Residue from r.
+     */
+    public Residue<C> parse(Reader r) {
+        GenPolynomial<C> x = ring.parse(r);
+        return new Residue<C>(this, x);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/ResidueSolvablePolynomial.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/ResidueSolvablePolynomial.java
@@ -1,0 +1,569 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.RecSolvablePolynomial;
+import edu.jas.poly.TableRelation;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * ResidueSolvablePolynomial generic solvable polynomials with solvable residue
+ * coefficients implementing RingElem. n-variate ordered solvable polynomials
+ * over solvable residue coefficients. Objects of this class are intended to be
+ * immutable. The implementation is based on TreeMap respectively SortedMap from
+ * exponents to coefficients by extension of GenPolynomial.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class ResidueSolvablePolynomial<C extends GcdRingElem<C>> extends
+                GenSolvablePolynomial<SolvableResidue<C>> {
+
+
+    /**
+     * The factory for the recursive solvable polynomial ring. Hides super.ring.
+     */
+    public final ResidueSolvablePolynomialRing<C> ring;
+
+
+    private static final Logger logger = LogManager.getLogger(ResidueSolvablePolynomial.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor for zero ResidueSolvablePolynomial.
+     * @param r solvable polynomial ring factory.
+     */
+    public ResidueSolvablePolynomial(ResidueSolvablePolynomialRing<C> r) {
+        super(r);
+        ring = r;
+    }
+
+
+    /**
+     * Constructor for ResidueSolvablePolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param e exponent.
+     */
+    public ResidueSolvablePolynomial(ResidueSolvablePolynomialRing<C> r, ExpVector e) {
+        this(r);
+        val.put(e, ring.getONECoefficient());
+    }
+
+
+    /**
+     * Constructor for ResidueSolvablePolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param c coefficient polynomial.
+     * @param e exponent.
+     */
+    public ResidueSolvablePolynomial(ResidueSolvablePolynomialRing<C> r, SolvableResidue<C> c, ExpVector e) {
+        this(r);
+        if (c != null && !c.isZERO()) {
+            val.put(e, c);
+        }
+    }
+
+
+    /**
+     * Constructor for ResidueSolvablePolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param c coefficient polynomial.
+     */
+    public ResidueSolvablePolynomial(ResidueSolvablePolynomialRing<C> r, SolvableResidue<C> c) {
+        this(r, c, r.evzero);
+    }
+
+
+    /**
+     * Constructor for ResidueSolvablePolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param S solvable polynomial.
+     */
+    public ResidueSolvablePolynomial(ResidueSolvablePolynomialRing<C> r,
+                    GenSolvablePolynomial<SolvableResidue<C>> S) {
+        this(r, S.getMap());
+    }
+
+
+    /**
+     * Constructor for ResidueSolvablePolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param v the SortedMap of some other (solvable) polynomial.
+     */
+    protected ResidueSolvablePolynomial(ResidueSolvablePolynomialRing<C> r,
+                    SortedMap<ExpVector, SolvableResidue<C>> v) {
+        this(r);
+        val.putAll(v); // assume no zero coefficients
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    @Override
+    public ResidueSolvablePolynomialRing<C> factory() {
+        return ring;
+    }
+
+
+    /**
+     * Clone this ResidueSolvablePolynomial.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public ResidueSolvablePolynomial<C> copy() {
+        return new ResidueSolvablePolynomial<C>(ring, this.val);
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object B) {
+        if (!(B instanceof ResidueSolvablePolynomial)) {
+            return false;
+        }
+        return super.equals(B);
+    }
+
+
+    /**
+     * Hash code for this polynomial.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+
+    /**
+     * ResidueSolvablePolynomial multiplication.
+     * @param Bp ResidueSolvablePolynomial.
+     * @return this*Bp, where * denotes solvable multiplication.
+     */
+    public ResidueSolvablePolynomial<C> multiply(ResidueSolvablePolynomial<C> Bp) {
+        if (Bp == null || Bp.isZERO()) {
+            return ring.getZERO();
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        assert (ring.nvar == Bp.ring.nvar);
+        if (debug) {
+            logger.debug("ring = " + ring);
+        }
+        ExpVector Z = ring.evzero;
+        ResidueSolvablePolynomial<C> Dp = ring.getZERO().copy();
+        ResidueSolvablePolynomial<C> zero = ring.getZERO().copy();
+        SolvableResidue<C> one = ring.getONECoefficient();
+
+        //ResidueSolvablePolynomial<C> C1 = null;
+        //ResidueSolvablePolynomial<C> C2 = null;
+        Map<ExpVector, SolvableResidue<C>> A = val;
+        Map<ExpVector, SolvableResidue<C>> B = Bp.val;
+        Set<Map.Entry<ExpVector, SolvableResidue<C>>> Bk = B.entrySet();
+        for (Map.Entry<ExpVector, SolvableResidue<C>> y : A.entrySet()) {
+            SolvableResidue<C> a = y.getValue();
+            ExpVector e = y.getKey();
+            if (debug)
+                logger.info("e = " + e + ", a = " + a);
+            //int[] ep = e.dependencyOnVariables();
+            //int el1 = ring.nvar + 1;
+            //if (ep.length > 0) {
+            //    el1 = ep[0];
+            //}
+            //int el1s = ring.nvar + 1 - el1;
+            for (Map.Entry<ExpVector, SolvableResidue<C>> x : Bk) {
+                SolvableResidue<C> b = x.getValue();
+                ExpVector f = x.getKey();
+                if (debug)
+                    logger.info("f = " + f + ", b = " + b);
+                int[] fp = f.dependencyOnVariables();
+                int fl1 = 0;
+                if (fp.length > 0) {
+                    fl1 = fp[fp.length - 1];
+                }
+                int fl1s = ring.nvar + 1 - fl1;
+                // polynomial coefficient multiplication 
+                ResidueSolvablePolynomial<C> Cps = ring.getZERO().copy();
+                //ResidueSolvablePolynomial<C> Cs = null;
+                if (ring.polCoeff.coeffTable.isEmpty() || b.isConstant() || e.isZERO()) { // symmetric
+                    Cps = new ResidueSolvablePolynomial<C>(ring, b, e);
+                    if (debug)
+                        logger.info("symmetric coeff: b = " + b + ", e = " + e);
+                } else { // unsymmetric
+                    if (debug)
+                        logger.info("unsymmetric coeff: b = " + b + ", e = " + e);
+                    // recursive polynomial coefficient multiplication : e * b.val
+                    RecSolvablePolynomial<C> rsp1 = new RecSolvablePolynomial<C>(ring.polCoeff, e);
+                    RecSolvablePolynomial<C> rsp2 = new RecSolvablePolynomial<C>(ring.polCoeff, b.val);
+                    RecSolvablePolynomial<C> rsp3 = rsp1.multiply(rsp2);
+                    Cps = ring.fromPolyCoefficients(rsp3);
+                }
+                if (debug) {
+                    logger.info("coeff-poly: Cps = " + Cps);
+                }
+                // polynomial multiplication 
+                ResidueSolvablePolynomial<C> Dps = ring.getZERO().copy();
+                ResidueSolvablePolynomial<C> Ds = null;
+                ResidueSolvablePolynomial<C> D1, D2;
+                if (ring.table.isEmpty() || Cps.isConstant() || f.isZERO()) { // symmetric
+                    if (debug)
+                        logger.info("symmetric poly: b = " + b + ", e = " + e);
+                    ExpVector g = e.sum(f);
+                    if (Cps.isConstant()) {
+                        Ds = new ResidueSolvablePolynomial<C>(ring, Cps.leadingBaseCoefficient(), g); // symmetric!
+                    } else {
+                        Ds = Cps.shift(f); // symmetric
+                    }
+                } else { // eventually unsymmetric
+                    if (debug)
+                        logger.info("unsymmetric poly: Cps = " + Cps + ", f = " + f);
+                    for (Map.Entry<ExpVector, SolvableResidue<C>> z : Cps.val.entrySet()) {
+                        // split g = g1 * g2, f = f1 * f2
+                        SolvableResidue<C> c = z.getValue();
+                        ExpVector g = z.getKey();
+                        if (debug)
+                            logger.info("g = " + g + ", c = " + c);
+                        int[] gp = g.dependencyOnVariables();
+                        int gl1 = ring.nvar + 1;
+                        if (gp.length > 0) {
+                            gl1 = gp[0];
+                        }
+                        int gl1s = ring.nvar + 1 - gl1;
+                        if (gl1s <= fl1s) { // symmetric
+                            ExpVector h = g.sum(f);
+                            if (debug)
+                                logger.info("disjoint poly: g = " + g + ", f = " + f + ", h = " + h);
+                            Ds = (ResidueSolvablePolynomial<C>) zero.sum(one, h); // symmetric!
+                        } else {
+                            ExpVector g1 = g.subst(gl1, 0);
+                            ExpVector g2 = Z.subst(gl1, g.getVal(gl1)); // bug el1, gl1
+                            ExpVector g4;
+                            ExpVector f1 = f.subst(fl1, 0);
+                            ExpVector f2 = Z.subst(fl1, f.getVal(fl1));
+                            if (debug)
+                                logger.info("poly, g1 = " + g1 + ", f1 = " + f1 + ", Dps = " + Dps);
+                            if (debug)
+                                logger.info("poly, g2 = " + g2 + ", f2 = " + f2);
+                            TableRelation<SolvableResidue<C>> rel = ring.table.lookup(g2, f2);
+                            if (debug)
+                                logger.info("poly, g  = " + g + ", f  = " + f + ", rel = " + rel);
+                            Ds = new ResidueSolvablePolynomial<C>(ring, rel.p); //ring.copy(rel.p);
+                            if (rel.f != null) {
+                                D2 = new ResidueSolvablePolynomial<C>(ring, one, rel.f);
+                                Ds = Ds.multiply(D2);
+                                if (rel.e == null) {
+                                    g4 = g2;
+                                } else {
+                                    g4 = g2.subtract(rel.e);
+                                }
+                                ring.table.update(g4, f2, Ds);
+                            }
+                            if (rel.e != null) {
+                                D1 = new ResidueSolvablePolynomial<C>(ring, one, rel.e);
+                                Ds = D1.multiply(Ds);
+                                ring.table.update(g2, f2, Ds);
+                            }
+                            if (!f1.isZERO()) {
+                                D2 = new ResidueSolvablePolynomial<C>(ring, one, f1);
+                                Ds = Ds.multiply(D2);
+                                //ring.table.update(?,f1,Ds)
+                            }
+                            if (!g1.isZERO()) {
+                                D1 = new ResidueSolvablePolynomial<C>(ring, one, g1);
+                                Ds = D1.multiply(Ds);
+                                //ring.table.update(e1,?,Ds)
+                            }
+                        }
+                        Ds = Ds.multiplyLeft(c); // assume c commutes with Cs
+                        Dps = (ResidueSolvablePolynomial<C>) Dps.sum(Ds);
+                    } // end Dps loop
+                    Ds = Dps;
+                }
+                Ds = Ds.multiplyLeft(a); // multiply(a,b); // non-symmetric 
+                if (debug)
+                    logger.debug("Ds = " + Ds);
+                Dp = (ResidueSolvablePolynomial<C>) Dp.sum(Ds);
+            } // end B loop
+        } // end A loop
+        return Dp;
+    }
+
+
+    /**
+     * ResidueSolvablePolynomial left and right multiplication. Product with two
+     * polynomials.
+     * @param S ResidueSolvablePolynomial.
+     * @param T ResidueSolvablePolynomial.
+     * @return S*this*T.
+     */
+    public ResidueSolvablePolynomial<C> multiply(ResidueSolvablePolynomial<C> S,
+                    ResidueSolvablePolynomial<C> T) {
+        if (S.isZERO() || T.isZERO() || this.isZERO()) {
+            return ring.getZERO();
+        }
+        if (S.isONE()) {
+            return multiply(T);
+        }
+        if (T.isONE()) {
+            return S.multiply(this);
+        }
+        return S.multiply(this).multiply(T);
+    }
+
+
+    /**
+     * ResidueSolvablePolynomial multiplication. Product with coefficient ring
+     * element.
+     * @param b coefficient polynomial.
+     * @return this*b, where * is coefficient multiplication.
+     */
+    @Override
+    public ResidueSolvablePolynomial<C> multiply(SolvableResidue<C> b) {
+        ResidueSolvablePolynomial<C> Cp = ring.getZERO().copy();
+        if (b == null || b.isZERO()) {
+            return Cp;
+        }
+        Cp = new ResidueSolvablePolynomial<C>(ring, b, ring.evzero);
+        return multiply(Cp);
+    }
+
+
+    /**
+     * ResidueSolvablePolynomial left and right multiplication. Product with
+     * coefficient ring element.
+     * @param b coefficient polynomial.
+     * @param c coefficient polynomial.
+     * @return b*this*c, where * is coefficient multiplication.
+     */
+    @Override
+    public ResidueSolvablePolynomial<C> multiply(SolvableResidue<C> b, SolvableResidue<C> c) {
+        ResidueSolvablePolynomial<C> Cp = ring.getZERO().copy();
+        if (b == null || b.isZERO()) {
+            return Cp;
+        }
+        if (c == null || c.isZERO()) {
+            return Cp;
+        }
+        ResidueSolvablePolynomial<C> Cb = new ResidueSolvablePolynomial<C>(ring, b, ring.evzero);
+        ResidueSolvablePolynomial<C> Cc = new ResidueSolvablePolynomial<C>(ring, c, ring.evzero);
+        return Cb.multiply(this).multiply(Cc);
+    }
+
+
+    /**
+     * ResidueSolvablePolynomial multiplication. Product with exponent vector.
+     * @param e exponent.
+     * @return this * x<sup>e</sup>, where * denotes solvable multiplication.
+     */
+    @Override
+    public ResidueSolvablePolynomial<C> multiply(ExpVector e) {
+        if (e == null || e.isZERO()) {
+            return this;
+        }
+        SolvableResidue<C> b = ring.getONECoefficient();
+        return multiply(b, e);
+    }
+
+
+    /**
+     * ResidueSolvablePolynomial left and right multiplication. Product with
+     * exponent vector.
+     * @param e exponent.
+     * @param f exponent.
+     * @return x<sup>e</sup> * this * x<sup>f</sup>, where * denotes solvable
+     *         multiplication.
+     */
+    @Override
+    public ResidueSolvablePolynomial<C> multiply(ExpVector e, ExpVector f) {
+        if (e == null || e.isZERO()) {
+            return this;
+        }
+        if (f == null || f.isZERO()) {
+            return this;
+        }
+        SolvableResidue<C> b = ring.getONECoefficient();
+        return multiply(b, e, b, f);
+    }
+
+
+    /**
+     * ResidueSolvablePolynomial multiplication. Product with ring element and
+     * exponent vector.
+     * @param b coefficient polynomial.
+     * @param e exponent.
+     * @return this * b x<sup>e</sup>, where * denotes solvable multiplication.
+     */
+    @Override
+    public ResidueSolvablePolynomial<C> multiply(SolvableResidue<C> b, ExpVector e) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        ResidueSolvablePolynomial<C> Cp = new ResidueSolvablePolynomial<C>(ring, b, e);
+        return multiply(Cp);
+    }
+
+
+    /**
+     * ResidueSolvablePolynomial left and right multiplication. Product with
+     * ring element and exponent vector.
+     * @param b coefficient polynomial.
+     * @param e exponent.
+     * @param c coefficient polynomial.
+     * @param f exponent.
+     * @return b x<sup>e</sup> * this * c x<sup>f</sup>, where * denotes
+     *         solvable multiplication.
+     */
+    @Override
+    public ResidueSolvablePolynomial<C> multiply(SolvableResidue<C> b, ExpVector e, SolvableResidue<C> c,
+                    ExpVector f) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        if (c == null || c.isZERO()) {
+            return ring.getZERO();
+        }
+        ResidueSolvablePolynomial<C> Cp = new ResidueSolvablePolynomial<C>(ring, b, e);
+        ResidueSolvablePolynomial<C> Dp = new ResidueSolvablePolynomial<C>(ring, c, f);
+        return multiply(Cp, Dp);
+    }
+
+
+    /**
+     * ResidueSolvablePolynomial multiplication. Left product with ring element
+     * and exponent vector.
+     * @param b coefficient polynomial.
+     * @param e exponent.
+     * @return b x<sup>e</sup> * this, where * denotes solvable multiplication.
+     */
+    @Override
+    public ResidueSolvablePolynomial<C> multiplyLeft(SolvableResidue<C> b, ExpVector e) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        ResidueSolvablePolynomial<C> Cp = new ResidueSolvablePolynomial<C>(ring, b, e);
+        return Cp.multiply(this);
+    }
+
+
+    /**
+     * ResidueSolvablePolynomial multiplication. Left product with exponent
+     * vector.
+     * @param e exponent.
+     * @return x<sup>e</sup> * this, where * denotes solvable multiplication.
+     */
+    @Override
+    public ResidueSolvablePolynomial<C> multiplyLeft(ExpVector e) {
+        if (e == null || e.isZERO()) {
+            return this;
+        }
+        SolvableResidue<C> b = ring.getONECoefficient();
+        ResidueSolvablePolynomial<C> Cp = new ResidueSolvablePolynomial<C>(ring, b, e);
+        return Cp.multiply(this);
+    }
+
+
+    /**
+     * ResidueSolvablePolynomial multiplication. Left product with coefficient
+     * ring element.
+     * @param b coefficient polynomial.
+     * @return b*this, where * is coefficient multiplication.
+     */
+    @Override
+    public ResidueSolvablePolynomial<C> multiplyLeft(SolvableResidue<C> b) {
+        ResidueSolvablePolynomial<C> Cp = ring.getZERO().copy();
+        if (b == null || b.isZERO()) {
+            return Cp;
+        }
+        Map<ExpVector, SolvableResidue<C>> Cm = Cp.val; //getMap();
+        Map<ExpVector, SolvableResidue<C>> Am = val;
+        SolvableResidue<C> c;
+        for (Map.Entry<ExpVector, SolvableResidue<C>> y : Am.entrySet()) {
+            ExpVector e = y.getKey();
+            SolvableResidue<C> a = y.getValue();
+            c = b.multiply(a);
+            if (!c.isZERO()) {
+                Cm.put(e, c);
+            }
+        }
+        return Cp;
+    }
+
+
+    /**
+     * ResidueSolvablePolynomial multiplication. Left product with 'monomial'.
+     * @param m 'monomial'.
+     * @return m * this, where * denotes solvable multiplication.
+     */
+    @Override
+    public ResidueSolvablePolynomial<C> multiplyLeft(Map.Entry<ExpVector, SolvableResidue<C>> m) {
+        if (m == null) {
+            return ring.getZERO();
+        }
+        return multiplyLeft(m.getValue(), m.getKey());
+    }
+
+
+    /**
+     * ResidueSolvablePolynomial multiplication. Product with 'monomial'.
+     * @param m 'monomial'.
+     * @return this * m, where * denotes solvable multiplication.
+     */
+    @Override
+    public ResidueSolvablePolynomial<C> multiply(Map.Entry<ExpVector, SolvableResidue<C>> m) {
+        if (m == null) {
+            return ring.getZERO();
+        }
+        return multiply(m.getValue(), m.getKey());
+    }
+
+
+    /**
+     * ResidueSolvablePolynomial multiplication with exponent vector.
+     * @param f exponent vector.
+     * @return B*f, where * is commutative multiplication.
+     */
+    protected ResidueSolvablePolynomial<C> shift(ExpVector f) {
+        ResidueSolvablePolynomial<C> C = ring.getZERO().copy();
+        if (this.isZERO()) {
+            return C;
+        }
+        if (f == null || f.isZERO()) {
+            return this;
+        }
+        Map<ExpVector, SolvableResidue<C>> Cm = C.val;
+        Map<ExpVector, SolvableResidue<C>> Bm = this.val;
+        for (Map.Entry<ExpVector, SolvableResidue<C>> y : Bm.entrySet()) {
+            ExpVector e = y.getKey();
+            SolvableResidue<C> a = y.getValue();
+            ExpVector d = e.sum(f);
+            if (!a.isZERO()) {
+                Cm.put(d, a);
+            }
+        }
+        return C;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/ResidueSolvablePolynomialRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/ResidueSolvablePolynomialRing.java
@@ -1,0 +1,781 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.kern.PrettyPrint;
+import edu.jas.kern.Scripting;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.GenPolynomialTokenizer;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.GenSolvablePolynomialRing;
+import edu.jas.poly.RecSolvablePolynomial;
+import edu.jas.poly.RecSolvablePolynomialRing;
+import edu.jas.poly.RelationTable;
+import edu.jas.poly.TermOrder;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * ResidueSolvablePolynomialRing generic solvable polynomial with residue
+ * coefficients factory implementing RingFactory and extending
+ * GenSolvablePolynomialRing factory. Factory for n-variate ordered solvable
+ * polynomials over solvable residue coefficients. The non-commutative
+ * multiplication relations are maintained in a relation table and the
+ * non-commutative multiplication relations between the coefficients and the
+ * main variables are maintained in a coefficient relation table. Almost
+ * immutable object, except variable names and relation table contents.
+ * @param <C> coefficient type.
+ * @author Heinz Kredel
+ */
+
+public class ResidueSolvablePolynomialRing<C extends GcdRingElem<C>> extends
+                GenSolvablePolynomialRing<SolvableResidue<C>> {
+
+
+    /*
+     * The solvable multiplication relations between variables and coefficients.
+     */
+    //public final RelationTable<GenPolynomial<C>> coeffTable;
+
+
+    /**
+     * Recursive solvable polynomial ring with polynomial coefficients.
+     */
+    public final RecSolvablePolynomialRing<C> polCoeff;
+
+
+    /**
+     * The constant polynomial 0 for this ring. Hides super ZERO.
+     */
+    public final ResidueSolvablePolynomial<C> ZERO;
+
+
+    /**
+     * The constant polynomial 1 for this ring. Hides super ONE.
+     */
+    public final ResidueSolvablePolynomial<C> ONE;
+
+
+    private static final Logger logger = LogManager.getLogger(ResidueSolvablePolynomialRing.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * default term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     */
+    public ResidueSolvablePolynomialRing(RingFactory<SolvableResidue<C>> cf, int n) {
+        this(cf, n, new TermOrder(), null, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * default term order.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param rt solvable multiplication relations.
+     */
+    public ResidueSolvablePolynomialRing(RingFactory<SolvableResidue<C>> cf, int n,
+                    RelationTable<SolvableResidue<C>> rt) {
+        this(cf, n, new TermOrder(), null, rt);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     */
+    public ResidueSolvablePolynomialRing(RingFactory<SolvableResidue<C>> cf, int n, TermOrder t) {
+        this(cf, n, t, null, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     * @param rt solvable multiplication relations.
+     */
+    public ResidueSolvablePolynomialRing(RingFactory<SolvableResidue<C>> cf, int n, TermOrder t,
+                    RelationTable<SolvableResidue<C>> rt) {
+        this(cf, n, t, null, rt);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     * @param v names for the variables.
+     */
+    public ResidueSolvablePolynomialRing(RingFactory<SolvableResidue<C>> cf, int n, TermOrder t, String[] v) {
+        this(cf, n, t, v, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param t a term order.
+     * @param v names for the variables.
+     */
+    public ResidueSolvablePolynomialRing(RingFactory<SolvableResidue<C>> cf, TermOrder t, String[] v) {
+        this(cf, v.length, t, v, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * default term order.
+     * @param cf factory for coefficients of type C.
+     * @param v names for the variables.
+     */
+    public ResidueSolvablePolynomialRing(RingFactory<SolvableResidue<C>> cf, String[] v) {
+        this(cf, v.length, new TermOrder(), v, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     * @param v names for the variables.
+     * @param rt solvable multiplication relations.
+     */
+    public ResidueSolvablePolynomialRing(RingFactory<SolvableResidue<C>> cf, int n, TermOrder t, String[] v,
+                    RelationTable<SolvableResidue<C>> rt) {
+        super(cf, n, t, v, rt);
+        //if (rt == null) { // handled in super }
+        SolvableResidueRing<C> cfring = (SolvableResidueRing<C>) cf; // == coFac
+        polCoeff = new RecSolvablePolynomialRing<C>(cfring.ring, n, t, v);
+        if (table.size() > 0) { // TODO
+            ExpVector e = null;
+            ExpVector f = null;
+            GenSolvablePolynomial<GenPolynomial<C>> p = null;
+            polCoeff.table.update(e, f, p); // from rt
+        }
+        //coeffTable = polCoeff.coeffTable; //new RelationTable<GenPolynomial<C>>(polCoeff, true);
+        ZERO = new ResidueSolvablePolynomial<C>(this);
+        SolvableResidue<C> coeff = coFac.getONE();
+        //evzero = ExpVector.create(nvar); // from super
+        ONE = new ResidueSolvablePolynomial<C>(this, coeff, evzero);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the the
+     * same term order, number of variables and variable names as the given
+     * polynomial factory, only the coefficient factories differ and the
+     * solvable multiplication relations are <b>empty</b>.
+     * @param cf factory for coefficients of type C.
+     * @param o other solvable polynomial ring.
+     */
+    public ResidueSolvablePolynomialRing(RingFactory<SolvableResidue<C>> cf, ResidueSolvablePolynomialRing o) {
+        this(cf, o.nvar, o.tord, o.getVars(), null);
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        String res = super.toString();
+        if (PrettyPrint.isTrue()) {
+            //res += "\n" + table.toString(vars);
+            res += "\n" + polCoeff.coeffTable.toString(vars);
+        } else {
+            res += ", #rel = " + table.size() + " + " + polCoeff.coeffTable.size();
+        }
+        return res;
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        StringBuffer s = new StringBuffer();
+        switch (Scripting.getLang()) {
+        case Ruby:
+            s.append("SolvPolyRing.new(");
+            break;
+        case Python:
+        default:
+            s.append("SolvPolyRing(");
+        }
+        if (coFac instanceof RingElem) {
+            s.append(((RingElem<SolvableResidue<C>>) coFac).toScriptFactory());
+        } else {
+            s.append(coFac.toScript().trim());
+        }
+        s.append(",\"" + varsToString() + "\",");
+        String to = tord.toScript();
+        s.append(to);
+        if (table.size() > 0) {
+            String rel = table.toScript();
+            s.append(",rel=");
+            s.append(rel);
+        }
+        if (polCoeff.coeffTable.size() > 0) {
+            String rel = polCoeff.coeffTable.toScript();
+            s.append(",coeffrel=");
+            s.append(rel);
+        }
+        s.append(")");
+        return s.toString();
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object other) {
+        if (!(other instanceof ResidueSolvablePolynomialRing)) {
+            return false;
+        }
+        ResidueSolvablePolynomialRing<C> oring = null;
+        try {
+            oring = (ResidueSolvablePolynomialRing<C>) other;
+        } catch (ClassCastException ignored) {
+        }
+        if (oring == null) {
+            return false;
+        }
+        // do a super.equals( )
+        if (!super.equals(other)) {
+            return false;
+        }
+        // check same base relations
+        //if ( ! table.equals(oring.table) ) { // done in super
+        //    return false;
+        //}
+        if (!polCoeff.coeffTable.equals(oring.polCoeff.coeffTable)) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Hash code for this polynomial ring.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = super.hashCode();
+        h = 37 * h + table.hashCode(); // may be different after some computations
+        h = 37 * h + polCoeff.coeffTable.hashCode(); // may be different
+        return h;
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as ResidueSolvablePolynomial<C>.
+     */
+    @Override
+    public ResidueSolvablePolynomial<C> getZERO() {
+        return ZERO;
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as ResidueSolvablePolynomial<C>.
+     */
+    @Override
+    public ResidueSolvablePolynomial<C> getONE() {
+        return ONE;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true if this ring is commutative, else false.
+     */
+    @Override
+    public boolean isCommutative() {
+        if (polCoeff.coeffTable.size() == 0) {
+            return super.isCommutative();
+        }
+        // check structure of relations?
+        return false;
+    }
+
+
+    /**
+     * Query if this ring is associative. Test if the relations between the mian
+     * variables and the coefficient generators define an associative solvable
+     * ring.
+     * @return true, if this ring is associative, else false.
+     */
+    @SuppressWarnings("unused")
+    @Override
+    public boolean isAssociative() {
+        if (!coFac.isAssociative()) {
+            return false;
+        }
+        //System.out.println("polCoeff = " + polCoeff.toScript());
+        if (!polCoeff.isAssociative()) { // not done via generators??
+            return false;
+        }
+        ResidueSolvablePolynomial<C> Xi, Xj, Xk, p, q;
+        List<GenPolynomial<SolvableResidue<C>>> gens = generators();
+        //System.out.println("Residu gens = " + gens);
+        int ngen = gens.size();
+        for (int i = 0; i < ngen; i++) {
+            Xi = (ResidueSolvablePolynomial<C>) gens.get(i);
+            for (int j = i + 1; j < ngen; j++) {
+                Xj = (ResidueSolvablePolynomial<C>) gens.get(j);
+                for (int k = j + 1; k < ngen; k++) {
+                    Xk = (ResidueSolvablePolynomial<C>) gens.get(k);
+                    p = Xk.multiply(Xj).multiply(Xi);
+                    q = Xk.multiply(Xj.multiply(Xi));
+                    if (!p.equals(q)) {
+                        if (logger.isInfoEnabled()) {
+                            logger.info("Xk = " + Xk + ", Xj = " + Xj + ", Xi = " + Xi);
+                            logger.info("p = ( Xk * Xj ) * Xi = " + p);
+                            logger.info("q = Xk * ( Xj * Xi ) = " + q);
+                        }
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Get a (constant) ResidueSolvablePolynomial&lt;C&gt; element from a long
+     * value.
+     * @param a long.
+     * @return a ResidueSolvablePolynomial&lt;C&gt;.
+     */
+    @Override
+    public ResidueSolvablePolynomial<C> fromInteger(long a) {
+        return new ResidueSolvablePolynomial<C>(this, coFac.fromInteger(a), evzero);
+    }
+
+
+    /**
+     * Get a (constant) ResidueSolvablePolynomial&lt;C&gt; element from a
+     * BigInteger value.
+     * @param a BigInteger.
+     * @return a ResidueSolvablePolynomial&lt;C&gt;.
+     */
+    @Override
+    public ResidueSolvablePolynomial<C> fromInteger(BigInteger a) {
+        return new ResidueSolvablePolynomial<C>(this, coFac.fromInteger(a), evzero);
+    }
+
+
+    /**
+     * Random solvable polynomial. Generates a random solvable polynomial with k
+     * = 5, l = n, d = (nvar == 1) ? n : 3, q = (nvar == 1) ? 0.7 : 0.3.
+     * @param n number of terms.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    public ResidueSolvablePolynomial<C> random(int n) {
+        return random(n, random);
+    }
+
+
+    /**
+     * Random solvable polynomial. Generates a random solvable polynomial with k
+     * = 5, l = n, d = (nvar == 1) ? n : 3, q = (nvar == 1) ? 0.7 : 0.3.
+     * @param n number of terms.
+     * @param rnd is a source for random bits.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    public ResidueSolvablePolynomial<C> random(int n, Random rnd) {
+        if (nvar == 1) {
+            return random(5, n, n, 0.7f, rnd);
+        }
+        return random(5, n, 3, 0.3f, rnd);
+    }
+
+
+    /**
+     * Generate a random solvable polynomial.
+     * @param k bitsize of random coefficients.
+     * @param l number of terms.
+     * @param d maximal degree in each variable.
+     * @param q density of nozero exponents.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    public ResidueSolvablePolynomial<C> random(int k, int l, int d, float q) {
+        return random(k, l, d, q, random);
+    }
+
+
+    /**
+     * Random solvable polynomial.
+     * @param k size of random coefficients.
+     * @param l number of terms.
+     * @param d maximal degree in each variable.
+     * @param q density of nozero exponents.
+     * @param rnd is a source for random bits.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    public ResidueSolvablePolynomial<C> random(int k, int l, int d, float q, Random rnd) {
+        ResidueSolvablePolynomial<C> r = getZERO(); // copy( ZERO ); 
+        ExpVector e;
+        SolvableResidue<C> a;
+        // add random coeffs and exponents
+        for (int i = 0; i < l; i++) {
+            e = ExpVector.random(nvar, d, q, rnd);
+            a = coFac.random(k, rnd);
+            r = (ResidueSolvablePolynomial<C>) r.sum(a, e);
+            // somewhat inefficient but clean
+        }
+        return r;
+    }
+
+
+    /**
+     * Copy polynomial c.
+     * @param c
+     * @return a copy of c.
+     */
+    public ResidueSolvablePolynomial<C> copy(ResidueSolvablePolynomial<C> c) {
+        return new ResidueSolvablePolynomial<C>(this, c.getMap());
+    }
+
+
+    /**
+     * Parse a solvable polynomial with the use of GenPolynomialTokenizer
+     * @param s String.
+     * @return ResidueSolvablePolynomial from s.
+     */
+    @Override
+    public ResidueSolvablePolynomial<C> parse(String s) {
+        return parse(new StringReader(s));
+    }
+
+
+    /**
+     * Parse a solvable polynomial with the use of GenPolynomialTokenizer
+     * @param r Reader.
+     * @return next ResidueSolvablePolynomial from r.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public ResidueSolvablePolynomial<C> parse(Reader r) {
+        GenPolynomialTokenizer pt = new GenPolynomialTokenizer(this, r);
+        ResidueSolvablePolynomial<C> p = null;
+        try {
+            GenSolvablePolynomial<SolvableResidue<C>> s = pt.nextSolvablePolynomial();
+            p = new ResidueSolvablePolynomial<C>(this, s);
+        } catch (IOException e) {
+            logger.error(e.toString() + " parse " + this);
+            p = ZERO;
+        }
+        return p;
+    }
+
+
+    /**
+     * Generate univariate solvable polynomial in a given variable.
+     * @param i the index of the variable.
+     * @return X_i as solvable univariate polynomial.
+     */
+    @Override
+    public ResidueSolvablePolynomial<C> univariate(int i) {
+        return (ResidueSolvablePolynomial<C>) super.univariate(i);
+    }
+
+
+    /**
+     * Generate univariate solvable polynomial in a given variable with given
+     * exponent.
+     * @param i the index of the variable.
+     * @param e the exponent of the variable.
+     * @return X_i^e as solvable univariate polynomial.
+     */
+    @Override
+    public ResidueSolvablePolynomial<C> univariate(int i, long e) {
+        return (ResidueSolvablePolynomial<C>) super.univariate(i, e);
+    }
+
+
+    /**
+     * Generate univariate solvable polynomial in a given variable with given
+     * exponent.
+     * @param modv number of module variables.
+     * @param i the index of the variable.
+     * @param e the exponent of the variable.
+     * @return X_i^e as solvable univariate polynomial.
+     */
+    @Override
+    public ResidueSolvablePolynomial<C> univariate(int modv, int i, long e) {
+        return (ResidueSolvablePolynomial<C>) super.univariate(modv, i, e);
+    }
+
+
+    /**
+     * Generate list of univariate polynomials in all variables.
+     * @return List(X_1,...,X_n) a list of univariate polynomials.
+     */
+    @Override
+    public List<ResidueSolvablePolynomial<C>> univariateList() {
+        return univariateList(0, 1L);
+    }
+
+
+    /**
+     * Generate list of univariate polynomials in all variables.
+     * @param modv number of module variables.
+     * @return List(X_1,...,X_n) a list of univariate polynomials.
+     */
+    @Override
+    public List<ResidueSolvablePolynomial<C>> univariateList(int modv) {
+        return univariateList(modv, 1L);
+    }
+
+
+    /**
+     * Generate list of univariate polynomials in all variables with given
+     * exponent.
+     * @param modv number of module variables.
+     * @param e the exponent of the variables.
+     * @return List(X_1^e,...,X_n^e) a list of univariate polynomials.
+     */
+    @Override
+    public List<ResidueSolvablePolynomial<C>> univariateList(int modv, long e) {
+        List<ResidueSolvablePolynomial<C>> pols = new ArrayList<ResidueSolvablePolynomial<C>>(nvar);
+        int nm = nvar - modv;
+        for (int i = 0; i < nm; i++) {
+            ResidueSolvablePolynomial<C> p = univariate(modv, nm - 1 - i, e);
+            pols.add(p);
+        }
+        return pols;
+    }
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by i.
+     * @param i number of variables to extend.
+     * @return extended solvable polynomial ring factory.
+     */
+    @Override
+    public ResidueSolvablePolynomialRing<C> extend(int i) {
+        return extend(i, false);
+    }
+
+    
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by i.
+     * @param i number of variables to extend.
+     * @param top true for TOP term order, false for POT term order.
+     * @return extended solvable polynomial ring factory.
+     */
+    @Override
+    public ResidueSolvablePolynomialRing<C> extend(int i, boolean top) {
+        GenPolynomialRing<SolvableResidue<C>> pfac = super.extend(i, top);
+        ResidueSolvablePolynomialRing<C> spfac = new ResidueSolvablePolynomialRing<C>(pfac.coFac, pfac.nvar,
+                        pfac.tord, pfac.getVars());
+        spfac.table.extend(this.table);
+        spfac.polCoeff.coeffTable.extend(this.polCoeff.coeffTable);
+        return spfac;
+    }
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by i.
+     * @param vn names for extended variables.
+     * @return extended solvable polynomial ring factory.
+     */
+    @Override
+    public ResidueSolvablePolynomialRing<C> extend(String[] vn) {
+        return extend(vn, false);
+    }
+
+    
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by i.
+     * @param vn names for extended variables.
+     * @param top true for TOP term order, false for POT term order.
+     * @return extended solvable polynomial ring factory.
+     */
+    @Override
+    public ResidueSolvablePolynomialRing<C> extend(String[] vn, boolean top) {
+        GenPolynomialRing<SolvableResidue<C>> pfac = super.extend(vn, top);
+        ResidueSolvablePolynomialRing<C> spfac = new ResidueSolvablePolynomialRing<C>(pfac.coFac, pfac.nvar,
+                        pfac.tord, pfac.getVars());
+        spfac.table.extend(this.table);
+        spfac.polCoeff.coeffTable.extend(this.polCoeff.coeffTable);
+        return spfac;
+    }
+
+    
+    /**
+     * Contract variables. Used e.g. in module embedding. Contract number of
+     * variables by i.
+     * @param i number of variables to remove.
+     * @return contracted solvable polynomial ring factory.
+     */
+    @Override
+    public ResidueSolvablePolynomialRing<C> contract(int i) {
+        GenPolynomialRing<SolvableResidue<C>> pfac = super.contract(i);
+        ResidueSolvablePolynomialRing<C> spfac = new ResidueSolvablePolynomialRing<C>(pfac.coFac, pfac.nvar,
+                        pfac.tord, pfac.getVars());
+        spfac.table.contract(this.table);
+        spfac.polCoeff.coeffTable.contract(this.polCoeff.coeffTable);
+        return spfac;
+    }
+
+
+    /**
+     * Reverse variables. Used e.g. in opposite rings.
+     * @return solvable polynomial ring factory with reversed variables.
+     */
+    @Override
+    public ResidueSolvablePolynomialRing<C> reverse() {
+        return reverse(false);
+    }
+
+
+    /**
+     * Reverse variables. Used e.g. in opposite rings.
+     * @param partial true for partialy reversed term orders.
+     * @return solvable polynomial ring factory with reversed variables.
+     */
+    @Override
+    public ResidueSolvablePolynomialRing<C> reverse(boolean partial) {
+        GenPolynomialRing<SolvableResidue<C>> pfac = super.reverse(partial);
+        ResidueSolvablePolynomialRing<C> spfac = new ResidueSolvablePolynomialRing<C>(pfac.coFac, pfac.nvar,
+                        pfac.tord, pfac.getVars());
+        spfac.partial = partial;
+        spfac.table.reverse(this.table);
+        spfac.polCoeff.coeffTable.reverse(this.polCoeff.coeffTable);
+        return spfac;
+    }
+
+
+    /**
+     * Solvable residue coefficients from integral polynomial coefficients.
+     * Represent as polynomial with type SolvableResidue<C> coefficients.
+     * @param A polynomial with integral polynomial coefficients to be
+     *            converted.
+     * @return polynomial with type SolvableResidue<C> coefficients.
+     */
+    public ResidueSolvablePolynomial<C> fromPolyCoefficients(GenSolvablePolynomial<GenPolynomial<C>> A) {
+        ResidueSolvablePolynomial<C> B = getZERO().copy();
+        if (A == null || A.isZERO()) {
+            return B;
+        }
+        RingFactory<SolvableResidue<C>> cfac = coFac;
+        SolvableResidueRing<C> qfac = (SolvableResidueRing<C>) cfac;
+        for (Map.Entry<ExpVector, GenPolynomial<C>> y : A.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            GenSolvablePolynomial<C> a = (GenSolvablePolynomial<C>) y.getValue();
+            SolvableResidue<C> p = new SolvableResidue<C>(qfac, a); // can be zero
+            if (!p.isZERO()) {
+                //B = B.sum( p, e ); // inefficient
+                B.doPutToMap(e, p);
+            }
+        }
+        return B;
+    }
+
+
+    /**
+     * Integral function from solvable residue coefficients. Represent as
+     * polynomial with type GenSolvablePolynomial<C> coefficients.
+     * @param A polynomial with solvable residue coefficients to be converted.
+     * @return polynomial with type GenSolvablePolynomial<C> coefficients.
+     */
+    public RecSolvablePolynomial<C> toPolyCoefficients(ResidueSolvablePolynomial<C> A) {
+        RecSolvablePolynomial<C> B = polCoeff.getZERO().copy();
+        if (A == null || A.isZERO()) {
+            return B;
+        }
+        for (Map.Entry<ExpVector, SolvableResidue<C>> y : A.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            SolvableResidue<C> a = y.getValue();
+            GenPolynomial<C> p = a.val; // can not be zero
+            if (!p.isZERO()) {
+                //B = B.sum( p, e ); // inefficient
+                B.doPutToMap(e, p);
+            }
+        }
+        return B;
+    }
+
+
+    /**
+     * Integral function from solvable residue coefficients. Represent as
+     * polynomial with type GenSolvablePolynomial<C> coefficients.
+     * @param A polynomial with solvable residue coefficients to be converted.
+     * @return polynomial with type GenSolvablePolynomial<C> coefficients.
+     */
+    public RecSolvablePolynomial<C> toPolyCoefficients(GenPolynomial<SolvableResidue<C>> A) {
+        RecSolvablePolynomial<C> B = polCoeff.getZERO().copy();
+        if (A == null || A.isZERO()) {
+            return B;
+        }
+        for (Map.Entry<ExpVector, SolvableResidue<C>> y : A.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            SolvableResidue<C> a = y.getValue();
+            GenPolynomial<C> p = a.val; // can not be zero
+            if (!p.isZERO()) {
+                //B = B.sum( p, e ); // inefficient
+                B.doPutToMap(e, p);
+            }
+        }
+        return B;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/ResidueSolvableWordPolynomial.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/ResidueSolvableWordPolynomial.java
@@ -1,0 +1,575 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.RecSolvableWordPolynomial;
+import edu.jas.poly.TableRelation;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * ResidueSolvableWordPolynomial solvable polynomials with WordResidue
+ * coefficients implementing RingElem. n-variate ordered solvable polynomials
+ * over non-commutative word residue coefficients. Objects of this class are
+ * intended to be immutable. The implementation is based on TreeMap respectively
+ * SortedMap from exponents to coefficients by extension of GenPolynomial.
+ * @param <C> base coefficient type
+ * @author Heinz Kredel
+ */
+
+public class ResidueSolvableWordPolynomial<C extends GcdRingElem<C>> extends
+                GenSolvablePolynomial<WordResidue<C>> {
+
+
+    /**
+     * The factory for the recursive solvable polynomial ring. Hides super.ring.
+     */
+    public final ResidueSolvableWordPolynomialRing<C> ring;
+
+
+    private static final Logger logger = LogManager.getLogger(ResidueSolvableWordPolynomial.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor for zero ResidueSolvableWordPolynomial.
+     * @param r solvable polynomial ring factory.
+     */
+    public ResidueSolvableWordPolynomial(ResidueSolvableWordPolynomialRing<C> r) {
+        super(r);
+        ring = r;
+    }
+
+
+    /**
+     * Constructor for ResidueSolvableWordPolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param e exponent.
+     */
+    public ResidueSolvableWordPolynomial(ResidueSolvableWordPolynomialRing<C> r, ExpVector e) {
+        this(r);
+        val.put(e, ring.getONECoefficient());
+    }
+
+
+    /**
+     * Constructor for ResidueSolvableWordPolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param c coefficient word residue.
+     * @param e exponent.
+     */
+    public ResidueSolvableWordPolynomial(ResidueSolvableWordPolynomialRing<C> r, WordResidue<C> c, ExpVector e) {
+        this(r);
+        if (c != null && !c.isZERO()) {
+            val.put(e, c);
+        }
+    }
+
+
+    /**
+     * Constructor for ResidueSolvableWordPolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param c coefficient word residue.
+     */
+    public ResidueSolvableWordPolynomial(ResidueSolvableWordPolynomialRing<C> r, WordResidue<C> c) {
+        this(r, c, r.evzero);
+    }
+
+
+    /**
+     * Constructor for ResidueSolvableWordPolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param S solvable polynomial.
+     */
+    public ResidueSolvableWordPolynomial(ResidueSolvableWordPolynomialRing<C> r,
+                    GenSolvablePolynomial<WordResidue<C>> S) {
+        this(r, S.getMap());
+    }
+
+
+    /**
+     * Constructor for ResidueSolvableWordPolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param v the SortedMap of some other (solvable) polynomial.
+     */
+    protected ResidueSolvableWordPolynomial(ResidueSolvableWordPolynomialRing<C> r,
+                    SortedMap<ExpVector, WordResidue<C>> v) {
+        this(r);
+        val.putAll(v); // assume no zero coefficients
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    @Override
+    public ResidueSolvableWordPolynomialRing<C> factory() {
+        return ring;
+    }
+
+
+    /**
+     * Clone this ResidueSolvableWordPolynomial.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public ResidueSolvableWordPolynomial<C> copy() {
+        return new ResidueSolvableWordPolynomial<C>(ring, this.val);
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object B) {
+        if (!(B instanceof ResidueSolvableWordPolynomial)) {
+            return false;
+        }
+        return super.equals(B);
+    }
+
+
+    /**
+     * Hash code for this polynomial.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+
+    /**
+     * ResidueSolvableWordPolynomial multiplication.
+     * @param Bp ResidueSolvableWordPolynomial.
+     * @return this*Bp, where * denotes solvable multiplication.
+     */
+    // cannot @Override, @NoOverride
+    public ResidueSolvableWordPolynomial<C> multiply(ResidueSolvableWordPolynomial<C> Bp) {
+        if (Bp == null || Bp.isZERO()) {
+            return ring.getZERO();
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        assert (ring.nvar == Bp.ring.nvar);
+        if (debug) {
+            logger.debug("ring = " + ring);
+        }
+        ExpVector Z = ring.evzero;
+        ResidueSolvableWordPolynomial<C> Dp = ring.getZERO().copy();
+        ResidueSolvableWordPolynomial<C> zero = ring.getZERO().copy();
+        WordResidue<C> one = ring.getONECoefficient();
+
+        Map<ExpVector, WordResidue<C>> A = val;
+        Map<ExpVector, WordResidue<C>> B = Bp.val;
+        Set<Map.Entry<ExpVector, WordResidue<C>>> Bk = B.entrySet();
+        for (Map.Entry<ExpVector, WordResidue<C>> y : A.entrySet()) {
+            WordResidue<C> a = y.getValue();
+            ExpVector e = y.getKey();
+            if (debug)
+                logger.info("e = " + e + ", a = " + a);
+            for (Map.Entry<ExpVector, WordResidue<C>> x : Bk) {
+                WordResidue<C> b = x.getValue();
+                ExpVector f = x.getKey();
+                if (debug)
+                    logger.info("f = " + f + ", b = " + b);
+                int[] fp = f.dependencyOnVariables();
+                int fl1 = 0;
+                if (fp.length > 0) {
+                    fl1 = fp[fp.length - 1];
+                }
+                int fl1s = ring.nvar + 1 - fl1;
+                // polynomial/residue coefficient multiplication 
+                ResidueSolvableWordPolynomial<C> Cps = ring.getZERO().copy();
+                if (ring.polCoeff.coeffTable.isEmpty() || b.isConstant() || e.isZERO()) { // symmetric
+                    Cps = new ResidueSolvableWordPolynomial<C>(ring, b, e);
+                    if (debug)
+                        logger.info("symmetric coeff: b = " + b + ", e = " + e);
+                } else { // unsymmetric
+                    if (debug)
+                        logger.info("unsymmetric coeff: b = " + b + ", e = " + e);
+                    // recursive polynomial coefficient multiplication : e * b.val
+                    RecSolvableWordPolynomial<C> rsp1 = new RecSolvableWordPolynomial<C>(ring.polCoeff, e);
+                    RecSolvableWordPolynomial<C> rsp2 = new RecSolvableWordPolynomial<C>(ring.polCoeff, b.val);
+                    RecSolvableWordPolynomial<C> rsp3 = rsp1.multiply(rsp2);
+                    Cps = ring.fromPolyCoefficients(rsp3);
+                }
+                if (debug) {
+                    logger.info("coeff-poly: Cps = " + Cps);
+                }
+                // polynomial multiplication 
+                ResidueSolvableWordPolynomial<C> Dps = ring.getZERO().copy();
+                ResidueSolvableWordPolynomial<C> Ds = null;
+                ResidueSolvableWordPolynomial<C> D1, D2;
+                if (ring.table.isEmpty() || Cps.isConstant() || f.isZERO()) { // symmetric
+                    if (debug)
+                        logger.info("symmetric poly: b = " + b + ", e = " + e);
+                    ExpVector g = e.sum(f);
+                    if (Cps.isConstant()) {
+                        Ds = new ResidueSolvableWordPolynomial<C>(ring, Cps.leadingBaseCoefficient(), g); // symmetric!
+                    } else {
+                        Ds = Cps.shift(f); // symmetric
+                    }
+                } else { // eventually unsymmetric
+                    if (debug)
+                        logger.info("unsymmetric poly: Cps = " + Cps + ", f = " + f);
+                    for (Map.Entry<ExpVector, WordResidue<C>> z : Cps.val.entrySet()) {
+                        // split g = g1 * g2, f = f1 * f2
+                        WordResidue<C> c = z.getValue();
+                        ExpVector g = z.getKey();
+                        if (debug)
+                            logger.info("g = " + g + ", c = " + c);
+                        int[] gp = g.dependencyOnVariables();
+                        int gl1 = ring.nvar + 1;
+                        if (gp.length > 0) {
+                            gl1 = gp[0];
+                        }
+                        int gl1s = ring.nvar + 1 - gl1;
+                        if (gl1s <= fl1s) { // symmetric
+                            ExpVector h = g.sum(f);
+                            if (debug)
+                                logger.info("disjoint poly: g = " + g + ", f = " + f + ", h = " + h);
+                            Ds = (ResidueSolvableWordPolynomial<C>) zero.sum(one, h); // symmetric!
+                        } else {
+                            ExpVector g1 = g.subst(gl1, 0);
+                            ExpVector g2 = Z.subst(gl1, g.getVal(gl1)); // bug el1, gl1
+                            ExpVector g4;
+                            ExpVector f1 = f.subst(fl1, 0);
+                            ExpVector f2 = Z.subst(fl1, f.getVal(fl1));
+                            if (debug)
+                                logger.info("poly, g1 = " + g1 + ", f1 = " + f1 + ", Dps = " + Dps);
+                            if (debug)
+                                logger.info("poly, g2 = " + g2 + ", f2 = " + f2);
+                            TableRelation<WordResidue<C>> rel = ring.table.lookup(g2, f2);
+                            if (debug)
+                                logger.info("poly, g  = " + g + ", f  = " + f + ", rel = " + rel);
+                            Ds = new ResidueSolvableWordPolynomial<C>(ring, rel.p); //ring.copy(rel.p);
+                            if (rel.f != null) {
+                                D2 = new ResidueSolvableWordPolynomial<C>(ring, one, rel.f);
+                                Ds = Ds.multiply(D2);
+                                if (rel.e == null) {
+                                    g4 = g2;
+                                } else {
+                                    g4 = g2.subtract(rel.e);
+                                }
+                                ring.table.update(g4, f2, Ds);
+                            }
+                            if (rel.e != null) {
+                                D1 = new ResidueSolvableWordPolynomial<C>(ring, one, rel.e);
+                                Ds = D1.multiply(Ds);
+                                ring.table.update(g2, f2, Ds);
+                            }
+                            if (!f1.isZERO()) {
+                                D2 = new ResidueSolvableWordPolynomial<C>(ring, one, f1);
+                                Ds = Ds.multiply(D2);
+                                //ring.table.update(?,f1,Ds)
+                            }
+                            if (!g1.isZERO()) {
+                                D1 = new ResidueSolvableWordPolynomial<C>(ring, one, g1);
+                                Ds = D1.multiply(Ds);
+                                //ring.table.update(e1,?,Ds)
+                            }
+                        }
+                        Ds = Ds.multiplyLeft(c); // assume c commutes with Cs
+                        Dps = (ResidueSolvableWordPolynomial<C>) Dps.sum(Ds);
+                    } // end Dps loop
+                    Ds = Dps;
+                }
+                Ds = Ds.multiplyLeft(a); // multiply(a,b); // non-symmetric 
+                if (debug)
+                    logger.debug("Ds = " + Ds);
+                Dp = (ResidueSolvableWordPolynomial<C>) Dp.sum(Ds);
+            } // end B loop
+        } // end A loop
+        return Dp;
+    }
+
+
+    /**
+     * ResidueSolvableWordPolynomial left and right multiplication. Product with
+     * two polynomials.
+     * @param S ResidueSolvableWordPolynomial.
+     * @param T ResidueSolvableWordPolynomial.
+     * @return S*this*T.
+     */
+    // cannot @Override, @NoOverride
+    public ResidueSolvableWordPolynomial<C> multiply(ResidueSolvableWordPolynomial<C> S,
+                    ResidueSolvableWordPolynomial<C> T) {
+        if (S.isZERO() || T.isZERO() || this.isZERO()) {
+            return ring.getZERO();
+        }
+        if (S.isONE()) {
+            return multiply(T);
+        }
+        if (T.isONE()) {
+            return S.multiply(this);
+        }
+        return S.multiply(this).multiply(T);
+    }
+
+
+    /**
+     * ResidueSolvableWordPolynomial multiplication. Product with coefficient
+     * ring element.
+     * @param b coefficient polynomial.
+     * @return this*b, where * is coefficient multiplication.
+     */
+    @Override
+    //public GenSolvablePolynomial<WordResidue<C>> multiply(WordResidue<C> b) {
+    public ResidueSolvableWordPolynomial<C> multiply(WordResidue<C> b) {
+        ResidueSolvableWordPolynomial<C> Cp = ring.getZERO().copy();
+        if (b == null || b.isZERO()) {
+            return Cp;
+        }
+        Cp = ring.valueOf(b);
+        return multiply(Cp);
+    }
+
+
+    /**
+     * ResidueSolvableWordPolynomial left and right multiplication. Product with
+     * coefficient ring element.
+     * @param b coefficient polynomial.
+     * @param c coefficient polynomial.
+     * @return b*this*c, where * is coefficient multiplication.
+     */
+    @Override
+    public ResidueSolvableWordPolynomial<C> multiply(WordResidue<C> b, WordResidue<C> c) {
+        ResidueSolvableWordPolynomial<C> Cp = ring.getZERO().copy();
+        if (b == null || b.isZERO()) {
+            return Cp;
+        }
+        if (c == null || c.isZERO()) {
+            return Cp;
+        }
+        ResidueSolvableWordPolynomial<C> Cb = ring.valueOf(b);
+        ResidueSolvableWordPolynomial<C> Cc = ring.valueOf(c);
+        return Cb.multiply(this).multiply(Cc);
+    }
+
+
+    /*
+     * ResidueSolvableWordPolynomial multiplication. Product with coefficient ring
+     * element.
+     * @param b coefficient of coefficient.
+     * @return this*b, where * is coefficient multiplication.
+     */
+    //@Override not possible, @NoOverride
+    //public ResidueSolvableWordPolynomial<C> multiply(C b) { ... }
+
+
+    /**
+     * ResidueSolvableWordPolynomial multiplication. Product with exponent
+     * vector.
+     * @param e exponent.
+     * @return this * x<sup>e</sup>, where * denotes solvable multiplication.
+     */
+    @Override
+    public ResidueSolvableWordPolynomial<C> multiply(ExpVector e) {
+        if (e == null || e.isZERO()) {
+            return this;
+        }
+        WordResidue<C> b = ring.getONECoefficient();
+        return multiply(b, e);
+    }
+
+
+    /**
+     * ResidueSolvableWordPolynomial left and right multiplication. Product with
+     * exponent vector.
+     * @param e exponent.
+     * @param f exponent.
+     * @return x<sup>e</sup> * this * x<sup>f</sup>, where * denotes solvable
+     *         multiplication.
+     */
+    @Override
+    public ResidueSolvableWordPolynomial<C> multiply(ExpVector e, ExpVector f) {
+        if (e == null || e.isZERO()) {
+            return this;
+        }
+        if (f == null || f.isZERO()) {
+            return this;
+        }
+        WordResidue<C> b = ring.getONECoefficient();
+        return multiply(b, e, b, f);
+    }
+
+
+    /**
+     * ResidueSolvableWordPolynomial multiplication. Product with ring element
+     * and exponent vector.
+     * @param b coefficient polynomial.
+     * @param e exponent.
+     * @return this * b x<sup>e</sup>, where * denotes solvable multiplication.
+     */
+    @Override
+    public ResidueSolvableWordPolynomial<C> multiply(WordResidue<C> b, ExpVector e) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        ResidueSolvableWordPolynomial<C> Cp = ring.valueOf(b, e);
+        return multiply(Cp);
+    }
+
+
+    /**
+     * ResidueSolvableWordPolynomial left and right multiplication. Product with
+     * ring element and exponent vector.
+     * @param b coefficient polynomial.
+     * @param e exponent.
+     * @param c coefficient polynomial.
+     * @param f exponent.
+     * @return b x<sup>e</sup> * this * c x<sup>f</sup>, where * denotes
+     *         solvable multiplication.
+     */
+    @Override
+    public ResidueSolvableWordPolynomial<C> multiply(WordResidue<C> b, ExpVector e, WordResidue<C> c,
+                    ExpVector f) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        if (c == null || c.isZERO()) {
+            return ring.getZERO();
+        }
+        ResidueSolvableWordPolynomial<C> Cp = ring.valueOf(b, e);
+        ResidueSolvableWordPolynomial<C> Dp = ring.valueOf(c, f);
+        return multiply(Cp, Dp);
+    }
+
+
+    /**
+     * ResidueSolvableWordPolynomial multiplication. Left product with ring
+     * element and exponent vector.
+     * @param b coefficient polynomial.
+     * @param e exponent.
+     * @return b x<sup>e</sup> * this, where * denotes solvable multiplication.
+     */
+    @Override
+    public ResidueSolvableWordPolynomial<C> multiplyLeft(WordResidue<C> b, ExpVector e) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        ResidueSolvableWordPolynomial<C> Cp = ring.valueOf(b, e);
+        return Cp.multiply(this);
+    }
+
+
+    /**
+     * ResidueSolvableWordPolynomial multiplication. Left product with exponent
+     * vector.
+     * @param e exponent.
+     * @return x<sup>e</sup> * this, where * denotes solvable multiplication.
+     */
+    @Override
+    public ResidueSolvableWordPolynomial<C> multiplyLeft(ExpVector e) {
+        if (e == null || e.isZERO()) {
+            return this;
+        }
+        ResidueSolvableWordPolynomial<C> Cp = ring.valueOf(e);
+        return Cp.multiply(this);
+    }
+
+
+    /**
+     * ResidueSolvableWordPolynomial multiplication. Left product with
+     * coefficient ring element.
+     * @param b coefficient polynomial.
+     * @return b*this, where * is coefficient multiplication.
+     */
+    @Override
+    public ResidueSolvableWordPolynomial<C> multiplyLeft(WordResidue<C> b) {
+        ResidueSolvableWordPolynomial<C> Cp = ring.getZERO().copy();
+        if (b == null || b.isZERO()) {
+            return Cp;
+        }
+        Map<ExpVector, WordResidue<C>> Cm = Cp.val; //getMap();
+        Map<ExpVector, WordResidue<C>> Am = val;
+        WordResidue<C> c;
+        for (Map.Entry<ExpVector, WordResidue<C>> y : Am.entrySet()) {
+            ExpVector e = y.getKey();
+            WordResidue<C> a = y.getValue();
+            c = b.multiply(a);
+            if (!c.isZERO()) {
+                Cm.put(e, c);
+            }
+        }
+        return Cp;
+    }
+
+
+    /**
+     * ResidueSolvableWordPolynomial multiplication. Left product with
+     * 'monomial'.
+     * @param m 'monomial'.
+     * @return m * this, where * denotes solvable multiplication.
+     */
+    @Override
+    public ResidueSolvableWordPolynomial<C> multiplyLeft(Map.Entry<ExpVector, WordResidue<C>> m) {
+        if (m == null) {
+            return ring.getZERO();
+        }
+        return multiplyLeft(m.getValue(), m.getKey());
+    }
+
+
+    /**
+     * ResidueSolvableWordPolynomial multiplication. Product with 'monomial'.
+     * @param m 'monomial'.
+     * @return this * m, where * denotes solvable multiplication.
+     */
+    @Override
+    public ResidueSolvableWordPolynomial<C> multiply(Map.Entry<ExpVector, WordResidue<C>> m) {
+        if (m == null) {
+            return ring.getZERO();
+        }
+        return multiply(m.getValue(), m.getKey());
+    }
+
+
+    /**
+     * ResidueSolvableWordPolynomial multiplication. Commutative product with
+     * exponent vector.
+     * @param f exponent vector.
+     * @return B*f, where * is commutative multiplication.
+     */
+    protected ResidueSolvableWordPolynomial<C> shift(ExpVector f) {
+        ResidueSolvableWordPolynomial<C> C = ring.getZERO().copy();
+        if (this.isZERO()) {
+            return C;
+        }
+        if (f == null || f.isZERO()) {
+            return this;
+        }
+        Map<ExpVector, WordResidue<C>> Cm = C.val;
+        Map<ExpVector, WordResidue<C>> Bm = this.val;
+        for (Map.Entry<ExpVector, WordResidue<C>> y : Bm.entrySet()) {
+            ExpVector e = y.getKey();
+            WordResidue<C> a = y.getValue();
+            ExpVector d = e.sum(f);
+            if (!a.isZERO()) {
+                Cm.put(d, a);
+            }
+        }
+        return C;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/ResidueSolvableWordPolynomialRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/ResidueSolvableWordPolynomialRing.java
@@ -1,0 +1,842 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.kern.PrettyPrint;
+import edu.jas.kern.Scripting;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.GenPolynomialTokenizer;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.GenSolvablePolynomialRing;
+import edu.jas.poly.GenWordPolynomial;
+import edu.jas.poly.RecSolvableWordPolynomial;
+import edu.jas.poly.RecSolvableWordPolynomialRing;
+import edu.jas.poly.RelationTable;
+import edu.jas.poly.TermOrder;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * ResidueSolvableWordPolynomialRing solvable polynomial with word residue
+ * coefficients factory. It implements RingFactory and extends
+ * GenSolvablePolynomialRing factory. Factory for n-variate ordered solvable
+ * polynomials over non-commutative word residue coefficients. The
+ * non-commutative multiplication relations are maintained in a relation table
+ * and the non-commutative multiplication relations between the coefficients and
+ * the main variables are maintained in a coefficient relation table. Almost
+ * immutable object, except variable names and relation table contents.
+ * @param <C> base coefficient type.
+ * @author Heinz Kredel
+ */
+
+public class ResidueSolvableWordPolynomialRing<C extends GcdRingElem<C>> extends
+                GenSolvablePolynomialRing<WordResidue<C>> {
+
+
+    /*
+     * The solvable multiplication relations between variables and coefficients.
+     */
+    //public final RelationTable<WordResidue<C>> coeffTable;
+
+
+    /**
+     * Recursive solvable polynomial ring with polynomial coefficients.
+     */
+    public final RecSolvableWordPolynomialRing<C> polCoeff;
+
+
+    /**
+     * The constant polynomial 0 for this ring. Hides super ZERO.
+     */
+    public final ResidueSolvableWordPolynomial<C> ZERO;
+
+
+    /**
+     * The constant polynomial 1 for this ring. Hides super ONE.
+     */
+    public final ResidueSolvableWordPolynomial<C> ONE;
+
+
+    private static final Logger logger = LogManager.getLogger(ResidueSolvableWordPolynomialRing.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * default term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     */
+    public ResidueSolvableWordPolynomialRing(RingFactory<WordResidue<C>> cf, int n) {
+        this(cf, n, new TermOrder(), null, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * default term order.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param rt solvable multiplication relations.
+     */
+    public ResidueSolvableWordPolynomialRing(RingFactory<WordResidue<C>> cf, int n,
+                    RelationTable<WordResidue<C>> rt) {
+        this(cf, n, new TermOrder(), null, rt);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     */
+    public ResidueSolvableWordPolynomialRing(RingFactory<WordResidue<C>> cf, int n, TermOrder t) {
+        this(cf, n, t, null, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     * @param rt solvable multiplication relations.
+     */
+    public ResidueSolvableWordPolynomialRing(RingFactory<WordResidue<C>> cf, int n, TermOrder t,
+                    RelationTable<WordResidue<C>> rt) {
+        this(cf, n, t, null, rt);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     * @param v names for the variables.
+     */
+    public ResidueSolvableWordPolynomialRing(RingFactory<WordResidue<C>> cf, int n, TermOrder t, String[] v) {
+        this(cf, n, t, v, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param t a term order.
+     * @param v names for the variables.
+     */
+    public ResidueSolvableWordPolynomialRing(RingFactory<WordResidue<C>> cf, TermOrder t, String[] v) {
+        this(cf, v.length, t, v, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * default term order.
+     * @param cf factory for coefficients of type C.
+     * @param v names for the variables.
+     */
+    public ResidueSolvableWordPolynomialRing(RingFactory<WordResidue<C>> cf, String[] v) {
+        this(cf, v.length, new TermOrder(), v, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     * @param v names for the variables.
+     * @param rt solvable multiplication relations.
+     */
+    public ResidueSolvableWordPolynomialRing(RingFactory<WordResidue<C>> cf, int n, TermOrder t, String[] v,
+                    RelationTable<WordResidue<C>> rt) {
+        super(cf, n, t, v, rt);
+        //if (rt == null) { // handled in super }
+        WordResidueRing<C> cfring = (WordResidueRing<C>) cf; // == coFac
+        polCoeff = new RecSolvableWordPolynomialRing<C>(cfring.ring, n, t, v);
+        if (table.size() > 0) { // TODO
+            ExpVector e = null;
+            ExpVector f = null;
+            GenSolvablePolynomial<GenWordPolynomial<C>> p = null;
+            polCoeff.table.update(e, f, p); // from rt
+        }
+        //coeffTable = new RelationTable<WordResidue<C>>(this, true);
+        ZERO = new ResidueSolvableWordPolynomial<C>(this);
+        WordResidue<C> coeff = coFac.getONE();
+        //evzero = ExpVector.create(nvar); // from super
+        ONE = new ResidueSolvableWordPolynomial<C>(this, coeff, evzero);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the the
+     * same term order, number of variables and variable names as the given
+     * polynomial factory, only the coefficient factories differ and the
+     * solvable multiplication relations are <b>empty</b>.
+     * @param cf factory for coefficients of type C.
+     * @param o other solvable polynomial ring.
+     */
+    public ResidueSolvableWordPolynomialRing(RingFactory<WordResidue<C>> cf,
+                    ResidueSolvableWordPolynomialRing o) {
+        this(cf, o.nvar, o.tord, o.getVars(), null);
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        String res = super.toString();
+        if (PrettyPrint.isTrue()) {
+            //res += "\n" + table.toString(vars);
+            res += "\n" + polCoeff.coeffTable.toString(vars);
+        } else {
+            res += ", #rel = " + table.size() + " + " + polCoeff.coeffTable.size();
+        }
+        return res;
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        StringBuffer s = new StringBuffer();
+        switch (Scripting.getLang()) {
+        case Ruby:
+            s.append("SolvPolyRing.new(");
+            break;
+        case Python:
+        default:
+            s.append("SolvPolyRing(");
+        }
+        if (coFac instanceof RingElem) {
+            s.append(((RingElem<WordResidue<C>>) coFac).toScriptFactory());
+        } else {
+            s.append(coFac.toScript().trim());
+        }
+        s.append(",\"" + varsToString() + "\",");
+        String to = tord.toScript();
+        s.append(to);
+        if (table.size() > 0) {
+            String rel = table.toScript();
+            s.append(",rel=");
+            s.append(rel);
+        }
+        if (polCoeff.coeffTable.size() > 0) {
+            String rel = polCoeff.coeffTable.toScript();
+            s.append(",coeffrel=");
+            s.append(rel);
+        }
+        s.append(")");
+        return s.toString();
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        }
+        if (!(other instanceof ResidueSolvableWordPolynomialRing)) {
+            return false;
+        }
+        // do a super.equals( )
+        if (!super.equals(other)) {
+            return false;
+        }
+        ResidueSolvableWordPolynomialRing<C> oring = (ResidueSolvableWordPolynomialRing<C>) other;
+        // check same base relations done in super
+        if (!polCoeff.coeffTable.equals(oring.polCoeff.coeffTable)) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Hash code for this polynomial ring.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = super.hashCode();
+        h = 37 * h + table.hashCode(); // may be different after some computations
+        h = 37 * h + polCoeff.coeffTable.hashCode(); // may be different
+        return h;
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as ResidueSolvableWordPolynomial<C>.
+     */
+    @Override
+    public ResidueSolvableWordPolynomial<C> getZERO() {
+        return ZERO;
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as ResidueSolvableWordPolynomial<C>.
+     */
+    @Override
+    public ResidueSolvableWordPolynomial<C> getONE() {
+        return ONE;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true if this ring is commutative, else false.
+     */
+    @Override
+    public boolean isCommutative() {
+        if (polCoeff.coeffTable.isEmpty()) {
+            return super.isCommutative();
+        }
+        return false;
+    }
+
+
+    /**
+     * Query if this ring is associative. Test if the relations between the mian
+     * variables and the coefficient generators define an associative solvable
+     * ring.
+     * @return true, if this ring is associative, else false.
+     */
+    @SuppressWarnings("unused")
+    @Override
+    public boolean isAssociative() {
+        if (!coFac.isAssociative()) {
+            return false;
+        }
+        ResidueSolvableWordPolynomial<C> Xi, Xj, Xk, p, q;
+        List<GenPolynomial<WordResidue<C>>> gens = generators();
+        //System.out.println("Rec word gens = " + gens);
+        int ngen = gens.size();
+        for (int i = 0; i < ngen; i++) {
+            Xi = (ResidueSolvableWordPolynomial<C>) gens.get(i);
+            if (Xi.isONE()) {
+                continue;
+            }
+            for (int j = i + 1; j < ngen; j++) {
+                Xj = (ResidueSolvableWordPolynomial<C>) gens.get(j);
+                for (int k = j + 1; k < ngen; k++) {
+                    Xk = (ResidueSolvableWordPolynomial<C>) gens.get(k);
+                    try {
+                        p = Xk.multiply(Xj).multiply(Xi);
+                        q = Xk.multiply(Xj.multiply(Xi));
+                        if (!p.equals(q)) {
+                            if (logger.isInfoEnabled()) {
+                                logger.info("Xk = " + Xk + ", Xj = " + Xj + ", Xi = " + Xi);
+                                logger.info("p = ( Xk * Xj ) * Xi = " + p);
+                                logger.info("q = Xk * ( Xj * Xi ) = " + q);
+                            }
+                            return false;
+                        }
+                    } catch (RuntimeException e) {
+                        e.printStackTrace();
+                        System.out.println("Xk = " + Xk + ", Xj = " + Xj + ", Xi = " + Xi);
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Get a (constant) ResidueSolvableWordPolynomial&lt;C&gt; element from a
+     * coefficient value.
+     * @param a coefficient.
+     * @return a ResidueSolvableWordPolynomial&lt;C&gt;.
+     */
+    @Override
+    public ResidueSolvableWordPolynomial<C> valueOf(WordResidue<C> a) {
+        return new ResidueSolvableWordPolynomial<C>(this, a, evzero);
+    }
+
+
+    /**
+     * Get a ResidueSolvableWordPolynomial&lt;C&gt; element from an ExpVector.
+     * @param e exponent vector.
+     * @return a ResidueSolvableWordPolynomial&lt;C&gt;.
+     */
+    @Override
+    public ResidueSolvableWordPolynomial<C> valueOf(ExpVector e) {
+        return valueOf(coFac.getONE(), e);
+    }
+
+
+    /**
+     * Get a ResidueSolvableWordPolynomial&lt;C&gt; element from a coeffcient
+     * and an ExpVector.
+     * @param a coefficient.
+     * @param e exponent vector.
+     * @return a ResidueSolvableWordPolynomial&lt;C&gt;.
+     */
+    @Override
+    public ResidueSolvableWordPolynomial<C> valueOf(WordResidue<C> a, ExpVector e) {
+        return new ResidueSolvableWordPolynomial<C>(this, a, e);
+    }
+
+
+    /**
+     * Get a (constant) ResidueSolvableWordPolynomial&lt;C&gt; element from a
+     * long value.
+     * @param a long.
+     * @return a ResidueSolvableWordPolynomial&lt;C&gt;.
+     */
+    @Override
+    public ResidueSolvableWordPolynomial<C> fromInteger(long a) {
+        return new ResidueSolvableWordPolynomial<C>(this, coFac.fromInteger(a), evzero);
+    }
+
+
+    /**
+     * Get a (constant) ResidueSolvableWordPolynomial&lt;C&gt; element from a
+     * BigInteger value.
+     * @param a BigInteger.
+     * @return a ResidueSolvableWordPolynomial&lt;C&gt;.
+     */
+    @Override
+    public ResidueSolvableWordPolynomial<C> fromInteger(BigInteger a) {
+        return new ResidueSolvableWordPolynomial<C>(this, coFac.fromInteger(a), evzero);
+    }
+
+
+    /**
+     * Random solvable polynomial. Generates a random solvable polynomial with k
+     * = 5, l = n, d = (nvar == 1) ? n : 3, q = (nvar == 1) ? 0.7 : 0.3.
+     * @param n number of terms.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    public ResidueSolvableWordPolynomial<C> random(int n) {
+        return random(n, random);
+    }
+
+
+    /**
+     * Random solvable polynomial. Generates a random solvable polynomial with k
+     * = 5, l = n, d = (nvar == 1) ? n : 3, q = (nvar == 1) ? 0.7 : 0.3.
+     * @param n number of terms.
+     * @param rnd is a source for random bits.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    public ResidueSolvableWordPolynomial<C> random(int n, Random rnd) {
+        if (nvar == 1) {
+            return random(5, n, n, 0.7f, rnd);
+        }
+        return random(5, n, 3, 0.3f, rnd);
+    }
+
+
+    /**
+     * Generate a random solvable polynomial.
+     * @param k bitsize of random coefficients.
+     * @param l number of terms.
+     * @param d maximal degree in each variable.
+     * @param q density of nozero exponents.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    public ResidueSolvableWordPolynomial<C> random(int k, int l, int d, float q) {
+        return random(k, l, d, q, random);
+    }
+
+
+    /**
+     * Random solvable polynomial.
+     * @param k size of random coefficients.
+     * @param l number of terms.
+     * @param d maximal degree in each variable.
+     * @param q density of nozero exponents.
+     * @param rnd is a source for random bits.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    public ResidueSolvableWordPolynomial<C> random(int k, int l, int d, float q, Random rnd) {
+        ResidueSolvableWordPolynomial<C> r = getZERO(); // copy( ZERO ); 
+        ExpVector e;
+        WordResidue<C> a;
+        // add random coeffs and exponents
+        for (int i = 0; i < l; i++) {
+            e = ExpVector.random(nvar, d, q, rnd);
+            a = coFac.random(k, rnd);
+            r = (ResidueSolvableWordPolynomial<C>) r.sum(a, e);
+            // somewhat inefficient but clean
+        }
+        return r;
+    }
+
+
+    /**
+     * Copy polynomial c.
+     * @param c
+     * @return a copy of c.
+     */
+    public ResidueSolvableWordPolynomial<C> copy(ResidueSolvableWordPolynomial<C> c) {
+        return new ResidueSolvableWordPolynomial<C>(this, c.getMap());
+    }
+
+
+    /**
+     * Parse a solvable polynomial with the use of GenPolynomialTokenizer
+     * @param s String.
+     * @return ResidueSolvableWordPolynomial from s.
+     */
+    @Override
+    public ResidueSolvableWordPolynomial<C> parse(String s) {
+        return parse(new StringReader(s));
+    }
+
+
+    /**
+     * Parse a solvable polynomial with the use of GenPolynomialTokenizer
+     * @param r Reader.
+     * @return next ResidueSolvableWordPolynomial from r.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public ResidueSolvableWordPolynomial<C> parse(Reader r) {
+        GenPolynomialTokenizer pt = new GenPolynomialTokenizer(this, r);
+        ResidueSolvableWordPolynomial<C> p = null;
+        try {
+            GenSolvablePolynomial<WordResidue<C>> s = pt.nextSolvablePolynomial();
+            p = new ResidueSolvableWordPolynomial<C>(this, s);
+        } catch (IOException e) {
+            logger.error(e.toString() + " parse " + this);
+            p = ZERO;
+        }
+        return p;
+    }
+
+
+    /**
+     * Generate univariate solvable polynomial in a given variable.
+     * @param i the index of the variable.
+     * @return X_i as solvable univariate polynomial.
+     */
+    @Override
+    public ResidueSolvableWordPolynomial<C> univariate(int i) {
+        return (ResidueSolvableWordPolynomial<C>) super.univariate(i);
+    }
+
+
+    /**
+     * Generate univariate solvable polynomial in a given variable with given
+     * exponent.
+     * @param i the index of the variable.
+     * @param e the exponent of the variable.
+     * @return X_i^e as solvable univariate polynomial.
+     */
+    @Override
+    public ResidueSolvableWordPolynomial<C> univariate(int i, long e) {
+        return (ResidueSolvableWordPolynomial<C>) super.univariate(i, e);
+    }
+
+
+    /**
+     * Generate univariate solvable polynomial in a given variable with given
+     * exponent.
+     * @param modv number of module variables.
+     * @param i the index of the variable.
+     * @param e the exponent of the variable.
+     * @return X_i^e as solvable univariate polynomial.
+     */
+    @Override
+    public ResidueSolvableWordPolynomial<C> univariate(int modv, int i, long e) {
+        return (ResidueSolvableWordPolynomial<C>) super.univariate(modv, i, e);
+    }
+
+
+    /**
+     * Generate list of univariate polynomials in all variables.
+     * @return List(X_1,...,X_n) a list of univariate polynomials.
+     */
+    @Override
+    public List<ResidueSolvableWordPolynomial<C>> univariateList() {
+        return univariateList(0, 1L);
+    }
+
+
+    /**
+     * Generate list of univariate polynomials in all variables.
+     * @param modv number of module variables.
+     * @return List(X_1,...,X_n) a list of univariate polynomials.
+     */
+    @Override
+    public List<ResidueSolvableWordPolynomial<C>> univariateList(int modv) {
+        return univariateList(modv, 1L);
+    }
+
+
+    /**
+     * Generate list of univariate polynomials in all variables with given
+     * exponent.
+     * @param modv number of module variables.
+     * @param e the exponent of the variables.
+     * @return List(X_1^e,...,X_n^e) a list of univariate polynomials.
+     */
+    @Override
+    public List<ResidueSolvableWordPolynomial<C>> univariateList(int modv, long e) {
+        List<ResidueSolvableWordPolynomial<C>> pols = new ArrayList<ResidueSolvableWordPolynomial<C>>(nvar);
+        int nm = nvar - modv;
+        for (int i = 0; i < nm; i++) {
+            ResidueSolvableWordPolynomial<C> p = univariate(modv, nm - 1 - i, e);
+            pols.add(p);
+        }
+        return pols;
+    }
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by i.
+     * @param i number of variables to extend.
+     * @return extended solvable polynomial ring factory.
+     */
+    @Override
+    public ResidueSolvableWordPolynomialRing<C> extend(int i) {
+        return extend(i, false);
+    }
+
+    
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by i.
+     * @param i number of variables to extend.
+     * @param top true for TOP term order, false for POT term order.
+     * @return extended solvable polynomial ring factory.
+     */
+    @Override
+    public ResidueSolvableWordPolynomialRing<C> extend(int i, boolean top) {
+        GenSolvablePolynomialRing<WordResidue<C>> pfac = super.extend(i, top);
+        ResidueSolvableWordPolynomialRing<C> spfac = new ResidueSolvableWordPolynomialRing<C>(pfac.coFac,
+                        pfac.nvar, pfac.tord, pfac.getVars());
+        spfac.table.extend(this.table); 
+        spfac.polCoeff.coeffTable.extend(this.polCoeff.coeffTable);
+        return spfac;
+    }
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by length(vn). New variables commute with the exiting
+     * variables.
+     * @param vs names for extended variables.
+     * @return extended polynomial ring factory.
+     */
+    @Override
+    public ResidueSolvableWordPolynomialRing<C> extend(String[] vs) {
+        return extend(vs, false);
+    }
+
+    
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by length(vn). New variables commute with the exiting
+     * variables.
+     * @param vs names for extended variables.
+     * @param top true for TOP term order, false for POT term order.
+     * @return extended polynomial ring factory.
+     */
+    @Override
+    public ResidueSolvableWordPolynomialRing<C> extend(String[] vs, boolean top) {
+        GenSolvablePolynomialRing<WordResidue<C>> pfac = super.extend(vs, top);
+        ResidueSolvableWordPolynomialRing<C> spfac = new ResidueSolvableWordPolynomialRing<C>(pfac.coFac,
+                        pfac.nvar, pfac.tord, pfac.getVars());
+        spfac.table.extend(this.table); 
+        spfac.polCoeff.coeffTable.extend(this.polCoeff.coeffTable);
+        return spfac;
+    }
+
+
+    /**
+     * Contract variables. Used e.g. in module embedding. Contract number of
+     * variables by i.
+     * @param i number of variables to remove.
+     * @return contracted solvable polynomial ring factory.
+     */
+    @Override
+    public ResidueSolvableWordPolynomialRing<C> contract(int i) {
+        GenPolynomialRing<WordResidue<C>> pfac = super.contract(i);
+        ResidueSolvableWordPolynomialRing<C> spfac = new ResidueSolvableWordPolynomialRing<C>(pfac.coFac,
+                        pfac.nvar, pfac.tord, pfac.getVars()); 
+        spfac.table.contract(this.table);
+        spfac.polCoeff.coeffTable.contract(this.polCoeff.coeffTable);
+        return spfac;
+    }
+
+
+    /**
+     * Reverse variables. Used e.g. in opposite rings.
+     * @return solvable polynomial ring factory with reversed variables.
+     */
+    @Override
+    public ResidueSolvableWordPolynomialRing<C> reverse() {
+        return reverse(false);
+    }
+
+
+    /**
+     * Reverse variables. Used e.g. in opposite rings.
+     * @param partial true for partialy reversed term orders.
+     * @return solvable polynomial ring factory with reversed variables.
+     */
+    @Override
+    public ResidueSolvableWordPolynomialRing<C> reverse(boolean partial) {
+        GenPolynomialRing<WordResidue<C>> pfac = super.reverse(partial);
+        ResidueSolvableWordPolynomialRing<C> spfac = new ResidueSolvableWordPolynomialRing<C>(pfac.coFac,
+                        pfac.nvar, pfac.tord, pfac.getVars()); //, pfac.table);
+        spfac.partial = partial;
+        spfac.table.reverse(this.table);
+        spfac.polCoeff.coeffTable.reverse(this.polCoeff.coeffTable);
+        return spfac;
+    }
+
+
+    /* not possible:
+     * Distributive representation as polynomial with all main variables.
+     * @return distributive polynomial ring factory.
+    @SuppressWarnings({"cast","unchecked"})
+    public static <C extends RingElem<C>> // must be static because of types
+       GenSolvablePolynomialRing<C> distribute(ResidueSolvableWordPolynomialRing<C> rf) {
+    }
+     */
+
+
+    /**
+     * Permutation of polynomial ring variables.
+     * @param P permutation.
+     * @return P(this).
+     */
+    @Override
+    public GenSolvablePolynomialRing<WordResidue<C>> permutation(List<Integer> P) {
+        if (!polCoeff.coeffTable.isEmpty()) {
+            throw new UnsupportedOperationException("permutation with coeff relations: " + this);
+        }
+        GenSolvablePolynomialRing<WordResidue<C>> pfac = (GenSolvablePolynomialRing<WordResidue<C>>) super
+                        .permutation(P);
+        return pfac;
+    }
+
+
+    /**
+     * Word residue coefficients from integral word polynomial coefficients.
+     * Represent as polynomial with type WordResidue<C> coefficients.
+     * @param A polynomial with integral word polynomial coefficients to be
+     *            converted.
+     * @return polynomial with type WordResidue<C> coefficients.
+     */
+    public ResidueSolvableWordPolynomial<C> fromPolyCoefficients(GenSolvablePolynomial<GenWordPolynomial<C>> A) {
+        ResidueSolvableWordPolynomial<C> B = getZERO().copy();
+        if (A == null || A.isZERO()) {
+            return B;
+        }
+        RingFactory<WordResidue<C>> cfac = coFac;
+        WordResidueRing<C> qfac = (WordResidueRing<C>) cfac;
+        for (Map.Entry<ExpVector, GenWordPolynomial<C>> y : A.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            GenWordPolynomial<C> a = y.getValue();
+            WordResidue<C> p = new WordResidue<C>(qfac, a); // can be zero
+            if (!p.isZERO()) {
+                //B = B.sum( p, e ); // inefficient
+                B.doPutToMap(e, p);
+            }
+        }
+        return B;
+    }
+
+
+    /**
+     * Integral word function from word residue coefficients. Represent as
+     * polynomial with type GenWordPolynomial<C> coefficients.
+     * @param A polynomial with word residue coefficients to be converted.
+     * @return polynomial with type GenWordPolynomial<C> coefficients.
+     */
+    public RecSolvableWordPolynomial<C> toPolyCoefficients(ResidueSolvableWordPolynomial<C> A) {
+        RecSolvableWordPolynomial<C> B = polCoeff.getZERO().copy();
+        if (A == null || A.isZERO()) {
+            return B;
+        }
+        for (Map.Entry<ExpVector, WordResidue<C>> y : A.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            WordResidue<C> a = y.getValue();
+            GenWordPolynomial<C> p = a.val; // can not be zero
+            if (!p.isZERO()) {
+                //B = B.sum( p, e ); // inefficient
+                B.doPutToMap(e, p);
+            }
+        }
+        return B;
+    }
+
+
+    /**
+     * Integral word function from word residue coefficients. Represent as
+     * polynomial with type GenWordPolynomial<C> coefficients.
+     * @param A polynomial with word residue coefficients to be converted.
+     * @return polynomial with type GenWordPolynomial<C> coefficients.
+     */
+    public RecSolvableWordPolynomial<C> toPolyCoefficients(GenPolynomial<WordResidue<C>> A) {
+        RecSolvableWordPolynomial<C> B = polCoeff.getZERO().copy();
+        if (A == null || A.isZERO()) {
+            return B;
+        }
+        for (Map.Entry<ExpVector, WordResidue<C>> y : A.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            WordResidue<C> a = y.getValue();
+            GenWordPolynomial<C> p = a.val; // can not be zero
+            if (!p.isZERO()) {
+                //B = B.sum( p, e ); // inefficient
+                B.doPutToMap(e, p);
+            }
+        }
+        return B;
+    }
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/RingFactoryTokenizer.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/RingFactoryTokenizer.java
@@ -1,0 +1,961 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StreamTokenizer;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Scanner;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.arith.BigComplex;
+import edu.jas.arith.BigDecimal;
+import edu.jas.arith.BigInteger;
+import edu.jas.arith.BigQuaternion;
+import edu.jas.arith.BigQuaternionRing;
+import edu.jas.arith.BigRational;
+import edu.jas.arith.ModInteger;
+import edu.jas.arith.ModIntegerRing;
+import edu.jas.arith.ModIntRing;
+import edu.jas.arith.ModLongRing;
+import edu.jas.poly.AlgebraicNumberRing;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.GenPolynomialTokenizer;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.GenSolvablePolynomialRing;
+import edu.jas.poly.InvalidExpressionException;
+import edu.jas.poly.RelationTable;
+import edu.jas.poly.TermOrder;
+import edu.jas.structure.RingFactory;
+import edu.jas.ufd.Quotient;
+import edu.jas.ufd.QuotientRing;
+
+
+/**
+ * RingFactory Tokenizer. Used to read ring factories from input streams. It can
+ * also read QuotientRing factory.
+ * @see edu.jas.poly.GenPolynomialTokenizer
+ * @author Heinz Kredel
+ */
+public class RingFactoryTokenizer {
+
+
+    private static final Logger logger = LogManager.getLogger(RingFactoryTokenizer.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    private String[] vars;
+
+
+    private int nvars = 1;
+
+
+    private TermOrder tord;
+
+
+    private RelationTable table;
+
+
+    private final StreamTokenizer tok;
+
+
+    private final Reader reader;
+
+
+    private RingFactory fac;
+
+
+    private static enum coeffType {
+        BigRat, BigInt, ModInt, BigC, BigQ, BigD, ANrat, ANmod, RatFunc, ModFunc, IntFunc
+    };
+
+
+    private coeffType parsedCoeff = coeffType.BigRat;
+
+
+    private GenPolynomialRing pfac;
+
+
+    private static enum polyType {
+        PolBigRat, PolBigInt, PolModInt, PolBigC, PolBigD, PolBigQ, PolANrat, PolANmod, PolRatFunc, PolModFunc, PolIntFunc
+    };
+
+
+    @SuppressWarnings("unused")
+    private polyType parsedPoly = polyType.PolBigRat;
+
+
+    private GenSolvablePolynomialRing spfac;
+
+
+    /**
+     * No-args constructor reads from System.in.
+     */
+    public RingFactoryTokenizer() {
+        this(new BufferedReader(new InputStreamReader(System.in, Charset.forName("UTF8"))));
+    }
+
+
+    /**
+     * Constructor with Ring and Reader.
+     * @param rf ring factory.
+     * @param r reader stream.
+     */
+    public RingFactoryTokenizer(GenPolynomialRing rf, Reader r) {
+        this(r);
+        if (rf == null) {
+            return;
+        }
+        if (rf instanceof GenSolvablePolynomialRing) {
+            pfac = rf;
+            spfac = (GenSolvablePolynomialRing) rf;
+        } else {
+            pfac = rf;
+            spfac = null;
+        }
+        fac = rf.coFac;
+        vars = rf.getVars();
+        if (vars != null) {
+            nvars = vars.length;
+        }
+        tord = rf.tord;
+        // relation table
+        if (spfac != null) {
+            table = spfac.table;
+        } else {
+            table = null;
+        }
+    }
+
+
+    /**
+     * Constructor with Reader.
+     * @param r reader stream.
+     */
+    @SuppressWarnings("unchecked")
+    public RingFactoryTokenizer(Reader r) {
+        vars = null;
+        tord = new TermOrder();
+        nvars = 1;
+        fac = new BigRational(1);
+
+        pfac = new GenPolynomialRing<BigRational>(fac, nvars, tord, vars);
+        spfac = new GenSolvablePolynomialRing<BigRational>(fac, nvars, tord, vars);
+
+        reader = r;
+        tok = new StreamTokenizer(reader);
+        tok.resetSyntax();
+        // tok.eolIsSignificant(true); no more
+        tok.eolIsSignificant(false);
+        tok.wordChars('0', '9');
+        tok.wordChars('a', 'z');
+        tok.wordChars('A', 'Z');
+        tok.wordChars('_', '_'); // for subscripts x_i
+        tok.wordChars('/', '/'); // wg. rational numbers
+        tok.wordChars('.', '.'); // wg. floats
+        tok.wordChars('~', '~'); // wg. quaternions // unused in this class
+        tok.wordChars(128 + 32, 255);
+        tok.whitespaceChars(0, ' ');
+        tok.commentChar('#');
+        tok.quoteChar('"');
+        tok.quoteChar('\'');
+        //tok.slashStarComments(true); does not work
+
+    }
+
+
+    /**
+     * Initialize coefficient and polynomial factories.
+     * @param rf ring factory.
+     * @param ct coefficient type.
+     */
+    @SuppressWarnings("unchecked")
+    public void initFactory(RingFactory rf, coeffType ct) {
+        fac = rf;
+        parsedCoeff = ct;
+
+        switch (ct) {
+        case BigRat:
+            pfac = new GenPolynomialRing<BigRational>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolBigRat;
+            break;
+        case BigInt:
+            pfac = new GenPolynomialRing<BigInteger>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolBigInt;
+            break;
+        case ModInt:
+            pfac = new GenPolynomialRing<ModInteger>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolModInt;
+            break;
+        case BigC:
+            pfac = new GenPolynomialRing<BigComplex>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolBigC;
+            break;
+        case BigQ:
+            pfac = new GenPolynomialRing<BigQuaternion>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolBigQ;
+            break;
+        case BigD:
+            pfac = new GenPolynomialRing<BigDecimal>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolBigD;
+            break;
+        case RatFunc:
+            pfac = new GenPolynomialRing<Quotient<BigInteger>>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolRatFunc;
+            break;
+        case ModFunc:
+            pfac = new GenPolynomialRing<Quotient<ModInteger>>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolModFunc;
+            break;
+        case IntFunc:
+            pfac = new GenPolynomialRing<GenPolynomial<BigRational>>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolIntFunc;
+            break;
+        default:
+            pfac = new GenPolynomialRing<BigRational>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolBigRat;
+        }
+    }
+
+
+    /**
+     * Initialize coefficient and solvable polynomial factories.
+     * @param rf ring factory.
+     * @param ct coefficient type.
+     */
+    @SuppressWarnings("unchecked")
+    public void initSolvableFactory(RingFactory rf, coeffType ct) {
+        fac = rf;
+        parsedCoeff = ct;
+
+        switch (ct) {
+        case BigRat:
+            spfac = new GenSolvablePolynomialRing<BigRational>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolBigRat;
+            break;
+        case BigInt:
+            spfac = new GenSolvablePolynomialRing<BigInteger>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolBigInt;
+            break;
+        case ModInt:
+            spfac = new GenSolvablePolynomialRing<ModInteger>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolModInt;
+            break;
+        case BigC:
+            spfac = new GenSolvablePolynomialRing<BigComplex>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolBigC;
+            break;
+        case BigQ:
+            spfac = new GenSolvablePolynomialRing<BigQuaternion>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolBigQ;
+            break;
+        case BigD:
+            spfac = new GenSolvablePolynomialRing<BigDecimal>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolBigD;
+            break;
+        case RatFunc:
+            spfac = new GenSolvablePolynomialRing<Quotient<BigInteger>>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolRatFunc;
+            break;
+        case ModFunc:
+            spfac = new GenSolvablePolynomialRing<Quotient<ModInteger>>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolModFunc;
+            break;
+        case IntFunc:
+            spfac = new GenSolvablePolynomialRing<GenPolynomial<BigRational>>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolIntFunc;
+            break;
+        default:
+            spfac = new GenSolvablePolynomialRing<BigRational>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolBigRat;
+        }
+    }
+
+
+    /**
+     * Parsing method for variable list. Syntax:
+     * 
+     * <pre>
+     * (a, b c, de)
+     * </pre>
+     * 
+     * gives <code>[ "a", "b", "c", "de" ]</code>
+     * @return the next variable list.
+     * @throws IOException
+     */
+    public String[] nextVariableList() throws IOException {
+        List<String> l = new ArrayList<String>();
+        int tt;
+        tt = tok.nextToken();
+        //System.out.println("vList tok = " + tok);
+        if (tt == '(' || tt == '{') {
+            logger.debug("variable list");
+            tt = tok.nextToken();
+            while (true) {
+                if (tt == StreamTokenizer.TT_EOF)
+                    break;
+                if (tt == ')' || tt == '}')
+                    break;
+                if (tt == StreamTokenizer.TT_WORD) {
+                    //System.out.println("TT_WORD: " + tok.sval);
+                    l.add(tok.sval);
+                }
+                tt = tok.nextToken();
+            }
+        } else {
+            tok.pushBack();
+        }
+        Object[] ol = l.toArray();
+        String[] v = new String[ol.length];
+        for (int i = 0; i < v.length; i++) {
+            v[i] = (String) ol[i];
+        }
+        return v;
+    }
+
+
+    /**
+     * Parsing method for coefficient ring. Syntax:
+     * 
+     * <pre>
+     * Rat | Q | Int | Z | Mod modul | Complex | C | D | Quat |
+    AN[ (var) ( poly ) | AN[ modul (var) ( poly ) ] | 
+    RatFunc (var_list) | ModFunc modul (var_list) | IntFunc (var_list)
+     * </pre>
+     * 
+     * @return the next coefficient factory.
+     * @throws IOException
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    public RingFactory nextCoefficientRing() throws IOException {
+        RingFactory coeff = null;
+        coeffType ct = null;
+        int tt;
+        tt = tok.nextToken();
+        if (tok.sval != null) {
+            if (tok.sval.equalsIgnoreCase("Q")) {
+                coeff = new BigRational(0);
+                ct = coeffType.BigRat;
+            } else if (tok.sval.equalsIgnoreCase("Rat")) {
+                coeff = new BigRational(0);
+                ct = coeffType.BigRat;
+            } else if (tok.sval.equalsIgnoreCase("D")) {
+                coeff = new BigDecimal(0);
+                ct = coeffType.BigD;
+            } else if (tok.sval.equalsIgnoreCase("Z")) {
+                coeff = new BigInteger(0);
+                ct = coeffType.BigInt;
+            } else if (tok.sval.equalsIgnoreCase("Int")) {
+                coeff = new BigInteger(0);
+                ct = coeffType.BigInt;
+            } else if (tok.sval.equalsIgnoreCase("C")) {
+                coeff = new BigComplex(0);
+                ct = coeffType.BigC;
+            } else if (tok.sval.equalsIgnoreCase("Complex")) {
+                coeff = new BigComplex(0);
+                ct = coeffType.BigC;
+            } else if (tok.sval.equalsIgnoreCase("Quat")) {
+                logger.warn("parse of quaternion coefficients may fail for negative components (use ~ for -)");
+                coeff = new BigQuaternionRing();
+                ct = coeffType.BigQ;
+            } else if (tok.sval.equalsIgnoreCase("Mod")) {
+                tt = tok.nextToken();
+                boolean openb = false;
+                if (tt == '[') { // optional
+                    openb = true;
+                    tt = tok.nextToken();
+                }
+                if (tok.sval != null && tok.sval.length() > 0) {
+                    if (digit(tok.sval.charAt(0))) {
+                        BigInteger mo = new BigInteger(tok.sval);
+                        BigInteger lm = new BigInteger(ModLongRing.MAX_LONG); //wrong: Long.MAX_VALUE);
+                        if (mo.compareTo(lm) < 0) {
+			    if (mo.compareTo(new BigInteger(ModIntRing.MAX_INT)) < 0) {
+                                coeff = new ModIntRing(mo.getVal());
+			    } else {
+                                coeff = new ModLongRing(mo.getVal());
+			    }
+                        } else {
+                            coeff = new ModIntegerRing(mo.getVal());
+                        }
+                        //System.out.println("coeff = " + coeff + " :: " + coeff.getClass());
+                        ct = coeffType.ModInt;
+                    } else {
+                        tok.pushBack();
+                    }
+                } else {
+                    tok.pushBack();
+                }
+                if (tt == ']' && openb) { // optional
+                    tt = tok.nextToken();
+                }
+            } else if (tok.sval.equalsIgnoreCase("RatFunc")) {
+                String[] rfv = nextVariableList();
+                //System.out.println("rfv = " + rfv.length + " " + rfv[0]);
+                int vr = rfv.length;
+                BigInteger bi = new BigInteger();
+                TermOrder to = new TermOrder(TermOrder.INVLEX);
+                GenPolynomialRing<BigInteger> pcf = new GenPolynomialRing<BigInteger>(bi, vr, to, rfv);
+                coeff = new QuotientRing(pcf);
+                ct = coeffType.RatFunc;
+            } else if (tok.sval.equalsIgnoreCase("ModFunc")) {
+                tt = tok.nextToken();
+                RingFactory mi = new ModIntegerRing("19");
+                if (tok.sval != null && tok.sval.length() > 0) {
+                    if (digit(tok.sval.charAt(0))) {
+                        mi = new ModIntegerRing(tok.sval);
+                    } else {
+                        tok.pushBack();
+                    }
+                } else {
+                    tok.pushBack();
+                }
+                String[] rfv = nextVariableList();
+                //System.out.println("rfv = " + rfv.length + " " + rfv[0]);
+                int vr = rfv.length;
+                TermOrder to = new TermOrder(TermOrder.INVLEX);
+                GenPolynomialRing<ModInteger> pcf = new GenPolynomialRing<ModInteger>(mi, vr, to, rfv);
+                coeff = new QuotientRing(pcf);
+                ct = coeffType.ModFunc;
+            } else if (tok.sval.equalsIgnoreCase("IntFunc")) {
+                String[] rfv = nextVariableList();
+                //System.out.println("rfv = " + rfv.length + " " + rfv[0]);
+                int vr = rfv.length;
+                BigRational bi = new BigRational();
+                TermOrder to = new TermOrder(TermOrder.INVLEX);
+                GenPolynomialRing<BigRational> pcf = new GenPolynomialRing<BigRational>(bi, vr, to, rfv);
+                coeff = pcf;
+                ct = coeffType.IntFunc;
+            } else if (tok.sval.equalsIgnoreCase("AN")) {
+                tt = tok.nextToken();
+                if (tt == '[') {
+                    tt = tok.nextToken();
+                    RingFactory tcfac = new ModIntegerRing("19");
+                    if (tok.sval != null && tok.sval.length() > 0) {
+                        if (digit(tok.sval.charAt(0))) {
+                            tcfac = new ModIntegerRing(tok.sval);
+                        } else {
+                            tcfac = new BigRational();
+                            tok.pushBack();
+                        }
+                    } else {
+                        tcfac = new BigRational();
+                        tok.pushBack();
+                    }
+                    String[] anv = nextVariableList();
+                    //System.out.println("anv = " + anv.length + " " + anv[0]);
+                    int vs = anv.length;
+                    if (vs != 1) {
+                        throw new InvalidExpressionException(
+                                        "AlgebraicNumber only for univariate polynomials "
+                                                        + Arrays.toString(anv));
+                    }
+                    String[] ovars = vars;
+                    vars = anv;
+                    GenPolynomialRing tpfac = pfac;
+                    RingFactory tfac = fac;
+                    fac = tcfac;
+                    // pfac and fac used in nextPolynomial()
+                    if (tcfac instanceof ModIntegerRing) {
+                        pfac = new GenPolynomialRing<ModInteger>(tcfac, vs, new TermOrder(), anv);
+                    } else {
+                        pfac = new GenPolynomialRing<BigRational>(tcfac, vs, new TermOrder(), anv);
+                    }
+                    if (debug) {
+                        logger.debug("pfac = " + pfac);
+                    }
+                    GenPolynomialTokenizer ptok = new GenPolynomialTokenizer(pfac, reader);
+                    GenPolynomial mod = ptok.nextPolynomial();
+                    ptok = null;
+                    if (debug) {
+                        logger.debug("mod = " + mod);
+                    }
+                    pfac = tpfac;
+                    fac = tfac;
+                    vars = ovars;
+                    if (tcfac instanceof ModIntegerRing) {
+                        GenPolynomial<ModInteger> gfmod;
+                        gfmod = (GenPolynomial<ModInteger>) mod;
+                        coeff = new AlgebraicNumberRing<ModInteger>(gfmod);
+                        ct = coeffType.ANmod;
+                    } else {
+                        GenPolynomial<BigRational> anmod;
+                        anmod = (GenPolynomial<BigRational>) mod;
+                        coeff = new AlgebraicNumberRing<BigRational>(anmod);
+                        ct = coeffType.ANrat;
+                    }
+                    if (debug) {
+                        logger.debug("coeff = " + coeff);
+                    }
+                    tt = tok.nextToken();
+                    if (tt == ']') {
+                        //ok, no nextToken();
+                    } else {
+                        tok.pushBack();
+                    }
+                } else {
+                    tok.pushBack();
+                }
+            }
+        }
+        if (coeff == null) {
+            tok.pushBack();
+            coeff = new BigRational();
+            ct = coeffType.BigRat;
+        }
+        parsedCoeff = ct;
+        return coeff;
+    }
+
+
+    /**
+     * Parsing method for weight list. Syntax:
+     * 
+     * <pre>
+     * (w1, w2, w3, ..., wn)
+     * </pre>
+     * 
+     * @return the next weight list.
+     * @throws IOException
+     */
+    public long[] nextWeightList() throws IOException {
+        List<Long> l = new ArrayList<Long>();
+        long e;
+        char first;
+        int tt;
+        tt = tok.nextToken();
+        if (tt == '(') {
+            logger.debug("weight list");
+            tt = tok.nextToken();
+            while (true) {
+                if (tt == StreamTokenizer.TT_EOF)
+                    break;
+                if (tt == ')')
+                    break;
+                if (tok.sval != null) {
+                    first = tok.sval.charAt(0);
+                    if (digit(first)) {
+                        e = Long.parseLong(tok.sval);
+                        l.add(Long.valueOf(e));
+                        //System.out.println("w: " + e);
+                    }
+                }
+                tt = tok.nextToken(); // also comma
+            }
+        } else {
+            tok.pushBack();
+        }
+        Long[] ol = new Long[1];
+        ol = l.toArray(ol);
+        long[] w = new long[ol.length];
+        for (int i = 0; i < w.length; i++) {
+            w[i] = ol[ol.length - i - 1].longValue();
+        }
+        return w;
+    }
+
+
+    /**
+     * Parsing method for weight array. Syntax:
+     * 
+     * <pre>
+     * ( (w11, ...,w1n), ..., (wm1, ..., wmn) )
+     * </pre>
+     * 
+     * @return the next weight array.
+     * @throws IOException
+     */
+    public long[][] nextWeightArray() throws IOException {
+        List<long[]> l = new ArrayList<long[]>();
+        long[][] w = null;
+        long[] e;
+        char first;
+        int tt;
+        tt = tok.nextToken();
+        if (tt == '(') {
+            logger.debug("weight array");
+            tt = tok.nextToken();
+            while (true) {
+                if (tt == StreamTokenizer.TT_EOF)
+                    break;
+                if (tt == ')')
+                    break;
+                if (tt == '(') {
+                    tok.pushBack();
+                    e = nextWeightList();
+                    l.add(e);
+                    //System.out.println("wa: " + e);
+                } else if (tok.sval != null) {
+                    first = tok.sval.charAt(0);
+                    if (digit(first)) {
+                        tok.pushBack();
+                        tok.pushBack();
+                        e = nextWeightList();
+                        l.add(e);
+                        break;
+                        //System.out.println("w: " + e);
+                    }
+                }
+                tt = tok.nextToken(); // also comma
+            }
+        } else {
+            tok.pushBack();
+        }
+        Object[] ol = l.toArray();
+        w = new long[ol.length][];
+        for (int i = 0; i < w.length; i++) {
+            w[i] = (long[]) ol[i];
+        }
+        return w;
+    }
+
+
+    /**
+     * Parsing method for split index. Syntax:
+     * 
+     * <pre>
+     * |i|
+     * </pre>
+     * 
+     * @return the next split index.
+     * @throws IOException
+     */
+    public int nextSplitIndex() throws IOException {
+        int e = -1; // =unknown
+        int e0 = -1; // =unknown
+        char first;
+        int tt;
+        tt = tok.nextToken();
+        if (tt == '|') {
+            if (debug) {
+                logger.debug("split index");
+            }
+            tt = tok.nextToken();
+            if (tt == StreamTokenizer.TT_EOF) {
+                return e;
+            }
+            if (tok.sval != null) {
+                first = tok.sval.charAt(0);
+                if (digit(first)) {
+                    e = Integer.parseInt(tok.sval);
+                    //System.out.println("w: " + i);
+                }
+                tt = tok.nextToken();
+                if (tt != '|') {
+                    tok.pushBack();
+                }
+            }
+        } else if (tt == '[') {
+            if (debug) {
+                logger.debug("split index");
+            }
+            tt = tok.nextToken();
+            if (tt == StreamTokenizer.TT_EOF) {
+                return e;
+            }
+            if (tok.sval != null) {
+                first = tok.sval.charAt(0);
+                if (digit(first)) {
+                    e0 = Integer.parseInt(tok.sval);
+                    //System.out.println("w: " + i);
+                }
+                tt = tok.nextToken();
+                if (tt == ',') {
+                    tt = tok.nextToken();
+                    if (tt == StreamTokenizer.TT_EOF) {
+                        return e0;
+                    }
+                    if (tok.sval != null) {
+                        first = tok.sval.charAt(0);
+                        if (digit(first)) {
+                            e = Integer.parseInt(tok.sval);
+                            //System.out.println("w: " + i);
+                        }
+                    }
+                    if (tt != ']') {
+                        tok.pushBack();
+                    }
+                }
+            }
+        } else {
+            tok.pushBack();
+        }
+        return e;
+    }
+
+
+    /**
+     * Parsing method for term order name. Syntax:
+     * 
+     * <pre>
+     * L | IL | LEX | G | IG | GRLEX | W(weights) | '|'split index'|'
+     * </pre>
+     * 
+     * @return the next term order.
+     * @throws IOException
+     */
+    public TermOrder nextTermOrder() throws IOException {
+        int evord = TermOrder.DEFAULT_EVORD;
+        int tt;
+        tt = tok.nextToken();
+        if (tt == StreamTokenizer.TT_EOF) { /* nop */
+        } else if (tt == StreamTokenizer.TT_WORD) {
+            // System.out.println("TT_WORD: " + tok.sval);
+            if (tok.sval != null) {
+                if (tok.sval.equalsIgnoreCase("L")) {
+                    evord = TermOrder.INVLEX;
+                } else if (tok.sval.equalsIgnoreCase("IL")) {
+                    evord = TermOrder.INVLEX;
+                } else if (tok.sval.equalsIgnoreCase("INVLEX")) {
+                    evord = TermOrder.INVLEX;
+                } else if (tok.sval.equalsIgnoreCase("LEX")) {
+                    evord = TermOrder.LEX;
+                } else if (tok.sval.equalsIgnoreCase("G")) {
+                    evord = TermOrder.IGRLEX;
+                } else if (tok.sval.equalsIgnoreCase("IG")) {
+                    evord = TermOrder.IGRLEX;
+                } else if (tok.sval.equalsIgnoreCase("IGRLEX")) {
+                    evord = TermOrder.IGRLEX;
+                } else if (tok.sval.equalsIgnoreCase("GRLEX")) {
+                    evord = TermOrder.GRLEX;
+                } else if (tok.sval.equalsIgnoreCase("REVITDG")) {
+                    evord = TermOrder.REVITDG;
+                } else if (tok.sval.equalsIgnoreCase("W")) {
+                    long[][] w = nextWeightArray();
+                    return new TermOrder(w);
+                }
+            }
+        } else {
+            tok.pushBack();
+        }
+        int s = nextSplitIndex();
+        if (s <= 0) {
+            return new TermOrder(evord);
+        }
+        return new TermOrder(evord, evord, nvars, s);
+    }
+
+
+    /**
+     * Parsing method for solvable polynomial relation table. Syntax:
+     * 
+     * <pre>
+     * ( p_1, p_2, p_3, ..., p_{n+1}, p_{n+2}, p_{n+3} )
+     * </pre>
+     * 
+     * semantics: <code>p_{n+1} * p_{n+2} = p_{n+3}</code>. The next relation
+     * table is stored into the solvable polynomial factory.
+     * @throws IOException
+     */
+    @SuppressWarnings("unchecked")
+    public void nextRelationTable() throws IOException {
+        if (spfac == null) {
+            return;
+        }
+        RelationTable table = spfac.table;
+        List<GenPolynomial> rels = null;
+        GenPolynomial p;
+        GenSolvablePolynomial sp;
+        int tt;
+        tt = tok.nextToken();
+        if (debug) {
+            logger.debug("start relation table: " + tt);
+        }
+        if (tok.sval != null) {
+            if (tok.sval.equalsIgnoreCase("RelationTable")) {
+                GenPolynomialTokenizer ptok = new GenPolynomialTokenizer(pfac, reader);
+                rels = ptok.nextPolynomialList();
+                ptok = null;
+            }
+        }
+        if (rels == null) {
+            tok.pushBack();
+            return;
+        }
+        for (Iterator<GenPolynomial> it = rels.iterator(); it.hasNext();) {
+            p = it.next();
+            ExpVector e = p.leadingExpVector();
+            if (it.hasNext()) {
+                p = it.next();
+                ExpVector f = p.leadingExpVector();
+                if (it.hasNext()) {
+                    p = it.next();
+                    sp = new GenSolvablePolynomial(spfac);
+                    sp.doPutToMap(p.getMap());
+                    table.update(e, f, sp);
+                }
+            }
+        }
+        if (debug) {
+            logger.info("table = " + table);
+        }
+        return;
+    }
+
+
+    /**
+     * Parsing method for polynomial ring. Syntax:
+     * 
+     * <pre>
+     * coeffRing varList termOrderName polyList
+     * </pre>
+     * 
+     * @return the next polynomial ring.
+     * @throws IOException
+     */
+    @SuppressWarnings("unchecked")
+    public GenPolynomialRing nextPolynomialRing() throws IOException {
+        //String comments = "";
+        //comments += nextComment();
+        //if (debug) logger.debug("comment = " + comments);
+
+        RingFactory coeff = nextCoefficientRing();
+        logger.info("coeff = " + coeff);
+
+        vars = nextVariableList();
+        logger.info("vars = " + Arrays.toString(vars));
+        if (vars != null) {
+            nvars = vars.length;
+        }
+
+        tord = nextTermOrder();
+        logger.info("tord = " + tord);
+        // check more TOs
+
+        initFactory(coeff, parsedCoeff); // global: nvars, tord, vars
+        // now pfac is initialized
+        return pfac;
+    }
+
+
+    /**
+     * Parsing method for solvable polynomial ring. Syntax:
+     * 
+     * <pre>
+     * varList termOrderName relationTable polyList
+     * </pre>
+     * 
+     * @return the next solvable polynomial ring.
+     * @throws IOException
+     */
+    @SuppressWarnings("unchecked")
+    public GenSolvablePolynomialRing nextSolvablePolynomialRing() throws IOException {
+        //String comments = "";
+        //comments += nextComment();
+        //if (debug) logger.debug("comment = " + comments);
+
+        RingFactory coeff = nextCoefficientRing();
+        logger.info("coeff = " + coeff.getClass().getSimpleName());
+
+        vars = nextVariableList();
+        logger.info("vars = " + Arrays.toString(vars));
+        if (vars != null) {
+            nvars = vars.length;
+        }
+
+        tord = nextTermOrder();
+        logger.info("tord = " + tord);
+        // check more TOs
+
+        initFactory(coeff, parsedCoeff); // must be because of symmetric read
+        initSolvableFactory(coeff, parsedCoeff); // global: nvars, tord, vars
+        //System.out.println("pfac = " + pfac);
+        //System.out.println("spfac = " + spfac);
+
+        nextRelationTable();
+        if (logger.isInfoEnabled()) {
+            logger.info("table = " + table + ", tok = " + tok);
+        }
+        // now spfac is initialized
+        return spfac;
+    }
+
+
+    static boolean digit(char x) {
+        return '0' <= x && x <= '9';
+    }
+
+
+    //static boolean letter(char x) {
+    //    return ('a' <= x && x <= 'z') || ('A' <= x && x <= 'Z');
+    //}
+
+
+    // unused
+    public void nextComma() throws IOException {
+        int tt;
+        if (tok.ttype == ',') {
+            tt = tok.nextToken();
+            if (debug) {
+                logger.debug("after comma: " + tt);
+            }
+        }
+    }
+
+
+    /**
+     * Parse variable list from String.
+     * @param s String. Syntax:
+     * 
+     *            <pre>
+     * (n1,...,nk)
+     *            </pre>
+     * 
+     *            or
+     * 
+     *            <pre>
+     * (n1 ... nk)
+     *            </pre>
+     * 
+     *            parenthesis are optional.
+     * @return array of variable names found in s.
+     */
+    public static String[] variableList(String s) {
+        String[] vl = null;
+        if (s == null) {
+            return vl;
+        }
+        String st = s.trim();
+        if (st.length() == 0) {
+            return new String[0];
+        }
+        if (st.charAt(0) == '(') {
+            st = st.substring(1);
+        }
+        if (st.charAt(st.length() - 1) == ')') {
+            st = st.substring(0, st.length() - 1);
+        }
+        st = st.replaceAll(",", " ");
+        List<String> sl = new ArrayList<String>();
+        Scanner sc = new Scanner(st);
+        while (sc.hasNext()) {
+            String sn = sc.next();
+            sl.add(sn);
+        }
+        sc.close();
+        vl = new String[sl.size()];
+        int i = 0;
+        for (String si : sl) {
+            vl[i] = si;
+            i++;
+        }
+        return vl;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/RootFactoryApp.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/RootFactoryApp.java
@@ -1,0 +1,295 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.arith.Rational;
+import edu.jas.poly.Complex;
+import edu.jas.poly.ComplexRing;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.AlgebraicNumberRing;
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.PolyUtil;
+import edu.jas.poly.TermOrder;
+import edu.jas.root.Interval;
+import edu.jas.root.RealRootTuple;
+import edu.jas.root.AlgebraicRoots;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.ufd.SquarefreeAbstract;
+import edu.jas.ufd.SquarefreeFactory;
+
+
+/**
+ * Roots factory.
+ * @author Heinz Kredel
+ */
+public class RootFactoryApp {
+
+
+    private static final Logger logger = LogManager.getLogger(RootFactoryApp.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Is complex algebraic number a root of a polynomial.
+     * @param f univariate polynomial.
+     * @param r complex algebraic number.
+     * @return true, if f(r) == 0, else false;
+     */
+    public static <C extends GcdRingElem<C> & Rational> boolean isRootRealCoeff(GenPolynomial<C> f,
+                    Complex<RealAlgebraicNumber<C>> r) {
+        RingFactory<C> cfac = f.ring.coFac;
+        ComplexRing<C> ccfac = new ComplexRing<C>(cfac);
+        GenPolynomialRing<Complex<C>> facc = new GenPolynomialRing<Complex<C>>(ccfac, f.ring);
+        GenPolynomial<Complex<C>> fc = PolyUtil.<C> complexFromAny(facc, f);
+        return isRoot(fc, r);
+    }
+
+
+    /**
+     * Is complex algebraic number a root of a polynomial.
+     * @param f univariate polynomial.
+     * @param r complex algebraic number.
+     * @return true, if f(r) == 0, else false;
+     */
+    public static <C extends GcdRingElem<C> & Rational> boolean isRoot(GenPolynomial<Complex<C>> f,
+                    Complex<RealAlgebraicNumber<C>> r) {
+        ComplexRing<RealAlgebraicNumber<C>> cr = r.factory();
+        GenPolynomialRing<Complex<RealAlgebraicNumber<C>>> cfac = new GenPolynomialRing<Complex<RealAlgebraicNumber<C>>>(
+                        cr, f.factory());
+        GenPolynomial<Complex<RealAlgebraicNumber<C>>> p;
+        p = PolyUtilApp.<C> convertToComplexRealCoefficients(cfac, f);
+        // test algebraic part
+        Complex<RealAlgebraicNumber<C>> a = PolyUtil.<Complex<RealAlgebraicNumber<C>>> evaluateMain(cr, p, r);
+        boolean t = a.isZERO();
+        if (!t) {
+            logger.info("f(r) = " + a + ", f = " + f + ", r  = " + r);
+            return t;
+        }
+        // test approximation? not working
+        return true;
+    }
+
+
+    /**
+     * Is complex algebraic number a root of a polynomial.
+     * @param f univariate polynomial.
+     * @param R list of complex algebraic numbers.
+     * @return true, if f(r) == 0 for all r in R, else false;
+     */
+    public static <C extends GcdRingElem<C> & Rational> boolean isRoot(GenPolynomial<Complex<C>> f,
+                    List<Complex<RealAlgebraicNumber<C>>> R) {
+        for (Complex<RealAlgebraicNumber<C>> r : R) {
+            boolean t = isRoot(f, r);
+            if (!t) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Complex algebraic number roots.
+     * @param f univariate polynomial.
+     * @return a list of different complex algebraic numbers, with f(c) == 0 for
+     *         c in roots.
+     */
+    public static <C extends GcdRingElem<C> & Rational> List<Complex<RealAlgebraicNumber<C>>> complexAlgebraicNumbersComplex(
+                    GenPolynomial<Complex<C>> f) {
+        GenPolynomialRing<Complex<C>> pfac = f.factory();
+        if (pfac.nvar != 1) {
+            throw new IllegalArgumentException("only for univariate polynomials");
+        }
+        ComplexRing<C> cfac = (ComplexRing<C>) pfac.coFac;
+        SquarefreeAbstract<Complex<C>> engine = SquarefreeFactory.<Complex<C>> getImplementation(cfac);
+        Map<GenPolynomial<Complex<C>>, Long> F = engine.squarefreeFactors(f.monic());
+        //System.out.println("S = " + F.keySet());
+        List<Complex<RealAlgebraicNumber<C>>> list = new ArrayList<Complex<RealAlgebraicNumber<C>>>();
+        for (Map.Entry<GenPolynomial<Complex<C>>,Long> me : F.entrySet()) {
+            GenPolynomial<Complex<C>> sp = me.getKey();
+            if (sp.isConstant() || sp.isZERO()) {
+                continue;
+            }
+            List<Complex<RealAlgebraicNumber<C>>> ls = RootFactoryApp.<C> complexAlgebraicNumbersSquarefree(sp);
+            long m = me.getValue();
+            for (long i = 0L; i < m; i++) {
+                list.addAll(ls);
+            }
+        }
+        return list;
+    }
+
+
+    /**
+     * Complex algebraic number roots.
+     * @param f univariate squarefree polynomial.
+     * @return a list of different complex algebraic numbers, with f(c) == 0 for
+     *         c in roots.
+     */
+    public static <C extends GcdRingElem<C> & Rational> 
+      List<Complex<RealAlgebraicNumber<C>>> complexAlgebraicNumbersSquarefree(
+                   GenPolynomial<Complex<C>> f) {
+        GenPolynomialRing<Complex<C>> pfac = f.factory();
+        if (pfac.nvar != 1) {
+            throw new IllegalArgumentException("only for univariate polynomials");
+        }
+        ComplexRing<C> cfac = (ComplexRing<C>) pfac.coFac;
+        TermOrder to = new TermOrder(TermOrder.INVLEX);
+        GenPolynomialRing<Complex<C>> tfac = new GenPolynomialRing<Complex<C>>(cfac, 2, to); //,new vars); //tord?
+        //System.out.println("tfac = " + tfac);
+        GenPolynomial<Complex<C>> t = tfac.univariate(1, 1L).sum(
+                        tfac.univariate(0, 1L).multiply(cfac.getIMAG()));
+        //System.out.println("t = " + t); // t = x + i y
+        GenPolynomialRing<C> rfac = new GenPolynomialRing<C>(cfac.ring, tfac); //tord?
+        //System.out.println("rfac = " + rfac);
+        List<Complex<RealAlgebraicNumber<C>>> list = new ArrayList<Complex<RealAlgebraicNumber<C>>>();
+        GenPolynomial<Complex<C>> sp = f;
+        if (sp.isConstant() || sp.isZERO()) {
+            return list;
+        }
+        // substitute t = x + i y
+        GenPolynomial<Complex<C>> su = PolyUtil.<Complex<C>> substituteUnivariate(sp, t);
+        //System.out.println("su = " + su);
+        su = su.monic();
+        //System.out.println("su = " + su);
+        GenPolynomial<C> re = PolyUtil.<C> realPartFromComplex(rfac, su);
+        GenPolynomial<C> im = PolyUtil.<C> imaginaryPartFromComplex(rfac, su);
+        if (debug) {
+            logger.debug("rfac = " + rfac.toScript());
+            logger.debug("t  = " + t + ", re = " + re.toScript() + ", im = " + im.toScript());
+        }
+        List<GenPolynomial<C>> li = new ArrayList<GenPolynomial<C>>(2);
+        li.add(re);
+        li.add(im);
+        Ideal<C> id = new Ideal<C>(rfac, li);
+        //System.out.println("id = " + id);
+        List<IdealWithUniv<C>> idul = id.zeroDimRootDecomposition();
+
+        IdealWithRealAlgebraicRoots<C> idr;
+        for (IdealWithUniv<C> idu : idul) {
+            //System.out.println("---idu = " + idu);
+            idr = PolyUtilApp.<C> realAlgebraicRoots(idu);
+            //System.out.println("---idr = " + idr);
+            for (List<edu.jas.root.RealAlgebraicNumber<C>> crr : idr.ran) {
+                //System.out.println("crr = " + crr);
+                RealRootTuple<C> root = new RealRootTuple<C>(crr);
+                //System.out.println("root = " + root);
+                RealAlgebraicRing<C> car = new RealAlgebraicRing<C>(idu, root);
+                //System.out.println("car = " + car);
+                List<RealAlgebraicNumber<C>> gens = car.generators();
+                //System.out.println("gens = " + gens);
+                int sg = gens.size();
+                RealAlgebraicNumber<C> rre = gens.get(sg - 2);
+                RealAlgebraicNumber<C> rim = gens.get(sg - 1);
+                ComplexRing<RealAlgebraicNumber<C>> cring = new ComplexRing<RealAlgebraicNumber<C>>(car);
+                Complex<RealAlgebraicNumber<C>> crn = new Complex<RealAlgebraicNumber<C>>(cring, rre, rim);
+                //System.out.println("crn = " + crn + " in " + crn.ring);
+                // refine intervals if necessary, not meaningful
+                list.add(crn);
+            }
+        }
+        return list;
+    }
+
+
+    /* approximation ?
+    List<ComplexAlgebraicNumber<C>> complexAlgebraicNumbersComplex(GenPolynomial<Complex<C>> f, BigRational eps)
+    */
+
+
+    /**
+     * Root reduce of real and complex algebraic numbers.
+     * @param a container of real and complex algebraic numbers.
+     * @param b container of real and complex algebraic numbers.
+     * @return container of real and complex algebraic numbers 
+     *         of the primitive element of a and b.
+     */
+    public static <C extends GcdRingElem<C> & Rational> 
+           AlgebraicRootsPrimElem<C> rootReduce(AlgebraicRoots<C> a, AlgebraicRoots<C> b) {
+        return rootReduce(a.getAlgebraicRing(), b.getAlgebraicRing());
+    }
+
+
+    /**
+     * Root reduce of real and complex algebraic numbers.
+     * @param a polynomial.
+     * @param b polynomial.
+     * @return container of real and complex algebraic numbers 
+     *         of the primitive element of a and b.
+     */
+    public static <C extends GcdRingElem<C> & Rational> 
+           AlgebraicRootsPrimElem<C> rootReduce(GenPolynomial<C> a, GenPolynomial<C> b) {
+        AlgebraicNumberRing<C> anr = new AlgebraicNumberRing<C>(a);
+        AlgebraicNumberRing<C> bnr = new AlgebraicNumberRing<C>(b);
+        return rootReduce(anr, bnr);
+    }
+
+
+    /**
+     * Root reduce of real and complex algebraic numbers.
+     * @param a algebraic number ring.
+     * @param b algebraic number ring.
+     * @return container of real and complex algebraic numbers 
+     *         of the primitive element of a and b.
+     */
+    public static <C extends GcdRingElem<C> & Rational> 
+           AlgebraicRootsPrimElem<C> rootReduce(AlgebraicNumberRing<C> a, AlgebraicNumberRing<C> b) {
+        PrimitiveElement<C> pe = PolyUtilApp.<C>primitiveElement(a, b);
+        AlgebraicRoots<C> ar = edu.jas.root.RootFactory.<C>algebraicRoots(pe.primitiveElem.modul);
+        return new AlgebraicRootsPrimElem<C>(ar, pe);
+    }
+
+
+    /**
+     * Roots of unity of real and complex algebraic numbers.
+     * @param ar container of real and complex algebraic numbers with primitive element.
+     * @return container of real and complex algebraic numbers which are roots
+     *         of unity.
+     */
+    public static <C extends GcdRingElem<C> & Rational> 
+           AlgebraicRootsPrimElem<C> rootsOfUnity(AlgebraicRootsPrimElem<C> ar) {
+        AlgebraicRoots<C> ur = edu.jas.root.RootFactory.rootsOfUnity(ar);
+        if (ar.pelem == null) {
+            return new AlgebraicRootsPrimElem<C>(ur, ar.pelem);
+        }
+        List<AlgebraicNumber<C>> al = new ArrayList<AlgebraicNumber<C>>();
+        long d = ar.pelem.primitiveElem.modul.degree();
+        AlgebraicNumber<C> c = ar.pelem.A;
+        AlgebraicNumber<C> m = c.ring.getONE();
+        for (long i = 1; i <= d; i++) {
+            m = m.multiply(c);
+            if (m.isRootOfUnity()) {
+                if (!al.contains(m)) {
+                    al.add(m);
+                }
+            }
+        }
+        c = ar.pelem.B;
+        m = c.ring.getONE();
+        for (long i = 1; i <= d; i++) {
+            m = m.multiply(c);
+            if (m.isRootOfUnity()) {
+                if (!al.contains(m)) {
+                    al.add(m);
+                }
+            }
+        }
+        return new AlgebraicRootsPrimElem<C>(ur, ar.pelem, al);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/RunGB.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/RunGB.java
@@ -1,0 +1,581 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StringReader;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+import edu.jas.gb.GroebnerBaseAbstract;
+import edu.jas.gb.GroebnerBaseDistributedEC;
+import edu.jas.gb.GroebnerBaseDistributedHybridEC;
+import edu.jas.gb.GroebnerBaseParallel;
+import edu.jas.gb.GroebnerBaseSeq;
+import edu.jas.gb.OrderedSyzPairlist;
+import edu.jas.gb.ReductionPar;
+import edu.jas.gb.ReductionSeq;
+import edu.jas.gbufd.GBFactory;
+import edu.jas.gbufd.GroebnerBasePseudoParallel;
+import edu.jas.kern.ComputerThreads;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.GenPolynomialTokenizer;
+import edu.jas.poly.PolynomialList;
+import edu.jas.util.CatReader;
+import edu.jas.util.ExecutableServer;
+
+
+/**
+ * Simple setup to run a GB example. <br>
+ * Usage: RunGB [seq(+)|par(+)|build=string|disthyb|cli] &lt;file&gt;
+ * #procs/#threadsPerNode [machinefile] &lt;check&gt; <br>
+ * Build string can be any combination of method calls from GBAlgorithmBuilder.
+ * Method polynomialRing() is called based on declaration from "file". Method
+ * build() is called automatically. For example <br>
+ * build=syzygyPairlist.iterated.graded.parallel(3)
+ * @see edu.jas.application.GBAlgorithmBuilder
+ * @author Heinz Kredel
+ */
+public class RunGB {
+
+
+    /**
+     * Check result GB if it is a GB.
+     */
+    static boolean doCheck = false;
+
+
+    /**
+     * main method to be called from commandline <br>
+     * Usage: RunGB [seq|par(+)|build=string|disthyb(+)|cli] &lt;file&gt;
+     * #procs/#threadsPerNode [machinefile] &lt;check&gt;
+     */
+    @SuppressWarnings("unchecked")
+    public static void main(String[] args) {
+
+        String[] allkinds = new String[] { "seq", "seq+", "par", "par+", "build=", "disthyb", "disthyb+",
+                "cli" }; // must be last
+
+        String usage = "Usage: RunGB [ " + join(allkinds, " | ") + "[port] ] " + "<file> "
+                        + "#procs/#threadsPerNode " + "[machinefile] " + "[check] ";
+
+        if (args.length < 1) {
+            System.out.println("args: " + Arrays.toString(args));
+            System.out.println(usage);
+            return;
+        }
+
+        boolean plusextra = false;
+        String kind = args[0];
+        boolean sup = false;
+        int k = -1;
+        for (int i = 0; i < args.length; i++) {
+            int j = indexOf(allkinds, args[i]);
+            if (j < 0) {
+                continue;
+            }
+            sup = true;
+            k = i;
+            kind = args[k];
+            break;
+        }
+        if (!sup) {
+            System.out.println("args(sup): " + Arrays.toString(args));
+            System.out.println(usage);
+            return;
+        }
+        if (kind.indexOf("+") >= 0) {
+            plusextra = true;
+        }
+        System.out.println("kind: " + kind + ", k = " + k);
+
+        final int GB_SERVER_PORT = 7114;
+        int port = GB_SERVER_PORT;
+
+        if (kind.equals("cli")) {
+            if (args.length - k >= 2) {
+                try {
+                    port = Integer.parseInt(args[k + 1]);
+                } catch (NumberFormatException e) {
+                    e.printStackTrace();
+                    System.out.println("args(port): " + Arrays.toString(args));
+                    System.out.println(usage);
+                    return;
+                }
+            }
+            runClient(port);
+            return;
+        }
+
+        String filename = null;
+        if (!kind.equals("cli")) {
+            if (args.length - k < 2) {
+                System.out.println("args(file): " + Arrays.toString(args));
+                System.out.println(usage);
+                return;
+            }
+            filename = args[k + 1];
+        }
+
+        int j = indexOf(args, "check");
+        if (j >= 0) {
+            doCheck = true;
+        }
+
+        int threads = 0;
+        int threadsPerNode = 1;
+        if (kind.startsWith("par") || kind.startsWith("dist")) {
+            if (args.length - k < 3) {
+                System.out.println("args(par|dist): " + Arrays.toString(args));
+                System.out.println(usage);
+                return;
+            }
+            String tup = args[k + 2];
+            String t = tup;
+            int i = tup.indexOf("/");
+            if (i >= 0) {
+                t = tup.substring(0, i).trim();
+                tup = tup.substring(i + 1).trim();
+                try {
+                    threadsPerNode = Integer.parseInt(tup);
+                } catch (NumberFormatException e) {
+                    e.printStackTrace();
+                    System.out.println("args(threadsPerNode): " + Arrays.toString(args));
+                    System.out.println(usage);
+                    return;
+                }
+            }
+            try {
+                threads = Integer.parseInt(t);
+            } catch (NumberFormatException e) {
+                e.printStackTrace();
+                System.out.println("args(threads): " + Arrays.toString(args));
+                System.out.println(usage);
+                return;
+            }
+        }
+
+        String mfile = null;
+        if (kind.startsWith("dist")) {
+            if (args.length - k >= 4) {
+                mfile = args[k + 3];
+            } else {
+                mfile = "machines";
+            }
+        }
+
+        Reader problem = getReader(filename);
+        if (problem == null) {
+            System.out.println("args(file): " + filename);
+            System.out.println("args(file): examples.jar(" + filename + ")");
+            System.out.println("args(file): " + Arrays.toString(args));
+            System.out.println(usage);
+            return;
+        }
+        RingFactoryTokenizer rftok = new RingFactoryTokenizer(problem);
+        GenPolynomialRing pfac = null;
+        try {
+            pfac = rftok.nextPolynomialRing();
+            rftok = null;
+        } catch (IOException e) {
+            e.printStackTrace();
+            return;
+        }
+        System.out.println("pfac: " + pfac.toScript());
+        Reader polyreader = new CatReader(new StringReader("("), problem); // ( has gone
+        //Reader polyreader = problem; 
+        GenPolynomialTokenizer tok = new GenPolynomialTokenizer(pfac, polyreader);
+        PolynomialList S = null;
+        try {
+            S = new PolynomialList(pfac, tok.nextPolynomialList());
+        } catch (IOException e) {
+            e.printStackTrace();
+            return;
+        }
+        System.out.println("input S =\n" + S);
+
+        GroebnerBaseAbstract gb = null;
+        if (kind.startsWith("build")) {
+            gb = getGBalgo(args, kind, S.ring);
+            if (gb == null) {
+                System.out.println(usage);
+                return;
+            }
+        }
+
+        if (kind.startsWith("seq")) {
+            runSequential(S, plusextra);
+        } else if (kind.startsWith("par")) {
+            runParallel(S, threads, plusextra);
+        } else if (kind.startsWith("disthyb")) {
+            runMasterHyb(S, threads, threadsPerNode, mfile, port, plusextra);
+            //} else if (kind.startsWith("dist")) {
+            //runMaster(S, threads, mfile, port, plusextra);
+        } else if (kind.startsWith("build")) {
+            runGB(S, gb);
+        }
+        ComputerThreads.terminate();
+        //System.exit(0);
+    }
+
+
+    // no more used
+    @SuppressWarnings("unchecked")
+    static void runMaster(PolynomialList S, int threads, String mfile, int port, boolean plusextra) {
+        List L = S.list;
+        List G = null;
+        long t, t1;
+        GroebnerBaseDistributedEC gbd = null;
+        GroebnerBaseDistributedEC gbds = null;
+
+        System.out.println("\nGroebner base distributed (" + threads + ", " + mfile + ", " + port + ") ...");
+        t = System.currentTimeMillis();
+        if (plusextra) {
+            //gbds = new GroebnerBaseDistributedEC(threads,mfile, port);
+            gbds = new GroebnerBaseDistributedEC(mfile, threads, new OrderedSyzPairlist(), port);
+        } else {
+            gbd = new GroebnerBaseDistributedEC(mfile, threads, port);
+        }
+        t1 = System.currentTimeMillis();
+        if (plusextra) {
+            G = gbds.GB(L);
+        } else {
+            G = gbd.GB(L);
+        }
+        t1 = System.currentTimeMillis() - t1;
+        if (plusextra) {
+            gbds.terminate(); //false);
+        } else {
+            gbd.terminate(); //false);
+        }
+        S = new PolynomialList(S.ring, G);
+        System.out.println("G =\n" + S);
+        System.out.println("G.size() = " + G.size());
+        t = System.currentTimeMillis() - t;
+        if (plusextra) {
+            System.out.print("d+ ");
+        } else {
+            System.out.print("d ");
+        }
+        System.out.println("= " + threads + ", time = " + t1 + " milliseconds, " + (t - t1) + " start-up "
+                        + ", total = " + t);
+        checkGB(S);
+        System.out.println("");
+    }
+
+
+    @SuppressWarnings("unchecked")
+    static void runMasterHyb(PolynomialList S, int threads, int threadsPerNode, String mfile, int port,
+                    boolean plusextra) {
+        List L = S.list;
+        List G = null;
+        long t, t1;
+        GroebnerBaseDistributedHybridEC gbd = null;
+        GroebnerBaseDistributedHybridEC gbds = null;
+
+        System.out.println("\nGroebner base distributed hybrid (" + threads + "/" + threadsPerNode + ", "
+                        + mfile + ", " + port + ") ...");
+        t = System.currentTimeMillis();
+        if (plusextra) {
+            // gbds = new GroebnerBaseDistributedHybridEC(mfile, threads,port);
+            gbds = new GroebnerBaseDistributedHybridEC(mfile, threads, threadsPerNode,
+                            new OrderedSyzPairlist(), port);
+        } else {
+            gbd = new GroebnerBaseDistributedHybridEC(mfile, threads, threadsPerNode, port);
+        }
+        t1 = System.currentTimeMillis();
+        if (plusextra) {
+            G = gbds.GB(L);
+        } else {
+            G = gbd.GB(L);
+        }
+        t1 = System.currentTimeMillis() - t1;
+        if (plusextra) {
+            gbds.terminate(); // true
+        } else {
+            gbd.terminate(); // false plus eventually killed by script
+        }
+        t = System.currentTimeMillis() - t;
+        S = new PolynomialList(S.ring, G);
+        System.out.println("G =\n" + S);
+        System.out.println("G.size() = " + G.size());
+        if (plusextra) {
+            System.out.print("d+ ");
+        } else {
+            System.out.print("d ");
+        }
+        System.out.println("= " + threads + ", ppn = " + threadsPerNode + ", time = " + t1 + " milliseconds, "
+                        + (t - t1) + " start-up " + ", total = " + t);
+        checkGB(S);
+        System.out.println("");
+    }
+
+
+    static void runClient(int port) {
+        System.out.println("\nGroebner base distributed client (" + port + ") ...");
+        ExecutableServer es = new ExecutableServer(port);
+        es.init();
+        try {
+            es.join();
+        } catch (InterruptedException e) {
+            // ignored
+        }
+        System.out.println("runClient() done: " + es);
+    }
+
+
+    @SuppressWarnings("unchecked")
+    static void runParallel(PolynomialList S, int threads, boolean plusextra) {
+        List L = S.list;
+        List G;
+        long t;
+        GroebnerBaseAbstract bb = null;
+        GroebnerBaseAbstract bbs = null;
+        if (plusextra) {
+            //bbs = new GroebnerBaseSeqPairParallel(threads);
+            bbs = new GroebnerBaseParallel(threads, new ReductionPar(), new OrderedSyzPairlist());
+        } else {
+            if (S.ring.coFac.isField()) {
+                bb = new GroebnerBaseParallel(threads);
+            } else {
+                bb = new GroebnerBasePseudoParallel(threads, S.ring.coFac);
+            }
+        }
+        System.out.println("\nGroebner base parallel (" + threads + ") ...");
+        t = System.currentTimeMillis();
+        if (plusextra) {
+            G = bbs.GB(L);
+        } else {
+            G = bb.GB(L);
+        }
+        t = System.currentTimeMillis() - t;
+        S = new PolynomialList(S.ring, G);
+        System.out.println("G =\n" + S);
+        System.out.println("G.size() = " + G.size());
+
+        if (plusextra) {
+            System.out.print("p+ ");
+        } else {
+            System.out.print("p ");
+        }
+        System.out.println("= " + threads + ", time = " + t + " milliseconds");
+        if (plusextra) {
+            bbs.terminate();
+        } else {
+            bb.terminate();
+        }
+        checkGB(S);
+        System.out.println("");
+    }
+
+
+    @SuppressWarnings("unchecked")
+    static void runSequential(PolynomialList S, boolean plusextra) {
+        List L = S.list;
+        List G;
+        long t;
+        GroebnerBaseAbstract bb = null;
+        if (plusextra) {
+            //bb = new GroebnerBaseSeqPlusextra();
+            bb = new GroebnerBaseSeq(new ReductionSeq(), new OrderedSyzPairlist());
+        } else {
+            bb = GBFactory.getImplementation(S.ring.coFac); //new GroebnerBaseSeq();
+        }
+        System.out.println("\nGroebner base sequential ...");
+        t = System.currentTimeMillis();
+        G = bb.GB(L);
+        t = System.currentTimeMillis() - t;
+        S = new PolynomialList(S.ring, G);
+        System.out.println("G =\n" + S);
+        System.out.println("G.size() = " + G.size());
+        if (plusextra) {
+            System.out.print("seq+, ");
+        } else {
+            System.out.print("seq, ");
+        }
+        System.out.println("time = " + t + " milliseconds");
+        checkGB(S);
+        System.out.println("");
+    }
+
+
+    @SuppressWarnings("unchecked")
+    static void runGB(PolynomialList S, GroebnerBaseAbstract bb) {
+        List L = S.list;
+        List G;
+        long t;
+        if (bb == null) { // should not happen
+            bb = GBFactory.getImplementation(S.ring.coFac);
+        }
+        String bbs = bb.toString().replaceAll(" ", "");
+        System.out.println("\nGroebner base build=" + bbs + " ...");
+        t = System.currentTimeMillis();
+        G = bb.GB(L);
+        t = System.currentTimeMillis() - t;
+        S = new PolynomialList(S.ring, G);
+        bbs = bb.toString().replaceAll(" ", "");
+        System.out.println("G =\n" + S);
+        System.out.println("G.size() = " + G.size());
+        System.out.print("build=" + bbs + ", ");
+        System.out.println("time = " + t + " milliseconds");
+        checkGB(S);
+        bb.terminate();
+        System.out.println("");
+    }
+
+
+    @SuppressWarnings("unchecked")
+    static void checkGB(PolynomialList S) {
+        if (!doCheck) {
+            return;
+        }
+        GroebnerBaseAbstract bb = GBFactory.getImplementation(S.ring.coFac);
+        long t = System.currentTimeMillis();
+        boolean chk = bb.isGB(S.list, false);
+        t = System.currentTimeMillis() - t;
+        System.out.println("check isGB = " + chk + " in " + t + " milliseconds");
+    }
+
+
+    static int indexOf(String[] args, String s) {
+        for (int i = 0; i < args.length; i++) {
+            if (s.startsWith(args[i])) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+
+    static String join(String[] args, String d) {
+        StringBuffer sb = new StringBuffer();
+        for (int i = 0; i < args.length; i++) {
+            if (i > 0) {
+                sb.append(d);
+            }
+            sb.append(args[i]);
+        }
+        return sb.toString();
+    }
+
+
+    @SuppressWarnings("resource")
+    static Reader getReader(String filename) {
+        Reader problem = null;
+        Exception fnf = null;
+        try {
+            problem = new InputStreamReader(new FileInputStream(filename), Charset.forName("UTF8"));
+            problem = new BufferedReader(problem);
+        } catch (FileNotFoundException e) {
+            fnf = e;
+        }
+        if (problem != null) {
+            return problem;
+        }
+        String examples = "examples.jar";
+        try {
+            JarFile jf = new JarFile(examples);
+            JarEntry je = jf.getJarEntry(filename);
+            if (je == null) {
+                    jf.close();
+                fnf.printStackTrace();
+                return problem;
+            }
+            problem = new InputStreamReader(jf.getInputStream(je), Charset.forName("UTF8"));
+            problem = new BufferedReader(problem);
+        } catch (FileNotFoundException e) {
+            fnf.printStackTrace();
+            e.printStackTrace();
+        } catch (IOException e) {
+            fnf.printStackTrace();
+            e.printStackTrace();
+            //} finally { not possible, problem must remain open
+            //jf.close();
+        }
+        return problem;
+    }
+
+
+    @SuppressWarnings("unchecked")
+    static GroebnerBaseAbstract getGBalgo(String[] args, String bstr, GenPolynomialRing ring) {
+        GroebnerBaseAbstract gb = null;
+        int i = bstr.indexOf("=");
+        if (i < 0) {
+            System.out.println("args(build): " + Arrays.toString(args));
+            return gb;
+        }
+        i += 1;
+        String tb = bstr.substring(i);
+        //System.out.println("build=" + tb);
+        GBAlgorithmBuilder ab = GBAlgorithmBuilder.polynomialRing(ring);
+        //System.out.println("ab = " + ab);
+        while (!tb.isEmpty()) {
+            int ii = tb.indexOf(".");
+            String mth;
+            if (ii >= 0) {
+                mth = tb.substring(0, ii);
+                tb = tb.substring(ii + 1);
+            } else {
+                mth = tb;
+                tb = "";
+            }
+            if (mth.startsWith("build")) {
+                continue;
+            }
+            String parm = "";
+            int jj = mth.indexOf("()");
+            if (jj >= 0) {
+                mth = mth.substring(0, jj);
+            } else {
+                jj = mth.indexOf("(");
+                if (jj >= 0) {
+                    parm = mth.substring(jj + 1);
+                    mth = mth.substring(0, jj);
+                    jj = parm.indexOf(")");
+                    parm = parm.substring(0, jj);
+                }
+            }
+            //System.out.println("mth = " + mth + ", parm = " + parm);
+            try {
+                Method method;
+                if (parm.isEmpty()) {
+                    method = ab.getClass().getMethod(mth, (Class<?>[]) null);
+                    ab = (GBAlgorithmBuilder) method.invoke(ab, (Object[]) null);
+                } else {
+                    int tparm = Integer.parseInt(parm);
+                    method = ab.getClass().getMethod(mth, int.class);
+                    ab = (GBAlgorithmBuilder) method.invoke(ab, tparm);
+                }
+            } catch (NoSuchMethodException e) {
+                System.out.println("args(build,method): " + Arrays.toString(args));
+                return gb;
+            } catch (IllegalAccessException e) {
+                System.out.println("args(build,access): " + Arrays.toString(args));
+                return gb;
+            } catch (InvocationTargetException e) {
+                System.out.println("args(build,invocation): " + Arrays.toString(args));
+                return gb;
+            } catch (NumberFormatException e) {
+                System.out.println("args(build,number): " + Arrays.toString(args));
+                return gb;
+            }
+        }
+        gb = ab.build();
+        //System.out.println("gb = " + gb);
+        return gb;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/RunSGB.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/RunSGB.java
@@ -1,0 +1,338 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.StringReader;
+import java.io.IOException;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.BufferedReader;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Arrays;
+
+import edu.jas.gb.SolvableGroebnerBase;
+import edu.jas.gb.SolvableGroebnerBaseAbstract;
+import edu.jas.gb.SolvableGroebnerBaseParallel;
+import edu.jas.gb.SolvableGroebnerBaseSeq;
+import edu.jas.gb.SolvableGroebnerBaseSeqPairParallel;
+import edu.jas.gb.SolvableReduction;
+import edu.jas.gb.SolvableReductionPar;
+import edu.jas.gb.SolvableReductionSeq;
+import edu.jas.kern.ComputerThreads;
+import edu.jas.poly.GenPolynomialTokenizer;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.GenSolvablePolynomialRing;
+import edu.jas.poly.PolynomialList;
+import edu.jas.util.CatReader;
+
+
+/**
+ * Simple setup to run a solvable GB example. <br> Usage: RunSGB
+ * [seq|par|par+] [irr|left|right|two] &lt;file&gt; #procs
+ * @author Heinz Kredel
+ */
+public class RunSGB {
+
+    /**
+     * Check result GB if it is a GB.
+     */
+    static boolean doCheck = false;
+
+
+    /**
+     * main method to be called from commandline <br> Usage: RunSGB
+     * [seq|seq+|par|par+] [irr|left|right|two] &lt;file&gt; #procs
+     */
+    @SuppressWarnings("unchecked")
+    public static void main(String[] args) {
+
+        String[] allkinds = new String[] { "seq", "seq+", 
+                                           "par", "par+", 
+                                           //"dist", "dist+", ,
+                                           //"disthyb", "disthyb+", 
+                                           //"cli" 
+                                         }; // must be last
+        String[] allmeth = new String[] { "irr", "left", "right", "two" };
+
+        String usage = "Usage: RunGB [ "
+                        + join(allkinds, " | ") 
+                        //+ "[port] ] " 
+                        + " ] ["
+                        + join(allmeth, " | ") 
+                        + "] <file> " 
+                        + "#threads " 
+                        //+ "#procs/#threadsPerNode " 
+                        //+ "[machinefile] ";
+                        + "[check] ";
+
+        if (args.length < 3) {
+            System.out.println("args: " + Arrays.toString(args));
+            System.out.println(usage);
+            return;
+        }
+
+        boolean plusextra = false;
+        String kind = args[0];
+        boolean sup = false;
+        int k = -1;
+        for (int i = 0; i < args.length; i++) {
+            int j = indexOf(allkinds, args[i]);
+            if (j < 0) {
+                continue;
+            }
+            sup = true;
+            k = i;
+            kind = args[k];
+            break;
+        }
+        if (!sup) {
+            System.out.println("args(sup): " + Arrays.toString(args));
+            System.out.println(usage);
+            return;
+        }
+        if (kind.indexOf("+") >= 0) {
+            plusextra = true;
+        }
+        System.out.println("kind: " + kind + ", k = " + k);
+
+        String action = args[k + 1];
+        sup = false;
+        int j = indexOf(allmeth, action);
+        if (j < 0) {
+            System.out.println(usage);
+            return;
+        }
+
+        String filename = args[k + 2];
+
+        int threads = 0;
+        if (kind.startsWith("par")) {
+            if (args.length < 4) {
+                System.out.println("args(par): " + Arrays.toString(args));
+                System.out.println(usage);
+                return;
+            }
+            String tup = args[k + 3];
+            String t = tup;
+            try {
+                threads = Integer.parseInt(t);
+            } catch (NumberFormatException e) {
+                e.printStackTrace();
+                System.out.println("args(threads): " + Arrays.toString(args));
+                System.out.println(usage);
+                return;
+            }
+            if (threads < 1) {
+                threads = 1;
+            }
+        }
+        j = indexOf(args, "check");
+        if (j >= 0) {
+            doCheck = true;
+        }
+
+        Reader problem = RunGB.getReader(filename);
+        if (problem == null) {
+            System.out.println("args(file): " + filename);
+            System.out.println("args(file): examples.jar(" + filename + ")");
+            System.out.println("args(file): " + Arrays.toString(args));
+            System.out.println(usage);
+            return;
+        }
+        RingFactoryTokenizer rftok = new RingFactoryTokenizer(problem);
+        GenSolvablePolynomialRing spfac = null;
+        try {
+            spfac = rftok.nextSolvablePolynomialRing();
+            rftok = null;
+        } catch (IOException e) {
+            e.printStackTrace();
+            return;
+        }
+        Reader polyreader = new CatReader(new StringReader("("),problem); // ( has gone
+        //Reader polyreader = problem; 
+        GenPolynomialTokenizer tok = new GenPolynomialTokenizer(spfac,polyreader);
+        PolynomialList S = null;
+        try {
+            S = new PolynomialList(spfac,tok.nextSolvablePolynomialList());
+        } catch (IOException e) {
+            e.printStackTrace();
+            return;
+        }
+        System.out.println("S =\n" + S);
+
+        if (kind.startsWith("seq")) {
+            runSequential(S, action, plusextra);
+        } else if (kind.startsWith("par")) {
+            runParallel(S, threads, action, plusextra);
+        }
+        ComputerThreads.terminate();
+    }
+
+
+    /**
+     * run Sequential.
+     * @param S polynomial list.
+     * @param action what to to.
+     */
+    @SuppressWarnings("unchecked")
+    static void runSequential(PolynomialList S, String action, boolean plusextra) {
+        List<GenSolvablePolynomial> L = S.list;
+        List<GenSolvablePolynomial> G = null;
+        long t;
+        SolvableReduction sred = new SolvableReductionSeq();
+        SolvableGroebnerBase sbb = null;
+        if (plusextra) {
+            //sbb = new SolvableGroebnerBaseSeqPlusextra();
+            //System.out.println("SolvableGroebnerBaseSeqPlusextra not implemented using SolvableGroebnerBaseSeq");
+            sbb = new SolvableGroebnerBaseSeq(sred);
+        } else {
+            sbb = new SolvableGroebnerBaseSeq();
+        }
+        t = System.currentTimeMillis();
+        System.out.println("\nSolvable GB [" + action + "] sequential ...");
+        if (action.equals("irr")) {
+            G = sred.leftIrreducibleSet(L);
+        }
+        if (action.equals("left")) {
+            G = sbb.leftGB(L);
+        }
+        if (action.equals("right")) {
+            G = sbb.rightGB(L);
+        }
+        if (action.equals("two")) {
+            G = sbb.twosidedGB(L);
+        }
+        if (G == null) {
+            System.out.println("unknown action = " + action + "\n");
+            return;
+        }
+        S = new PolynomialList(S.ring, G);
+        System.out.println("G =\n" + S);
+        System.out.println("G.size() = " + G.size());
+        t = System.currentTimeMillis() - t;
+        if (plusextra) {
+            System.out.print("seq+, ");
+        } else {
+            System.out.print("seq, ");
+        }
+        System.out.println("time = " + t + " milliseconds");
+        checkGB(S);
+        System.out.println("");
+    }
+
+
+    /**
+     * run Parallel.
+     * @param S polynomial list.
+     * @param action what to to.
+     */
+    @SuppressWarnings("unchecked")
+    static void runParallel(PolynomialList S, int threads, String action, boolean plusextra) {
+        List<GenSolvablePolynomial> L = S.list;
+        List<GenSolvablePolynomial> G = null;
+        long t;
+        SolvableReduction sred = new SolvableReductionPar();
+        SolvableGroebnerBaseParallel sbb = null;
+        SolvableGroebnerBaseSeqPairParallel sbbs = null;
+        if (plusextra) {
+            sbbs = new SolvableGroebnerBaseSeqPairParallel(threads);
+        } else {
+            sbb = new SolvableGroebnerBaseParallel(threads);
+        }
+
+        t = System.currentTimeMillis();
+        System.out.println("\nSolvable GB [" + action + "] parallel " + threads + " threads ...");
+        if (action.equals("irr")) {
+            G = sred.leftIrreducibleSet(L);
+        }
+        if (action.equals("left")) {
+            if (plusextra) {
+                G = sbbs.leftGB(L);
+            } else {
+                G = sbb.leftGB(L);
+            }
+        }
+        if (action.equals("right")) {
+            if (plusextra) {
+                G = sbbs.rightGB(L);
+            } else {
+                G = sbb.rightGB(L);
+            }
+        }
+        if (action.equals("two")) {
+            if (plusextra) {
+                G = sbbs.twosidedGB(L);
+            } else {
+                G = sbb.twosidedGB(L);
+            }
+        }
+        if (G == null) {
+            System.out.println("unknown action = " + action + "\n");
+            return;
+        }
+        if (G.size() > 0) {
+            S = new PolynomialList(G.get(0).ring, G);
+        } else {
+            S = new PolynomialList(S.ring, G);
+        }
+        System.out.println("G =\n" + S);
+        System.out.println("G.size() = " + G.size());
+        t = System.currentTimeMillis() - t;
+        if (plusextra) {
+            System.out.print("p+ ");
+        } else {
+            System.out.print("p ");
+        }
+        System.out.println("= " + threads + ", time = " + t + " milliseconds");
+        checkGB(S);
+        System.out.println("");
+        if (plusextra) {
+            sbbs.terminate();
+        } else {
+            sbb.terminate();
+        }
+    }
+
+
+    @SuppressWarnings("unchecked")
+    static void checkGB(PolynomialList S) {
+        if (!doCheck) {
+            return;
+        }
+        SolvableGroebnerBaseAbstract sbb = new SolvableGroebnerBaseSeq();
+        long t = System.currentTimeMillis();
+        boolean chk = sbb.isLeftGB(S.list,false);
+        t = System.currentTimeMillis() - t;
+        System.out.println("check isGB = " + chk + " in " + t + " milliseconds");
+    }
+
+
+    static int indexOf(String[] args, String s) {
+        for (int i = 0; i < args.length; i++) {
+            if (s.equals(args[i])) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+
+    static String join(String[] args, String d) {
+        StringBuffer sb = new StringBuffer();
+        for (int i = 0; i < args.length; i++) {
+            if (i > 0) {
+                sb.append(d);
+            }
+            sb.append(args[i]);
+        }
+        return sb.toString();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/SolvableIdeal.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/SolvableIdeal.java
@@ -1,0 +1,1519 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.SolvableExtendedGB;
+import edu.jas.gb.SolvableGroebnerBaseAbstract;
+import edu.jas.gb.SolvableReduction;
+import edu.jas.gb.SolvableReductionSeq;
+import edu.jas.gbufd.PolyGBUtil;
+import edu.jas.gbufd.SGBFactory;
+import edu.jas.gbufd.SolvableSyzygyAbstract;
+import edu.jas.gbufd.SolvableSyzygySeq;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.GenSolvablePolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.poly.PolynomialList;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.NotInvertibleException;
+
+
+/**
+ * Solvable Ideal implements some methods for ideal arithmetic, for example sum,
+ * intersection, quotient. <b>Note:</b> only left ideals at the moment.
+ * @author Heinz Kredel
+ */
+public class SolvableIdeal<C extends GcdRingElem<C>> implements Comparable<SolvableIdeal<C>>, Serializable {
+
+
+    private static final Logger logger = LogManager.getLogger(SolvableIdeal.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Side variant of ideal.
+     */
+    public static enum Side {
+        left, right, twosided
+    }
+
+
+    /**
+     * The data structure is a PolynomialList.
+     */
+    protected PolynomialList<C> list;
+
+
+    /**
+     * Indicator if list is a Groebner Base.
+     */
+    protected boolean isGB;
+
+
+    /**
+     * Indicator of side of Groebner Base.
+     */
+    protected Side sided;
+
+
+    /**
+     * Indicator if test has been performed if this is a Groebner Base.
+     */
+    protected boolean testGB;
+
+
+    /**
+     * Indicator if list has optimized term order.
+     */
+    protected boolean isTopt;
+
+
+    /**
+     * Groebner base engine.
+     */
+    protected final SolvableGroebnerBaseAbstract<C> bb;
+
+
+    /**
+     * Reduction engine.
+     */
+    protected final SolvableReduction<C> red;
+
+
+    /**
+     * Constructor.
+     * @param ring solvable polynomial ring
+     */
+    public SolvableIdeal(GenSolvablePolynomialRing<C> ring) {
+        this(ring, new ArrayList<GenSolvablePolynomial<C>>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param ring solvable polynomial ring
+     * @param F list of solvable polynomials
+     */
+    public SolvableIdeal(GenSolvablePolynomialRing<C> ring, List<GenSolvablePolynomial<C>> F) {
+        this(new PolynomialList<C>(ring, F));
+    }
+
+
+    /**
+     * Constructor.
+     * @param ring solvable polynomial ring
+     * @param F list of solvable polynomials
+     * @param gb true if F is known to be a Groebner Base, else false
+     */
+    public SolvableIdeal(GenSolvablePolynomialRing<C> ring, List<GenSolvablePolynomial<C>> F, boolean gb) {
+        this(new PolynomialList<C>(ring, F), gb);
+    }
+
+
+    /**
+     * Constructor.
+     * @param ring solvable polynomial ring
+     * @param F list of solvable polynomials
+     * @param gb true if F is known to be a Groebner Base, else false
+     * @param topt true if term order is optimized, else false
+     */
+    public SolvableIdeal(GenSolvablePolynomialRing<C> ring, List<GenSolvablePolynomial<C>> F, boolean gb,
+                    boolean topt) {
+        this(new PolynomialList<C>(ring, F), gb, topt);
+    }
+
+
+    /**
+     * Constructor.
+     * @param ring solvable polynomial ring
+     * @param F list of solvable polynomials
+     * @param s side variant of ideal or Groebner Base
+     */
+    public SolvableIdeal(GenSolvablePolynomialRing<C> ring, List<GenSolvablePolynomial<C>> F, Side s) {
+        this(new PolynomialList<C>(ring, F), false, false, s);
+    }
+
+
+    /**
+     * Constructor.
+     * @param ring solvable polynomial ring
+     * @param F list of solvable polynomials
+     * @param gb true if F is known to be a Groebner Base, else false
+     * @param s side variant of ideal or Groebner Base
+     */
+    public SolvableIdeal(GenSolvablePolynomialRing<C> ring, List<GenSolvablePolynomial<C>> F, boolean gb,
+                    Side s) {
+        this(new PolynomialList<C>(ring, F), gb, false, s);
+    }
+
+
+    /**
+     * Constructor.
+     * @param list solvable polynomial list
+     */
+    public SolvableIdeal(PolynomialList<C> list) {
+        this(list, false);
+    }
+
+
+    /**
+     * Constructor.
+     * @param list solvable polynomial list
+     * @param bb Groebner Base engine
+     * @param red Reduction engine
+     */
+    public SolvableIdeal(PolynomialList<C> list, SolvableGroebnerBaseAbstract<C> bb,
+                    SolvableReduction<C> red) {
+        this(list, false, bb, red);
+    }
+
+
+    /**
+     * Constructor.
+     * @param list solvable polynomial list
+     * @param gb true if list is known to be a Groebner Base, else false
+     */
+    public SolvableIdeal(PolynomialList<C> list, boolean gb) {
+        //this(list, gb, new SolvableGroebnerBaseSeq<C>(), new SolvableReductionSeq<C>());
+        this(list, gb, SGBFactory.getImplementation(list.ring.coFac), new SolvableReductionSeq<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param list solvable polynomial list
+     * @param gb true if list is known to be a Groebner Base, else false
+     * @param topt true if term order is optimized, else false
+     */
+    public SolvableIdeal(PolynomialList<C> list, boolean gb, boolean topt) {
+        //this(list, gb, topt, new SolvableGroebnerBaseSeq<C>(), new SolvableReductionSeq<C>());
+        this(list, gb, topt, SGBFactory.getImplementation(list.ring.coFac), new SolvableReductionSeq<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param list solvable polynomial list
+     * @param gb true if list is known to be a Groebner Base, else false
+     * @param s side variant of ideal or Groebner Base
+     */
+    public SolvableIdeal(PolynomialList<C> list, boolean gb, Side s) {
+        //this(list, gb, false, new SolvableGroebnerBaseSeq<C>(), new SolvableReductionSeq<C>());
+        this(list, gb, false, SGBFactory.getImplementation(list.ring.coFac), new SolvableReductionSeq<C>(),
+                        s);
+    }
+
+
+    /**
+     * Constructor.
+     * @param list solvable polynomial list
+     * @param gb true if list is known to be a Groebner Base, else false
+     * @param topt true if term order is optimized, else false
+     * @param s side variant of ideal or Groebner Base
+     */
+    public SolvableIdeal(PolynomialList<C> list, boolean gb, boolean topt, Side s) {
+        //this(list, gb, topt, new SolvableGroebnerBaseSeq<C>(), new SolvableReductionSeq<C>());
+        this(list, gb, topt, SGBFactory.getImplementation(list.ring.coFac), new SolvableReductionSeq<C>(), s);
+    }
+
+
+    /**
+     * Constructor.
+     * @param list solvable polynomial list
+     * @param gb true if list is known to be a Groebner Base, else false
+     * @param bb Groebner Base engine
+     * @param red Reduction engine
+     */
+    public SolvableIdeal(PolynomialList<C> list, boolean gb, SolvableGroebnerBaseAbstract<C> bb,
+                    SolvableReduction<C> red) {
+        this(list, gb, false, bb, red);
+    }
+
+
+    /**
+     * Constructor.
+     * @param list solvable polynomial list
+     * @param gb true if list is known to be a Groebner Base, else false
+     * @param bb Groebner Base engine
+     */
+    public SolvableIdeal(PolynomialList<C> list, boolean gb, SolvableGroebnerBaseAbstract<C> bb) {
+        this(list, gb, false, bb, bb.sred);
+    }
+
+
+    /**
+     * Constructor.
+     * @param list solvable polynomial list
+     * @param gb true if list is known to be a Groebner Base, else false
+     * @param topt true if term order is optimized, else false
+     * @param bb Groebner Base engine
+     */
+    public SolvableIdeal(PolynomialList<C> list, boolean gb, boolean topt,
+                    SolvableGroebnerBaseAbstract<C> bb) {
+        this(list, gb, topt, bb, bb.sred);
+    }
+
+
+    /**
+     * Constructor.
+     * @param list solvable polynomial list
+     * @param gb true if list is known to be a Groebner Base, else false
+     * @param topt true if term order is optimized, else false
+     * @param bb Groebner Base engine
+     * @param red Reduction engine
+     */
+    public SolvableIdeal(PolynomialList<C> list, boolean gb, boolean topt, SolvableGroebnerBaseAbstract<C> bb,
+                    SolvableReduction<C> red) {
+        this(list, gb, topt, bb, red, Side.left);
+    }
+
+
+    /**
+     * Constructor.
+     * @param list solvable polynomial list
+     * @param gb true if list is known to be a Groebner Base, else false
+     * @param topt true if term order is optimized, else false
+     * @param bb Groebner Base engine
+     * @param red Reduction engine
+     * @param s side variant of ideal or Groebner Base
+     */
+    public SolvableIdeal(PolynomialList<C> list, boolean gb, boolean topt, SolvableGroebnerBaseAbstract<C> bb,
+                    SolvableReduction<C> red, Side s) {
+        if (list == null || list.list == null) {
+            throw new IllegalArgumentException("list and list.list may not be null");
+        }
+        this.list = list;
+        this.isGB = gb;
+        this.isTopt = topt;
+        this.testGB = (gb ? true : false); // ??
+        this.bb = bb;
+        this.red = red;
+        if (s == null) {
+            s = Side.left; // default
+        }
+        this.sided = s;
+    }
+
+
+    /**
+     * Clone this.
+     * @return a copy of this.
+     */
+    public SolvableIdeal<C> copy() {
+        return new SolvableIdeal<C>(list.copy(), isGB, isTopt, bb, red, sided);
+    }
+
+
+    /**
+     * Get the List of GenSolvablePolynomials.
+     * @return (cast) list.list
+     */
+    public List<GenSolvablePolynomial<C>> getList() {
+        return list.getSolvableList();
+    }
+
+
+    /**
+     * Get the GenSolvablePolynomialRing.
+     * @return (cast) list.ring
+     */
+    public GenSolvablePolynomialRing<C> getRing() {
+        return list.getSolvableRing();
+    }
+
+
+    /**
+     * Get the zero ideal.
+     * @return ideal(0)
+     */
+    public SolvableIdeal<C> getZERO() {
+        List<GenSolvablePolynomial<C>> z = new ArrayList<GenSolvablePolynomial<C>>(0);
+        PolynomialList<C> pl = new PolynomialList<C>(getRing(), z);
+        return new SolvableIdeal<C>(pl, true, isTopt, bb, red, sided);
+    }
+
+
+    /**
+     * Get the one ideal.
+     * @return ideal(1)
+     */
+    public SolvableIdeal<C> getONE() {
+        List<GenSolvablePolynomial<C>> one = new ArrayList<GenSolvablePolynomial<C>>(1);
+        one.add(getRing().getONE());
+        PolynomialList<C> pl = new PolynomialList<C>(getRing(), one);
+        return new SolvableIdeal<C>(pl, true, isTopt, bb, red, sided);
+    }
+
+
+    /**
+     * String representation of the solvable ideal.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return list.toString() + " # " + sided;
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    public String toScript() {
+        // any script case
+        return list.toScript() + " # " + sided;
+    }
+
+
+    /**
+     * Comparison with any other object. <b>Note:</b> If not both ideals are
+     * Groebner Bases, then false may be returned even the ideals are equal.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (!(b instanceof SolvableIdeal)) {
+            logger.warn("equals no Ideal");
+            return false;
+        }
+        SolvableIdeal<C> B = null;
+        try {
+            B = (SolvableIdeal<C>) b;
+        } catch (ClassCastException ignored) {
+            return false;
+        }
+        //if ( isGB && B.isGB ) {
+        //   return list.equals( B.list ); requires also monic polys
+        //} else { // compute GBs ?
+        return this.contains(B) && B.contains(this);
+        //}
+    }
+
+
+    /**
+     * SolvableIdeal comparison.
+     * @param L other solvable ideal.
+     * @return compareTo() of polynomial lists.
+     */
+    public int compareTo(SolvableIdeal<C> L) {
+        return list.compareTo(L.list);
+    }
+
+
+    /**
+     * Hash code for this solvable ideal.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = list.hashCode();
+        if (isGB) {
+            h = h << 1;
+        }
+        if (testGB) {
+            h += 1;
+        }
+        return h;
+    }
+
+
+    /**
+     * Test if ZERO ideal.
+     * @return true, if this is the 0 ideal, else false
+     */
+    public boolean isZERO() {
+        return list.isZERO();
+    }
+
+
+    /**
+     * Test if ONE is contained in the ideal. To test for a proper ideal use
+     * <code>! id.isONE()</code>.
+     * @return true, if this is the 1 ideal, else false
+     */
+    public boolean isONE() {
+        return list.isONE();
+    }
+
+
+    /**
+     * Test if this is a left Groebner base.
+     * @return true, if this is a left Groebner base, else false
+     */
+    public boolean isGB() {
+        if (testGB && sided == Side.left) {
+            return isGB;
+        }
+        logger.warn("isLeftGB computing");
+        boolean igb = bb.isLeftGB(getList());
+        if (sided != Side.left) {
+            logger.warn("wrong usage for is left sided GB: " + sided);
+            //sided = Side.left;
+        } else {
+            isGB = igb;
+            testGB = true;
+        }
+        return igb;
+    }
+
+
+    /**
+     * Do Groebner Base. compute the left Groebner Base for this ideal.
+     */
+    @SuppressWarnings("unchecked")
+    public void doGB() {
+        if (isGB && sided == Side.left) {
+            return;
+        }
+        if (isGB && sided == Side.twosided) {
+            return;
+        }
+        if (sided == Side.right) {
+            logger.warn("wrong usage for left sided GB: " + sided);
+            throw new IllegalArgumentException("wrong usage for left sided GB: " + sided);
+        }
+        List<GenSolvablePolynomial<C>> G = getList();
+        if (sided == Side.left) {
+            logger.info("leftGB computing = " + G);
+            G = bb.leftGB(G);
+        }
+        if (sided == Side.twosided) {
+            logger.info("twosidedGB computing = " + G);
+            G = bb.twosidedGB(G);
+        }
+        //if (isTopt) {
+        //    List<Integer> perm = ((OptimizedPolynomialList<C>) list).perm;
+        //    list = new OptimizedPolynomialList<C>(perm, getRing(), G);
+        //} else {
+        //}
+        list = new PolynomialList<C>(getRing(), G);
+        isGB = true;
+        testGB = true;
+        //sided = Side.left;
+        return;
+    }
+
+
+    /**
+     * Groebner Base. Get a left Groebner Base for this ideal.
+     * @return leftGB(this)
+     */
+    public SolvableIdeal<C> GB() {
+        if (isGB && sided == Side.left) {
+            return this;
+        }
+        doGB();
+        return this;
+    }
+
+
+    /**
+     * Test if this is a twosided Groebner base.
+     * @return true, if this is a twosided Groebner base, else false
+     */
+    public boolean isTwosidedGB() {
+        if (testGB && sided == Side.twosided) {
+            return isGB;
+        }
+        logger.warn("isTwosidedGB computing");
+        isGB = bb.isTwosidedGB(getList());
+        testGB = true;
+        sided = Side.twosided;
+        return isGB;
+    }
+
+
+    /**
+     * Groebner Base. Get a twosided Groebner Base for this ideal.
+     * @return twosidedGB(this)
+     */
+    public SolvableIdeal<C> twosidedGB() {
+        if (isGB && sided == Side.twosided) {
+            return this;
+        }
+        //logger.warn("GB computing");
+        List<GenSolvablePolynomial<C>> G = getList();
+        logger.info("twosidedGB computing = " + G);
+        G = bb.twosidedGB(G);
+        PolynomialList<C> li = new PolynomialList<C>(getRing(), G);
+        SolvableIdeal<C> tsgb = new SolvableIdeal<C>(li, true, true, bb, red, Side.twosided);
+        return tsgb;
+    }
+
+
+    /**
+     * Test if this is a right Groebner base.
+     * @return true, if this is a right Groebner base, else false
+     */
+    public boolean isRightGB() {
+        if (testGB && sided == Side.right) {
+            return isGB;
+        }
+        if (isGB && sided == Side.twosided) {
+            return true;
+        }
+        logger.warn("isRightGB computing");
+        isGB = bb.isRightGB(getList());
+        testGB = true;
+        sided = Side.right;
+        return isGB;
+    }
+
+
+    /**
+     * Groebner Base. Get a right Groebner Base for this ideal.
+     * @return rightGB(this)
+     */
+    public SolvableIdeal<C> rightGB() {
+        if (isGB && sided == Side.twosided) {
+            return this;
+        }
+        if (isGB && sided == Side.right) {
+            return this;
+        }
+        //logger.warn("GB computing");
+        List<GenSolvablePolynomial<C>> G = getList();
+        logger.info("rightGB computing = " + G);
+        G = bb.rightGB(G);
+        PolynomialList<C> li = new PolynomialList<C>(getRing(), G);
+        SolvableIdeal<C> rgb = new SolvableIdeal<C>(li, true, true, bb, red, Side.right);
+        return rgb;
+    }
+
+
+    /**
+     * Solvable ideal containment. Test if B is contained in this ideal. Note:
+     * this is eventually modified to become a Groebner Base.
+     * @param B solvable ideal
+     * @return true, if B is contained in this, else false
+     */
+    public boolean contains(SolvableIdeal<C> B) {
+        if (B == null || B.isZERO()) {
+            return true;
+        }
+        return contains(B.getList());
+    }
+
+
+    /**
+     * Solvable ideal containment. Test if b is contained in this ideal. Note:
+     * this is eventually modified to become a Groebner Base.
+     * @param b solvable polynomial
+     * @return true, if b is contained in this, else false
+     */
+    public boolean contains(GenSolvablePolynomial<C> b) {
+        if (b == null || b.isZERO()) {
+            return true;
+        }
+        if (this.isONE()) {
+            return true;
+        }
+        if (this.isZERO()) {
+            return false;
+        }
+        if (!isGB) {
+            doGB();
+        }
+        GenSolvablePolynomial<C> z = red.leftNormalform(getList(), b);
+        if (z == null || z.isZERO()) {
+            return true;
+        }
+        return false;
+    }
+
+
+    /**
+     * Solvable ideal containment. Test if each b in B is contained in this
+     * ideal. Note: this is eventually modified to become a Groebner Base.
+     * @param B list of solvable polynomials
+     * @return true, if each b in B is contained in this, else false
+     */
+    public boolean contains(List<GenSolvablePolynomial<C>> B) {
+        if (B == null || B.size() == 0) {
+            return true;
+        }
+        if (this.isONE()) {
+            return true;
+        }
+        if (!isGB) {
+            doGB();
+        }
+        List<GenSolvablePolynomial<C>> si = getList();
+        for (GenSolvablePolynomial<C> b : B) {
+            if (b == null) {
+                continue;
+            }
+            GenSolvablePolynomial<C> z = red.leftNormalform(si, b);
+            if (!z.isZERO()) {
+                logger.info("contains nf(b) != 0: " + z + " of " + b);
+                //        + ", si = " + si + ", ring = " + z.ring.toScript());
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Solvable ideal summation. Generators for the sum of ideals. Note: if both
+     * ideals are Groebner bases, a Groebner base is returned.
+     * @param B solvable ideal
+     * @return ideal(this+B)
+     */
+    public SolvableIdeal<C> sum(SolvableIdeal<C> B) {
+        if (B == null || B.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return B;
+        }
+        int s = getList().size() + B.getList().size();
+        List<GenSolvablePolynomial<C>> c;
+        c = new ArrayList<GenSolvablePolynomial<C>>(s);
+        c.addAll(getList());
+        c.addAll(B.getList());
+        SolvableIdeal<C> I = new SolvableIdeal<C>(getRing(), c, false, sided);
+        if (isGB && B.isGB) {
+            I.doGB(); // left, twosided, right handled in doGB
+        }
+        return I;
+    }
+
+
+    /**
+     * Solvable summation. Generators for the sum of ideal and a polynomial.
+     * Note: if this ideal is a Groebner base, a Groebner base is returned.
+     * @param b solvable polynomial
+     * @return ideal(this+{b})
+     */
+    public SolvableIdeal<C> sum(GenSolvablePolynomial<C> b) {
+        if (b == null || b.isZERO()) {
+            return this;
+        }
+        int s = getList().size() + 1;
+        List<GenSolvablePolynomial<C>> c;
+        c = new ArrayList<GenSolvablePolynomial<C>>(s);
+        c.addAll(getList());
+        c.add(b);
+        SolvableIdeal<C> I = new SolvableIdeal<C>(getRing(), c, false, sided);
+        if (isGB) {
+            I.doGB();
+        }
+        return I;
+    }
+
+
+    /**
+     * Solvable summation. Generators for the sum of this ideal and a list of
+     * polynomials. Note: if this ideal is a Groebner base, a Groebner base is
+     * returned.
+     * @param L list of solvable polynomials
+     * @return ideal(this+L)
+     */
+    public SolvableIdeal<C> sum(List<GenSolvablePolynomial<C>> L) {
+        if (L == null || L.isEmpty()) {
+            return this;
+        }
+        int s = getList().size() + L.size();
+        List<GenSolvablePolynomial<C>> c = new ArrayList<GenSolvablePolynomial<C>>(s);
+        c.addAll(getList());
+        c.addAll(L);
+        SolvableIdeal<C> I = new SolvableIdeal<C>(getRing(), c, false, sided);
+        if (isGB) {
+            I.doGB();
+        }
+        return I;
+    }
+
+
+    /**
+     * Product. Generators for the product of ideals. Note: if both ideals are
+     * Groebner bases, a Groebner base is returned.
+     * @param B solvable ideal
+     * @return ideal(this*B)
+     */
+    public SolvableIdeal<C> product(SolvableIdeal<C> B) {
+        if (B == null || B.isZERO()) {
+            return B;
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        int s = getList().size() * B.getList().size();
+        List<GenSolvablePolynomial<C>> c;
+        c = new ArrayList<GenSolvablePolynomial<C>>(s);
+        for (GenSolvablePolynomial<C> p : getList()) {
+            for (GenSolvablePolynomial<C> q : B.getList()) {
+                q = p.multiply(q);
+                c.add(q);
+            }
+        }
+        SolvableIdeal<C> I = new SolvableIdeal<C>(getRing(), c, false, sided);
+        if (isGB && B.isGB) {
+            I.doGB();
+        }
+        return I;
+    }
+
+
+    /**
+     * Left product. Generators for the product this by a polynomial.
+     * @param b solvable polynomial
+     * @return ideal(this*b)
+     */
+    public SolvableIdeal<C> product(GenSolvablePolynomial<C> b) {
+        if (b == null || b.isZERO()) {
+            return getZERO();
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        List<GenSolvablePolynomial<C>> c;
+        c = new ArrayList<GenSolvablePolynomial<C>>(getList().size());
+        for (GenSolvablePolynomial<C> p : getList()) {
+            GenSolvablePolynomial<C> q = p.multiply(b);
+            c.add(q);
+        }
+        SolvableIdeal<C> I = new SolvableIdeal<C>(getRing(), c, false, sided);
+        if (isGB) {
+            I.doGB();
+        }
+        return I;
+    }
+
+
+    /**
+     * Intersection. Generators for the intersection of ideals. Using an
+     * iterative algorithm.
+     * @param Bl list of solvable ideals
+     * @return ideal(cap_i B_i), a Groebner base
+     */
+    public SolvableIdeal<C> intersect(List<SolvableIdeal<C>> Bl) {
+        if (Bl == null || Bl.size() == 0) {
+            return getZERO();
+        }
+        SolvableIdeal<C> I = null;
+        for (SolvableIdeal<C> B : Bl) {
+            if (I == null) {
+                I = B;
+                continue;
+            }
+            if (I.isONE()) {
+                return I;
+            }
+            I = I.intersect(B);
+        }
+        return I;
+    }
+
+
+    /**
+     * Intersection. Generators for the intersection of ideals.
+     * @param B solvable ideal
+     * @return ideal(this \cap B), a Groebner base
+     */
+    public SolvableIdeal<C> intersect(SolvableIdeal<C> B) {
+        if (B == null || B.isZERO()) { // (0)
+            return B;
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        List<GenSolvablePolynomial<C>> c = PolyGBUtil.<C> intersect(getRing(), getList(), B.getList());
+        SolvableIdeal<C> I = new SolvableIdeal<C>(getRing(), c, true, sided);
+        return I;
+    }
+
+
+    /**
+     * Intersection. Generators for the intersection of a ideal with a
+     * polynomial ring. The polynomial ring R must be a contraction
+     * of this ideal and the TermOrder must be an elimination order.
+     * @param R solvable polynomial ring
+     * @return ideal(this \cap R)
+     */
+    public SolvableIdeal<C> intersect(GenSolvablePolynomialRing<C> R) {
+        if (R == null) {
+            throw new IllegalArgumentException("R may not be null");
+        }
+        String[] rvars = R.getVars();
+        String[] tvars = getRing().getVars();
+        for (int i = 0; i < rvars.length; i++) {
+            if (!rvars[i].equals(tvars[i])) {
+                throw new IllegalArgumentException("no contraction: " + R.toScript() 
+                                                 + " of " + getRing().toScript());
+            }
+        }
+        List<GenSolvablePolynomial<C>> H = PolyUtil.<C> intersect(R, getList());
+        return new SolvableIdeal<C>(R, H, isGB, sided);
+    }
+
+
+    /**
+     * Eliminate. Generators for the intersection of this ideal with a solvable
+     * polynomial ring. The solvable polynomial ring of this ideal must be a
+     * contraction of R and the TermOrder must be an elimination order.
+     * @param R solvable polynomial ring
+     * @return ideal(this \cap R)
+     */
+    public SolvableIdeal<C> eliminate(GenSolvablePolynomialRing<C> R) {
+        if (R == null) {
+            throw new IllegalArgumentException("R may not be null");
+        }
+        if (getRing().equals(R)) {
+            return this;
+        }
+        return intersect(R);
+    }
+
+
+    /**
+     * Quotient. Generators for the solvable ideal quotient.
+     * @param h solvable polynomial
+     * @return ideal(this : h), a Groebner base
+     */
+    //@SuppressWarnings("unchecked")
+    public SolvableIdeal<C> quotient(GenSolvablePolynomial<C> h) {
+        if (h == null) { // == (0)
+            return this;
+        }
+        if (h.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        List<GenSolvablePolynomial<C>> H;
+        H = new ArrayList<GenSolvablePolynomial<C>>(1);
+        H.add(h);
+        SolvableIdeal<C> Hi = new SolvableIdeal<C>(getRing(), H, true, sided);
+
+        SolvableIdeal<C> I = this.intersect(Hi);
+
+        List<GenSolvablePolynomial<C>> Q;
+        Q = new ArrayList<GenSolvablePolynomial<C>>(I.getList().size());
+        GenSolvablePolynomial<C> p;
+        for (GenSolvablePolynomial<C> q : I.getList()) {
+            p = q.divide(h); // remainder == 0, (GenSolvablePolynomial<C>)
+            if (!p.isZERO()) {
+                p = p.monic();
+                Q.add(p);
+            }
+            if (debug) {
+                GenSolvablePolynomial<C> r = q.remainder(h); // (GenSolvablePolynomial<C>)
+                if (!r.isZERO()) {
+                    System.out.println("error remainder !=0: " + r + ", q = " + q + ", h = " + h);
+                    throw new RuntimeException("remainder !=0");
+                }
+            }
+        }
+        return new SolvableIdeal<C>(getRing(), Q, true /*false?*/, sided);
+    }
+
+
+    /**
+     * Quotient. Generators for the solvable ideal quotient.
+     * @param H solvable ideal
+     * @return ideal(this : H), a Groebner base
+     */
+    public SolvableIdeal<C> quotient(SolvableIdeal<C> H) {
+        if (H == null || H.isZERO()) { // == (0)
+            return this;
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        SolvableIdeal<C> Q = null;
+        for (GenSolvablePolynomial<C> h : H.getList()) {
+            SolvableIdeal<C> Hi = this.quotient(h);
+            if (Q == null) {
+                Q = Hi;
+            } else {
+                Q = Q.intersect(Hi);
+            }
+        }
+        return Q;
+    }
+
+
+    /**
+     * Infinite quotient. Generators for the infinite solvable ideal quotient.
+     * @param h solvable polynomial
+     * @return ideal(this : h<sup>s</sup>), a Groebner base
+     */
+    public SolvableIdeal<C> infiniteQuotientRab(GenSolvablePolynomial<C> h) {
+        if (h == null || h.isZERO()) { // == (0)
+            return getONE();
+        }
+        if (h.isONE()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        if (!getRing().isCommutative()) {
+            throw new UnsupportedOperationException("Rabinowich trick only for commutative polynomial rings");
+        }
+        SolvableIdeal<C> I = this.GB(); // should be already
+        List<GenSolvablePolynomial<C>> a = I.getList();
+        List<GenSolvablePolynomial<C>> c;
+        c = new ArrayList<GenSolvablePolynomial<C>>(a.size() + 1);
+
+        GenSolvablePolynomialRing<C> tfac = getRing().extend(1);
+        // term order is also adjusted
+        for (GenSolvablePolynomial<C> p : a) {
+            p = (GenSolvablePolynomial<C>) p.extend(tfac, 0, 0L); // p
+            c.add(p);
+        }
+        GenSolvablePolynomial<C> q = (GenSolvablePolynomial<C>) h.extend(tfac, 0, 1L);
+        GenSolvablePolynomial<C> r = tfac.getONE(); // h.extend( tfac, 0, 0L );
+        GenSolvablePolynomial<C> hs = (GenSolvablePolynomial<C>) q.subtract(r); // 1 - t*h // (1-t)*h
+        c.add(hs);
+        logger.warn("infiniteQuotientRab computing GB ");
+        List<GenSolvablePolynomial<C>> g = bb.leftGB(c);
+        if (debug) {
+            logger.info("infiniteQuotientRab    = " + tfac + ", c = " + c);
+            logger.info("infiniteQuotientRab GB = " + g);
+        }
+        SolvableIdeal<C> E = new SolvableIdeal<C>(tfac, g, true, sided);
+        SolvableIdeal<C> Is = E.intersect(getRing());
+        return Is;
+    }
+
+
+    /**
+     * Infinite quotient exponent.
+     * @param h solvable polynomial
+     * @param Q quotient this : h^\infinity
+     * @return s with Q = this : h<sup>s</sup>
+     */
+    public int infiniteQuotientExponent(GenSolvablePolynomial<C> h, SolvableIdeal<C> Q) {
+        int s = 0;
+        if (h == null) { // == 0
+            return s;
+        }
+        if (h.isZERO() || h.isONE()) {
+            return s;
+        }
+        if (this.isZERO() || this.isONE()) {
+            return s;
+        }
+        //see below: if (this.contains(Q)) {
+        //    return s;
+        //}
+        GenSolvablePolynomial<C> p = getRing().getONE();
+        for (GenSolvablePolynomial<C> q : Q.getList()) {
+            if (this.contains(q)) {
+                continue;
+            }
+            //System.out.println("q = " + q + ", p = " + p + ", s = " + s);
+            GenSolvablePolynomial<C> qp = q.multiply(p);
+            while (!this.contains(qp)) {
+                p = p.multiply(h);
+                s++;
+                qp = q.multiply(p);
+            }
+        }
+        return s;
+    }
+
+
+    /**
+     * Infinite quotient. Generators for the infinite solvable ideal quotient.
+     * @param h solvable polynomial
+     * @return ideal(this : h<sup>s</sup>), a Groebner base
+     */
+    public SolvableIdeal<C> infiniteQuotient(GenSolvablePolynomial<C> h) {
+        if (h == null) { // == (0)
+            return this;
+        }
+        if (h.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        int s = 0;
+        SolvableIdeal<C> I = this.GB(); // should be already
+        GenSolvablePolynomial<C> hs = h;
+        SolvableIdeal<C> Is = null;
+        logger.info("infiniteQuotient hs = " + hs);
+        long dm = -1;
+        boolean eq = false;
+        while (!eq) {
+            Is = I.quotient(hs);
+            Is = Is.GB(); // should be already
+            //logger.info("ideal Is = " + Is);
+            logger.info("infiniteQuotient s = " + s);
+            if (Is.isZERO()) {
+                logger.warn("infiniteQuotient does not exist");
+                return I;
+            }
+            eq = Is.contains(I); // I.contains(Is) always
+            if (!eq) {
+                long ds = PolyUtil.<C> totalDegree(Is.list.getList());
+                if (dm < 0) {
+                    dm = ds;
+                }
+                //System.out.println("deg(Is) = " + ds);
+                if (ds > dm) {
+                    logger.warn("no convergence in infiniteQuotient (dm,ds): " + dm + " < " + ds);
+                    return I;
+                    //throw new RuntimeException("no convergence in infiniteQuotient");
+                }
+                I = Is;
+                s++;
+                // hs = hs.multiply( h );
+            }
+        }
+        return Is;
+    }
+
+
+    /**
+     * Radical membership test.
+     * @param h solvable polynomial
+     * @return true if h is contained in the radical of ideal(this), else false.
+     */
+    public boolean isRadicalMember(GenSolvablePolynomial<C> h) {
+        if (h == null) { // == (0)
+            return true;
+        }
+        if (h.isZERO()) {
+            return true;
+        }
+        if (this.isZERO()) {
+            return true;
+        }
+        SolvableIdeal<C> x = infiniteQuotientRab(h); // may fail
+        if (debug) {
+            logger.debug("infiniteQuotientRab = " + x);
+        }
+        return x.isONE();
+    }
+
+
+    /**
+     * Infinite Quotient. Generators for the solvable ideal infinite quotient.
+     * @param H solvable ideal
+     * @return ideal(this : H<sup>s</sup>), a Groebner base
+     */
+    public SolvableIdeal<C> infiniteQuotient(SolvableIdeal<C> H) {
+        if (H == null) { // == (0)
+            return this;
+        }
+        if (H.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        SolvableIdeal<C> Q = null;
+        for (GenSolvablePolynomial<C> h : H.getList()) {
+            SolvableIdeal<C> Hi = this.infiniteQuotient(h);
+            if (Q == null) {
+                Q = Hi;
+            } else {
+                Q = Q.intersect(Hi);
+            }
+        }
+        return Q;
+    }
+
+
+    /**
+     * Infinite Quotient. Generators for the solvable ideal infinite quotient.
+     * @param H solvable ideal
+     * @return ideal(this : H<sup>s</sup>), a Groebner base
+     */
+    public SolvableIdeal<C> infiniteQuotientRab(SolvableIdeal<C> H) {
+        if (H == null) { // == (0)
+            return this;
+        }
+        if (H.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        SolvableIdeal<C> Q = null;
+        for (GenSolvablePolynomial<C> h : H.getList()) {
+            SolvableIdeal<C> Hi = this.infiniteQuotientRab(h); // may fail
+            if (Q == null) {
+                Q = Hi;
+            } else {
+                Q = Q.intersect(Hi);
+            }
+        }
+        return Q;
+    }
+
+
+    /**
+     * Power. Generators for the power of this solvable ideal. Note: if this
+     * ideal is a Groebner base, a Groebner base is returned.
+     * @param d integer
+     * @return ideal(this^d)
+     */
+    public SolvableIdeal<C> power(int d) {
+        if (d <= 0) {
+            return getONE();
+        }
+        if (this.isZERO() || this.isONE()) {
+            return this;
+        }
+        SolvableIdeal<C> c = this;
+        for (int i = 1; i < d; i++) {
+            c = c.product(this);
+        }
+        return c;
+    }
+
+
+    /**
+     * Normalform for element.
+     * @param h solvable polynomial
+     * @return left normalform of h with respect to this
+     */
+    public GenSolvablePolynomial<C> normalform(GenSolvablePolynomial<C> h) {
+        if (h == null) {
+            return h;
+        }
+        if (h.isZERO()) {
+            return h;
+        }
+        if (this.isZERO()) {
+            return h;
+        }
+        GenSolvablePolynomial<C> r;
+        r = red.leftNormalform(getList(), h);
+        return r;
+    }
+
+
+    /**
+     * Normalform for list of solvable elements.
+     * @param L solvable polynomial list
+     * @return list of left normalforms of the elements of L with respect to
+     *         this
+     */
+    public List<GenSolvablePolynomial<C>> normalform(List<GenSolvablePolynomial<C>> L) {
+        if (L == null) {
+            return L;
+        }
+        if (L.size() == 0) {
+            return L;
+        }
+        if (this.isZERO()) {
+            return L;
+        }
+        List<GenSolvablePolynomial<C>> M = new ArrayList<GenSolvablePolynomial<C>>(L.size());
+        for (GenSolvablePolynomial<C> h : L) {
+            GenSolvablePolynomial<C> r = normalform(h);
+            if (r != null && !r.isZERO()) {
+                M.add(r);
+            }
+        }
+        return M;
+    }
+
+
+    /**
+     * Annihilator for element modulo this ideal.
+     * @param h solvable polynomial
+     * @return annihilator of h with respect to this
+     */
+    public SolvableIdeal<C> annihilator(GenSolvablePolynomial<C> h) {
+        if (h == null || h.isZERO()) {
+            return getZERO();
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        doGB();
+        List<GenSolvablePolynomial<C>> F = new ArrayList<GenSolvablePolynomial<C>>(1 + getList().size());
+        F.add(h);
+        F.addAll(getList());
+        //System.out.println("F = " + F);
+        SolvableSyzygyAbstract<C> syz = new SolvableSyzygySeq<C>(getRing().coFac);
+        List<List<GenSolvablePolynomial<C>>> S = syz.leftZeroRelationsArbitrary(F);
+        //System.out.println("S = " + S);
+        List<GenSolvablePolynomial<C>> gen = new ArrayList<GenSolvablePolynomial<C>>(S.size());
+        for (List<GenSolvablePolynomial<C>> rel : S) {
+            if (rel == null || rel.isEmpty()) {
+                continue;
+            }
+            GenSolvablePolynomial<C> p = rel.get(0);
+            if (p == null || p.isZERO()) {
+                continue;
+            }
+            gen.add(p);
+        }
+        SolvableIdeal<C> ann = new SolvableIdeal<C>(getRing(), gen, false, sided);
+        //System.out.println("ann = " + ann);
+        return ann;
+    }
+
+
+    /**
+     * Test for annihilator of element modulo this ideal.
+     * @param h solvable polynomial
+     * @param A solvable ideal
+     * @return true, if A is the annihilator of h with respect to this
+     */
+    public boolean isAnnihilator(GenSolvablePolynomial<C> h, SolvableIdeal<C> A) {
+        SolvableIdeal<C> B = A.product(h);
+        return contains(B);
+    }
+
+
+    /**
+     * Annihilator for ideal modulo this ideal.
+     * @param H solvable ideal
+     * @return annihilator of H with respect to this
+     */
+    public SolvableIdeal<C> annihilator(SolvableIdeal<C> H) {
+        if (H == null || H.isZERO()) {
+            return getZERO();
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        SolvableIdeal<C> ann = null;
+        for (GenSolvablePolynomial<C> h : H.getList()) {
+            SolvableIdeal<C> Hi = this.annihilator(h);
+            if (ann == null) {
+                ann = Hi;
+            } else {
+                ann = ann.intersect(Hi);
+            }
+        }
+        return ann;
+    }
+
+
+    /**
+     * Test for annihilator of ideal modulo this ideal.
+     * @param H solvable ideal
+     * @param A solvable ideal
+     * @return true, if A is the annihilator of H with respect to this
+     */
+    public boolean isAnnihilator(SolvableIdeal<C> H, SolvableIdeal<C> A) {
+        SolvableIdeal<C> B = A.product(H);
+        return contains(B);
+    }
+
+
+    /**
+     * Inverse for element modulo this ideal.
+     * @param h solvable polynomial
+     * @return inverse of h with respect to this, if defined
+     */
+    public GenSolvablePolynomial<C> inverse(GenSolvablePolynomial<C> h) {
+        if (h == null || h.isZERO()) {
+            throw new NotInvertibleException("zero not invertible");
+        }
+        if (this.isZERO()) {
+            throw new NotInvertibleException("zero ideal");
+        }
+        if (h.isUnit()) {
+            return (GenSolvablePolynomial<C>) h.inverse();
+        }
+        doGB();
+        List<GenSolvablePolynomial<C>> F = new ArrayList<GenSolvablePolynomial<C>>(1 + list.list.size());
+        F.add(h);
+        F.addAll(getList());
+        //System.out.println("F = " + F);
+        SolvableExtendedGB<C> x = bb.extLeftGB(F);
+        List<GenSolvablePolynomial<C>> G = x.G;
+        //System.out.println("G = " + G);
+        GenSolvablePolynomial<C> one = null;
+        int i = -1;
+        for (GenSolvablePolynomial<C> p : G) {
+            i++;
+            if (p == null) {
+                continue;
+            }
+            if (p.isUnit()) {
+                one = p;
+                break;
+            }
+        }
+        if (one == null) {
+            throw new NotInvertibleException("one == null: h = " + h);
+        }
+        List<GenSolvablePolynomial<C>> row = x.G2F.get(i); // != -1
+        //System.out.println("row = " + row);
+        GenSolvablePolynomial<C> g = row.get(0);
+        if (g == null || g.isZERO()) {
+            throw new NotInvertibleException("g == 0: h = " + h);
+        }
+        GenSolvablePolynomial<C> gp = red.leftNormalform(getList(), g);
+        if (gp.isZERO()) { // can happen with solvable rings
+            throw new NotInvertibleException("solv|gp == 0: h = " + h + ", g = " + g);
+        }
+        // adjust leading coefficient of g to get g*h == 1
+        GenSolvablePolynomial<C> f = g.multiply(h);
+        //System.out.println("f = " + f);
+        GenSolvablePolynomial<C> k = red.leftNormalform(getList(), f);
+        //System.out.println("k = " + k);
+        if (!k.isONE()) {
+            C lbc = k.leadingBaseCoefficient();
+            lbc = lbc.inverse();
+            g = g.multiply(lbc);
+        }
+        if (debug) {
+            //logger.info("inv G = " + G);
+            //logger.info("inv G2F = " + x.G2F);
+            //logger.info("inv row "+i+" = " + row);
+            //logger.info("inv h = " + h);
+            //logger.info("inv g = " + g);
+            //logger.info("inv f = " + f);
+            f = g.multiply(h);
+            k = red.leftNormalform(getList(), f);
+            logger.debug("inv k = " + k);
+            if (!k.isUnit()) {
+                throw new NotInvertibleException(" k = " + k);
+            }
+        }
+        return g;
+    }
+
+
+    /**
+     * Test if element is a unit modulo this ideal.
+     * @param h solvable polynomial
+     * @return true if h is a unit with respect to this, else false
+     */
+    public boolean isUnit(GenSolvablePolynomial<C> h) {
+        if (h == null || h.isZERO()) {
+            return false;
+        }
+        if (this.isZERO()) {
+            return false;
+        }
+        List<GenSolvablePolynomial<C>> F = new ArrayList<GenSolvablePolynomial<C>>(1 + list.list.size());
+        F.add(h);
+        F.addAll(getList());
+        List<GenSolvablePolynomial<C>> G = bb.leftGB(F);
+        for (GenSolvablePolynomial<C> p : G) {
+            if (p == null) {
+                continue;
+            }
+            if (p.isUnit()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    /**
+     * Ideal common zero test.
+     * @return -1, 0 or 1 if dimension(this) &eq; -1, 0 or &ge; 1.
+     */
+    public int commonZeroTest() {
+        if (this.isZERO()) {
+            return 1;
+        }
+        if (!isGB) {
+            doGB();
+        }
+        if (this.isONE()) {
+            return -1;
+        }
+        return bb.commonZeroTest(getList());
+    }
+
+
+    /**
+     * Test if this ideal is maximal.
+     * @return true, if this is maximal and not one, else false.
+     */
+    public boolean isMaximal() {
+        if (commonZeroTest() != 0) {
+            return false;
+        }
+        for (Long d : univariateDegrees()) {
+            if (d > 1L) {
+                // todo: test if univariate irreducible and no multiple polynomials
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Univariate head term degrees.
+     * @return a list of the degrees of univariate head terms.
+     */
+    public List<Long> univariateDegrees() {
+        List<Long> ud = new ArrayList<Long>();
+        if (this.isZERO()) {
+            return ud;
+        }
+        if (!isGB) {
+            doGB();
+        }
+        if (this.isONE()) {
+            return ud;
+        }
+        return bb.univariateDegrees(getList());
+    }
+
+
+    /**
+     * Ideal dimension.
+     * @return a dimension container (dim,maxIndep,list(maxIndep),vars).
+     */
+    public Dimension dimension() {
+        Ideal<C> ci = new Ideal<C>(list);
+        return ci.dimension();
+    }
+
+
+    /**
+     * Construct univariate polynomials of minimal degree in all variables in
+     * zero dimensional ideal(G).
+     * @return list of univariate solvable polynomial of minimal degree in each
+     *         variable in ideal(G)
+     */
+    public List<GenSolvablePolynomial<C>> constructUnivariate() {
+        List<GenSolvablePolynomial<C>> univs = new ArrayList<GenSolvablePolynomial<C>>();
+        for (int i = getRing().nvar - 1; i >= 0; i--) {
+            GenSolvablePolynomial<C> u = constructUnivariate(i);
+            univs.add(u);
+        }
+        return univs;
+    }
+
+
+    /**
+     * Construct univariate polynomial of minimal degree in variable i in zero
+     * dimensional ideal(G).
+     * @param i variable index.
+     * @return univariate solvable polynomial of minimal degree in variable i in
+     *         ideal(G)
+     */
+    public GenSolvablePolynomial<C> constructUnivariate(int i) {
+        doGB();
+        return bb.constructUnivariate(i, getList());
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/SolvableLocal.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/SolvableLocal.java
@@ -1,0 +1,648 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.util.Arrays;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.fd.FDUtil;
+import edu.jas.gbufd.PolyModUtil;
+import edu.jas.kern.PrettyPrint;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.QuotPair;
+
+
+/**
+ * SolvableLocal ring element based on pairs of GenSolvablePolynomial with
+ * GcdRingElem interface. Objects of this class are immutable.
+ * @author Heinz Kredel
+ */
+public class SolvableLocal<C extends GcdRingElem<C>> implements GcdRingElem<SolvableLocal<C>>,
+                QuotPair<GenPolynomial<C>> {
+
+
+    private static final Logger logger = LogManager.getLogger(SolvableLocal.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * SolvableLocal class factory data structure.
+     */
+    public final SolvableLocalRing<C> ring;
+
+
+    /**
+     * Numerator part of the element data structure.
+     */
+    public final GenSolvablePolynomial<C> num;
+
+
+    /**
+     * Denominator part of the element data structure.
+     */
+    public final GenSolvablePolynomial<C> den;
+
+
+    /**
+     * Flag to remember if this local element is a unit. -1 is unknown, 1 is
+     * unit, 0 not a unit.
+     */
+    protected int isunit = -1; // initially unknown
+
+
+    /**
+     * The constructor creates a SolvableLocal object from a ring factory.
+     * @param r ring factory.
+     */
+    public SolvableLocal(SolvableLocalRing<C> r) {
+        this(r, r.ring.getZERO());
+    }
+
+
+    /**
+     * The constructor creates a SolvableLocal object from a ring factory and a
+     * numerator polynomial. The denominator is assumed to be 1.
+     * @param r ring factory.
+     * @param n numerator polynomial.
+     */
+    public SolvableLocal(SolvableLocalRing<C> r, GenSolvablePolynomial<C> n) {
+        this(r, n, r.ring.getONE(), true);
+    }
+
+
+    /**
+     * The constructor creates a SolvableLocal object from a ring factory and a
+     * numerator and denominator polynomial.
+     * @param r ring factory.
+     * @param n numerator polynomial.
+     * @param d denominator polynomial.
+     */
+    public SolvableLocal(SolvableLocalRing<C> r, GenSolvablePolynomial<C> n, GenSolvablePolynomial<C> d) {
+        this(r, n, d, false);
+    }
+
+
+    /**
+     * The constructor creates a SolvableLocal object from a ring factory and a
+     * numerator and denominator polynomial.
+     * @param r ring factory.
+     * @param n numerator polynomial.
+     * @param d denominator polynomial.
+     * @param isred true if gcd(n,d) == 1, else false.
+     */
+    protected SolvableLocal(SolvableLocalRing<C> r, GenSolvablePolynomial<C> n, GenSolvablePolynomial<C> d,
+                    boolean isred) {
+        if (d == null || d.isZERO()) {
+            throw new IllegalArgumentException("denominator may not be zero");
+        }
+        ring = r;
+        if (d.signum() < 0) {
+            n = (GenSolvablePolynomial<C>) n.negate();
+            d = (GenSolvablePolynomial<C>) d.negate();
+        }
+        if (isred) {
+            num = n;
+            den = d;
+            return;
+        }
+        if (debug) {
+            System.out.println("n = " + n + ", d = " + d);
+        }
+        GenSolvablePolynomial<C> p = ring.ideal.normalform(d);
+        if (p == null || p.isZERO()) {
+            throw new IllegalArgumentException("denominator may not be in ideal, d = " + d);
+        }
+        //d = p; can't do this
+        C lc = d.leadingBaseCoefficient();
+        if (!lc.isONE() && lc.isUnit()) {
+            lc = lc.inverse();
+            n = n.multiplyLeft(lc);
+            d = d.multiplyLeft(lc);
+        }
+        if (n.compareTo(d) == 0) {
+            num = ring.ring.getONE();
+            den = ring.ring.getONE();
+            return;
+        }
+        if (n.negate().compareTo(d) == 0) {
+            num = (GenSolvablePolynomial<C>) ring.ring.getONE().negate();
+            den = ring.ring.getONE();
+            return;
+        }
+        if (n.isZERO()) {
+            num = n;
+            den = ring.ring.getONE();
+            return;
+        }
+        if (n.isONE()) {
+            num = n;
+            den = d;
+            return;
+        }
+        // must reduce to lowest terms
+        // not perfect, TODO improve
+        //GenSolvablePolynomial<C>[] gcd = PolyModUtil.<C> syzGcdCofactors(r.ring, n, d);
+        GenSolvablePolynomial<C>[] gcd = FDUtil.<C> leftGcdCofactors(r.ring, n, d);
+        if (!gcd[0].isONE()) {
+            logger.info("constructor: gcd = " + Arrays.toString(gcd)); // + ", " + n + ", " +d);
+            n = gcd[1];
+            d = gcd[2];
+        }
+        gcd = FDUtil.<C> rightGcdCofactors(r.ring, n, d);
+        if (!gcd[0].isONE()) {
+            logger.info("constructor: gcd = " + Arrays.toString(gcd)); // + ", " + n + ", " +d);
+            n = gcd[1];
+            d = gcd[2];
+        }
+        // not perfect, TODO improve
+        GenSolvablePolynomial<C>[] simp = ring.engine.leftSimplifier(n, d);
+        logger.info("simp: " + Arrays.toString(simp) + ", " + n + ", " + d);
+        num = simp[0];
+        den = simp[1];
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public SolvableLocalRing<C> factory() {
+        return ring;
+    }
+
+
+    /**
+     * Numerator.
+     * @see edu.jas.structure.QuotPair#numerator()
+     */
+    public GenSolvablePolynomial<C> numerator() {
+        return num;
+    }
+
+
+    /**
+     * Denominator.
+     * @see edu.jas.structure.QuotPair#denominator()
+     */
+    public GenSolvablePolynomial<C> denominator() {
+        return den;
+    }
+
+
+    /**
+     * Clone this.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public SolvableLocal<C> copy() {
+        return new SolvableLocal<C>(ring, num, den, true);
+    }
+
+
+    /**
+     * Is SolvableLocal zero.
+     * @return If this is 0 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isZERO()
+     */
+    public boolean isZERO() {
+        return num.isZERO();
+    }
+
+
+    /**
+     * Is SolvableLocal one.
+     * @return If this is 1 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isONE()
+     */
+    public boolean isONE() {
+        return num.compareTo(den) == 0;
+    }
+
+
+    /**
+     * Is SolvableLocal unit.
+     * @return If this is a unit then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isUnit()
+     */
+    public boolean isUnit() {
+        if (isunit > 0) {
+            return true;
+        }
+        if (isunit == 0) {
+            return false;
+        }
+        // not jet known
+        if (num.isZERO()) {
+            isunit = 0;
+            return false;
+        }
+        GenSolvablePolynomial<C> p = ring.ideal.normalform(num);
+        boolean u = (p != null && !p.isZERO());
+        if (u) {
+            isunit = 1;
+        } else {
+            isunit = 0;
+        }
+        return u;
+    }
+
+
+    /**
+     * Is Qoutient a constant.
+     * @return true, if this has constant numerator and denominator, else false.
+     */
+    public boolean isConstant() {
+        return num.isConstant() && den.isConstant();
+    }
+
+
+    /**
+     * Get the String representation as RingElem.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        if (PrettyPrint.isTrue()) {
+            String s = "{ " + num.toString(ring.ring.getVars());
+            if (den.isONE()) {
+                return s + " }";
+            }
+            return s + "| " + den.toString(ring.ring.getVars()) + " }";
+        }
+        return "SolvableLocal[ " + num.toString() + " | " + den.toString() + " ]";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        if (den.isONE()) {
+            return num.toScript();
+        }
+        return num.toScript() + " / " + den.toScript();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python case
+        return factory().toScript();
+    }
+
+
+    /**
+     * SolvableLocal comparison.
+     * @param b SolvableLocal.
+     * @return sign(this-b).
+     */
+    @Override
+    public int compareTo(SolvableLocal<C> b) {
+        if (b == null || b.isZERO()) {
+            return this.signum();
+        }
+        if (this.isZERO()) {
+            return -b.signum();
+        }
+        // assume sign(den,b.den) > 0
+        int s1 = num.signum();
+        int s2 = b.num.signum();
+        int t = (s1 - s2) / 2;
+        if (t != 0) {
+            System.out.println("compareTo: t = " + t);
+            return t;
+        }
+        if (den.compareTo(b.den) == 0) {
+            return num.compareTo(b.num);
+        }
+        GenSolvablePolynomial<C> r, s;
+        // if (den.isONE()) { }
+        // if (b.den.isONE()) { }
+        GenSolvablePolynomial<C>[] oc = ring.engine.leftOreCond(den, b.den);
+        if (debug) {
+            System.out.println("oc[0] den =<>= oc[1] b.den: (" + oc[0] + ") (" + den + ") = (" + oc[1]
+                            + ") (" + b.den + ")");
+        }
+        //System.out.println("oc[0] = " + oc[0]);
+        //System.out.println("oc[1] = " + oc[1]);
+        r = oc[0].multiply(num);
+        s = oc[1].multiply(b.num);
+        return r.compareTo(s);
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean equals(Object b) {
+        if (!(b instanceof SolvableLocal)) {
+            return false;
+        }
+        SolvableLocal<C> a = null;
+        try {
+            a = (SolvableLocal<C>) b;
+        } catch (ClassCastException e) {
+        }
+        if (a == null) {
+            return false;
+        }
+        return compareTo(a) == 0;
+    }
+
+
+    /**
+     * Hash code for this local.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = ring.hashCode();
+        h = 37 * h + num.hashCode();
+        h = 37 * h + den.hashCode();
+        return h;
+    }
+
+
+    /**
+     * SolvableLocal absolute value.
+     * @return the absolute value of this.
+     * @see edu.jas.structure.RingElem#abs()
+     */
+    public SolvableLocal<C> abs() {
+        return new SolvableLocal<C>(ring, (GenSolvablePolynomial<C>) num.abs(), den, true);
+    }
+
+
+    /**
+     * SolvableLocal summation.
+     * @param S SolvableLocal.
+     * @return this+S.
+     */
+    public SolvableLocal<C> sum(SolvableLocal<C> S) {
+        if (S == null || S.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return S;
+        }
+        GenSolvablePolynomial<C> n, d, n1, n2;
+        if (den.isONE() && S.den.isONE()) {
+            n = (GenSolvablePolynomial<C>) num.sum(S.num);
+            return new SolvableLocal<C>(ring, n, den, true);
+        }
+        /* wrong:
+        if (den.isONE()) { }
+        if (S.den.isONE()) { }
+        */
+        if (den.compareTo(S.den) == 0) { // correct ?
+            n = (GenSolvablePolynomial<C>) num.sum(S.num);
+            return new SolvableLocal<C>(ring, n, den, false);
+        }
+        // general case
+        GenSolvablePolynomial<C>[] oc = ring.engine.leftOreCond(den, S.den);
+        if (debug) {
+            System.out.println("oc[0] den =sum= oc[1] S.den: (" + oc[0] + ") (" + den + ") = (" + oc[1]
+                            + ") (" + S.den + ")");
+        }
+        //System.out.println("oc[0] = " + oc[0]);
+        //System.out.println("oc[1] = " + oc[1]);
+        d = oc[0].multiply(den);
+        n1 = oc[0].multiply(num);
+        n2 = oc[1].multiply(S.num);
+        n = (GenSolvablePolynomial<C>) n1.sum(n2);
+        //System.out.println("n = " + n);
+        //System.out.println("d = " + d);
+        return new SolvableLocal<C>(ring, n, d, false);
+    }
+
+
+    /**
+     * SolvableLocal negate.
+     * @return -this.
+     * @see edu.jas.structure.RingElem#negate()
+     */
+    public SolvableLocal<C> negate() {
+        return new SolvableLocal<C>(ring, (GenSolvablePolynomial<C>) num.negate(), den, true);
+    }
+
+
+    /**
+     * SolvableLocal signum.
+     * @see edu.jas.structure.RingElem#signum()
+     * @return signum(this).
+     */
+    public int signum() {
+        return num.signum();
+    }
+
+
+    /**
+     * SolvableLocal subtraction.
+     * @param S SolvableLocal.
+     * @return this-S.
+     */
+    public SolvableLocal<C> subtract(SolvableLocal<C> S) {
+        return sum(S.negate());
+    }
+
+
+    /**
+     * SolvableLocal division.
+     * @param S SolvableLocal.
+     * @return this/S.
+     */
+    public SolvableLocal<C> divide(SolvableLocal<C> S) {
+        return multiply(S.inverse());
+    }
+
+
+    /**
+     * SolvableLocal inverse.
+     * @see edu.jas.structure.RingElem#inverse()
+     * @return S with S = 1/this if defined.
+     */
+    public SolvableLocal<C> inverse() {
+        if (isONE()) {
+            return this;
+        }
+        if (isUnit()) {
+            return new SolvableLocal<C>(ring, den, num, true);
+        }
+        throw new ArithmeticException("element not invertible " + this);
+    }
+
+
+    /**
+     * SolvableLocal remainder.
+     * @param S SolvableLocal.
+     * @return this - (this/S)*S.
+     */
+    public SolvableLocal<C> remainder(SolvableLocal<C> S) {
+        if (S.isUnit()) {
+            return ring.getZERO();
+        }
+        throw new UnsupportedOperationException("remainder not implemented" + S);
+    }
+
+
+    /**
+     * SolvableLocal multiplication.
+     * @param S SolvableLocal.
+     * @return this*S.
+     */
+    public SolvableLocal<C> multiply(SolvableLocal<C> S) {
+        if (S == null || S.isZERO()) {
+            return S;
+        }
+        if (num.isZERO()) {
+            return this;
+        }
+        if (S.isONE()) {
+            return this;
+        }
+        if (this.isONE()) {
+            return S;
+        }
+        GenSolvablePolynomial<C> n, d;
+        if (den.isONE() && S.den.isONE()) {
+            n = num.multiply(S.num);
+            return new SolvableLocal<C>(ring, n, den, true);
+        }
+        /* wrong:
+        if (den.isONE()) { }
+        if (S.den.isONE()) { }
+        if ( den.compareTo(S.den) == 0 ) { }
+        */
+        GenSolvablePolynomial<C>[] oc = ring.engine.leftOreCond(num, S.den);
+        if (debug) {
+            System.out.println("oc[0] num =mult= oc[1] S.den: (" + oc[0] + ") (" + num + ") = (" + oc[1]
+                            + ") (" + S.den + ")");
+        }
+        //System.out.println("oc[0] = " + oc[0]);
+        //System.out.println("oc[1] = " + oc[1]);
+        n = oc[1].multiply(S.num);
+        d = oc[0].multiply(den);
+        return new SolvableLocal<C>(ring, n, d, false);
+    }
+
+
+    /**
+     * SolvableLocal multiplication by GenSolvablePolynomial.
+     * @param b GenSolvablePolynomial.
+     * @return this*b.
+     */
+    public SolvableLocal<C> multiply(GenSolvablePolynomial<C> b) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        if (num.isZERO()) {
+            return this;
+        }
+        if (b.isONE()) {
+            return this;
+        }
+        SolvableLocal<C> B = new SolvableLocal<C>(ring, b);
+        return multiply(B);
+    }
+
+
+    /**
+     * SolvableLocal multiplication by coefficient.
+     * @param b coefficient.
+     * @return this*b.
+     */
+    public SolvableLocal<C> multiply(C b) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        if (num.isZERO()) {
+            return this;
+        }
+        if (b.isONE()) {
+            return this;
+        }
+        GenSolvablePolynomial<C> B = ring.ring.getONE().multiply(b);
+        return multiply(B);
+    }
+
+
+    /**
+     * SolvableLocal multiplication by exponent.
+     * @param e exponent vector.
+     * @return this*b.
+     */
+    public SolvableLocal<C> multiply(ExpVector e) {
+        if (e == null || e.isZERO()) {
+            return this;
+        }
+        if (num.isZERO()) {
+            return this;
+        }
+        GenSolvablePolynomial<C> B = ring.ring.getONE().multiply(e);
+        return multiply(B);
+    }
+
+
+    /**
+     * SolvableLocal monic.
+     * @return this with monic value part.
+     */
+    public SolvableLocal<C> monic() {
+        if (num.isZERO()) {
+            return this;
+        }
+        return this;
+        // non sense:
+        //C lbc = num.leadingBaseCoefficient();
+        //lbc = lbc.inverse();
+        //GenSolvablePolynomial<C> n = num.multiply(lbc);
+        //GenSolvablePolynomial<C> d = den.multiply(lbc);
+        //return new SolvableLocal<C>(ring, n, d, true);
+    }
+
+
+    /**
+     * Greatest common divisor.
+     * @param b other element.
+     * @return gcd(this,b).
+     */
+    public SolvableLocal<C> gcd(SolvableLocal<C> b) {
+        throw new UnsupportedOperationException("gcd not implemented " + this.getClass().getName());
+    }
+
+
+    /**
+     * Extended greatest common divisor. <b>Note: </b>Not implemented, throws
+     * UnsupportedOperationException.
+     * @param b other element.
+     * @return [ gcd(this,b), c1, c2 ] with c1*this + c2*b = gcd(this,b).
+     */
+    public SolvableLocal<C>[] egcd(SolvableLocal<C> b) {
+        throw new UnsupportedOperationException("egcd not implemented " + this.getClass().getName());
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/SolvableLocalResidue.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/SolvableLocalResidue.java
@@ -1,0 +1,653 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.util.Arrays;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.fd.FDUtil;
+import edu.jas.gbufd.PolyModUtil;
+import edu.jas.kern.PrettyPrint;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.QuotPair;
+
+
+/**
+ * SolvableLocalResidue, that is a (left) rational function, based on pairs of
+ * GenSolvablePolynomial with GcdRingElem interface. Objects of this class are
+ * immutable.
+ * @author Heinz Kredel
+ */
+public class SolvableLocalResidue<C extends GcdRingElem<C>> implements GcdRingElem<SolvableLocalResidue<C>>,
+                QuotPair<GenPolynomial<C>> {
+
+
+    // Can not extend SolvableLocal or SolvableQuotient because of 
+    // different constructor semantics.
+
+
+    private static final Logger logger = LogManager.getLogger(SolvableLocalResidue.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * SolvableLocalResidue class factory data structure.
+     */
+    public final SolvableLocalResidueRing<C> ring;
+
+
+    /**
+     * Numerator part of the element data structure.
+     */
+    public final GenSolvablePolynomial<C> num;
+
+
+    /**
+     * Denominator part of the element data structure.
+     */
+    public final GenSolvablePolynomial<C> den;
+
+
+    /**
+     * The constructor creates a SolvableLocalResidue object from a ring
+     * factory.
+     * @param r ring factory.
+     */
+    public SolvableLocalResidue(SolvableLocalResidueRing<C> r) {
+        this(r, r.ring.getZERO());
+    }
+
+
+    /**
+     * The constructor creates a SolvableLocalResidue object from a ring factory
+     * and a numerator polynomial. The denominator is assumed to be 1.
+     * @param r ring factory.
+     * @param n numerator solvable polynomial.
+     */
+    public SolvableLocalResidue(SolvableLocalResidueRing<C> r, GenSolvablePolynomial<C> n) {
+        this(r, n, r.ring.getONE(), false); // false because of normalform
+    }
+
+
+    /**
+     * The constructor creates a SolvableLocalResidue object from a ring factory
+     * and a numerator and denominator solvable polynomial.
+     * @param r ring factory.
+     * @param n numerator polynomial.
+     * @param d denominator polynomial.
+     */
+    public SolvableLocalResidue(SolvableLocalResidueRing<C> r, GenSolvablePolynomial<C> n,
+                    GenSolvablePolynomial<C> d) {
+        this(r, n, d, false);
+    }
+
+
+    /**
+     * The constructor creates a SolvableLocalResidue object from a ring factory
+     * and a numerator and denominator polynomial.
+     * @param r ring factory.
+     * @param n numerator polynomial.
+     * @param d denominator polynomial.
+     * @param isred <em>unused at the moment</em>.
+     */
+    protected SolvableLocalResidue(SolvableLocalResidueRing<C> r, GenSolvablePolynomial<C> n,
+                    GenSolvablePolynomial<C> d, boolean isred) {
+        if (d == null || d.isZERO()) {
+            throw new IllegalArgumentException("denominator may not be zero");
+        }
+        ring = r;
+        if (d.signum() < 0) {
+            n = (GenSolvablePolynomial<C>) n.negate();
+            d = (GenSolvablePolynomial<C>) d.negate();
+        }
+        if (isred) {
+            num = n;
+            den = d;
+            return;
+        }
+        GenSolvablePolynomial<C> p = ring.ideal.normalform(d);
+        if (p.isZERO()) {
+            throw new IllegalArgumentException("denominator may not be in ideal, d = " + d);
+        }
+        //d = p; // not always working
+        GenSolvablePolynomial<C> nr = ring.ideal.normalform(n); // leftNF
+        if (nr.isZERO()) {
+            num = nr;
+            den = ring.ring.getONE();
+            return;
+        }
+        //logger.info("constructor: n = " + n + ", NF(n) = " + nr);
+        //n = nr; // not always working, failed
+        C lc = d.leadingBaseCoefficient();
+        if (!lc.isONE() && lc.isUnit()) {
+            lc = lc.inverse();
+            n = n.multiply(lc);
+            d = d.multiply(lc);
+        }
+        if (n.compareTo(d) == 0) {
+            num = ring.ring.getONE();
+            den = ring.ring.getONE();
+            return;
+        }
+        if (n.negate().compareTo(d) == 0) {
+            num = (GenSolvablePolynomial<C>) ring.ring.getONE().negate();
+            den = ring.ring.getONE();
+            return;
+        }
+        if (n.isZERO()) {
+            num = n;
+            den = ring.ring.getONE();
+            return;
+        }
+        if (n.isONE()) {
+            num = n;
+            den = d;
+            return;
+        }
+        // must reduce to lowest terms
+        // not perfect, TODO improve
+        //GenSolvablePolynomial<C>[] gcd = PolyModUtil.<C> syzGcdCofactors(r.ring, n, d);
+        GenSolvablePolynomial<C>[] gcd = FDUtil.<C> leftGcdCofactors(r.ring, n, d);
+        if (!gcd[0].isONE()) {
+            logger.info("constructor: gcd = " + Arrays.toString(gcd)); // + ", " + n + ", " +d);
+            n = gcd[1];
+            d = gcd[2];
+        }
+        gcd = FDUtil.<C> rightGcdCofactors(r.ring, n, d);
+        if (!gcd[0].isONE()) {
+            logger.info("constructor: gcd = " + Arrays.toString(gcd)); // + ", " + n + ", " +d);
+            n = gcd[1];
+            d = gcd[2];
+        }
+        // not perfect, TODO improve
+        GenSolvablePolynomial<C>[] simp = ring.engine.leftSimplifier(n, d);
+        logger.info("simp: " + Arrays.toString(simp) + ", " + n + ", " + d);
+        num = simp[0];
+        den = simp[1];
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public SolvableLocalResidueRing<C> factory() {
+        return ring;
+    }
+
+
+    /**
+     * Numerator.
+     * @see edu.jas.structure.QuotPair#numerator()
+     */
+    public GenSolvablePolynomial<C> numerator() {
+        return num;
+    }
+
+
+    /**
+     * Denominator.
+     * @see edu.jas.structure.QuotPair#denominator()
+     */
+    public GenSolvablePolynomial<C> denominator() {
+        return den;
+    }
+
+
+    /**
+     * Clone this.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public SolvableLocalResidue<C> copy() {
+        return new SolvableLocalResidue<C>(ring, num, den, true);
+    }
+
+
+    /**
+     * Is SolvableLocalResidue zero.
+     * @return If this is 0 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isZERO()
+     */
+    public boolean isZERO() {
+        return num.isZERO();
+    }
+
+
+    /**
+     * Is SolvableLocalResidue one.
+     * @return If this is 1 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isONE()
+     */
+    public boolean isONE() {
+        return num.compareTo(den) == 0;
+    }
+
+
+    /**
+     * Is SolvableLocalResidue a unit.
+     * @return If this is a unit then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isUnit()
+     */
+    public boolean isUnit() {
+        if (num.isZERO()) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Is Quotient a constant.
+     * @return true, if this has constant numerator and denominator, else false.
+     */
+    public boolean isConstant() {
+        return num.isConstant() && den.isConstant();
+    }
+
+
+    /**
+     * Get the String representation as RingElem.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        if (PrettyPrint.isTrue()) {
+            String s = "{ " + num.toString(ring.ring.getVars());
+            if (!den.isONE()) {
+                s += " | " + den.toString(ring.ring.getVars());
+            }
+            return s + " }";
+        }
+        return "SolvableLocalResidue[ " + num.toString() + " | " + den.toString() + " ]";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // any scripting case
+        if (den.isONE()) {
+            return num.toScript();
+        }
+        return num.toScript() + " / " + den.toScript();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        return factory().toScript();
+    }
+
+
+    /**
+     * SolvableLocalResidue comparison.
+     * @param b SolvableLocalResidue.
+     * @return sign(this-b).
+     */
+    @Override
+    public int compareTo(SolvableLocalResidue<C> b) {
+        if (b == null || b.isZERO()) {
+            return this.signum();
+        }
+        if (this.isZERO()) {
+            return -b.signum();
+        }
+        return this.subtract(b).signum();
+        // GenSolvablePolynomial<C> n, p, q;
+        // if ( den.compareTo(b.den) == 0 ) {
+        //     n = (GenSolvablePolynomial<C>) num.subtract(b.num);
+        //     //\\ p = ring.ideal.normalform(n);
+        //     //logger.info("p.signum() = " + p.signum());
+        //     return p.signum();
+        // }
+        // GenSolvablePolynomial<C> r, s;
+        // // if (den.isONE()) { }
+        // // if (b.den.isONE()) { }
+        // GenSolvablePolynomial<C>[] oc = ring.engine.leftOreCond(den,b.den);
+        // if (debug) {
+        //     logger.info("oc[0] den =<>= oc[1] b.den: (" + oc[0] + ") (" + den + ") = (" + oc[1]
+        //                 + ") (" + b.den + ")");
+        // }
+        // q = oc[0].multiply(den); 
+        // q = ring.ideal.normalform(q);
+        // int t = q.signum(); //oc[0].signum() * den.signum(); // sign only
+        // r = oc[0].multiply(num);
+        // s = oc[1].multiply(b.num);
+        // p = (GenSolvablePolynomial<C>) r.subtract(s);
+        // //\\ p = ring.ideal.normalform(p);
+        // //logger.info("p.signum() = " + p.signum());
+        // if ( t == 0 ) {
+        //     throw new RuntimeException("can not happen: denominator is zero: this " + this + ", b = " + b);
+        // } 
+        // return t * p.signum();
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean equals(Object b) {
+        if (!(b instanceof SolvableLocalResidue)) {
+            return false;
+        }
+        SolvableLocalResidue<C> a = null;
+        try {
+            a = (SolvableLocalResidue<C>) b;
+        } catch (ClassCastException e) {
+        }
+        if (a == null) {
+            return false;
+        }
+        if (num.equals(a.num) && den.equals(a.den)) { // short cut
+            return true;
+        }
+        return compareTo(a) == 0;
+    }
+
+
+    /**
+     * Hash code for this element.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = ring.hashCode();
+        h = 37 * h + num.hashCode();
+        h = 37 * h + den.hashCode();
+        return h;
+    }
+
+
+    /**
+     * SolvableLocalResidue absolute value.
+     * @return the absolute value of this.
+     * @see edu.jas.structure.RingElem#abs()
+     */
+    public SolvableLocalResidue<C> abs() {
+        return new SolvableLocalResidue<C>(ring, (GenSolvablePolynomial<C>) num.abs(), den, true);
+    }
+
+
+    /**
+     * SolvableLocalResidue summation.
+     * @param S SolvableLocalResidue.
+     * @return this+S.
+     */
+    public SolvableLocalResidue<C> sum(SolvableLocalResidue<C> S) {
+        if (S == null || S.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return S;
+        }
+        GenSolvablePolynomial<C> n, d, n1, n2;
+        if (den.isONE() && S.den.isONE()) {
+            n = (GenSolvablePolynomial<C>) num.sum(S.num);
+            return new SolvableLocalResidue<C>(ring, n, den, false); // true
+        }
+        /* wrong:
+        if (den.isONE()) { }
+        if (S.den.isONE()) { }
+        */
+        if (den.compareTo(S.den) == 0) { // correct ?
+            n = (GenSolvablePolynomial<C>) num.sum(S.num);
+            return new SolvableLocalResidue<C>(ring, n, den, false);
+        }
+        // general case
+        GenSolvablePolynomial<C>[] oc = ring.engine.leftOreCond(den, S.den);
+        if (debug) {
+            logger.info("oc[0] den =sum= oc[1] S.den: (" + oc[0] + ") (" + den + ") = (" + oc[1] + ") ("
+                            + S.den + ")");
+        }
+        d = oc[0].multiply(den);
+        n1 = oc[0].multiply(num);
+        n2 = oc[1].multiply(S.num);
+        n = (GenSolvablePolynomial<C>) n1.sum(n2);
+        //logger.info("n = " + n + ", d = " + d);
+        return new SolvableLocalResidue<C>(ring, n, d, false);
+    }
+
+
+    /**
+     * SolvableLocalResidue negate.
+     * @return -this.
+     * @see edu.jas.structure.RingElem#negate()
+     */
+    public SolvableLocalResidue<C> negate() {
+        return new SolvableLocalResidue<C>(ring, (GenSolvablePolynomial<C>) num.negate(), den, true);
+    }
+
+
+    /**
+     * SolvableLocalResidue signum.
+     * @see edu.jas.structure.RingElem#signum()
+     * @return signum(this).
+     */
+    public int signum() {
+        // assume sign(den) > 0
+        return num.signum();
+    }
+
+
+    /**
+     * SolvableLocalResidue subtraction.
+     * @param S SolvableLocalResidue.
+     * @return this-S.
+     */
+    public SolvableLocalResidue<C> subtract(SolvableLocalResidue<C> S) {
+        return sum(S.negate());
+    }
+
+
+    /**
+     * SolvableLocalResidue division.
+     * @param S SolvableLocalResidue.
+     * @return this/S.
+     */
+    public SolvableLocalResidue<C> divide(SolvableLocalResidue<C> S) {
+        return multiply(S.inverse());
+    }
+
+
+    /**
+     * SolvableLocalResidue inverse.
+     * @see edu.jas.structure.RingElem#inverse()
+     * @return S with S = 1/this.
+     */
+    public SolvableLocalResidue<C> inverse() {
+        if (num.isZERO()) {
+            throw new ArithmeticException("element not invertible " + this);
+        }
+        return new SolvableLocalResidue<C>(ring, den, num, false); // true
+    }
+
+
+    /**
+     * SolvableLocalResidue remainder.
+     * @param S SolvableLocalResidue.
+     * @return this - (this/S)*S.
+     */
+    public SolvableLocalResidue<C> remainder(SolvableLocalResidue<C> S) {
+        if (S.isZERO()) {
+            throw new ArithmeticException("element not invertible " + S);
+        }
+        return ring.getZERO();
+    }
+
+
+    /**
+     * SolvableLocalResidue multiplication.
+     * @param S SolvableLocalResidue.
+     * @return this*S.
+     */
+    public SolvableLocalResidue<C> multiply(SolvableLocalResidue<C> S) {
+        if (S == null || S.isZERO()) {
+            return S;
+        }
+        if (num.isZERO()) {
+            return this;
+        }
+        if (S.isONE()) {
+            return this;
+        }
+        if (this.isONE()) {
+            return S;
+        }
+        GenSolvablePolynomial<C> n, d;
+        if (den.isONE() && S.den.isONE()) {
+            n = num.multiply(S.num);
+            return new SolvableLocalResidue<C>(ring, n, den, false); // true
+        }
+        /* wrong:
+        if (den.isONE()) { }
+        if (S.den.isONE()) { }
+        if ( den.compareTo(S.den) == 0 ) { }
+        */
+        GenSolvablePolynomial<C>[] oc = ring.engine.leftOreCond(num, S.den);
+        if (debug) {
+            System.out.println("oc[0] num =mult= oc[1] S.den: (" + oc[0] + ") (" + num + ") = (" + oc[1]
+                            + ") (" + S.den + ")");
+        }
+        n = oc[1].multiply(S.num);
+        d = oc[0].multiply(den);
+        return new SolvableLocalResidue<C>(ring, n, d, false);
+    }
+
+
+    /**
+     * SolvableLocalResidue multiplication by GenSolvablePolynomial.
+     * @param b GenSolvablePolynomial<C>.
+     * @return this*b.
+     */
+    public SolvableLocalResidue<C> multiply(GenSolvablePolynomial<C> b) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        if (num.isZERO()) {
+            return this;
+        }
+        if (b.isONE()) {
+            return this;
+        }
+        SolvableLocalResidue<C> B = new SolvableLocalResidue<C>(ring, b);
+        return multiply(B);
+    }
+
+
+    /**
+     * SolvableLocalResidue multiplication by coefficient.
+     * @param b coefficient.
+     * @return this*b.
+     */
+    public SolvableLocalResidue<C> multiply(C b) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        if (num.isZERO()) {
+            return this;
+        }
+        if (b.isONE()) {
+            return this;
+        }
+        GenSolvablePolynomial<C> B = ring.ring.getONE().multiply(b);
+        return multiply(B);
+    }
+
+
+    /**
+     * SolvableLocalResidue multiplication by exponent.
+     * @param e exponent vector.
+     * @return this*b.
+     */
+    public SolvableLocalResidue<C> multiply(ExpVector e) {
+        if (e == null || e.isZERO()) {
+            return this;
+        }
+        if (num.isZERO()) {
+            return this;
+        }
+        GenSolvablePolynomial<C> B = ring.ring.getONE().multiply(e);
+        return multiply(B);
+    }
+
+
+    /**
+     * SolvableLocalResidue monic.
+     * @return this with monic value part.
+     */
+    public SolvableLocalResidue<C> monic() {
+        if (num.isZERO()) {
+            return this;
+        }
+        return this;
+    }
+
+
+    /**
+     * Greatest common divisor.
+     * @param b other element.
+     * @return gcd(this,b).
+     */
+    public SolvableLocalResidue<C> gcd(SolvableLocalResidue<C> b) {
+        if (b == null || b.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return b;
+        }
+        return ring.getONE();
+    }
+
+
+    /**
+     * Extended greatest common divisor.
+     * @param b other element.
+     * @return [ gcd(this,b), c1, c2 ] with c1*this + c2*b = gcd(this,b).
+     */
+    @SuppressWarnings("unchecked")
+    public SolvableLocalResidue<C>[] egcd(SolvableLocalResidue<C> b) {
+        SolvableLocalResidue<C>[] ret = (SolvableLocalResidue<C>[]) new SolvableLocalResidue[3];
+        ret[0] = null;
+        ret[1] = null;
+        ret[2] = null;
+        if (b == null || b.isZERO()) {
+            ret[0] = this;
+            return ret;
+        }
+        if (this.isZERO()) {
+            ret[0] = b;
+            return ret;
+        }
+        GenSolvablePolynomial<C> two = ring.ring.fromInteger(2);
+        ret[0] = ring.getONE();
+        ret[1] = (this.multiply(two)).inverse();
+        ret[2] = (b.multiply(two)).inverse();
+        return ret;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/SolvableLocalResidueRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/SolvableLocalResidueRing.java
@@ -1,0 +1,455 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.SolvableGroebnerBaseAbstract;
+import edu.jas.gbufd.SGBFactory;
+import edu.jas.gbufd.SolvableSyzygyAbstract;
+import edu.jas.gbufd.SolvableSyzygySeq;
+import edu.jas.kern.StringUtil;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.GenSolvablePolynomialRing;
+import edu.jas.poly.PolynomialList;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.QuotPairFactory;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * SolvableLocalResidue ring factory for SolvableLocalResidue based on
+ * GenSolvablePolynomial with GcdRingElem interface. Objects of this class are
+ * immutable. It represents the "classical quotient ring modulo an ideal".
+ * @author Heinz Kredel
+ */
+public class SolvableLocalResidueRing<C extends GcdRingElem<C>> implements
+                RingFactory<SolvableLocalResidue<C>>,
+                QuotPairFactory<GenPolynomial<C>, SolvableLocalResidue<C>> {
+
+
+    // Can not extend SolvableLocalRing or SolvableQuotientRing 
+    // because of different constructor semantics.
+
+
+    private static final Logger logger = LogManager.getLogger(SolvableLocalResidueRing.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Solvable polynomial ring of the factory.
+     */
+    public final GenSolvablePolynomialRing<C> ring;
+
+
+    /**
+     * Solvable polynomial ideal for the reduction.
+     */
+    public final SolvableIdeal<C> ideal;
+
+
+    /**
+     * Syzygy engine of the factory.
+     */
+    public final SolvableSyzygyAbstract<C> engine;
+
+
+    /**
+     * Groebner base engine.
+     */
+    protected final SolvableGroebnerBaseAbstract<C> bb;
+
+
+    /**
+     * Indicator if this ring is a field.
+     */
+    protected int isField = -1; // initially unknown
+
+
+    /**
+     * The constructor creates a SolvableLocalResidueRing object from a
+     * SolvableIdeal.
+     * @param i ideal in solvable polynomial ring.
+     */
+    public SolvableLocalResidueRing(SolvableIdeal<C> i) {
+        if (i == null) {
+            throw new IllegalArgumentException("ideal may not be null");
+        }
+        ring = i.getRing();
+        ideal = i.GB(); // cheap if isGB
+        if (ideal.isONE()) {
+            throw new IllegalArgumentException("ideal may not be 1");
+        }
+        if (ideal.isMaximal()) {
+            isField = 1;
+            //} else if (ideal.isPrime()) {
+            //    isField = 1;
+        } else {
+            //isField = 0;
+            logger.warn("ideal not maximal and not known to be prime");
+            //throw new IllegalArgumentException("ideal must be prime or maximal");
+        }
+        engine = new SolvableSyzygySeq<C>(ring.coFac);
+        bb = SGBFactory.getImplementation(ring.coFac); //new SolvableGroebnerBaseSeq<C>();
+        logger.debug("solvable local residue ring constructed");
+    }
+
+
+    /**
+     * Factory for base elements.
+     */
+    public GenSolvablePolynomialRing<C> pairFactory() {
+        return ring;
+    }
+
+
+    /**
+     * Create from numerator.
+     */
+    @SuppressWarnings("unchecked")
+    public SolvableLocalResidue<C> create(GenPolynomial<C> n) {
+        return new SolvableLocalResidue<C>(this, (GenSolvablePolynomial<C>) n);
+    }
+
+
+    /**
+     * Create from numerator, denominator pair.
+     */
+    @SuppressWarnings("unchecked")
+    public SolvableLocalResidue<C> create(GenPolynomial<C> n, GenPolynomial<C> d) {
+        return new SolvableLocalResidue<C>(this, (GenSolvablePolynomial<C>) n, (GenSolvablePolynomial<C>) d);
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     */
+    public boolean isFinite() {
+        return ring.isFinite() && bb.commonZeroTest(ideal.getList()) <= 0;
+    }
+
+
+    /**
+     * Copy SolvableLocalResidue element c.
+     * @param c
+     * @return a copy of c.
+     */
+    public SolvableLocalResidue<C> copy(SolvableLocalResidue<C> c) {
+        return new SolvableLocalResidue<C>(c.ring, c.num, c.den, true);
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as SolvableLocalResidue.
+     */
+    public SolvableLocalResidue<C> getZERO() {
+        return new SolvableLocalResidue<C>(this, ring.getZERO());
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as SolvableLocalResidue.
+     */
+    public SolvableLocalResidue<C> getONE() {
+        return new SolvableLocalResidue<C>(this, ring.getONE());
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     */
+    public List<SolvableLocalResidue<C>> generators() {
+        List<GenSolvablePolynomial<C>> pgens = PolynomialList.<C> castToSolvableList(ring.generators());
+        List<SolvableLocalResidue<C>> gens = new ArrayList<SolvableLocalResidue<C>>(pgens.size() * 2 - 1);
+        GenSolvablePolynomial<C> one = ring.getONE();
+        for (GenSolvablePolynomial<C> p : pgens) {
+            SolvableLocalResidue<C> q = new SolvableLocalResidue<C>(this, p);
+            if (!q.isZERO() && !gens.contains(q)) {
+                gens.add(q);
+                if (!p.isONE() && !ideal.contains(p)) {
+                    q = new SolvableLocalResidue<C>(this, one, p);
+                    gens.add(q);
+                }
+            }
+        }
+        return gens;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true if this ring is commutative, else false.
+     */
+    public boolean isCommutative() {
+        return ring.isCommutative();
+    }
+
+
+    /**
+     * Query if this ring is associative.
+     * @return true if this ring is associative, else false.
+     */
+    @SuppressWarnings("unused")
+    public boolean isAssociative() {
+        if (!ring.isAssociative()) {
+            return false;
+        }
+        SolvableLocalResidue<C> Xi, Xj, Xk, p, q;
+        List<SolvableLocalResidue<C>> gens = generators();
+        int ngen = gens.size();
+        for (int i = 0; i < ngen; i++) {
+            Xi = gens.get(i);
+            for (int j = i + 1; j < ngen; j++) {
+                Xj = gens.get(j);
+                for (int k = j + 1; k < ngen; k++) {
+                    Xk = gens.get(k);
+                    if (Xi.num.degree() == 0 && Xj.num.degree() == 0 && Xk.num.degree() == 0 &&
+                        Xi.den.degree() == 0 && Xj.den.degree() == 0 && Xk.den.degree() == 0) {
+                        //System.out.println("lr degree == 0");
+                        continue; // skip all base elements
+                    }
+                    try {
+                        p = Xk.multiply(Xj).multiply(Xi);
+                        q = Xk.multiply(Xj.multiply(Xi));
+                    } catch (IllegalArgumentException e) {
+                        e.printStackTrace();
+                        continue; // ignore undefined multiplication
+                    }
+                    if (p.num.equals(q.num) && p.den.equals(q.den)) { // short cut
+                        continue;
+                    // } else {
+                    //     int s = p.num.length() + q.num.length() + p.den.length() + q.den.length();
+                    //     if (s > 5) {
+                    //         System.out.println("lr assoc: p = " + p.toScript());
+                    //         System.out.println("lr assoc: q = " + q.toScript());
+                    //         System.out.println("lr assoc: Xk = " + Xk.toScript() + ", Xj = " + Xj.toScript() + ", Xi = " + Xi.toScript());
+                    //         System.out.println("lr size = " + s);
+                    //      continue;
+                    //     }
+                    }
+                    if (!p.equals(q)) {
+                        if (true || debug) {
+                            System.out.println("lr assoc: p = " + p.toScript());
+                            System.out.println("lr assoc: q = " + q.toScript());
+                            System.out.println("lr assoc: Xk = " + Xk.toScript() + ", Xj = " + Xj.toScript() + ", Xi = " + Xi.toScript());
+                            logger.info("Xk = " + Xk + ", Xj = " + Xj + ", Xi = " + Xi);
+                            logger.info("p = ( Xk * Xj ) * Xi = " + p);
+                            logger.info("q = Xk * ( Xj * Xi ) = " + q);
+                        }
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Query if this ring is a field.
+     * @return true.
+     */
+    public boolean isField() {
+        if (isField > 0) {
+            return true;
+        }
+        if (isField == 0) {
+            return false;
+        }
+        // not reached
+        return false;
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic() {
+        return ring.characteristic();
+    }
+
+
+    /**
+     * Get a SolvableLocalResidue element from a BigInteger value.
+     * @param a BigInteger.
+     * @return a SolvableLocalResidue.
+     */
+    public SolvableLocalResidue<C> fromInteger(java.math.BigInteger a) {
+        return new SolvableLocalResidue<C>(this, ring.fromInteger(a));
+    }
+
+
+    /**
+     * Get a SolvableLocalResidue element from a long value.
+     * @param a long.
+     * @return a SolvableLocalResidue.
+     */
+    public SolvableLocalResidue<C> fromInteger(long a) {
+        return new SolvableLocalResidue<C>(this, ring.fromInteger(a));
+    }
+
+
+    /**
+     * Get the String representation as RingFactory.
+     */
+    @Override
+    public String toString() {
+        return "SolvableLocalResidueRing[ " + ideal.toString() + " ]";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this ElemFactory.
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        return "SLR(" + ideal.list.toScript() + ")";
+    }
+
+
+    /**
+     * Comparison with any other object.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (!(b instanceof SolvableLocalResidueRing)) {
+            return false;
+        }
+        SolvableLocalResidueRing<C> a = null;
+        try {
+            a = (SolvableLocalResidueRing<C>) b;
+        } catch (ClassCastException e) {
+        }
+        if (a == null) {
+            return false;
+        }
+        return ring.equals(a.ring);
+    }
+
+
+    /**
+     * Hash code for this quotient ring.
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = ideal.hashCode();
+        return h;
+    }
+
+
+    /**
+     * SolvableLocalResidue random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @return a random quotient element.
+     */
+    public SolvableLocalResidue<C> random(int n) {
+        GenSolvablePolynomial<C> r = ring.random(n).monic();
+        r = ideal.normalform(r);
+        GenSolvablePolynomial<C> s;
+        do {
+            s = ring.random(n).monic();
+            s = ideal.normalform(s);
+        } while (s.isZERO());
+        return new SolvableLocalResidue<C>(this, r, s, false);
+    }
+
+
+    /**
+     * Generate a random quotient.
+     * @param k bitsize of random coefficients.
+     * @param l number of terms.
+     * @param d maximal degree in each variable.
+     * @param q density of nozero exponents.
+     * @return a random quotient.
+     */
+    public SolvableLocalResidue<C> random(int k, int l, int d, float q) {
+        GenSolvablePolynomial<C> r = ring.random(k, l, d, q).monic();
+        r = ideal.normalform(r);
+        GenSolvablePolynomial<C> s;
+        do {
+            s = ring.random(k, l, d, q).monic();
+            s = ideal.normalform(s);
+        } while (s.isZERO());
+        return new SolvableLocalResidue<C>(this, r, s, false);
+    }
+
+
+    /**
+     * SolvableLocalResidue random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @param rnd is a source for random bits.
+     * @return a random quotient element.
+     */
+    public SolvableLocalResidue<C> random(int n, Random rnd) {
+        GenSolvablePolynomial<C> r = ring.random(n, rnd).monic();
+        r = ideal.normalform(r);
+        GenSolvablePolynomial<C> s;
+        do {
+            s = ring.random(n, rnd).monic();
+            s = ideal.normalform(s);
+        } while (s.isZERO());
+        return new SolvableLocalResidue<C>(this, r, s, false);
+    }
+
+
+    /**
+     * Parse SolvableLocalResidue from String. Syntax:
+     * "{ polynomial | polynomial }" or "{ polynomial }" or
+     * " polynomial | polynomial " or " polynomial "
+     * @param s String.
+     * @return SolvableLocalResidue from s.
+     */
+    public SolvableLocalResidue<C> parse(String s) {
+        int i = s.indexOf("{");
+        if (i >= 0) {
+            s = s.substring(i + 1);
+        }
+        i = s.lastIndexOf("}");
+        if (i >= 0) {
+            s = s.substring(0, i);
+        }
+        i = s.indexOf("|");
+        if (i < 0) {
+            GenSolvablePolynomial<C> n = ring.parse(s);
+            return new SolvableLocalResidue<C>(this, n);
+        }
+        String s1 = s.substring(0, i);
+        String s2 = s.substring(i + 1);
+        GenSolvablePolynomial<C> n = ring.parse(s1);
+        GenSolvablePolynomial<C> d = ring.parse(s2);
+        return new SolvableLocalResidue<C>(this, n, d);
+    }
+
+
+    /**
+     * Parse SolvableLocalResidue from Reader.
+     * @param r Reader.
+     * @return next SolvableLocalResidue from r.
+     */
+    public SolvableLocalResidue<C> parse(Reader r) {
+        String s = StringUtil.nextPairedString(r, '{', '}');
+        return parse(s);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/SolvableLocalRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/SolvableLocalRing.java
@@ -1,0 +1,432 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.SolvableGroebnerBaseAbstract;
+import edu.jas.gbufd.SGBFactory;
+import edu.jas.gbufd.SolvableSyzygyAbstract;
+import edu.jas.gbufd.SolvableSyzygySeq;
+import edu.jas.kern.StringUtil;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.GenSolvablePolynomialRing;
+import edu.jas.poly.PolynomialList;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.QuotPairFactory;
+import edu.jas.structure.RingFactory;
+
+
+// import edu.jas.ufd.GreatestCommonDivisor;
+// import edu.jas.ufd.GCDFactory;
+
+/**
+ * SolvableLocal ring factory for SolvableLocal with GcdRingElem interface.
+ * Objects of this class are immutable.
+ * @author Heinz Kredel
+ */
+public class SolvableLocalRing<C extends GcdRingElem<C>> implements RingFactory<SolvableLocal<C>>,
+                QuotPairFactory<GenPolynomial<C>, SolvableLocal<C>> {
+
+
+    // Can not extend SolvableQuotientRing 
+    // because of different constructor semantics.
+
+
+    private static final Logger logger = LogManager.getLogger(SolvableLocalRing.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Solvable polynomial ideal for localization.
+     */
+    public final SolvableIdeal<C> ideal;
+
+
+    /**
+     * Solvable polynomial ring of the factory.
+     */
+    public final GenSolvablePolynomialRing<C> ring;
+
+
+    /**
+     * Syzygy engine of the factory.
+     */
+    public final SolvableSyzygyAbstract<C> engine;
+
+
+    /**
+     * Groebner base engine.
+     */
+    protected final SolvableGroebnerBaseAbstract<C> bb;
+
+
+    /**
+     * Indicator if this ring is a field.
+     */
+    protected int isField = -1; // initially unknown
+
+
+    /**
+     * The constructor creates a SolvableLocalRing object from a SolvableIdeal.
+     * @param i solvable localization polynomial ideal.
+     */
+    public SolvableLocalRing(SolvableIdeal<C> i) {
+        if (i == null) {
+            throw new IllegalArgumentException("ideal may not be null");
+        }
+        ring = i.getRing();
+        ideal = i.GB(); // cheap if isGB
+        if (ideal.isONE()) {
+            throw new IllegalArgumentException("ideal may not be 1");
+        }
+        if (ideal.isMaximal()) {
+            isField = 1;
+        } else {
+            isField = 0;
+            logger.warn("ideal not maximal");
+            //throw new IllegalArgumentException("ideal must be maximal");
+        }
+        engine = new SolvableSyzygySeq<C>(ring.coFac);
+        bb = SGBFactory.getImplementation(ring.coFac); // new SolvableGroebnerBaseSeq<C>();
+        logger.debug("solvable local ring constructed");
+    }
+
+
+    /**
+     * Factory for base elements.
+     */
+    public GenSolvablePolynomialRing<C> pairFactory() {
+        return ring;
+    }
+
+
+    /**
+     * Create from numerator.
+     */
+    @SuppressWarnings("unchecked")
+    public SolvableLocal<C> create(GenPolynomial<C> n) {
+        return new SolvableLocal<C>(this, (GenSolvablePolynomial<C>) n);
+    }
+
+
+    /**
+     * Create from numerator, denominator pair.
+     */
+    @SuppressWarnings("unchecked")
+    public SolvableLocal<C> create(GenPolynomial<C> n, GenPolynomial<C> d) {
+        return new SolvableLocal<C>(this, (GenSolvablePolynomial<C>) n, (GenSolvablePolynomial<C>) d);
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     */
+    public boolean isFinite() {
+        return ring.isFinite() && bb.commonZeroTest(ideal.getList()) <= 0;
+    }
+
+
+    /**
+     * Copy SolvableLocal element c.
+     * @param c element to copy
+     * @return a copy of c.
+     */
+    public SolvableLocal<C> copy(SolvableLocal<C> c) {
+        return new SolvableLocal<C>(c.ring, c.num, c.den, true);
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as SolvableLocal.
+     */
+    public SolvableLocal<C> getZERO() {
+        return new SolvableLocal<C>(this, ring.getZERO());
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as SolvableLocal.
+     */
+    public SolvableLocal<C> getONE() {
+        return new SolvableLocal<C>(this, ring.getONE());
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     */
+    public List<SolvableLocal<C>> generators() {
+        List<GenSolvablePolynomial<C>> pgens = PolynomialList.<C> castToSolvableList(ring.generators());
+        List<SolvableLocal<C>> gens = new ArrayList<SolvableLocal<C>>(pgens.size() * 2 - 1);
+        GenSolvablePolynomial<C> one = ring.getONE();
+        for (GenSolvablePolynomial<C> p : pgens) {
+            SolvableLocal<C> q = new SolvableLocal<C>(this, p);
+            gens.add(q);
+            if (!p.isONE() && !ideal.contains(p)) { // q.isUnit()
+                q = new SolvableLocal<C>(this, one, p);
+                gens.add(q);
+            }
+        }
+        return gens;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true if this ring is commutative, else false.
+     */
+    public boolean isCommutative() {
+        return ring.isCommutative();
+    }
+
+
+    /**
+     * Query if this ring is associative.
+     * @return true if this ring is associative, else false.
+     */
+    @SuppressWarnings("unused")
+    public boolean isAssociative() {
+        if (!ring.isAssociative()) {
+            return false;
+        }
+        SolvableLocal<C> Xi, Xj, Xk, p, q;
+        List<SolvableLocal<C>> gens = generators();
+        int ngen = gens.size();
+        for (int i = 0; i < ngen; i++) {
+            Xi = gens.get(i);
+            for (int j = i + 1; j < ngen; j++) {
+                Xj = gens.get(j);
+                for (int k = j + 1; k < ngen; k++) {
+                    Xk = gens.get(k);
+                    try {
+                        p = Xk.multiply(Xj).multiply(Xi);
+                        q = Xk.multiply(Xj.multiply(Xi));
+                    } catch (IllegalArgumentException e) {
+                        //e.printStackTrace();
+                        continue; // ignore undefined multiplication
+                    }
+                    if (!p.equals(q)) {
+                        if (true || debug) {
+                            logger.info("Xk = " + Xk + ", Xj = " + Xj + ", Xi = " + Xi);
+                            logger.info("p = ( Xk * Xj ) * Xi = " + p);
+                            logger.info("q = Xk * ( Xj * Xi ) = " + q);
+                        }
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Query if this ring is a field.
+     * @return false.
+     */
+    public boolean isField() {
+        if (isField > 0) {
+            return true;
+        }
+        if (isField == 0) {
+            return false;
+        }
+        // not reached
+        return false;
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic() {
+        return ring.characteristic();
+    }
+
+
+    /**
+     * Get a SolvableLocal element from a BigInteger value.
+     * @param a BigInteger.
+     * @return a SolvableLocal.
+     */
+    public SolvableLocal<C> fromInteger(java.math.BigInteger a) {
+        return new SolvableLocal<C>(this, ring.fromInteger(a));
+    }
+
+
+    /**
+     * Get a SolvableLocal element from a long value.
+     * @param a long.
+     * @return a SolvableLocal.
+     */
+    public SolvableLocal<C> fromInteger(long a) {
+        return new SolvableLocal<C>(this, ring.fromInteger(a));
+    }
+
+
+    /**
+     * Get the String representation as RingFactory.
+     */
+    @Override
+    public String toString() {
+        return "SolvableLocalRing[ " + ideal.toString() + " ]";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this ElemFactory.
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        return "SLC(" + ideal.list.toScript() + ")";
+    }
+
+
+    /**
+     * Comparison with any other object.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (!(b instanceof SolvableLocalRing)) {
+            return false;
+        }
+        SolvableLocalRing<C> a = null;
+        try {
+            a = (SolvableLocalRing<C>) b;
+        } catch (ClassCastException e) {
+        }
+        if (a == null) {
+            return false;
+        }
+        if (!ring.equals(a.ring)) {
+            return false;
+        }
+        return ideal.equals(a.ideal);
+    }
+
+
+    /**
+     * Hash code for this local ring.
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = ideal.hashCode();
+        return h;
+    }
+
+
+    /**
+     * SolvableLocal random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @return a random residue element.
+     */
+    public SolvableLocal<C> random(int n) {
+        GenSolvablePolynomial<C> r = ring.random(n).monic();
+        r = ideal.normalform(r);
+        GenSolvablePolynomial<C> s;
+        do {
+            s = ring.random(n).monic();
+            s = ideal.normalform(s);
+        } while (s.isZERO());
+        return new SolvableLocal<C>(this, r, s, false);
+    }
+
+
+    /**
+     * Generate a random residum polynomial.
+     * @param k bitsize of random coefficients.
+     * @param l number of terms.
+     * @param d maximal degree in each variable.
+     * @param q density of nozero exponents.
+     * @return a random residue polynomial.
+     */
+    public SolvableLocal<C> random(int k, int l, int d, float q) {
+        GenSolvablePolynomial<C> r = ring.random(k, l, d, q).monic();
+        r = ideal.normalform(r);
+        GenSolvablePolynomial<C> s;
+        do {
+            s = ring.random(k, l, d, q).monic();
+            s = ideal.normalform(s);
+        } while (s.isZERO());
+        return new SolvableLocal<C>(this, r, s, false);
+    }
+
+
+    /**
+     * SolvableLocal random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @param rnd is a source for random bits.
+     * @return a random residue element.
+     */
+    public SolvableLocal<C> random(int n, Random rnd) {
+        GenSolvablePolynomial<C> r = ring.random(n, rnd).monic();
+        r = ideal.normalform(r);
+        GenSolvablePolynomial<C> s;
+        do {
+            s = ring.random(n).monic();
+            s = ideal.normalform(s);
+        } while (s.isZERO());
+        return new SolvableLocal<C>(this, r, s, false);
+    }
+
+
+    /**
+     * Parse SolvableLocal from String.
+     * @param s String.
+     * @return SolvableLocal from s.
+     */
+    public SolvableLocal<C> parse(String s) {
+        int i = s.indexOf("{");
+        if (i >= 0) {
+            s = s.substring(i + 1);
+        }
+        i = s.lastIndexOf("}");
+        if (i >= 0) {
+            s = s.substring(0, i);
+        }
+        i = s.indexOf("|");
+        if (i < 0) {
+            GenSolvablePolynomial<C> n = ring.parse(s);
+            return new SolvableLocal<C>(this, n);
+        }
+        String s1 = s.substring(0, i);
+        String s2 = s.substring(i + 1);
+        GenSolvablePolynomial<C> n = ring.parse(s1);
+        GenSolvablePolynomial<C> d = ring.parse(s2);
+        return new SolvableLocal<C>(this, n, d);
+    }
+
+
+    /**
+     * Parse SolvableLocal from Reader.
+     * @param r Reader.
+     * @return next SolvableLocal from r.
+     */
+    public SolvableLocal<C> parse(Reader r) {
+        String s = StringUtil.nextPairedString(r, '{', '}');
+        return parse(s);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/SolvableResidue.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/SolvableResidue.java
@@ -1,0 +1,511 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.jas.kern.PrettyPrint;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.NotInvertibleException;
+import edu.jas.structure.QuotPair;
+import edu.jas.structure.QuotPairFactory;
+import edu.jas.structure.Value;
+import edu.jas.structure.ValueFactory;
+
+
+/**
+ * SolvableResidue ring element based on GenSolvablePolynomial with GcdRingElem
+ * interface. Objects of this class are immutable.
+ * @author Heinz Kredel
+ */
+public class SolvableResidue<C extends GcdRingElem<C>> 
+    implements GcdRingElem<SolvableResidue<C>>, QuotPair<GenPolynomial<C>>, Value<GenPolynomial<C>> {
+
+
+    /**
+     * SolvableResidue class factory data structure.
+     */
+    public final SolvableResidueRing<C> ring;
+
+
+    /**
+     * Value part of the element data structure.
+     */
+    public final GenSolvablePolynomial<C> val;
+
+
+    /**
+     * Flag to remember if this residue element is a unit. -1 is unknown, 1 is
+     * unit, 0 not a unit.
+     */
+    protected int isunit = -1; // initially unknown
+
+
+    /**
+     * The constructor creates a SolvableResidue object from a ring factory.
+     * @param r solvable residue ring factory.
+     */
+    public SolvableResidue(SolvableResidueRing<C> r) {
+        this(r, r.ring.getZERO(), 0);
+    }
+
+
+    /**
+     * The constructor creates a SolvableResidue object from a ring factory and
+     * a polynomial.
+     * @param r solvable residue ring factory.
+     * @param a solvable polynomial.
+     */
+    public SolvableResidue(SolvableResidueRing<C> r, GenSolvablePolynomial<C> a) {
+        this(r, a, -1);
+    }
+
+
+    /**
+     * The constructor creates a SolvableResidue object from a ring factory, a
+     * polynomial and an indicator if a is a unit.
+     * @param r solvable residue ring factory.
+     * @param a solvable polynomial.
+     * @param u isunit indicator, -1, 0, 1.
+     */
+    public SolvableResidue(SolvableResidueRing<C> r, GenSolvablePolynomial<C> a, int u) {
+        ring = r;
+        val = ring.ideal.normalform(a); //.monic() no go
+        if (u == 0 || u == 1) {
+            isunit = u;
+            return;
+        }
+        if (val.isZERO()) {
+            isunit = 0;
+            return;
+        }
+        if (ring.isField()) {
+            isunit = 1;
+            return;
+        }
+        if (val.isUnit()) {
+            isunit = 1;
+            //} else { // not possible
+            //isunit = 0;
+        }
+        isunit = -1;
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public SolvableResidueRing<C> factory() {
+        return ring;
+    }
+
+
+    /**
+     * Value. Returns the value.
+     * @see edu.jas.structure.Value#value()
+     */
+    public GenSolvablePolynomial<C> value() {
+        return val;
+    }
+
+
+    /**
+     * Numerator. Returns the value.
+     * @see edu.jas.structure.QuotPair#numerator()
+     */
+    public GenSolvablePolynomial<C> numerator() {
+        return val;
+    }
+
+
+    /**
+     * Denominator. Returns 1.
+     * @see edu.jas.structure.QuotPair#denominator()
+     */
+    public GenSolvablePolynomial<C> denominator() {
+        return ring.ring.getONE();
+    }
+
+
+    /**
+     * Clone this.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public SolvableResidue<C> copy() {
+        return new SolvableResidue<C>(ring, val, isunit);
+    }
+
+
+    /**
+     * Is SolvableResidue zero.
+     * @return If this is 0 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isZERO()
+     */
+    public boolean isZERO() {
+        return val.isZERO();
+    }
+
+
+    /**
+     * Is SolvableResidue one.
+     * @return If this is 1 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isONE()
+     */
+    public boolean isONE() {
+        return val.isONE();
+    }
+
+
+    /**
+     * Is SolvableResidue unit.
+     * @return If this is a unit then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isUnit()
+     */
+    public boolean isUnit() {
+        if (isunit > 0) {
+            return true;
+        }
+        if (isunit == 0) {
+            return false;
+        }
+        // not jet known
+        boolean u = ring.ideal.isUnit(val);
+        if (u) {
+            isunit = 1; // seems to be wrong for solvable polynomial rings
+        } else {
+            isunit = 0;
+        }
+        return isunit > 0;
+    }
+
+
+    /**
+     * Is SolvableResidue a constant.
+     * @return true if this.val is a constant polynomial, else false.
+     */
+    public boolean isConstant() {
+        return val.isConstant();
+    }
+
+
+    /**
+     * Get the String representation as RingElem.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        if (PrettyPrint.isTrue()) {
+            return val.toString(ring.ring.getVars());
+        }
+        return "SolvableResidue[ " + val.toString() + " mod " + ring.toString() + " ]";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        return val.toScript();
+        //         return "PolySolvableResidue( " + val.toScript() 
+        //                         + ", " + ring.toScript() + " )";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python case
+        return factory().toScript();
+    }
+
+
+    /**
+     * SolvableResidue comparison.
+     * @param b SolvableResidue.
+     * @return sign(this-b), 0 means that this and b are equivalent in this
+     *         residue class ring.
+     */
+    @Override
+    public int compareTo(SolvableResidue<C> b) {
+        GenSolvablePolynomial<C> v = b.val;
+        if (!ring.equals(b.ring)) {
+            v = ring.ideal.normalform(v);
+        }
+        return val.compareTo(v);
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     * @return true means that this and b are equivalent in this residue class
+     *         ring.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (!(b instanceof SolvableResidue)) {
+            return false;
+        }
+        SolvableResidue<C> a = null;
+        try {
+            a = (SolvableResidue<C>) b;
+        } catch (ClassCastException e) {
+        }
+        if (a == null) {
+            return false;
+        }
+        return compareTo(a) == 0;
+    }
+
+
+    /**
+     * Hash code for this residue.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = ring.hashCode();
+        h = 37 * h + val.hashCode();
+        return h;
+    }
+
+
+    /**
+     * SolvableResidue absolute value.
+     * @return the absolute value of this.
+     * @see edu.jas.structure.RingElem#abs()
+     */
+    public SolvableResidue<C> abs() {
+        return new SolvableResidue<C>(ring, (GenSolvablePolynomial<C>) val.abs(), isunit);
+    }
+
+
+    /**
+     * SolvableResidue summation.
+     * @param S SolvableResidue.
+     * @return this+S.
+     */
+    public SolvableResidue<C> sum(SolvableResidue<C> S) {
+        return new SolvableResidue<C>(ring, (GenSolvablePolynomial<C>) val.sum(S.val));
+    }
+
+
+    /**
+     * SolvableResidue negate.
+     * @return -this.
+     * @see edu.jas.structure.RingElem#negate()
+     */
+    public SolvableResidue<C> negate() {
+        return new SolvableResidue<C>(ring, (GenSolvablePolynomial<C>) val.negate(), isunit);
+    }
+
+
+    /**
+     * SolvableResidue signum.
+     * @see edu.jas.structure.RingElem#signum()
+     * @return signum(this).
+     */
+    public int signum() {
+        return val.signum();
+    }
+
+
+    /**
+     * SolvableResidue subtraction.
+     * @param S SolvableResidue.
+     * @return this-S.
+     */
+    public SolvableResidue<C> subtract(SolvableResidue<C> S) {
+        return new SolvableResidue<C>(ring, (GenSolvablePolynomial<C>) val.subtract(S.val));
+    }
+
+
+    /**
+     * SolvableResidue division.
+     * @param S SolvableResidue.
+     * @return this/S.
+     */
+    public SolvableResidue<C> divide(SolvableResidue<C> S) {
+        if (ring.isField()) {
+            return multiply(S.inverse());
+        }
+        try {
+            return multiply(S.inverse());
+        } catch (NotInvertibleException ignored) {
+            System.out.println("catch: " + ignored);
+            //ignored.printStackTrace();
+            // ignored
+        }
+        List<GenSolvablePolynomial<C>> Q = new ArrayList<GenSolvablePolynomial<C>>(1);
+        Q.add(ring.ring.getZERO());
+        List<GenSolvablePolynomial<C>> V = new ArrayList<GenSolvablePolynomial<C>>(1);
+        V.add(S.val);
+        GenSolvablePolynomial<C> x = ring.bb.sred.leftNormalform(Q, V, val);
+        GenSolvablePolynomial<C> y = Q.get(0);
+        System.out.println("SolvableResidue val = " + val + ", div = " + S.val + ", quotient = " + y
+                        + ", remainder = " + x);
+        return new SolvableResidue<C>(ring, y);
+    }
+
+
+    /**
+     * SolvableResidue inverse.
+     * @see edu.jas.structure.RingElem#inverse()
+     * @return S with S = 1/this if defined.
+     */
+    public SolvableResidue<C> inverse() {
+        GenSolvablePolynomial<C> x = ring.ideal.inverse(val);
+        SolvableResidue<C> xp = new SolvableResidue<C>(ring, x, 1);
+        if (xp.isZERO()) {
+            throw new NotInvertibleException("(" + x + ") * (" + val + ") = " + x.multiply(val) + " = 0 mod "
+                            + ring.ideal);
+        }
+        if (!xp.multiply(this).isONE()) {
+            throw new NotInvertibleException("(" + x + ") * (" + val + ") = " + x.multiply(val)
+                            + " != 1 mod " + ring.ideal);
+        }
+        return xp;
+    }
+
+
+    /**
+     * SolvableResidue remainder.
+     * @param S SolvableResidue.
+     * @return this - (this/S)*S.
+     */
+    public SolvableResidue<C> remainder(SolvableResidue<C> S) {
+        List<GenSolvablePolynomial<C>> V = new ArrayList<GenSolvablePolynomial<C>>(1);
+        V.add(S.val);
+        GenSolvablePolynomial<C> x = ring.bb.sred.leftNormalform(V, val);
+        return new SolvableResidue<C>(ring, x);
+    }
+
+
+    /**
+     * SolvableResidue multiplication.
+     * @param S SolvableResidue.
+     * @return this*S.
+     */
+    public SolvableResidue<C> multiply(SolvableResidue<C> S) {
+        GenSolvablePolynomial<C> x = val.multiply(S.val);
+        int i = -1;
+        if (isunit == 1 && S.isunit == 1) {
+            i = 1;
+        } else if (isunit == 0 || S.isunit == 0) {
+            i = 0;
+        }
+        return new SolvableResidue<C>(ring, x, i);
+    }
+
+
+    /**
+     * SolvableResidue multiplication.
+     * @param S GenSolvablePolynomial.
+     * @return this*S.
+     */
+    public SolvableResidue<C> multiply(GenSolvablePolynomial<C> S) {
+        GenSolvablePolynomial<C> x = val.multiply(S);
+        int i = -1;
+        if (isunit == 1 && S.isUnit()) {
+            i = 1;
+        } else if (isunit == 0 || !S.isUnit()) {
+            i = 0;
+        }
+        return new SolvableResidue<C>(ring, x, i);
+    }
+
+
+    /*
+     * SolvableResidue multiplication.
+     * @param s coefficient.
+     * @return this*s.
+     */
+    public SolvableResidue<C> multiply(C s) {
+        GenSolvablePolynomial<C> x = val.multiply(s);
+        int i = -1;
+        if (isunit == 1 && s.isUnit()) {
+            i = 1;
+        } else if (isunit == 0 || !s.isUnit()) {
+            i = 0;
+        }
+        return new SolvableResidue<C>(ring, x, i);
+    }
+
+
+    /**
+     * SolvableResidue multiplication.
+     * @param e exponent.
+     * @return this*X<sup>e</sup>.
+     */
+    public SolvableResidue<C> multiply(ExpVector e) {
+        GenSolvablePolynomial<C> x = val.multiply(e);
+        int i = -1;
+        if (isunit == 1 && e.isZERO()) {
+            i = 1;
+        } else if (isunit == 0 || !e.isZERO()) {
+            i = 0;
+        }
+        return new SolvableResidue<C>(ring, x, i);
+    }
+
+
+    /**
+     * SolvableResidue monic.
+     * @return this with monic value part.
+     */
+    public SolvableResidue<C> monic() {
+        return new SolvableResidue<C>(ring, val.monic(), isunit);
+    }
+
+
+    /**
+     * Greatest common divisor.
+     * @param b other element.
+     * @return gcd(this,b).
+     */
+    public SolvableResidue<C> gcd(SolvableResidue<C> b) {
+        throw new UnsupportedOperationException("gcd not implemented");
+        // GenSolvablePolynomial<C> x = ring.engine.gcd(val, b.val);
+        // int i = -1; // gcd might become a unit
+        // if (x.isONE()) {
+        //     i = 1;
+        // } else {
+        //     System.out.println("SolvableResidue gcd = " + x);
+        // }
+        // if (isunit == 1 && b.isunit == 1) {
+        //     i = 1;
+        // }
+        // return new SolvableResidue<C>(ring, x, i);
+    }
+
+
+    /**
+     * Extended greatest common divisor. <b>Note: </b>Not implemented, throws
+     * UnsupportedOperationException.
+     * @param b other element.
+     * @return [ gcd(this,b), c1, c2 ] with c1*this + c2*b = gcd(this,b).
+     */
+    public SolvableResidue<C>[] egcd(SolvableResidue<C> b) {
+        throw new UnsupportedOperationException("egcd not implemented");
+    }
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/SolvableResidueRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/SolvableResidueRing.java
@@ -1,0 +1,421 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.SolvableGroebnerBaseAbstract;
+import edu.jas.gb.SolvableGroebnerBaseSeq;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.GenSolvablePolynomialRing;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.structure.QuotPair;
+import edu.jas.structure.QuotPairFactory;
+import edu.jas.structure.Value;
+import edu.jas.structure.ValueFactory;
+
+
+/**
+ * SolvableResidue ring factory based on GenSolvablePolynomialRing with
+ * GcdRingFactory interface. Objects of this class are immutable.
+ * @author Heinz Kredel
+ */
+public class SolvableResidueRing<C extends GcdRingElem<C>> 
+    implements RingFactory<SolvableResidue<C>>, 
+               QuotPairFactory<GenPolynomial<C>, SolvableResidue<C>>,
+               ValueFactory<GenPolynomial<C>, SolvableResidue<C>> {
+
+
+    private static final Logger logger = LogManager.getLogger(SolvableResidueRing.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Groebner base engine.
+     */
+    protected final SolvableGroebnerBaseAbstract<C> bb;
+
+
+    /**
+     * Solvable polynomial ideal for the reduction.
+     */
+    public final SolvableIdeal<C> ideal;
+
+
+    /**
+     * Polynomial ring of the factory. Shortcut to ideal.list.ring.
+     */
+    public final GenSolvablePolynomialRing<C> ring;
+
+
+    /**
+     * Indicator if this ring is a field.
+     */
+    protected int isField = -1; // initially unknown
+
+
+    /**
+     * The constructor creates a SolvableResidueRing object from an Ideal.
+     * @param i polynomial ideal.
+     */
+    public SolvableResidueRing(SolvableIdeal<C> i) {
+        this(i, false);
+    }
+
+
+    /**
+     * The constructor creates a SolvableResidueRing object from an
+     * SolvableIdeal.
+     * @param i solvable polynomial ideal.
+     * @param isMaximal true, if ideal is maxmal.
+     */
+    public SolvableResidueRing(SolvableIdeal<C> i, boolean isMaximal) {
+        ideal = i.GB(); // cheap if isGB
+        ring = ideal.getRing();
+        bb = new SolvableGroebnerBaseSeq<C>();
+        if (isMaximal) {
+            isField = 1;
+            return;
+        }
+        if (ideal.isONE()) {
+            logger.warn("ideal is one, so all residues are 0");
+        }
+        //System.out.println("rr ring   = " + ring.getClass().getName());
+        //System.out.println("rr cofac  = " + ring.coFac.getClass().getName());
+    }
+
+ 
+    /**
+     * Factory for base elements.
+     */
+    public GenSolvablePolynomialRing<C> pairFactory() {
+        return ring;
+    }
+
+
+    /**
+     * Factory for base elements.
+     */
+    public GenSolvablePolynomialRing<C> valueFactory() {
+        return ring;
+    }
+
+
+    /**
+     * Create from numerator.
+     */
+    @SuppressWarnings("unchecked")
+    public SolvableResidue<C> create(GenPolynomial<C> n) {
+        return new SolvableResidue<C>(this, (GenSolvablePolynomial<C>) n);
+    }
+
+
+    /**
+     * Create from numerator, denominator pair.
+     */
+    @SuppressWarnings("unchecked")
+    public SolvableResidue<C> create(GenPolynomial<C> n, GenPolynomial<C> d) {
+        if (d != null && !d.isONE()) {
+            throw new UnsupportedOperationException("d must be 1, but d = " + d);
+        }
+        return new SolvableResidue<C>(this, (GenSolvablePolynomial<C>) n);
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite()
+     */
+    public boolean isFinite() {
+        return ideal.commonZeroTest() <= 0 && ring.coFac.isFinite();
+    }
+
+
+    /**
+     * Copy SolvableResidue element c.
+     * @param c
+     * @return a copy of c.
+     */
+    public SolvableResidue<C> copy(SolvableResidue<C> c) {
+        //System.out.println("rr copy in    = " + c.val);
+        if (c == null) { // where does this happen?
+            return getZERO(); // or null?
+        }
+        SolvableResidue<C> r = new SolvableResidue<C>(this, c.val);
+        //System.out.println("rr copy out   = " + r.val);
+        //System.out.println("rr copy ideal = " + ideal.list.list);
+        return r; //new SolvableResidue<C>( c.ring, c.val );
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as SolvableResidue.
+     */
+    public SolvableResidue<C> getZERO() {
+        return new SolvableResidue<C>(this, ring.getZERO());
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as SolvableResidue.
+     */
+    public SolvableResidue<C> getONE() {
+        SolvableResidue<C> one = new SolvableResidue<C>(this, ring.getONE());
+        if (one.isZERO()) {
+            logger.warn("ideal is one, so all residues are 0");
+        }
+        return one;
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     * @see edu.jas.structure.ElemFactory#generators()
+     */
+    public List<SolvableResidue<C>> generators() {
+        List<GenPolynomial<C>> pgens = ring.generators();
+        List<SolvableResidue<C>> gens = new ArrayList<SolvableResidue<C>>(pgens.size());
+        SortedSet<SolvableResidue<C>> sgens = new TreeSet<SolvableResidue<C>>();
+        List<GenSolvablePolynomial<C>> rgens = new ArrayList<GenSolvablePolynomial<C>>(pgens.size());
+        SolvableIdeal<C> gi = new SolvableIdeal<C>(ring, rgens);
+        SolvableResidueRing<C> gr = new SolvableResidueRing<C>(gi);
+        for (GenPolynomial<C> p : pgens) {
+            GenSolvablePolynomial<C> s = (GenSolvablePolynomial<C>) p;
+            SolvableResidue<C> r = new SolvableResidue<C>(this, s);
+            if (r.isZERO()) {
+                continue;
+            }
+            if (!r.isONE() && r.val.isConstant()) {
+                continue;
+            }
+            // avoid duplicate generators
+            SolvableResidue<C> x = new SolvableResidue<C>(gr, r.val);
+            if (x.isZERO()) {
+                continue;
+            }
+            if (!x.isONE() && x.val.isConstant()) {
+                continue;
+            }
+            r = new SolvableResidue<C>(this, x.val);
+            if (r.isZERO()) {
+                continue;
+            }
+            r = r.monic();
+            if (!r.isONE() && !r.val.isConstant()) {
+                rgens.add(r.val);
+                //System.out.println("rgens = " + rgens);
+                gi = new SolvableIdeal<C>(ring, rgens);
+                gr = new SolvableResidueRing<C>(gi);
+            }
+            //gens.add(r);
+            sgens.add(r);
+        }
+        gens.addAll(sgens);
+        return gens;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true if this ring is commutative, else false.
+     */
+    public boolean isCommutative() {
+        return ring.isCommutative(); // check also vector space structure
+    }
+
+
+    /**
+     * Query if this ring is associative.
+     * @return true if this ring is associative, else false.
+     */
+    public boolean isAssociative() {
+        return ring.isAssociative(); // sufficient ??
+    }
+
+
+    /**
+     * Query if this ring is a field.
+     * @return false.
+     */
+    public boolean isField() {
+        if (isField > 0) {
+            return true;
+        }
+        if (isField == 0) {
+            return false;
+        }
+        if (ideal.isMaximal()) {
+            isField = 1;
+            return true;
+        }
+        return false;
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic() {
+        return ring.characteristic();
+    }
+
+
+    /**
+     * Get a SolvableResidue element from a BigInteger value.
+     * @param a BigInteger.
+     * @return a SolvableResidue.
+     */
+    public SolvableResidue<C> fromInteger(java.math.BigInteger a) {
+        return new SolvableResidue<C>(this, ring.fromInteger(a));
+    }
+
+
+    /**
+     * Get a SolvableResidue element from a long value.
+     * @param a long.
+     * @return a SolvableResidue.
+     */
+    public SolvableResidue<C> fromInteger(long a) {
+        return new SolvableResidue<C>(this, ring.fromInteger(a));
+    }
+
+
+    /**
+     * Get the String representation as RingFactory.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "SolvableResidueRing[ " + ideal.toString() + " ]";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.ElemFactory#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        return "SRC(" + ideal.list.toScript() + ")";
+        //return "SRC(" + ideal.toScript() + "," + ring.toScript()  + ")";
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (!(b instanceof SolvableResidueRing)) {
+            return false;
+        }
+        SolvableResidueRing<C> a = null;
+        try {
+            a = (SolvableResidueRing<C>) b;
+        } catch (ClassCastException e) {
+        }
+        if (a == null) {
+            return false;
+        }
+        if (!ring.equals(a.ring)) {
+            return false;
+        }
+        return ideal.equals(a.ideal);
+    }
+
+
+    /**
+     * Hash code for this residue ring.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = ideal.hashCode();
+        return h;
+    }
+
+
+    /**
+     * SolvableResidue random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @return a random residue element.
+     */
+    public SolvableResidue<C> random(int n) {
+        GenSolvablePolynomial<C> x = ring.random(n).monic();
+        return new SolvableResidue<C>(this, x);
+    }
+
+
+    /**
+     * Generate a random residum polynomial.
+     * @param k bitsize of random coefficients.
+     * @param l number of terms.
+     * @param d maximal degree in each variable.
+     * @param q density of nozero exponents.
+     * @return a random residue polynomial.
+     */
+    public SolvableResidue<C> random(int k, int l, int d, float q) {
+        GenSolvablePolynomial<C> x = ring.random(k, l, d, q).monic();
+        return new SolvableResidue<C>(this, x);
+    }
+
+
+    /**
+     * SolvableResidue random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @param rnd is a source for random bits.
+     * @return a random residue element.
+     */
+    public SolvableResidue<C> random(int n, Random rnd) {
+        GenSolvablePolynomial<C> x = ring.random(n, rnd).monic();
+        return new SolvableResidue<C>(this, x);
+    }
+
+
+    /**
+     * Parse SolvableResidue from String.
+     * @param s String.
+     * @return SolvableResidue from s.
+     */
+    public SolvableResidue<C> parse(String s) {
+        GenSolvablePolynomial<C> x = ring.parse(s);
+        return new SolvableResidue<C>(this, x);
+    }
+
+
+    /**
+     * Parse SolvableResidue from Reader.
+     * @param r Reader.
+     * @return next SolvableResidue from r.
+     */
+    public SolvableResidue<C> parse(Reader r) {
+        GenSolvablePolynomial<C> x = ring.parse(r);
+        return new SolvableResidue<C>(this, x);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/WordIdeal.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/WordIdeal.java
@@ -1,0 +1,1064 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.gb.WordGroebnerBaseAbstract;
+import edu.jas.gb.WordGroebnerBaseSeq;
+import edu.jas.gb.WordReduction;
+import edu.jas.gb.WordReductionSeq;
+import edu.jas.gbufd.PolyGBUtil;
+import edu.jas.kern.Scripting;
+import edu.jas.poly.GenWordPolynomial;
+import edu.jas.poly.GenWordPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.poly.Word;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.NotInvertibleException;
+
+
+/**
+ * Word Ideal implements some methods for ideal arithmetic, for example
+ * containment, sum or product. <b>Note:</b> only two-sided ideals.
+ * @author Heinz Kredel
+ */
+public class WordIdeal<C extends GcdRingElem<C>> implements Comparable<WordIdeal<C>>, Serializable {
+
+
+    private static final Logger logger = LogManager.getLogger(WordIdeal.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * The data structure is a list of word polynomials.
+     */
+    protected List<GenWordPolynomial<C>> list;
+
+
+    /**
+     * Reference to the word polynomial ring.
+     */
+    protected GenWordPolynomialRing<C> ring;
+
+
+    /**
+     * Indicator if list is a Groebner Base.
+     */
+    protected boolean isGB;
+
+
+    /**
+     * Indicator if test has been performed if this is a Groebner Base.
+     */
+    protected boolean testGB;
+
+
+    /**
+     * Groebner base engine.
+     */
+    protected final WordGroebnerBaseAbstract<C> bb;
+
+
+    /**
+     * Reduction engine.
+     */
+    protected final WordReduction<C> red;
+
+
+    /**
+     * Constructor.
+     * @param ring word polynomial ring
+     */
+    public WordIdeal(GenWordPolynomialRing<C> ring) {
+        this(ring, new ArrayList<GenWordPolynomial<C>>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param ring word polynomial ring
+     * @param list word polynomial list
+     */
+    public WordIdeal(GenWordPolynomialRing<C> ring, List<GenWordPolynomial<C>> list) {
+        this(ring, list, false);
+    }
+
+
+    /**
+     * Constructor.
+     * @param ring word polynomial ring
+     * @param list word polynomial list
+     * @param bb Groebner Base engine
+     * @param red Reduction engine
+     */
+    public WordIdeal(GenWordPolynomialRing<C> ring, List<GenWordPolynomial<C>> list,
+                    WordGroebnerBaseAbstract<C> bb, WordReduction<C> red) {
+        this(ring, list, false, bb, red);
+    }
+
+
+    /**
+     * Constructor.
+     * @param ring word polynomial ring
+     * @param list word polynomial list
+     * @param gb true if list is known to be a Groebner Base, else false
+     */
+    public WordIdeal(GenWordPolynomialRing<C> ring, List<GenWordPolynomial<C>> list, boolean gb) {
+        this(ring, list, gb, new WordGroebnerBaseSeq<C>(), new WordReductionSeq<C>());
+        //this(list, gb, topt, GBFactory.getImplementation(list.ring.coFac));
+    }
+
+
+    /**
+     * Constructor.
+     * @param ring word polynomial ring
+     * @param list word polynomial list
+     * @param gb true if list is known to be a Groebner Base, else false
+     * @param bb Groebner Base engine
+     */
+    public WordIdeal(GenWordPolynomialRing<C> ring, List<GenWordPolynomial<C>> list, boolean gb,
+                    WordGroebnerBaseAbstract<C> bb) {
+        this(ring, list, gb, bb, bb.red);
+    }
+
+
+    /**
+     * Constructor.
+     * @param ring word polynomial ring
+     * @param list word polynomial list
+     * @param gb true if list is known to be a Groebner Base, else false
+     * @param bb Groebner Base engine
+     * @param red Reduction engine
+     */
+    public WordIdeal(GenWordPolynomialRing<C> ring, List<GenWordPolynomial<C>> list, boolean gb,
+                    WordGroebnerBaseAbstract<C> bb, WordReduction<C> red) {
+        if (ring == null) {
+            throw new IllegalArgumentException("ring may not be null");
+        }
+        if (list == null) {
+            throw new IllegalArgumentException("list may not be null");
+        }
+        this.ring = ring;
+        this.list = list;
+        this.isGB = gb;
+        this.testGB = (gb ? true : false); // ??
+        this.bb = bb;
+        this.red = red;
+        if (debug) {
+            logger.info("constructed: " + this);
+        }
+    }
+
+
+    /**
+     * Clone this.
+     * @return a copy of this.
+     */
+    public WordIdeal<C> copy() {
+        return new WordIdeal<C>(ring, new ArrayList<GenWordPolynomial<C>>(list), isGB, bb, red);
+    }
+
+
+    /**
+     * Get the List of GenWordPolynomials.
+     * @return (cast) list.list
+     */
+    public List<GenWordPolynomial<C>> getList() {
+        return list;
+    }
+
+
+    /**
+     * Get the GenWordPolynomialRing.
+     * @return (cast) list.ring
+     */
+    public GenWordPolynomialRing<C> getRing() {
+        return ring;
+    }
+
+
+    /**
+     * Get the zero ideal.
+     * @return ideal(0)
+     */
+    public WordIdeal<C> getZERO() {
+        List<GenWordPolynomial<C>> z = new ArrayList<GenWordPolynomial<C>>(0);
+        return new WordIdeal<C>(ring, z, true, bb, red);
+    }
+
+
+    /**
+     * Get the one ideal.
+     * @return ideal(1)
+     */
+    public WordIdeal<C> getONE() {
+        List<GenWordPolynomial<C>> one = new ArrayList<GenWordPolynomial<C>>(1);
+        one.add(getRing().getONE());
+        return new WordIdeal<C>(ring, one, true, bb, red);
+    }
+
+
+    /**
+     * String representation of the word ideal.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer("(");
+        boolean first = true;
+        for (GenWordPolynomial<C> p : list) {
+            if (!first) {
+                sb.append(",");
+            } else {
+                first = false;
+            }
+            sb.append(p.toString());
+        }
+        sb.append(")");
+        return sb.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    public String toScript() {
+        StringBuffer s = new StringBuffer();
+        switch (Scripting.getLang()) {
+        case Ruby:
+            s.append("WordPolyIdeal.new(");
+            break;
+        case Python:
+        default:
+            s.append("WordIdeal(");
+        }
+        if (ring != null) {
+            s.append(ring.toScript());
+        }
+        if (list == null) {
+            s.append(")");
+            return s.toString();
+        }
+        switch (Scripting.getLang()) {
+        case Ruby:
+            s.append(",\"\",[");
+            break;
+        case Python:
+        default:
+            s.append(",list=[");
+        }
+        boolean first = true;
+        String sa = null;
+        for (GenWordPolynomial<C> oa : list) {
+            sa = oa.toScript();
+            if (first) {
+                first = false;
+            } else {
+                s.append(", ");
+            }
+            //s.append("( " + sa + " )");
+            s.append(sa);
+        }
+        s.append("])");
+        return s.toString();
+    }
+
+
+    /**
+     * Comparison with any other object. <b>Note:</b> If not both ideals are
+     * Groebner Bases, then false may be returned even the ideals are equal.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (!(b instanceof WordIdeal)) {
+            logger.warn("equals no Ideal");
+            return false;
+        }
+        WordIdeal<C> B = null;
+        try {
+            B = (WordIdeal<C>) b;
+        } catch (ClassCastException ignored) {
+            return false;
+        }
+        SortedSet<GenWordPolynomial<C>> s = new TreeSet<GenWordPolynomial<C>>(list);
+        SortedSet<GenWordPolynomial<C>> t = new TreeSet<GenWordPolynomial<C>>(B.list);
+        if (isGB && B.isGB) { //requires also monic polys
+            return s.equals(t);
+        }
+        if (s.equals(t)) {
+            return true;
+        }
+        //System.out.println("no GBs contains");
+        return this.contains(B) && B.contains(this);
+    }
+
+
+    /**
+     * WordIdeal comparison.
+     * @param L other word ideal.
+     * @return compareTo() of polynomial lists.
+     */
+    public int compareTo(WordIdeal<C> L) {
+        int si = Math.min(L.list.size(), list.size());
+        int s = 0;
+        final Comparator<Word> wc = ring.alphabet.getAscendComparator();
+        Comparator<GenWordPolynomial<C>> cmp = new Comparator<GenWordPolynomial<C>>() {
+
+
+            public int compare(GenWordPolynomial<C> p1, GenWordPolynomial<C> p2) {
+                Word w1 = p1.leadingWord();
+                Word w2 = p2.leadingWord();
+                if (w1 == null) {
+                    return -1; // dont care
+                }
+                if (w2 == null) {
+                    return 1; // dont care
+                }
+                if (w1.length() != w2.length()) {
+                    if (w1.length() > w2.length()) {
+                        return 1; // dont care
+                    }
+                    return -1; // dont care
+                }
+                return wc.compare(w1, w2);
+            }
+        };
+
+        List<GenWordPolynomial<C>> l1 = new ArrayList<GenWordPolynomial<C>>(list);
+        List<GenWordPolynomial<C>> l2 = new ArrayList<GenWordPolynomial<C>>(L.list);
+        //Collections.sort(l1);
+        //Collections.sort(l2);
+        Collections.sort(l1, cmp);
+        Collections.sort(l2, cmp);
+        for (int i = 0; i < si; i++) {
+            GenWordPolynomial<C> a = l1.get(i);
+            GenWordPolynomial<C> b = l2.get(i);
+            s = a.compareTo(b);
+            if (s != 0) {
+                return s;
+            }
+        }
+        if (list.size() > si) {
+            return 1;
+        }
+        if (L.list.size() > si) {
+            return -1;
+        }
+        return s;
+    }
+
+
+    /**
+     * Hash code for this word ideal.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = list.hashCode();
+        if (isGB) {
+            h = h << 1;
+        }
+        if (testGB) {
+            h += 1;
+        }
+        return h;
+    }
+
+
+    /**
+     * Test if ZERO ideal.
+     * @return true, if this is the 0 ideal, else false
+     */
+    public boolean isZERO() {
+        //return list.isZERO();
+        if (list == null) { // never true
+            return true;
+        }
+        for (GenWordPolynomial<C> p : list) {
+            if (p == null) {
+                continue;
+            }
+            if (!p.isZERO()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Test if ONE is contained in the ideal. To test for a proper ideal use
+     * <code>! id.isONE()</code>.
+     * @return true, if this is the 1 ideal, else false
+     */
+    public boolean isONE() {
+        //return list.isONE();
+        if (list == null) {
+            return false;
+        }
+        for (GenWordPolynomial<C> p : list) {
+            if (p == null) {
+                continue;
+            }
+            if (p.isONE()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    /**
+     * Test if this is a twosided Groebner base.
+     * @return true, if this is a twosided Groebner base, else false
+     */
+    public boolean isGB() {
+        if (testGB) {
+            return isGB;
+        }
+        logger.warn("isGB computing");
+        isGB = bb.isGB(getList());
+        testGB = true;
+        return isGB;
+    }
+
+
+    /**
+     * Do Groebner Base. Compute the Groebner Base for this ideal.
+     */
+    @SuppressWarnings("unchecked")
+    public void doGB() {
+        if (isGB && testGB) {
+            return;
+        }
+        List<GenWordPolynomial<C>> G = getList();
+        logger.info("doGB computing = " + G);
+        list = bb.GB(G);
+        isGB = true;
+        testGB = true;
+        return;
+    }
+
+
+    /**
+     * Groebner Base. Get a Groebner Base for this ideal.
+     * @return twosidedGB(this)
+     */
+    public WordIdeal<C> GB() {
+        if (isGB) {
+            return this;
+        }
+        doGB();
+        return this;
+    }
+
+
+    /**
+     * Word ideal containment. Test if B is contained in this ideal. Note: this
+     * is eventually modified to become a Groebner Base.
+     * @param B word ideal
+     * @return true, if B is contained in this, else false
+     */
+    public boolean contains(WordIdeal<C> B) {
+        if (B == null || B.isZERO()) {
+            return true;
+        }
+        return contains(B.getList());
+    }
+
+
+    /**
+     * Word ideal containment. Test if b is contained in this ideal. Note: this
+     * is eventually modified to become a Groebner Base.
+     * @param b word polynomial
+     * @return true, if b is contained in this, else false
+     */
+    public boolean contains(GenWordPolynomial<C> b) {
+        if (b == null || b.isZERO()) {
+            return true;
+        }
+        if (this.isONE()) {
+            return true;
+        }
+        if (this.isZERO()) {
+            return false;
+        }
+        if (!isGB) {
+            doGB();
+        }
+        GenWordPolynomial<C> z = red.normalform(getList(), b);
+        if (z == null || z.isZERO()) {
+            return true;
+        }
+        return false;
+    }
+
+
+    /**
+     * Word ideal containment. Test if each b in B is contained in this ideal.
+     * Note: this is eventually modified to become a Groebner Base.
+     * @param B list of word polynomials
+     * @return true, if each b in B is contained in this, else false
+     */
+    public boolean contains(List<GenWordPolynomial<C>> B) {
+        if (B == null || B.size() == 0) {
+            return true;
+        }
+        if (this.isONE()) {
+            return true;
+        }
+        if (!isGB) {
+            doGB();
+        }
+        List<GenWordPolynomial<C>> si = getList();
+        for (GenWordPolynomial<C> b : B) {
+            if (b == null) {
+                continue;
+            }
+            GenWordPolynomial<C> z = red.normalform(si, b);
+            if (!z.isZERO()) {
+                System.out.println("contains nf(b) != 0: " + b + ", z = " + z);
+                //System.out.println("contains nf(b) != 0: si = " + si);
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Word ideal summation. Generators for the sum of ideals. Note: if both
+     * ideals are Groebner bases, a Groebner base is returned.
+     * @param B word ideal
+     * @return ideal(this+B)
+     */
+    public WordIdeal<C> sum(WordIdeal<C> B) {
+        if (B == null || B.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return B;
+        }
+        int s = getList().size() + B.getList().size();
+        List<GenWordPolynomial<C>> c;
+        c = new ArrayList<GenWordPolynomial<C>>(s);
+        c.addAll(getList());
+        c.addAll(B.getList());
+        WordIdeal<C> I = new WordIdeal<C>(getRing(), c, false);
+        if (isGB && B.isGB) {
+            I.doGB();
+        }
+        return I;
+    }
+
+
+    /**
+     * Word summation. Generators for the sum of ideal and a polynomial. Note:
+     * if this ideal is a Groebner base, a Groebner base is returned.
+     * @param b word polynomial
+     * @return ideal(this+{b})
+     */
+    public WordIdeal<C> sum(GenWordPolynomial<C> b) {
+        if (b == null || b.isZERO()) {
+            return this;
+        }
+        int s = getList().size() + 1;
+        List<GenWordPolynomial<C>> c;
+        c = new ArrayList<GenWordPolynomial<C>>(s);
+        c.addAll(getList());
+        c.add(b);
+        WordIdeal<C> I = new WordIdeal<C>(getRing(), c, false);
+        if (isGB) {
+            I.doGB();
+        }
+        return I;
+    }
+
+
+    /**
+     * Word summation. Generators for the sum of this ideal and a list of
+     * polynomials. Note: if this ideal is a Groebner base, a Groebner base is
+     * returned.
+     * @param L list of word polynomials
+     * @return ideal(this+L)
+     */
+    public WordIdeal<C> sum(List<GenWordPolynomial<C>> L) {
+        if (L == null || L.isEmpty()) {
+            return this;
+        }
+        int s = getList().size() + L.size();
+        List<GenWordPolynomial<C>> c = new ArrayList<GenWordPolynomial<C>>(s);
+        c.addAll(getList());
+        c.addAll(L);
+        WordIdeal<C> I = new WordIdeal<C>(getRing(), c, false);
+        if (isGB) {
+            I.doGB();
+        }
+        return I;
+    }
+
+
+    /**
+     * Product. Generators for the product of ideals. Note: if both ideals are
+     * Groebner bases, a Groebner base is returned.
+     * @param B word ideal
+     * @return ideal(this*B)
+     */
+    public WordIdeal<C> product(WordIdeal<C> B) {
+        if (B == null || B.isZERO()) {
+            return B;
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        int s = getList().size() * B.getList().size();
+        List<GenWordPolynomial<C>> c;
+        c = new ArrayList<GenWordPolynomial<C>>(s);
+        for (GenWordPolynomial<C> p : getList()) {
+            for (GenWordPolynomial<C> q : B.getList()) {
+                q = p.multiply(q);
+                c.add(q);
+            }
+        }
+        WordIdeal<C> I = new WordIdeal<C>(getRing(), c, false);
+        if (isGB && B.isGB) {
+            I.doGB();
+        }
+        return I;
+    }
+
+
+    /**
+     * Left product. Generators for the product this by a polynomial.
+     * @param b word polynomial
+     * @return ideal(this*b)
+     */
+    public WordIdeal<C> product(GenWordPolynomial<C> b) {
+        if (b == null || b.isZERO()) {
+            return getZERO();
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        List<GenWordPolynomial<C>> c;
+        c = new ArrayList<GenWordPolynomial<C>>(getList().size());
+        for (GenWordPolynomial<C> p : getList()) {
+            GenWordPolynomial<C> q = p.multiply(b);
+            c.add(q);
+        }
+        WordIdeal<C> I = new WordIdeal<C>(getRing(), c, false);
+        if (isGB) {
+            I.doGB();
+        }
+        return I;
+    }
+
+
+    /*
+     * Intersection. Generators for the intersection of ideals. Using an
+     * iterative algorithm.
+     * @param Bl list of word ideals
+     * @return ideal(cap_i B_i), a Groebner base
+     */
+    public WordIdeal<C> intersect(List<WordIdeal<C>> Bl) {
+        if (Bl == null || Bl.size() == 0) {
+            return getZERO();
+        }
+        WordIdeal<C> I = null;
+        for (WordIdeal<C> B : Bl) {
+            if (I == null) {
+                I = B;
+                continue;
+            }
+            if (I.isONE()) {
+                return I;
+            }
+            I = I.intersect(B);
+        }
+        return I;
+    }
+
+
+    /*
+     * Intersection. Generators for the intersection of ideals.
+     * @param B word ideal
+     * @return ideal(this cap B), a Groebner base
+     */
+    public WordIdeal<C> intersect(WordIdeal<C> B) {
+        if (B == null || B.isZERO()) { // (0)
+            return B;
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        List<GenWordPolynomial<C>> c = PolyGBUtil.<C> intersect(getRing(), getList(), B.getList());
+        WordIdeal<C> I = new WordIdeal<C>(getRing(), c, true);
+        return I;
+    }
+
+
+    /*
+     * Intersection. Generators for the intersection of a ideal with a
+     * word polynomial ring. The polynomial ring of this ideal must be
+     * a contraction of R and the TermOrder must be an elimination
+     * order.
+     * @param R word polynomial ring
+     * @return ideal(this cap R)
+     */
+    public WordIdeal<C> intersect(GenWordPolynomialRing<C> R) {
+        if (R == null) {
+            throw new IllegalArgumentException("R may not be null");
+        }
+        List<GenWordPolynomial<C>> H = PolyUtil.<C> intersect(R, getList());
+        return new WordIdeal<C>(R, H, isGB);
+    }
+
+
+    /*
+     * Eliminate. Generators for the intersection of this ideal with a word
+     * polynomial ring. The word polynomial ring of this ideal must be a
+     * contraction of R and the TermOrder must be an elimination order.
+     * @param R word polynomial ring
+     * @return ideal(this cap R)
+     */
+    public WordIdeal<C> eliminate(GenWordPolynomialRing<C> R) {
+        if (R == null) {
+            throw new IllegalArgumentException("R may not be null");
+        }
+        if (getRing().equals(R)) {
+            return this;
+        }
+        return intersect(R);
+    }
+
+
+    /*
+     * Quotient. Generators for the word ideal quotient.
+     * @param h word polynomial
+     * @return ideal(this : h), a Groebner base
+    public WordIdeal<C> quotient(GenWordPolynomial<C> h) {
+        if (h == null) { // == (0)
+            return this;
+        }
+        if (h.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        List<GenWordPolynomial<C>> H;
+        H = new ArrayList<GenWordPolynomial<C>>(1);
+        H.add(h);
+        WordIdeal<C> Hi = new WordIdeal<C>(getRing(), H, true);
+        WordIdeal<C> I = this.intersect(Hi);
+        List<GenWordPolynomial<C>> Q;
+        Q = new ArrayList<GenWordPolynomial<C>>(I.getList().size());
+        for (GenWordPolynomial<C> q : I.getList()) {
+            q = (GenWordPolynomial<C>) q.divide(h); // remainder == 0
+            Q.add(q);
+        }
+        return new WordIdeal<C>(getRing(), Q, true);
+    }
+     */
+
+
+    /*
+     * Quotient. Generators for the word ideal quotient.
+     * @param H word ideal
+     * @return ideal(this : H), a Groebner base
+    public WordIdeal<C> quotient(WordIdeal<C> H) {
+        if (H == null || H.isZERO()) { // == (0)
+            return this;
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        WordIdeal<C> Q = null;
+        for (GenWordPolynomial<C> h : H.getList()) {
+            WordIdeal<C> Hi = this.quotient(h);
+            if (Q == null) {
+                Q = Hi;
+            } else {
+                Q = Q.intersect(Hi);
+            }
+        }
+        return Q;
+    }
+     */
+
+
+    /**
+     * Power. Generators for the power of this word ideal. Note: if this ideal
+     * is a Groebner base, a Groebner base is returned.
+     * @param d integer
+     * @return ideal(this^d)
+     */
+    public WordIdeal<C> power(int d) {
+        if (d <= 0) {
+            return getONE();
+        }
+        if (this.isZERO() || this.isONE()) {
+            return this;
+        }
+        WordIdeal<C> c = this;
+        for (int i = 1; i < d; i++) {
+            c = c.product(this);
+        }
+        return c;
+    }
+
+
+    /**
+     * Normalform for element.
+     * @param h word polynomial
+     * @return left normalform of h with respect to this
+     */
+    public GenWordPolynomial<C> normalform(GenWordPolynomial<C> h) {
+        if (h == null) {
+            return h;
+        }
+        if (h.isZERO()) {
+            return h;
+        }
+        if (this.isZERO()) {
+            return h;
+        }
+        GenWordPolynomial<C> r;
+        r = red.normalform(getList(), h);
+        return r;
+    }
+
+
+    /**
+     * Normalform for list of word elements.
+     * @param L word polynomial list
+     * @return list of left normalforms of the elements of L with respect to
+     *         this
+     */
+    public List<GenWordPolynomial<C>> normalform(List<GenWordPolynomial<C>> L) {
+        if (L == null) {
+            return L;
+        }
+        if (L.size() == 0) {
+            return L;
+        }
+        if (this.isZERO()) {
+            return L;
+        }
+        List<GenWordPolynomial<C>> M = new ArrayList<GenWordPolynomial<C>>(L.size());
+        for (GenWordPolynomial<C> h : L) {
+            GenWordPolynomial<C> r = normalform(h);
+            if (r != null && !r.isZERO()) {
+                M.add(r);
+            }
+        }
+        return M;
+    }
+
+
+    /**
+     * Inverse for element modulo this ideal.
+     * @param h word polynomial
+     * @return inverse of h with respect to this, if defined
+     */
+    public GenWordPolynomial<C> inverse(GenWordPolynomial<C> h) {
+        if (h == null || h.isZERO()) {
+            throw new NotInvertibleException("zero not invertible");
+        }
+        if (this.isZERO()) {
+            throw new NotInvertibleException("zero ideal");
+        }
+        if (h.isUnit()) {
+            return h.inverse();
+        }
+        throw new UnsupportedOperationException("inverse of " + h);
+        /* TODO together with isUnit
+        doGB();
+        List<GenWordPolynomial<C>> F = new ArrayList<GenWordPolynomial<C>>(1 + list.list.size());
+        F.add(h);
+        F.addAll(getList());
+        //System.out.println("F = " + F);
+        WordExtendedGB<C> x = bb.extLeftGB(F);
+        List<GenWordPolynomial<C>> G = x.G;
+        //System.out.println("G = " + G);
+        GenWordPolynomial<C> one = null;
+        int i = -1;
+        for (GenWordPolynomial<C> p : G) {
+            i++;
+            if (p == null) {
+                continue;
+            }
+            if (p.isUnit()) {
+                one = p;
+                break;
+            }
+        }
+        if (one == null) {
+            throw new NotInvertibleException("one == null: h = " + h);
+        }
+        List<GenWordPolynomial<C>> row = x.G2F.get(i); // != -1
+        //System.out.println("row = " + row);
+        GenWordPolynomial<C> g = row.get(0);
+        if (g == null || g.isZERO()) {
+            throw new NotInvertibleException("g == 0: h = " + h);
+        }
+        GenWordPolynomial<C> gp = red.leftNormalform(getList(), g);
+        if (gp.isZERO()) { // can happen with solvable rings
+            throw new NotInvertibleException("solv|gp == 0: h = " + h + ", g = " + g);
+        }
+        // adjust leading coefficient of g to get g*h == 1
+        GenWordPolynomial<C> f = g.multiply(h);
+        //System.out.println("f = " + f);
+        GenWordPolynomial<C> k = red.leftNormalform(getList(), f);
+        //System.out.println("k = " + k);
+        if (!k.isONE()) {
+            C lbc = k.leadingBaseCoefficient();
+            lbc = lbc.inverse();
+            g = g.multiply(lbc);
+        }
+        return g;
+        */
+    }
+
+
+    /**
+     * Test if element is a unit modulo this ideal.
+     * @param h word polynomial
+     * @return true if h is a unit with respect to this, else false
+     */
+    public boolean isUnit(GenWordPolynomial<C> h) {
+        if (h == null || h.isZERO()) {
+            return false;
+        }
+        if (this.isZERO()) {
+            return false;
+        }
+        if (h.isUnit()) {
+            return true;
+        }
+        /* TODO together with inverse
+        // test this + (h) == 1
+        List<GenWordPolynomial<C>> F = new ArrayList<GenWordPolynomial<C>>(1 + list.size());
+        F.add(h);
+        F.addAll(getList());
+        List<GenWordPolynomial<C>> G = bb.GB(F);
+        if (debug) {
+            logger.info("isUnit GB = " + G);
+        }
+        for (GenWordPolynomial<C> p : G) {
+            if (p == null) {
+                continue;
+            }
+            if (p.isUnit()) {
+                return true;
+            }
+        }
+        */
+        return false;
+    }
+
+
+    /**
+     * Ideal common zero test.
+     * @return -1, 0 or 1 if dimension(this) &eq; -1, 0 or &ge; 1.
+     */
+    public int commonZeroTest() {
+        if (this.isZERO()) {
+            return 1;
+        }
+        if (!isGB) {
+            doGB();
+        }
+        if (this.isONE()) {
+            return -1;
+        }
+        return bb.commonZeroTest(getList());
+    }
+
+
+    /**
+     * Test if this ideal is maximal.
+     * @return true, if this is maximal and not one, else false.
+     */
+    public boolean isMaximal() {
+        if (commonZeroTest() != 0) {
+            return false;
+        }
+        for (Long d : univariateDegrees()) {
+            if (d > 1L) {
+                // todo: test if univariate irreducible and no multiple polynomials
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Univariate head term degrees.
+     * @return a list of the degrees of univariate head terms.
+     */
+    public List<Long> univariateDegrees() {
+        List<Long> ud = new ArrayList<Long>();
+        if (this.isZERO()) {
+            return ud;
+        }
+        if (!isGB) {
+            doGB();
+        }
+        if (this.isONE()) {
+            return ud;
+        }
+        return bb.univariateDegrees(getList());
+    }
+
+
+    /*
+     * Construct univariate polynomials of minimal degree in all variables in
+     * zero dimensional ideal(G).
+     * @return list of univariate word polynomial of minimal degree in each
+     *         variable in ideal(G)
+    public List<GenWordPolynomial<C>> constructUnivariate() {
+        List<GenWordPolynomial<C>> univs = new ArrayList<GenWordPolynomial<C>>();
+        for (int i = ring.alphabet.length() - 1; i >= 0; i--) {
+            GenWordPolynomial<C> u = constructUnivariate(i);
+            univs.add(u);
+        }
+        return univs;
+    }
+     */
+
+
+    /*
+     * Construct univariate polynomial of minimal degree in variable i in zero
+     * dimensional ideal(G).
+     * @param i variable index.
+     * @return univariate word polynomial of minimal degree in variable i in
+     *         ideal(G)
+    public GenWordPolynomial<C> constructUnivariate(int i) {
+        doGB();
+        return bb.constructUnivariate(i, getList());
+    }
+     */
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/WordResidue.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/WordResidue.java
@@ -1,0 +1,606 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.jas.kern.PrettyPrint;
+import edu.jas.poly.GenWordPolynomial;
+import edu.jas.poly.Word;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.NoncomRingElem;
+import edu.jas.structure.NotDivisibleException;
+import edu.jas.structure.NotInvertibleException;
+import edu.jas.structure.QuotPair;
+import edu.jas.structure.Value;
+
+
+/**
+ * WordResidue ring element based on GenWordPolynomial with GcdRingElem
+ * interface. Objects of this class are immutable.
+ * @author Heinz Kredel
+ */
+public class WordResidue<C extends GcdRingElem<C>> implements GcdRingElem<WordResidue<C>>,
+                NoncomRingElem<WordResidue<C>>, QuotPair<GenWordPolynomial<C>>, Value<GenWordPolynomial<C>> {
+
+
+    /**
+     * WordResidue class factory data structure.
+     */
+    public final WordResidueRing<C> ring;
+
+
+    /**
+     * Value part of the element data structure.
+     */
+    public final GenWordPolynomial<C> val;
+
+
+    /**
+     * Flag to remember if this residue element is a unit. -1 is unknown, 1 is
+     * unit, 0 not a unit.
+     */
+    protected int isunit = -1; // initially unknown
+
+
+    /**
+     * The constructor creates a WordResidue object from a ring factory.
+     * @param r solvable residue ring factory.
+     */
+    public WordResidue(WordResidueRing<C> r) {
+        this(r, r.ring.getZERO(), 0);
+    }
+
+
+    /**
+     * The constructor creates a WordResidue object from a ring factory and a
+     * polynomial.
+     * @param r solvable residue ring factory.
+     * @param a solvable polynomial.
+     */
+    public WordResidue(WordResidueRing<C> r, GenWordPolynomial<C> a) {
+        this(r, a, -1);
+    }
+
+
+    /**
+     * The constructor creates a WordResidue object from a ring factory, a
+     * polynomial and an indicator if a is a unit.
+     * @param r solvable residue ring factory.
+     * @param a solvable polynomial.
+     * @param u isunit indicator, -1, 0, 1.
+     */
+    public WordResidue(WordResidueRing<C> r, GenWordPolynomial<C> a, int u) {
+        ring = r;
+        val = ring.ideal.normalform(a); //.monic() no go
+        if (u == 0 || u == 1) {
+            isunit = u;
+            return;
+        }
+        if (val.isZERO()) {
+            isunit = 0;
+            return;
+        }
+        if (ring.isField()) {
+            isunit = 1;
+            return;
+        }
+        if (val.isUnit()) {
+            isunit = 1;
+            //} else { // not possible
+            //isunit = 0;
+        }
+        isunit = -1;
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public WordResidueRing<C> factory() {
+        return ring;
+    }
+
+
+    /**
+     * Value. Returns the value.
+     * @see edu.jas.structure.Value#value()
+     */
+    public GenWordPolynomial<C> value() {
+        return val;
+    }
+
+
+    /**
+     * Numerator. Returns the value.
+     * @see edu.jas.structure.QuotPair#numerator()
+     */
+    public GenWordPolynomial<C> numerator() {
+        return val;
+    }
+
+
+    /**
+     * Denominator. Returns 1.
+     * @see edu.jas.structure.QuotPair#denominator()
+     */
+    public GenWordPolynomial<C> denominator() {
+        return ring.ring.getONE();
+    }
+
+
+    /**
+     * Clone this.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public WordResidue<C> copy() {
+        return new WordResidue<C>(ring, val, isunit);
+    }
+
+
+    /**
+     * Is WordResidue zero.
+     * @return If this is 0 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isZERO()
+     */
+    public boolean isZERO() {
+        return val.isZERO();
+    }
+
+
+    /**
+     * Is WordResidue one.
+     * @return If this is 1 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isONE()
+     */
+    public boolean isONE() {
+        return val.isONE();
+    }
+
+
+    /**
+     * Is WordResidue unit.
+     * @return If this is a unit then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isUnit()
+     */
+    public boolean isUnit() {
+        if (isunit > 0) {
+            return true;
+        }
+        if (isunit == 0) {
+            return false;
+        }
+        // not jet known
+        boolean u = ring.ideal.isUnit(val);
+        //System.out.println("WordResidue.isUnit " + val);
+        if (u) {
+            isunit = 1; // seems to be wrong for solvable polynomial rings
+        } else {
+            isunit = 0;
+        }
+        return isunit > 0;
+    }
+
+
+    /**
+     * Is WordResidue a constant.
+     * @return true if this.val is a constant polynomial, else false.
+     */
+    public boolean isConstant() {
+        return val.isConstant();
+    }
+
+
+    /**
+     * Get the String representation as RingElem.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        if (PrettyPrint.isTrue()) {
+            return val.toString();
+        }
+        return "WordResidue[ " + val.toString() + " mod " + ring.toString() + " ]";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        return val.toScript();
+        // return "PolyWordResidue( " + val.toScript() 
+        //                         + ", " + ring.toScript() + " )";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python case
+        return factory().toScript();
+    }
+
+
+    /**
+     * WordResidue comparison.
+     * @param b WordResidue.
+     * @return sign(this-b), 0 means that this and b are equivalent in this
+     *         residue class ring.
+     */
+    @Override
+    public int compareTo(WordResidue<C> b) {
+        GenWordPolynomial<C> v = b.val;
+        if (!ring.equals(b.ring)) {
+            v = ring.ideal.normalform(v);
+        }
+        return val.compareTo(v);
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     * @return true means that this and b are equivalent in this residue class
+     *         ring.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (!(b instanceof WordResidue)) {
+            return false;
+        }
+        WordResidue<C> a = null;
+        try {
+            a = (WordResidue<C>) b;
+        } catch (ClassCastException e) {
+        }
+        if (a == null) {
+            return false;
+        }
+        return compareTo(a) == 0;
+    }
+
+
+    /**
+     * Hash code for this residue.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = ring.hashCode();
+        h = 37 * h + val.hashCode();
+        return h;
+    }
+
+
+    /**
+     * WordResidue absolute value.
+     * @return the absolute value of this.
+     * @see edu.jas.structure.RingElem#abs()
+     */
+    public WordResidue<C> abs() {
+        return new WordResidue<C>(ring, val.abs(), isunit);
+    }
+
+
+    /**
+     * WordResidue summation.
+     * @param S WordResidue.
+     * @return this+S.
+     */
+    public WordResidue<C> sum(WordResidue<C> S) {
+        return new WordResidue<C>(ring, val.sum(S.val));
+    }
+
+
+    /**
+     * WordResidue negate.
+     * @return -this.
+     * @see edu.jas.structure.RingElem#negate()
+     */
+    public WordResidue<C> negate() {
+        return new WordResidue<C>(ring, val.negate(), isunit);
+    }
+
+
+    /**
+     * WordResidue signum.
+     * @see edu.jas.structure.RingElem#signum()
+     * @return signum(this).
+     */
+    public int signum() {
+        return val.signum();
+    }
+
+
+    /**
+     * WordResidue subtraction.
+     * @param S WordResidue.
+     * @return this-S.
+     */
+    public WordResidue<C> subtract(WordResidue<C> S) {
+        return new WordResidue<C>(ring, val.subtract(S.val));
+    }
+
+
+    /**
+     * WordResidue left division.
+     * @param S WordResidue.
+     * @return left, with left*S = this
+     */
+    public WordResidue<C> divide(WordResidue<C> S) {
+        if (ring.isField()) {
+            return multiply(S.inverse());
+        }
+        try {
+            return multiply(S.inverse());
+        } catch (NotInvertibleException ignored) {
+            System.out.println("catch: " + ignored);
+            //ignored.printStackTrace();
+            // ignored
+        } catch (UnsupportedOperationException ignored) {
+            //System.out.println("catch: " + ignored);
+            //ignored.printStackTrace();
+            // ignored
+        }
+        List<GenWordPolynomial<C>> L = new ArrayList<GenWordPolynomial<C>>(1);
+        L.add(ring.ring.getZERO());
+        List<GenWordPolynomial<C>> V = new ArrayList<GenWordPolynomial<C>>(1);
+        V.add(S.val);
+        //@SuppressWarnings("unused")
+        GenWordPolynomial<C> x = ring.bb.red.leftNormalform(L, V, val);
+        GenWordPolynomial<C> y = L.get(0);
+        GenWordPolynomial<C> t = y.multiply(S.val).sum(x);
+        if (!val.equals(t)) {
+            throw new NotDivisibleException("val != t: val = " + val + ", t = " + t);
+        }
+        return new WordResidue<C>(ring, y);
+    }
+
+
+    /**
+     * WordResidue two-sided division.
+     * @param S WordResidue.
+     * @return [left, right] with left*S*right + remainder = this.
+     */
+    @SuppressWarnings("unchecked")
+    public WordResidue<C>[] twosidedDivide(WordResidue<C> S) {
+        List<GenWordPolynomial<C>> L = new ArrayList<GenWordPolynomial<C>>(1);
+        L.add(ring.ring.getZERO());
+        List<GenWordPolynomial<C>> R = new ArrayList<GenWordPolynomial<C>>(1);
+        R.add(ring.ring.getZERO());
+        List<GenWordPolynomial<C>> V = new ArrayList<GenWordPolynomial<C>>(1);
+        V.add(S.val);
+        GenWordPolynomial<C> x = ring.bb.red.normalform(L, R, V, val);
+        GenWordPolynomial<C> y = L.get(0);
+        GenWordPolynomial<C> z = R.get(0);
+        if (!ring.bb.red.isReductionNF(L, R, V, val, x)) {
+            throw new NotDivisibleException("val != x: val = " + val + ", S.val = " + S.val);
+        }
+        WordResidue<C>[] ret = new WordResidue[2];
+        ret[0] = new WordResidue<C>(ring, y);
+        ret[1] = new WordResidue<C>(ring, z);
+        return ret;
+    }
+
+
+    /**
+     * WordResidue right division.
+     * @param S WordResidue.
+     * @return right, with S * right = this
+     */
+    public WordResidue<C> rightDivide(WordResidue<C> S) {
+        if (ring.isField()) {
+            return multiply(S.inverse());
+        }
+        try {
+            return multiply(S.inverse());
+        } catch (NotInvertibleException ignored) {
+            System.out.println("catch: " + ignored);
+            //ignored.printStackTrace();
+            // ignored
+        } catch (UnsupportedOperationException ignored) {
+            //System.out.println("catch: " + ignored);
+            //ignored.printStackTrace();
+            // ignored
+        }
+        List<GenWordPolynomial<C>> R = new ArrayList<GenWordPolynomial<C>>(1);
+        R.add(ring.ring.getZERO());
+        List<GenWordPolynomial<C>> V = new ArrayList<GenWordPolynomial<C>>(1);
+        V.add(S.val);
+        //@SuppressWarnings("unused")
+        GenWordPolynomial<C> x = ring.bb.red.rightNormalform(R, V, val);
+        GenWordPolynomial<C> y = R.get(0);
+        GenWordPolynomial<C> t = S.val.multiply(y).sum(x);
+        if (!val.equals(t)) {
+            throw new NotDivisibleException("val != t: val = " + val + ", t = " + t);
+        }
+        return new WordResidue<C>(ring, y);
+    }
+
+
+    /**
+     * WordResidue inverse.
+     * @see edu.jas.structure.RingElem#inverse()
+     * @return S with S = 1/this if defined.
+     */
+    public WordResidue<C> inverse() {
+        GenWordPolynomial<C> x = ring.ideal.inverse(val);
+        WordResidue<C> xp = new WordResidue<C>(ring, x, 1);
+        if (xp.isZERO()) {
+            throw new NotInvertibleException(
+                            "(" + x + ") * (" + val + ") = " + x.multiply(val) + " = 0 mod " + ring.ideal);
+        }
+        if (!xp.multiply(this).isONE()) {
+            throw new NotInvertibleException(
+                            "(" + x + ") * (" + val + ") = " + x.multiply(val) + " != 1 mod " + ring.ideal);
+        }
+        return xp;
+    }
+
+
+    /**
+     * WordResidue remainder.
+     * @param S WordResidue.
+     * @return this - (this/S) * S.
+     */
+    public WordResidue<C> remainder(WordResidue<C> S) {
+        List<GenWordPolynomial<C>> V = new ArrayList<GenWordPolynomial<C>>(1);
+        V.add(S.val);
+        GenWordPolynomial<C> x = ring.bb.red.leftNormalform(V, val);
+        return new WordResidue<C>(ring, x);
+    }
+
+
+    /**
+     * WordResidue right remainder.
+     * @param S WordResidue.
+     * @return r = this - S * (S/right), where S * right = this.
+     */
+    public WordResidue<C> rightRemainder(WordResidue<C> S) {
+        List<GenWordPolynomial<C>> V = new ArrayList<GenWordPolynomial<C>>(1);
+        V.add(S.val);
+        GenWordPolynomial<C> x = ring.bb.red.rightNormalform(V, val);
+        return new WordResidue<C>(ring, x);
+    }
+
+
+    /**
+     * WordResidue two-sided remainder.
+     * @param S WordResidue.
+     * @return r = this - left*S*right.
+     */
+    public WordResidue<C> twosidedRemainder(WordResidue<C> S) {
+        List<GenWordPolynomial<C>> V = new ArrayList<GenWordPolynomial<C>>(1);
+        V.add(S.val);
+        GenWordPolynomial<C> x = ring.bb.red.normalform(V, val);
+        WordResidue<C> ret = new WordResidue<C>(ring, x);
+        return ret;
+    }
+
+
+    /**
+     * WordResidue multiplication.
+     * @param S WordResidue.
+     * @return this*S.
+     */
+    public WordResidue<C> multiply(WordResidue<C> S) {
+        GenWordPolynomial<C> x = val.multiply(S.val);
+        int i = -1;
+        if (isunit == 1 && S.isunit == 1) {
+            i = 1;
+        } else if (isunit == 0 || S.isunit == 0) {
+            i = 0;
+        }
+        return new WordResidue<C>(ring, x, i);
+    }
+
+
+    /**
+     * WordResidue multiplication.
+     * @param S GenWordPolynomial.
+     * @return this*S.
+     */
+    public WordResidue<C> multiply(GenWordPolynomial<C> S) {
+        GenWordPolynomial<C> x = val.multiply(S);
+        int i = -1;
+        if (isunit == 1 && S.isUnit()) {
+            i = 1;
+        } else if (isunit == 0 || !S.isUnit()) {
+            i = 0;
+        }
+        return new WordResidue<C>(ring, x, i);
+    }
+
+
+    /*
+     * WordResidue multiplication.
+     * @param s coefficient.
+     * @return this*s.
+     */
+    public WordResidue<C> multiply(C s) {
+        GenWordPolynomial<C> x = val.multiply(s);
+        int i = -1;
+        if (isunit == 1 && s.isUnit()) {
+            i = 1;
+        } else if (isunit == 0 || !s.isUnit()) {
+            i = 0;
+        }
+        return new WordResidue<C>(ring, x, i);
+    }
+
+
+    /**
+     * WordResidue multiplication.
+     * @param e word.
+     * @return this*e.
+     */
+    public WordResidue<C> multiply(Word e) {
+        GenWordPolynomial<C> x = val.multiply(e);
+        int i = -1;
+        if (isunit == 1 && e.isONE()) {
+            i = 1;
+        } else if (isunit == 0 || !e.isONE()) {
+            i = 0;
+        }
+        return new WordResidue<C>(ring, x, i);
+    }
+
+
+    /**
+     * WordResidue monic.
+     * @return this with monic value part.
+     */
+    public WordResidue<C> monic() {
+        return new WordResidue<C>(ring, val.monic(), isunit);
+    }
+
+
+    /**
+     * Greatest common divisor.
+     * @param b other element.
+     * @return gcd(this,b).
+     */
+    public WordResidue<C> gcd(WordResidue<C> b) {
+        throw new UnsupportedOperationException("gcd not implemented");
+        // GenWordPolynomial<C> x = ring.engine.gcd(val, b.val);
+        // int i = -1; // gcd might become a unit
+        // if (x.isONE()) {
+        //     i = 1;
+        // } else {
+        //     System.out.println("WordResidue gcd = " + x);
+        // }
+        // if (isunit == 1 && b.isunit == 1) {
+        //     i = 1;
+        // }
+        // return new WordResidue<C>(ring, x, i);
+    }
+
+
+    /**
+     * Extended greatest common divisor. <b>Note: </b>Not implemented, throws
+     * UnsupportedOperationException.
+     * @param b other element.
+     * @return [ gcd(this,b), c1, c2 ] with c1*this + c2*b = gcd(this,b).
+     */
+    public WordResidue<C>[] egcd(WordResidue<C> b) {
+        throw new UnsupportedOperationException("egcd not implemented");
+    }
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/WordResidueRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/WordResidueRing.java
@@ -1,0 +1,414 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.application;
+
+
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.WordGroebnerBaseAbstract;
+import edu.jas.gb.WordGroebnerBaseSeq;
+import edu.jas.poly.GenWordPolynomial;
+import edu.jas.poly.GenWordPolynomialRing;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.QuotPairFactory;
+import edu.jas.structure.RingFactory;
+import edu.jas.structure.ValueFactory;
+
+
+/**
+ * WordResidue ring factory based on GenWordPolynomialRing with GcdRingFactory
+ * interface. Objects of this class are immutable.
+ * @author Heinz Kredel
+ */
+public class WordResidueRing<C extends GcdRingElem<C>> implements RingFactory<WordResidue<C>>,
+                QuotPairFactory<GenWordPolynomial<C>, WordResidue<C>>,
+                ValueFactory<GenWordPolynomial<C>, WordResidue<C>> {
+
+
+    private static final Logger logger = LogManager.getLogger(WordResidueRing.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Groebner base engine.
+     */
+    protected final WordGroebnerBaseAbstract<C> bb;
+
+
+    /**
+     * Word polynomial ideal for the reduction.
+     */
+    public final WordIdeal<C> ideal;
+
+
+    /**
+     * Polynomial ring of the factory. Shortcut to ideal.list.ring.
+     */
+    public final GenWordPolynomialRing<C> ring;
+
+
+    /**
+     * Indicator if this ring is a field.
+     */
+    protected int isField = -1; // initially unknown
+
+
+    /**
+     * The constructor creates a WordResidueRing object from an Ideal.
+     * @param i polynomial ideal.
+     */
+    public WordResidueRing(WordIdeal<C> i) {
+        this(i, false);
+    }
+
+
+    /**
+     * The constructor creates a WordResidueRing object from an WordIdeal.
+     * @param i solvable polynomial ideal.
+     * @param isMaximal true, if ideal is maxmal.
+     */
+    public WordResidueRing(WordIdeal<C> i, boolean isMaximal) {
+        //System.out.println("i    = " + i);
+        ideal = i.GB(); // cheap if isGB
+        //System.out.println("i.GB = " + ideal);
+        ring = ideal.getRing();
+        bb = new WordGroebnerBaseSeq<C>();
+        if (isMaximal) {
+            isField = 1;
+            return;
+        }
+        if (ideal.isONE()) {
+            logger.warn("ideal is one, so all residues are 0");
+        }
+        //System.out.println("rr ring   = " + ring.getClass().getName());
+        //System.out.println("rr cofac  = " + ring.coFac.getClass().getName());
+    }
+
+
+    /**
+     * Factory for base elements.
+     */
+    public GenWordPolynomialRing<C> pairFactory() {
+        return ring;
+    }
+
+
+    /**
+     * Factory for base elements.
+     */
+    public GenWordPolynomialRing<C> valueFactory() {
+        return ring;
+    }
+
+
+    /**
+     * Create from numerator.
+     */
+    public WordResidue<C> create(GenWordPolynomial<C> n) {
+        return new WordResidue<C>(this, n);
+    }
+
+
+    /**
+     * Create from numerator, denominator pair.
+     */
+    public WordResidue<C> create(GenWordPolynomial<C> n, GenWordPolynomial<C> d) {
+        if (d != null && !d.isONE()) {
+            throw new UnsupportedOperationException("d must be 1, but d = " + d);
+        }
+        return new WordResidue<C>(this, n);
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite()
+     */
+    public boolean isFinite() {
+        return ideal.commonZeroTest() <= 0 && ring.coFac.isFinite();
+    }
+
+
+    /**
+     * Copy WordResidue element c.
+     * @param c
+     * @return a copy of c.
+     */
+    public WordResidue<C> copy(WordResidue<C> c) {
+        //System.out.println("rr copy in    = " + c.val);
+        if (c == null) { // where does this happen?
+            return getZERO(); // or null?
+        }
+        WordResidue<C> r = new WordResidue<C>(this, c.val);
+        //System.out.println("rr copy out   = " + r.val);
+        //System.out.println("rr copy ideal = " + ideal.list.list);
+        return r; //new WordResidue<C>( c.ring, c.val );
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as WordResidue.
+     */
+    public WordResidue<C> getZERO() {
+        return new WordResidue<C>(this, ring.getZERO());
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as WordResidue.
+     */
+    public WordResidue<C> getONE() {
+        WordResidue<C> one = new WordResidue<C>(this, ring.getONE());
+        if (one.isZERO()) {
+            logger.warn("ideal is one, so all residues are 0");
+        }
+        return one;
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     * @see edu.jas.structure.ElemFactory#generators()
+     */
+    public List<WordResidue<C>> generators() {
+        List<GenWordPolynomial<C>> pgens = ring.generators();
+        List<WordResidue<C>> gens = new ArrayList<WordResidue<C>>(pgens.size());
+        SortedSet<WordResidue<C>> sgens = new TreeSet<WordResidue<C>>();
+        List<GenWordPolynomial<C>> rgens = new ArrayList<GenWordPolynomial<C>>(pgens.size());
+        WordIdeal<C> gi = new WordIdeal<C>(ring, rgens);
+        WordResidueRing<C> gr = new WordResidueRing<C>(gi);
+        for (GenWordPolynomial<C> s : pgens) {
+            WordResidue<C> r = new WordResidue<C>(this, s);
+            if (r.isZERO()) {
+                continue;
+            }
+            if (!r.isONE() && r.val.isConstant()) {
+                continue;
+            }
+            // avoid duplicate generators with sgens
+            WordResidue<C> x = new WordResidue<C>(gr, r.val);
+            if (x.isZERO()) {
+                continue;
+            }
+            if (!x.isONE() && x.val.isConstant()) {
+                continue;
+            }
+            r = new WordResidue<C>(this, x.val);
+            if (r.isZERO()) {
+                continue;
+            }
+            r = r.monic();
+            if (!r.isONE() && !r.val.isConstant()) {
+                rgens.add(r.val);
+                //System.out.println("rgens = " + rgens);
+                gi = new WordIdeal<C>(ring, rgens);
+                gr = new WordResidueRing<C>(gi);
+            }
+            //gens.add(r);
+            sgens.add(r);
+        }
+        gens.addAll(sgens);
+        return gens;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true if this ring is commutative, else false.
+     */
+    public boolean isCommutative() {
+        return ring.isCommutative(); // check also vector space structure
+    }
+
+
+    /**
+     * Query if this ring is associative.
+     * @return true if this ring is associative, else false.
+     */
+    public boolean isAssociative() {
+        return ring.isAssociative(); // sufficient ??
+    }
+
+
+    /**
+     * Query if this ring is a field.
+     * @return false.
+     */
+    public boolean isField() {
+        if (isField > 0) {
+            return true;
+        }
+        if (isField == 0) {
+            return false;
+        }
+        if (ideal.isMaximal()) {
+            isField = 1;
+            return true;
+        }
+        return false;
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic() {
+        return ring.characteristic();
+    }
+
+
+    /**
+     * Get a WordResidue element from a BigInteger value.
+     * @param a BigInteger.
+     * @return a WordResidue.
+     */
+    public WordResidue<C> fromInteger(java.math.BigInteger a) {
+        return new WordResidue<C>(this, ring.fromInteger(a));
+    }
+
+
+    /**
+     * Get a WordResidue element from a long value.
+     * @param a long.
+     * @return a WordResidue.
+     */
+    public WordResidue<C> fromInteger(long a) {
+        return new WordResidue<C>(this, ring.fromInteger(a));
+    }
+
+
+    /**
+     * Get the String representation as RingFactory.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "WordResidueRing[ " + ideal.toString() + " ]";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.ElemFactory#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        return "WRC(" + ideal.toScript() + ")";
+        //return "WRC(" + ideal.toScript() + "," + ring.toScript()  + ")";
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (!(b instanceof WordResidueRing)) {
+            return false;
+        }
+        WordResidueRing<C> a = null;
+        try {
+            a = (WordResidueRing<C>) b;
+        } catch (ClassCastException e) {
+        }
+        if (a == null) {
+            return false;
+        }
+        if (!ring.equals(a.ring)) {
+            return false;
+        }
+        return ideal.equals(a.ideal);
+    }
+
+
+    /**
+     * Hash code for this residue ring.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = ideal.hashCode();
+        return h;
+    }
+
+
+    /**
+     * WordResidue random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @return a random residue element.
+     */
+    public WordResidue<C> random(int n) {
+        GenWordPolynomial<C> x = ring.random(n).monic();
+        return new WordResidue<C>(this, x);
+    }
+
+
+    /**
+     * Generate a random residum polynomial.
+     * @param k bitsize of random coefficients.
+     * @param l number of terms.
+     * @param d maximal degree in each variable.
+     * @return a random residue polynomial.
+     */
+    public WordResidue<C> random(int k, int l, int d) {
+        GenWordPolynomial<C> x = ring.random(k, l, d).monic();
+        return new WordResidue<C>(this, x);
+    }
+
+
+    /**
+     * WordResidue random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @param rnd is a source for random bits.
+     * @return a random residue element.
+     */
+    public WordResidue<C> random(int n, Random rnd) {
+        GenWordPolynomial<C> x = ring.random(n, rnd).monic();
+        return new WordResidue<C>(this, x);
+    }
+
+
+    /**
+     * Parse WordResidue from String.
+     * @param s String.
+     * @return WordResidue from s.
+     */
+    public WordResidue<C> parse(String s) {
+        GenWordPolynomial<C> x = ring.parse(s);
+        return new WordResidue<C>(this, x);
+    }
+
+
+    /**
+     * Parse WordResidue from Reader.
+     * @param r Reader.
+     * @return next WordResidue from r.
+     */
+    public WordResidue<C> parse(Reader r) {
+        GenWordPolynomial<C> x = ring.parse(r);
+        return new WordResidue<C>(this, x);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/package.html
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/application/package.html
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+          "../DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>GB application classes</title>
+  </head>
+
+  <body>
+    <h1>Groebner base application package.</h1>
+
+<p>
+  This package contains classes with applications of Groebner bases
+  such as ideal intersections, ideal quotients or ideal dimension are
+  implemented in <code>Ideal</code> and <code>SolvableIdeal</code>.
+  Class <code>Residue</code> provides polynomials residues modulo an
+  ideal defined in <code>ResidueRing</code>.  Comprehensive Groebner
+  bases for polynomial rings over parameter rings are implemented in
+  <code>ComprehensiveGroebnerBaseSeq</code>.
+</p>
+<p>
+  Method <code>rootReduce()</code> from class <code>RootFactoryApp</code>
+  computes a primitive element of two algebraic roots.
+</p>
+
+
+    <hr />
+    <address><a href="mailto:kredel at rz.uni-mannheim.de">Heinz Kredel</a></address>
+<p>
+<!-- Created: Wed Mar  1 12:29:04 CET 2006 -->
+<!-- hhmts start -->
+Last modified: Wed Aug 17 23:35:02 CEST 2016
+<!-- hhmts end -->
+</p>
+<p>$Id$ 
+</p>
+  </body>
+</html>

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/ArithUtil.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/ArithUtil.java
@@ -1,0 +1,88 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.arith;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * Arithmetic utilities.
+ * @author Heinz Kredel
+ */
+
+public class ArithUtil {
+
+
+    private static final Logger logger = LogManager.getLogger(ArithUtil.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Continued fraction.
+     * @param A rational number.
+     * @return continued fraction for A.
+     */
+    public static List<BigInteger> continuedFraction(BigRational A) {
+        List<BigInteger> cf = new ArrayList<BigInteger>();
+        if (A == null) {
+            return cf;
+        }
+        if (A.isZERO() || A.isONE()) {
+            cf.add(new BigInteger(A.num));
+            return cf;
+        }
+        BigRational x = A;
+        BigInteger q = new BigInteger(x.floor());
+        cf.add(q);
+        BigRational xd = x.subtract(new BigRational(q));
+        while (!xd.isZERO()) {
+            x = xd.inverse();
+            q = new BigInteger(x.floor());
+            cf.add(q);
+            xd = x.subtract(new BigRational(q));
+        }
+        if (debug) {
+            logger.info("cf = " + cf);
+        }
+        return cf;
+    }
+
+
+    /**
+     * Continued fraction approximation.
+     * @param A continued fraction.
+     * @return ratonal number approximation for A.
+     */
+    public static BigRational continuedFractionApprox(List<BigInteger> A) {
+        BigRational ab = BigRational.ZERO;
+        if (A == null || A.isEmpty()) {
+            return ab;
+        }
+        BigInteger a2, a1, b2, b1, a, b;
+        a2 = BigInteger.ZERO;
+        a1 = BigInteger.ONE;
+        b2 = BigInteger.ONE;
+        b1 = BigInteger.ZERO;
+        for (BigInteger q : A) {
+            a = q.multiply(a1).sum(a2);
+            b = q.multiply(b1).sum(b2);
+            //System.out.println("A/B = " + new BigRational(a,b));
+            a2 = a1;
+            a1 = a;
+            b2 = b1;
+            b1 = b;
+        }
+        ab = new BigRational(a1, b1);
+        return ab;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/BigComplex.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/BigComplex.java
@@ -1,0 +1,830 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.arith;
+
+
+import java.io.Reader;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.kern.StringUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.structure.StarRingElem;
+
+
+/**
+ * BigComplex class based on BigRational implementing the RingElem respectively
+ * the StarRingElem interface. Objects of this class are immutable. The SAC2
+ * static methods are also provided.
+ * @author Heinz Kredel
+ */
+public final class BigComplex
+                implements StarRingElem<BigComplex>, GcdRingElem<BigComplex>, RingFactory<BigComplex> {
+
+
+    /**
+     * Real part of the data structure.
+     */
+    public final BigRational re;
+
+
+    /**
+     * Imaginary part of the data structure.
+     */
+    public final BigRational im;
+
+
+    private final static Random random = new Random();
+
+
+    private static final Logger logger = LogManager.getLogger(BigComplex.class);
+
+
+    /**
+     * The constructor creates a BigComplex object from two BigRational objects
+     * real and imaginary part.
+     * @param r real part.
+     * @param i imaginary part.
+     */
+    public BigComplex(BigRational r, BigRational i) {
+        re = r;
+        im = i;
+    }
+
+
+    /**
+     * The constructor creates a BigComplex object from a BigRational object as
+     * real part, the imaginary part is set to 0.
+     * @param r real part.
+     */
+    public BigComplex(BigRational r) {
+        this(r, BigRational.ZERO);
+    }
+
+
+    /**
+     * The constructor creates a BigComplex object from a long element as real
+     * part, the imaginary part is set to 0.
+     * @param r real part.
+     */
+    public BigComplex(long r) {
+        this(new BigRational(r), BigRational.ZERO);
+    }
+
+
+    /**
+     * The constructor creates a BigComplex object with real part 0 and
+     * imaginary part 0.
+     */
+    public BigComplex() {
+        this(BigRational.ZERO);
+    }
+
+
+    /**
+     * The constructor creates a BigComplex object from a String representation.
+     * @param s string of a BigComplex.
+     * @throws NumberFormatException
+     */
+    public BigComplex(String s) throws NumberFormatException {
+        if (s == null || s.length() == 0) {
+            re = BigRational.ZERO;
+            im = BigRational.ZERO;
+            return;
+        }
+        s = s.trim();
+        int i = s.indexOf("i");
+        if (i < 0) {
+            re = new BigRational(s);
+            im = BigRational.ZERO;
+            return;
+        }
+        //logger.warn("String constructor not done");
+        String sr = "";
+        if (i > 0) {
+            sr = s.substring(0, i);
+        }
+        String si = "";
+        if (i < s.length()) {
+            si = s.substring(i + 1, s.length());
+        }
+        //int j = sr.indexOf("+");
+        re = new BigRational(sr.trim());
+        im = new BigRational(si.trim());
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public BigComplex factory() {
+        return this;
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     * @see edu.jas.structure.ElemFactory#generators()
+     */
+    public List<BigComplex> generators() {
+        List<BigComplex> g = new ArrayList<BigComplex>(2);
+        g.add(getONE());
+        g.add(getIMAG());
+        return g;
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite()
+     */
+    public boolean isFinite() {
+        return false;
+    }
+
+
+    /**
+     * Clone this.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public BigComplex copy() {
+        return new BigComplex(re, im);
+    }
+
+
+    /**
+     * Copy BigComplex element c.
+     * @param c BigComplex.
+     * @return a copy of c.
+     */
+    public BigComplex copy(BigComplex c) {
+        return new BigComplex(c.re, c.im);
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as BigComplex.
+     */
+    public BigComplex getZERO() {
+        return ZERO;
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as BigComplex.
+     */
+    public BigComplex getONE() {
+        return ONE;
+    }
+
+
+    /**
+     * Get the i element.
+     * @return i as BigComplex.
+     */
+    public BigComplex getIMAG() {
+        return I;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true.
+     */
+    public boolean isCommutative() {
+        return true;
+    }
+
+
+    /**
+     * Query if this ring is associative.
+     * @return true.
+     */
+    public boolean isAssociative() {
+        return true;
+    }
+
+
+    /**
+     * Query if this ring is a field.
+     * @return true.
+     */
+    public boolean isField() {
+        return true;
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic() {
+        return java.math.BigInteger.ZERO;
+    }
+
+
+    /**
+     * Get a BigComplex element from a BigInteger.
+     * @param a BigInteger.
+     * @return a BigComplex.
+     */
+    public BigComplex fromInteger(BigInteger a) {
+        return new BigComplex(new BigRational(a));
+    }
+
+
+    /**
+     * Get a BigComplex element from a long.
+     * @param a long.
+     * @return a BigComplex.
+     */
+    public BigComplex fromInteger(long a) {
+        return new BigComplex(new BigRational(a));
+    }
+
+
+    /**
+     * The constant 0.
+     */
+    public static final BigComplex ZERO = new BigComplex();
+
+
+    /**
+     * The constant 1.
+     */
+    public static final BigComplex ONE = new BigComplex(BigRational.ONE);
+
+
+    /**
+     * The constant i.
+     */
+    public static final BigComplex I = new BigComplex(BigRational.ZERO, BigRational.ONE);
+
+
+    /**
+     * Get the real part.
+     * @return re.
+     */
+    public BigRational getRe() {
+        return re;
+    }
+
+
+    /**
+     * Get the imaginary part.
+     * @return im.
+     */
+    public BigRational getIm() {
+        return im;
+    }
+
+
+    /**
+     * Get the String representation.
+     */
+    @Override
+    public String toString() {
+        String s = "" + re;
+        int i = im.compareTo(BigRational.ZERO);
+        //logger.info("compareTo "+im+" ? 0 = "+i);
+        if (i == 0)
+            return s;
+        s += "i" + im;
+        return s;
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case: re or re+im*i 
+        // was (re,im) or (re,) 
+        StringBuffer s = new StringBuffer();
+        boolean iz = im.isZERO();
+        if (iz) {
+            s.append(re.toScript());
+            return s.toString();
+        }
+        boolean rz = re.isZERO();
+        if (rz) {
+            if (!im.isONE()) {
+                if (im.signum() > 0) {
+                    s.append(im.toScript() + "*");
+                } else {
+                    s.append("-");
+                    BigRational ii = im.negate();
+                    if (!ii.isONE()) {
+                        s.append(ii.toScript() + "*");
+                    }
+                }
+            }
+        } else {
+            s.append(re.toScript());
+            if (im.signum() > 0) {
+                s.append("+");
+                if (!im.isONE()) {
+                    s.append(im.toScript() + "*");
+                }
+            } else {
+                s.append("-");
+                BigRational ii = im.negate();
+                if (!ii.isONE()) {
+                    s.append(ii.toScript() + "*");
+                }
+            }
+        }
+        s.append("I");
+        return s.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python case
+        return "CC()";
+    }
+
+
+    /**
+     * Complex number zero.
+     * @param A is a complex number.
+     * @return If A is 0 then true is returned, else false.
+     */
+    public static boolean isCZERO(BigComplex A) {
+        if (A == null)
+            return false;
+        return A.isZERO();
+    }
+
+
+    /**
+     * Is Complex number zero.
+     * @return If this is 0 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isZERO()
+     */
+    public boolean isZERO() {
+        return re.isZERO() && im.isZERO();
+    }
+
+
+    /**
+     * Complex number one.
+     * @param A is a complex number.
+     * @return If A is 1 then true is returned, else false.
+     */
+    public static boolean isCONE(BigComplex A) {
+        if (A == null)
+            return false;
+        return A.isONE();
+    }
+
+
+    /**
+     * Is Complex number one.
+     * @return If this is 1 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isONE()
+     */
+    public boolean isONE() {
+        return re.isONE() && im.isZERO();
+    }
+
+
+    /**
+     * Is Complex imaginary one.
+     * @return If this is i then true is returned, else false.
+     */
+    public boolean isIMAG() {
+        return re.isZERO() && im.isONE();
+    }
+
+
+    /**
+     * Is Complex unit element.
+     * @return If this is a unit then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isUnit()
+     */
+    public boolean isUnit() {
+        return (!isZERO());
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object b) {
+        if (!(b instanceof BigComplex)) {
+            return false;
+        }
+        BigComplex bc = (BigComplex) b;
+        return re.equals(bc.re) && im.equals(bc.im);
+    }
+
+
+    /**
+     * Hash code for this BigComplex.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return 37 * re.hashCode() + im.hashCode();
+    }
+
+
+    /**
+     * Since complex numbers are unordered, we use lexicographical order of re
+     * and im.
+     * @return 0 if this is equal to b; 1 if re &gt; b.re, or re == b.re and im
+     *         &gt; b.im; -1 if re &lt; b.re, or re == b.re and im &lt; b.im
+     */
+    @Override
+    public int compareTo(BigComplex b) {
+        int s = re.compareTo(b.re);
+        if (s != 0) {
+            return s;
+        }
+        return im.compareTo(b.im);
+    }
+
+
+    /**
+     * Since complex numbers are unordered, we use lexicographical order of re
+     * and im.
+     * @return 0 if this is equal to 0; 1 if re &gt; 0, or re == 0 and im &gt;
+     *         0; -1 if re &lt; 0, or re == 0 and im &lt; 0
+     * @see edu.jas.structure.RingElem#signum()
+     */
+    public int signum() {
+        int s = re.signum();
+        if (s != 0) {
+            return s;
+        }
+        return im.signum();
+    }
+
+
+    /* arithmetic operations: +, -, -
+     */
+
+    /**
+     * Complex number summation.
+     * @param B a BigComplex number.
+     * @return this+B.
+     */
+    public BigComplex sum(BigComplex B) {
+        return new BigComplex(re.sum(B.re), im.sum(B.im));
+    }
+
+
+    /**
+     * Complex number sum.
+     * @param A and B are complex numbers.
+     * @return A+B.
+     */
+    public static BigComplex CSUM(BigComplex A, BigComplex B) {
+        if (A == null)
+            return null;
+        return A.sum(B);
+    }
+
+
+    /**
+     * Complex number difference.
+     * @param A and B are complex numbers.
+     * @return A-B.
+     */
+    public static BigComplex CDIF(BigComplex A, BigComplex B) {
+        if (A == null)
+            return null;
+        return A.subtract(B);
+    }
+
+
+    /**
+     * Complex number subtract.
+     * @param B a BigComplex number.
+     * @return this-B.
+     */
+    public BigComplex subtract(BigComplex B) {
+        return new BigComplex(re.subtract(B.re), im.subtract(B.im));
+    }
+
+
+    /**
+     * Complex number negative.
+     * @param A is a complex number.
+     * @return -A
+     */
+    public static BigComplex CNEG(BigComplex A) {
+        if (A == null)
+            return null;
+        return A.negate();
+    }
+
+
+    /**
+     * Complex number negative.
+     * @return -this.
+     * @see edu.jas.structure.RingElem#negate()
+     */
+    public BigComplex negate() {
+        return new BigComplex(re.negate(), im.negate());
+    }
+
+
+    /**
+     * Complex number conjugate.
+     * @param A is a complex number.
+     * @return the complex conjugate of A.
+     */
+    public static BigComplex CCON(BigComplex A) {
+        if (A == null)
+            return null;
+        return A.conjugate();
+    }
+
+
+    /* arithmetic operations: conjugate, absolut value 
+     */
+
+    /**
+     * Complex number conjugate.
+     * @return the complex conjugate of this.
+     */
+    public BigComplex conjugate() {
+        return new BigComplex(re, im.negate());
+    }
+
+
+    /**
+     * Complex number norm.
+     * @see edu.jas.structure.StarRingElem#norm()
+     * @return ||this||.
+     */
+    public BigComplex norm() {
+        // this.multiply(this.conjugate());
+        BigRational v = re.multiply(re);
+        v = v.sum(im.multiply(im));
+        return new BigComplex(v);
+    }
+
+
+    /**
+     * Complex number absolute value.
+     * @see edu.jas.structure.RingElem#abs()
+     * @return |this|.
+     */
+    public BigComplex abs() {
+        BigComplex n = norm();
+        BigRational r = Roots.sqrt(n.re);
+        logger.debug("abs() square root approximaton {}", r);
+        return new BigComplex(r);
+    }
+
+
+    /**
+     * Complex number absolute value.
+     * @param A is a complex number.
+     * @return the absolute value of A, a rational number. Note: The square root
+     *         is not jet implemented.
+     */
+    public static BigRational CABS(BigComplex A) {
+        if (A == null)
+            return null;
+        return A.abs().re;
+    }
+
+
+    /**
+     * Complex number product.
+     * @param A and B are complex numbers.
+     * @return A*B.
+     */
+    public static BigComplex CPROD(BigComplex A, BigComplex B) {
+        if (A == null)
+            return null;
+        return A.multiply(B);
+    }
+
+
+    /* arithmetic operations: *, inverse, / 
+     */
+
+
+    /**
+     * Complex number product.
+     * @param B is a complex number.
+     * @return this*B.
+     */
+    public BigComplex multiply(BigComplex B) {
+        return new BigComplex(re.multiply(B.re).subtract(im.multiply(B.im)),
+                        re.multiply(B.im).sum(im.multiply(B.re)));
+    }
+
+
+    /**
+     * Complex number inverse.
+     * @param A is a non-zero complex number.
+     * @return S with S*A = 1.
+     */
+    public static BigComplex CINV(BigComplex A) {
+        if (A == null)
+            return null;
+        return A.inverse();
+    }
+
+
+    /**
+     * Complex number inverse.
+     * @return S with S*this = 1.
+     * @see edu.jas.structure.RingElem#inverse()
+     */
+    public BigComplex inverse() {
+        BigRational a = norm().re.inverse();
+        return new BigComplex(re.multiply(a), im.multiply(a.negate()));
+    }
+
+
+    /**
+     * Complex number inverse.
+     * @param S is a complex number.
+     * @return 0.
+     */
+    public BigComplex remainder(BigComplex S) {
+        if (S.isZERO()) {
+            throw new ArithmeticException("division by zero");
+        }
+        return ZERO;
+    }
+
+
+    /**
+     * Complex number quotient.
+     * @param A and B are complex numbers, B non-zero.
+     * @return A/B.
+     */
+    public static BigComplex CQ(BigComplex A, BigComplex B) {
+        if (A == null)
+            return null;
+        return A.divide(B);
+    }
+
+
+    /**
+     * Complex number divide.
+     * @param B is a complex number, non-zero.
+     * @return this/B.
+     */
+    public BigComplex divide(BigComplex B) {
+        return this.multiply(B.inverse());
+    }
+
+
+    /**
+     * Quotient and remainder by division of this by S.
+     * @param S a complex number
+     * @return [this/S, this - (this/S)*S].
+     */
+    public BigComplex[] quotientRemainder(BigComplex S) {
+        return new BigComplex[] { divide(S), ZERO };
+    }
+
+
+    /**
+     * Complex number, random. Random rational numbers A and B are generated
+     * using random(n). Then R is the complex number with real part A and
+     * imaginary part B.
+     * @param n such that 0 &le; A, B &le; (2<sup>n</sup>-1).
+     * @return R.
+     */
+    public BigComplex random(int n) {
+        return random(n, random);
+    }
+
+
+    /**
+     * Complex number, random. Random rational numbers A and B are generated
+     * using random(n). Then R is the complex number with real part A and
+     * imaginary part B.
+     * @param n such that 0 &le; A, B &le; (2<sup>n</sup>-1).
+     * @param rnd is a source for random bits.
+     * @return R.
+     */
+    public BigComplex random(int n, Random rnd) {
+        BigRational r = BigRational.ONE.random(n, rnd);
+        BigRational i = BigRational.ONE.random(n, rnd);
+        return new BigComplex(r, i);
+    }
+
+
+    /**
+     * Complex number, random. Random rational numbers A and B are generated
+     * using random(n). Then R is the complex number with real part A and
+     * imaginary part B.
+     * @param n such that 0 &le; A, B &le; (2<sup>n</sup>-1).
+     * @return R.
+     */
+    public static BigComplex CRAND(int n) {
+        return ONE.random(n, random);
+    }
+
+
+    /**
+     * Parse complex number from string.
+     * @param s String.
+     * @return BigComplex from s.
+     */
+    public BigComplex parse(String s) {
+        return new BigComplex(s);
+    }
+
+
+    /**
+     * Parse complex number from Reader.
+     * @param r Reader.
+     * @return next BigComplex from r.
+     */
+    public BigComplex parse(Reader r) {
+        return parse(StringUtil.nextString(r));
+    }
+
+
+    /**
+     * Complex number greatest common divisor.
+     * @param S BigComplex.
+     * @return gcd(this,S).
+     */
+    public BigComplex gcd(BigComplex S) {
+        if (S == null || S.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return S;
+        }
+        return ONE;
+    }
+
+
+    /**
+     * BigComplex extended greatest common divisor.
+     * @param S BigComplex.
+     * @return [ gcd(this,S), a, b ] with a*this + b*S = gcd(this,S).
+     */
+    public BigComplex[] egcd(BigComplex S) {
+        BigComplex[] ret = new BigComplex[3];
+        ret[0] = null;
+        ret[1] = null;
+        ret[2] = null;
+        if (S == null || S.isZERO()) {
+            ret[0] = this;
+            return ret;
+        }
+        if (this.isZERO()) {
+            ret[0] = S;
+            return ret;
+        }
+        BigComplex half = new BigComplex(new BigRational(1, 2));
+        ret[0] = ONE;
+        ret[1] = this.inverse().multiply(half);
+        ret[2] = S.inverse().multiply(half);
+        return ret;
+    }
+
+
+    /**
+     * Returns the number of bits in the representation of this BigComplex,
+     * including a sign bit. It is equivalent to
+     * {@code re.bitLength() + im.bitLength()}.)
+     * @return number of bits in the representation of this BigComplex,
+     *         including a sign bit.
+     */
+    public long bitLength() {
+        return re.bitLength() + im.bitLength();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/BigDecimal.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/BigDecimal.java
@@ -1,0 +1,775 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.arith;
+
+
+import java.io.Reader;
+import java.math.MathContext;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import edu.jas.kern.StringUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * BigDecimal class to make java.math.BigDecimal available with RingElem
+ * interface. Objects of this class are immutable. Experimental, use with care,
+ * compareTo is some times hacked.
+ * @author Heinz Kredel
+ * @see java.math.BigDecimal
+ */
+
+public final class BigDecimal implements GcdRingElem<BigDecimal>, RingFactory<BigDecimal>,
+                                         Rational {
+
+
+    /**
+     * The data structure.
+     */
+    public final java.math.BigDecimal val;
+
+
+    private final static Random random = new Random();
+
+
+    public static final MathContext DEFAULT_CONTEXT = MathContext.DECIMAL64; //32; //64; //128;
+
+
+    public static final int DEFAULT_PRECISION = DEFAULT_CONTEXT.getPrecision();
+
+
+    public final MathContext context;
+
+
+    /**
+     * If true, then use equals from java.math.BigDecimal, else use hacked
+     * approximate compareTo().
+     */
+    public final static boolean EXACT_EQUAL = true;
+
+
+    /**
+     * The constant 0.
+     */
+    public final static BigDecimal ZERO = new BigDecimal(java.math.BigDecimal.ZERO);
+
+
+    /**
+     * The constant 1.
+     */
+    public final static BigDecimal ONE = new BigDecimal(java.math.BigDecimal.ONE);
+
+
+    /**
+     * Constructor for BigDecimal from math.BigDecimal.
+     * @param a java.math.BigDecimal.
+     */
+    public BigDecimal(java.math.BigDecimal a) {
+        this(a, DEFAULT_CONTEXT);
+    }
+
+
+    /**
+     * Constructor for BigDecimal from math.BigDecimal.
+     * @param a java.math.BigDecimal.
+     * @param mc MathContext.
+     */
+    public BigDecimal(java.math.BigDecimal a, MathContext mc) {
+        val = a;
+        context = mc;
+    }
+
+
+    /**
+     * Constructor for BigDecimal from long.
+     * @param a long.
+     */
+    public BigDecimal(long a) {
+        this(a, DEFAULT_CONTEXT);
+    }
+
+
+    /**
+     * Constructor for BigDecimal from long and a context.
+     * @param a long.
+     * @param mc MathContext.
+     */
+    public BigDecimal(long a, MathContext mc) {
+        this(new java.math.BigDecimal(String.valueOf(a)), mc);
+    }
+
+
+    /**
+     * Constructor for BigDecimal from double.
+     * @param a double.
+     */
+    public BigDecimal(double a) {
+        this(a, DEFAULT_CONTEXT);
+    }
+
+
+    /**
+     * Constructor for BigDecimal from double and a context.
+     * @param a double.
+     * @param mc MathContext.
+     */
+    public BigDecimal(double a, MathContext mc) {
+        this(new java.math.BigDecimal(a, mc), mc);
+    }
+
+
+    /**
+     * Constructor for BigDecimal from java.math.BigInteger.
+     * @param a java.math.BigInteger.
+     */
+    public BigDecimal(java.math.BigInteger a) {
+        this(a, DEFAULT_CONTEXT);
+    }
+
+
+    /**
+     * Constructor for BigDecimal from java.math.BigInteger.
+     * @param a java.math.BigInteger.
+     * @param mc MathContext.
+     */
+    public BigDecimal(java.math.BigInteger a, MathContext mc) {
+        this(new java.math.BigDecimal(a), mc);
+    }
+
+
+    /**
+     * Constructor for BigDecimal from BigRational.
+     * @param a edu.jas.arith.BigRational.
+     */
+    public BigDecimal(BigRational a) {
+        this(a, DEFAULT_CONTEXT);
+    }
+
+
+    /**
+     * Constructor for BigDecimal from BigRational.
+     * @param a edu.jas.arith.BigRational.
+     * @param mc MathContext.
+     */
+    public BigDecimal(BigRational a, MathContext mc) {
+        this((new java.math.BigDecimal(a.num, mc)).divide(new java.math.BigDecimal(a.den, mc), mc), mc);
+    }
+
+
+    /**
+     * Constructor for BigDecimal from String.
+     * @param s String.
+     */
+    public BigDecimal(String s) {
+        this(s, DEFAULT_CONTEXT);
+    }
+
+
+    /**
+     * Constructor for BigDecimal from String.
+     * @param s String.
+     * @param mc MathContext.
+     */
+    public BigDecimal(String s, MathContext mc) {
+        this(new java.math.BigDecimal(s.trim()), mc);
+    }
+
+
+    /**
+     * Constructor for BigDecimal without parameters.
+     */
+    public BigDecimal() {
+        this(java.math.BigDecimal.ZERO, DEFAULT_CONTEXT);
+    }
+
+
+    /*
+     * Get the value.
+     * @return val java.math.BigDecimal. public java.math.BigDecimal getVal() {
+     *         return val; }
+     */
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public BigDecimal factory() {
+        return this;
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     * @see edu.jas.structure.ElemFactory#generators()
+     */
+    public List<BigDecimal> generators() {
+        List<BigDecimal> g = new ArrayList<BigDecimal>(1);
+        g.add(getONE());
+        return g;
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite() <b>Note: </b> is actually
+     *      finite but returns false.
+     */
+    public boolean isFinite() {
+        return false;
+    }
+
+
+    /**
+     * Clone this.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public BigDecimal copy() {
+        return new BigDecimal(val, context);
+    }
+
+
+    /**
+     * Copy BigDecimal element c.
+     * @param c BigDecimal.
+     * @return a copy of c.
+     */
+    public BigDecimal copy(BigDecimal c) {
+        return new BigDecimal(c.val, c.context);
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0.
+     */
+    public BigDecimal getZERO() {
+        return ZERO;
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1.
+     */
+    public BigDecimal getONE() {
+        return ONE;
+    }
+
+
+    /**
+     * Get the decimal representation.
+     * @return decimal.
+     */
+    public BigDecimal getDecimal() {
+        return this;
+    }
+
+
+    /**
+     * Get the rational representation.
+     * @return rational number.
+     */
+    public BigRational getRational() {
+        return new BigRational(toString());
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true.
+     */
+    public boolean isCommutative() {
+        return true;
+    }
+
+
+    /**
+     * Query if this ring is associative. Floating point number addition is not
+     * associative, but multiplication is.
+     * @return true.
+     */
+    public boolean isAssociative() {
+        return true;
+    }
+
+
+    /**
+     * Query if this ring is a field.
+     * @return true.
+     */
+    public boolean isField() {
+        return true;
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic() {
+        return java.math.BigInteger.ZERO;
+    }
+
+
+    /**
+     * Get a BigDecimal element from a math.BigDecimal.
+     * @param a math.BigDecimal.
+     * @return a as BigDecimal.
+     */
+    public BigDecimal fromInteger(java.math.BigInteger a) {
+        return new BigDecimal(new java.math.BigDecimal(a), context);
+    }
+
+
+    /**
+     * Get a BigDecimal element from a math.BigDecimal.
+     * @param a math.BigDecimal.
+     * @return a as BigDecimal.
+     */
+    public static BigDecimal valueOf(java.math.BigDecimal a) {
+        return new BigDecimal(a, DEFAULT_CONTEXT);
+    }
+
+
+    /**
+     * Get a BigDecimal element from long.
+     * @param a long.
+     * @return a as BigDecimal.
+     */
+    public BigDecimal fromInteger(long a) {
+        return new BigDecimal(a, context);
+    }
+
+
+    /**
+     * Get a BigDecimal element from long.
+     * @param a long.
+     * @return a as BigDecimal.
+     */
+    public static BigDecimal valueOf(long a) {
+        return new BigDecimal(a, DEFAULT_CONTEXT);
+    }
+
+
+    /**
+     * Is BigDecimal number zero.
+     * @return If this is 0 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isZERO()
+     */
+    public boolean isZERO() {
+        if (EXACT_EQUAL) {
+            return val.compareTo(java.math.BigDecimal.ZERO) == 0;
+        }
+        return compareTo(ZERO) == 0;
+    }
+
+
+    /**
+     * Is BigDecimal number one.
+     * @see edu.jas.structure.RingElem#isONE()
+     */
+    public boolean isONE() {
+        if (EXACT_EQUAL) {
+            return val.compareTo(java.math.BigDecimal.ONE) == 0;
+        }
+        return compareTo(ONE) == 0;
+    }
+
+
+    /**
+     * Is BigDecimal number unit.
+     * @see edu.jas.structure.RingElem#isUnit()
+     */
+    public boolean isUnit() {
+        return (!isZERO());
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        //return val.toString() + "(ulp=" + val.ulp() + ")";
+        return val.toString();
+    }
+
+
+    /**
+     * Get this decimal as a <tt>double</tt>.
+     * @return the decimal as a <tt>double</tt>
+     * @see java.lang.Number#doubleValue()
+     */
+    public double doubleValue() {
+        return val.doubleValue();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python+Ruby case
+        return toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python+Ruby case
+        return "DD()";
+    }
+
+
+    /**
+     * Compare to BigDecimal b. Experimental, is hacked.
+     * @param b BigDecimal.
+     * @return 0 if abs(this-b) &lt; epsilon, 1 if this &gt; b, -1 if this &lt;
+     *         b.
+     */
+    @Override
+    public int compareTo(BigDecimal b) {
+        //return compareToAbsolute(b);
+        //return compareToRelative(b);
+        return val.compareTo(b.val);
+    }
+
+
+    /**
+     * Compare absolute to BigDecimal b. Experimental, is hacked.
+     * @param b BigDecimal.
+     * @return 0 if abs(this-b) &lt; epsilon, 1 if this &gt; b, -1 if this &lt;
+     *         b.
+     */
+    public int compareToAbsolute(BigDecimal b) {
+        //if (EXACT_EQUAL) {
+        //    return val.compareTo(b.val);
+        //}
+        java.math.BigDecimal s = val.subtract(b.val, context);
+        java.math.BigDecimal u1 = val.ulp();
+        java.math.BigDecimal u2 = b.val.ulp();
+        int u = Math.min(u1.scale(), u2.scale());
+        //System.out.println("u = " + u + ", s = " + s);
+        java.math.BigDecimal eps;
+        if (u <= 0) {
+            eps = u1.max(u2);
+        } else {
+            eps = u1.min(u2);
+        }
+        //eps = eps.movePointRight(1);
+        //System.out.println("ctx = " + context);
+        //System.out.println("eps = " + eps);
+        int t = s.abs().compareTo(eps);
+        if (t < 1) {
+            return 0;
+        }
+        return s.signum();
+    }
+
+
+    /**
+     * Compare to relative BigDecimal b. Experimental, is hacked.
+     * @param b BigDecimal.
+     * @return 0 if abs(this-b)/max(this,b) &lt; epsilon, 1 if this &gt; b, -1
+     *         if this &lt; b.
+     */
+    public int compareToRelative(BigDecimal b) {
+        //if (EXACT_EQUAL) {
+        //    return val.compareTo(b.val);
+        //}
+        java.math.BigDecimal s = val.subtract(b.val, context);
+        java.math.BigDecimal u1 = val.ulp();
+        java.math.BigDecimal u2 = b.val.ulp();
+        int u = Math.min(u1.scale(), u2.scale());
+        //System.out.println("u = " + u + ", s = " + s);
+        java.math.BigDecimal eps;
+        if (u <= 0) {
+            eps = u1.max(u2);
+        } else {
+            eps = u1.min(u2);
+        }
+        eps = eps.movePointRight(1);
+        //System.out.println("ctx = " + context);
+        //System.out.println("eps = " + eps);
+        java.math.BigDecimal m = val.abs().max(b.val.abs());
+        int t;
+        if (m.compareTo(java.math.BigDecimal.ONE) <= 1) {
+            t = s.abs().compareTo(eps);
+        } else {
+            t = s.abs().divide(m, context).compareTo(eps);
+        }
+        if (t < 1) {
+            return 0;
+        }
+        return s.signum();
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object b) {
+        if (!(b instanceof BigDecimal)) {
+            return false;
+        }
+        BigDecimal bi = (BigDecimal) b;
+        if (EXACT_EQUAL) {
+            return val.equals(bi.val);
+        }
+        return compareTo(bi) == 0;
+    }
+
+
+    /**
+     * Hash code for this BigDecimal.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return val.hashCode();
+    }
+
+
+    /**
+     * Absolute value of this.
+     * @see edu.jas.structure.RingElem#abs()
+     */
+    public BigDecimal abs() {
+        return new BigDecimal(val.abs(), context);
+    }
+
+
+    /* Negative value of this.
+     * @see edu.jas.structure.RingElem#negate()
+     */
+    public BigDecimal negate() {
+        return new BigDecimal(val.negate(), context);
+    }
+
+
+    /**
+     * signum.
+     * @see edu.jas.structure.RingElem#signum()
+     */
+    public int signum() {
+        return val.signum();
+    }
+
+
+    /**
+     * BigDecimal subtract.
+     * @param S BigDecimal.
+     * @return this-S.
+     */
+    public BigDecimal subtract(BigDecimal S) {
+        return new BigDecimal(val.subtract(S.val, context), context);
+    }
+
+
+    /**
+     * BigDecimal divide.
+     * @param S BigDecimal.
+     * @return this/S.
+     */
+    public BigDecimal divide(BigDecimal S) {
+        return new BigDecimal(val.divide(S.val, context), context);
+    }
+
+
+    /**
+     * Integer inverse. R is a non-zero integer. S=1/R if defined else 0.
+     * @see edu.jas.structure.RingElem#inverse()
+     */
+    public BigDecimal inverse() {
+        return ONE.divide(this);
+    }
+
+
+    /**
+     * BigDecimal remainder.
+     * @param S BigDecimal.
+     * @return this - (this/S)*S.
+     */
+    public BigDecimal remainder(BigDecimal S) {
+        return new BigDecimal(val.remainder(S.val, context), context);
+    }
+
+
+    /**
+     * BigDecimal compute quotient and remainder.
+     * @param S BigDecimal.
+     * @return BigDecimal[] { q, r } with q = this/S and r = rem(this,S).
+     */
+    public BigDecimal[] quotientRemainder(BigDecimal S) {
+        BigDecimal[] qr = new BigDecimal[2];
+        java.math.BigDecimal[] C = val.divideAndRemainder(S.val, context);
+        qr[0] = new BigDecimal(C[0], context);
+        qr[1] = new BigDecimal(C[1], context);
+        return qr;
+    }
+
+
+    /**
+     * BigDecimal greatest common divisor.
+     * @param S BigDecimal.
+     * @return gcd(this,S).
+     */
+    public BigDecimal gcd(BigDecimal S) {
+        throw new UnsupportedOperationException("BigDecimal.gcd() not implemented");
+        //return new BigDecimal( val.gcd( S.val ) );
+    }
+
+
+    /**
+     * BigDecimal extended greatest common divisor.
+     * @param S BigDecimal.
+     * @return [ gcd(this,S), a, b ] with a*this + b*S = gcd(this,S).
+     */
+    public BigDecimal[] egcd(BigDecimal S) {
+        throw new UnsupportedOperationException("BigDecimal.egcd() not implemented");
+    }
+
+
+    /**
+     * BigDecimal random.
+     * @param n such that 0 &le; val(r) &le; (2<sup>n</sup>-1). 0 &le; exp(r)
+     *            &le; (10-1).
+     * @return r, a random BigDecimal.
+     */
+    public BigDecimal random(int n) {
+        return random(n, random);
+    }
+
+
+    /**
+     * BigDecimal random.
+     * @param n such that 0 &le; val(r) &le; (2<sup>n</sup>-1). 0 &le; exp(r)
+     *            &le; (10-1).
+     * @param rnd is a source for random bits.
+     * @return r, a random BigDecimal.
+     */
+    public BigDecimal random(int n, Random rnd) {
+        return random(n, 10, rnd);
+    }
+
+
+    /**
+     * BigDecimal random.
+     * @param n such that 0 &le; val(r) &le; (2<sup>n</sup>-1).
+     * @param e such that 0 &le; exp(r) &le; (e-1).
+     * @return r, a random BigDecimal.
+     */
+    public BigDecimal random(int n, int e) {
+        return random(n, e, random);
+    }
+
+
+    /**
+     * BigDecimal random.
+     * @param n such that 0 &le; val(r) &le; (2<sup>n</sup>-1).
+     * @param e such that 0 &le; exp(r) &le; (e-1).
+     * @param rnd is a source for random bits.
+     * @return r, a random BigDecimal.
+     */
+    public BigDecimal random(int n, int e, Random rnd) {
+        java.math.BigInteger r = new java.math.BigInteger(n, rnd);
+        if (rnd.nextBoolean()) {
+            r = r.negate();
+        }
+        int scale = rnd.nextInt(e);
+        //if (rnd.nextBoolean()) { // not according to param spec
+        //    scale = -scale;
+        //}
+        java.math.BigDecimal d = new java.math.BigDecimal(r, scale, context);
+        return new BigDecimal(d, context);
+    }
+
+
+    /**
+     * BigDecimal multiply.
+     * @param S BigDecimal.
+     * @return this*S.
+     */
+    public BigDecimal multiply(BigDecimal S) {
+        return new BigDecimal(val.multiply(S.val, context), context);
+    }
+
+
+    /**
+     * BigDecimal summation.
+     * @param S BigDecimal.
+     * @return this+S.
+     */
+    public BigDecimal sum(BigDecimal S) {
+        return new BigDecimal(val.add(S.val, context), context);
+    }
+
+
+    /**
+     * BigDecimal parse from String.
+     * @param s String.
+     * @return Biginteger from s.
+     */
+    public BigDecimal parse(String s) {
+        int i = s.indexOf("/");
+        if (i < 0) { // i = 0 also error
+           return new BigDecimal(s, context);
+        }
+        String sd = s.substring(0,i);
+        String sn = s.substring(i+1);
+        //System.out.println("s = " + s + ", sd = " + sd + ", sn = " + sn);
+        BigDecimal dd = new BigDecimal(sd, context);
+        BigDecimal dn = new BigDecimal(sn, context);
+        return dd.divide(dn);
+    }
+
+
+    /**
+     * BigDecimal parse from Reader.
+     * @param r Reader.
+     * @return next Biginteger from r.
+     */
+    public BigDecimal parse(Reader r) {
+        return parse(StringUtil.nextString(r));
+    }
+
+
+    /**
+     * Returns the number of bits in the representation of this BigDecimal,
+     * including a sign bit. For positive BigDecimal, this is equivalent to
+     * {@code val.unscaledValue().bitLength()}.)
+     * @return number of bits in the representation of this BigDecimal,
+     *         including a sign bit.
+     */
+    public long bitLength() {
+        long n = val.unscaledValue().bitLength();
+        if (val.signum() < 0) {
+            n++;
+        }
+        n++;
+        n += BigInteger.bitLength(val.scale());
+        return n;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/BigDecimalComplex.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/BigDecimalComplex.java
@@ -1,0 +1,862 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.arith;
+
+
+import java.io.Reader;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.kern.StringUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.structure.StarRingElem;
+
+
+/**
+ * BigComplex class based on BigDecimal implementing the RingElem respectively
+ * the StarRingElem interface. Objects of this class are immutable.
+ * @author Heinz Kredel
+ */
+public final class BigDecimalComplex implements StarRingElem<BigDecimalComplex>,
+                GcdRingElem<BigDecimalComplex>, RingFactory<BigDecimalComplex> {
+
+
+    /**
+     * Real part of the data structure.
+     */
+    public final BigDecimal re;
+
+
+    /**
+     * Imaginary part of the data structure.
+     */
+    public final BigDecimal im;
+
+
+    private final static Random random = new Random();
+
+
+    private static final Logger logger = LogManager.getLogger(BigDecimalComplex.class);
+
+
+    /**
+     * The constructor creates a BigDecimalComplex object from two BigDecimal
+     * objects real and imaginary part.
+     * @param r real part.
+     * @param i imaginary part.
+     */
+    public BigDecimalComplex(BigDecimal r, BigDecimal i) {
+        re = r;
+        im = i;
+    }
+
+
+    /**
+     * The constructor creates a BigDecimalComplex object from a BigDecimal
+     * object as real part, the imaginary part is set to 0.
+     * @param r real part.
+     */
+    public BigDecimalComplex(BigDecimal r) {
+        this(r, BigDecimal.ZERO);
+    }
+
+
+    /**
+     * The constructor creates a BigDecimalComplex object from a long element as
+     * real part, the imaginary part is set to 0.
+     * @param r real part.
+     */
+    public BigDecimalComplex(long r) {
+        this(new BigDecimal(r), BigDecimal.ZERO);
+    }
+
+
+    /**
+     * The constructor creates a BigDecimalComplex object with real part 0 and
+     * imaginary part 0.
+     */
+    public BigDecimalComplex() {
+        this(BigDecimal.ZERO);
+    }
+
+
+    /**
+     * The constructor creates a BigDecimalComplex object from a String
+     * representation.
+     * @param s string of a BigDecimalComplex.
+     * @throws NumberFormatException
+     */
+    public BigDecimalComplex(String s) throws NumberFormatException {
+        if (s == null || s.length() == 0) {
+            re = BigDecimal.ZERO;
+            im = BigDecimal.ZERO;
+            return;
+        }
+        s = s.trim();
+        int i = s.indexOf("i");
+        if (i < 0) {
+            re = new BigDecimal(s);
+            im = BigDecimal.ZERO;
+            return;
+        }
+        //logger.warn("String constructor not done");
+        String sr = "";
+        if (i > 0) {
+            sr = s.substring(0, i);
+        }
+        String si = "";
+        if (i < s.length()) {
+            si = s.substring(i + 1, s.length());
+        }
+        //int j = sr.indexOf("+");
+        re = new BigDecimal(sr.trim());
+        im = new BigDecimal(si.trim());
+    }
+
+    
+    /**
+     * The constructor creates a BigDecimalComplex object from a BigComplex
+     * object.
+     * @param a rational BigComplex.
+     */
+    public BigDecimalComplex(BigComplex a) {
+        this(new BigDecimal(a.re), new BigDecimal(a.im));
+    }
+
+    
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public BigDecimalComplex factory() {
+        return this;
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     * @see edu.jas.structure.ElemFactory#generators()
+     */
+    public List<BigDecimalComplex> generators() {
+        List<BigDecimalComplex> g = new ArrayList<BigDecimalComplex>(2);
+        g.add(getONE());
+        g.add(getIMAG());
+        return g;
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite()
+     */
+    public boolean isFinite() {
+        return false;
+    }
+
+
+    /**
+     * Clone this.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public BigDecimalComplex copy() {
+        return new BigDecimalComplex(re, im);
+    }
+
+
+    /**
+     * Copy BigDecimalComplex element c.
+     * @param c BigDecimalComplex.
+     * @return a copy of c.
+     */
+    public BigDecimalComplex copy(BigDecimalComplex c) {
+        return new BigDecimalComplex(c.re, c.im);
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as BigDecimalComplex.
+     */
+    public BigDecimalComplex getZERO() {
+        return ZERO;
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as BigDecimalComplex.
+     */
+    public BigDecimalComplex getONE() {
+        return ONE;
+    }
+
+
+    /**
+     * Get the i element.
+     * @return i as BigDecimalComplex.
+     */
+    public BigDecimalComplex getIMAG() {
+        return I;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true.
+     */
+    public boolean isCommutative() {
+        return true;
+    }
+
+
+    /**
+     * Query if this ring is associative.
+     * @return true.
+     */
+    public boolean isAssociative() {
+        return true;
+    }
+
+
+    /**
+     * Query if this ring is a field.
+     * @return true.
+     */
+    public boolean isField() {
+        return true;
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic() {
+        return java.math.BigInteger.ZERO;
+    }
+
+
+    /**
+     * Get a BigDecimalComplex element from a BigInteger.
+     * @param a BigInteger.
+     * @return a BigDecimalComplex.
+     */
+    public BigDecimalComplex fromInteger(BigInteger a) {
+        return new BigDecimalComplex(new BigDecimal(a));
+    }
+
+
+    /**
+     * Get a BigDecimalComplex element from a long.
+     * @param a long.
+     * @return a BigDecimalComplex.
+     */
+    public BigDecimalComplex fromInteger(long a) {
+        return new BigDecimalComplex(new BigDecimal(a));
+    }
+
+
+    /**
+     * The constant 0.
+     */
+    public static final BigDecimalComplex ZERO = new BigDecimalComplex();
+
+
+    /**
+     * The constant 1.
+     */
+    public static final BigDecimalComplex ONE = new BigDecimalComplex(BigDecimal.ONE);
+
+
+    /**
+     * The constant i.
+     */
+    public static final BigDecimalComplex I = new BigDecimalComplex(BigDecimal.ZERO, BigDecimal.ONE);
+
+
+    /**
+     * Get the real part.
+     * @return re.
+     */
+    public BigDecimal getRe() {
+        return re;
+    }
+
+
+    /**
+     * Get the imaginary part.
+     * @return im.
+     */
+    public BigDecimal getIm() {
+        return im;
+    }
+
+
+    /**
+     * Get the String representation.
+     */
+    @Override
+    public String toString() {
+        String s = re.toString();
+        //int i = im.compareTo(BigDecimal.ZERO);
+        //logger.info("compareTo "+im+" ? 0 = "+i);
+        if (im.isZERO()) {
+            return s;
+        }
+        s += "i" + im;
+        return s;
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case: re or re+im*i 
+        // was (re,im) or (re,) 
+        StringBuffer s = new StringBuffer();
+        boolean iz = im.isZERO();
+        if (iz) {
+            s.append(re.toScript());
+            return s.toString();
+        }
+        boolean rz = re.isZERO();
+        if (rz) {
+            if (!im.isONE()) {
+                if (im.signum() > 0) {
+                    s.append(im.toScript() + "*");
+                } else {
+                    s.append("-");
+                    BigDecimal ii = im.negate();
+                    if (!ii.isONE()) {
+                        s.append(ii.toScript() + "*");
+                    }
+                }
+            }
+        } else {
+            s.append(re.toScript());
+            if (im.signum() > 0) {
+                s.append("+");
+                if (!im.isONE()) {
+                    s.append(im.toScript() + "*");
+                }
+            } else {
+                s.append("-");
+                BigDecimal ii = im.negate();
+                if (!ii.isONE()) {
+                    s.append(ii.toScript() + "*");
+                }
+            }
+        }
+        s.append("I");
+        return s.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python case
+        return "CD()";
+    }
+
+
+    /**
+     * Complex number zero.
+     * @param A is a complex number.
+     * @return If A is 0 then true is returned, else false.
+     */
+    public static boolean isCZERO(BigDecimalComplex A) {
+        if (A == null) {
+            return false;
+        }
+        return A.isZERO();
+    }
+
+
+    /**
+     * Is Complex number zero.
+     * @return If this is 0 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isZERO()
+     */
+    public boolean isZERO() {
+        return re.isZERO() && im.isZERO();
+    }
+
+
+    /**
+     * Complex number one.
+     * @param A is a complex number.
+     * @return If A is 1 then true is returned, else false.
+     */
+    public static boolean isCONE(BigDecimalComplex A) {
+        if (A == null) {
+            return false;
+        }
+        return A.isONE();
+    }
+
+
+    /**
+     * Is Complex number one.
+     * @return If this is 1 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isONE()
+     */
+    public boolean isONE() {
+        return re.isONE() && im.isZERO();
+    }
+
+
+    /**
+     * Is Complex imaginary one.
+     * @return If this is i then true is returned, else false.
+     */
+    public boolean isIMAG() {
+        return re.isZERO() && im.isONE();
+    }
+
+
+    /**
+     * Is Complex unit element.
+     * @return If this is a unit then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isUnit()
+     */
+    public boolean isUnit() {
+        return (!isZERO());
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object b) {
+        if (!(b instanceof BigDecimalComplex)) {
+            return false;
+        }
+        BigDecimalComplex bc = (BigDecimalComplex) b;
+        //return re.equals(bc.re) && im.equals(bc.im);
+        return re.compareTo(bc.re) == 0 && im.compareTo(bc.im) == 0;
+    }
+
+
+    /**
+     * Hash code for this BigDecimalComplex.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return 37 * re.hashCode() + im.hashCode();
+    }
+
+
+    /**
+     * Since complex numbers are unordered, we use lexicographical order of re
+     * and im.
+     * @return 0 if this is equal to b; 1 if re &gt; b.re, or re == b.re and im
+     *         &gt; b.im; -1 if re &lt; b.re, or re == b.re and im &lt; b.im
+     */
+    @Override
+    public int compareTo(BigDecimalComplex b) {
+        int s = re.compareTo(b.re);
+        //System.out.println("compareTo(a.re,b.re) = " + s);
+        if (s != 0) {
+            return s;
+        }
+        s = im.compareTo(b.im);
+        //System.out.println("compareTo(a.im,b.im) = " + s);
+        return s;
+    }
+
+
+    /**
+     * Since complex numbers are unordered, we use lexicographical order of re
+     * and im.
+     * @return 0 if this is equal to 0; 1 if re &gt; 0, or re == 0 and im &gt;
+     *         0; -1 if re &lt; 0, or re == 0 and im &lt; 0
+     * @see edu.jas.structure.RingElem#signum()
+     */
+    public int signum() {
+        int s = re.signum();
+        if (s != 0) {
+            return s;
+        }
+        return im.signum();
+    }
+
+
+    /* arithmetic operations: +, -, -
+     */
+
+    /**
+     * Complex number summation.
+     * @param B a BigDecimalComplex number.
+     * @return this+B.
+     */
+    public BigDecimalComplex sum(BigDecimalComplex B) {
+        return new BigDecimalComplex(re.sum(B.re), im.sum(B.im));
+    }
+
+
+    /**
+     * Complex number sum.
+     * @param A and B are complex numbers.
+     * @return A+B.
+     */
+    public static BigDecimalComplex CSUM(BigDecimalComplex A, BigDecimalComplex B) {
+        if (A == null) {
+            return null;
+        }
+        return A.sum(B);
+    }
+
+
+    /**
+     * Complex number difference.
+     * @param A and B are complex numbers.
+     * @return A-B.
+     */
+    public static BigDecimalComplex CDIF(BigDecimalComplex A, BigDecimalComplex B) {
+        if (A == null) {
+            return null;
+        }
+        return A.subtract(B);
+    }
+
+
+    /**
+     * Complex number subtract.
+     * @param B a BigDecimalComplex number.
+     * @return this-B.
+     */
+    public BigDecimalComplex subtract(BigDecimalComplex B) {
+        return new BigDecimalComplex(re.subtract(B.re), im.subtract(B.im));
+    }
+
+
+    /**
+     * Complex number negative.
+     * @param A is a complex number.
+     * @return -A
+     */
+    public static BigDecimalComplex CNEG(BigDecimalComplex A) {
+        if (A == null) {
+            return null;
+        }
+        return A.negate();
+    }
+
+
+    /**
+     * Complex number negative.
+     * @return -this.
+     * @see edu.jas.structure.RingElem#negate()
+     */
+    public BigDecimalComplex negate() {
+        return new BigDecimalComplex(re.negate(), im.negate());
+    }
+
+
+    /**
+     * Complex number conjugate.
+     * @param A is a complex number.
+     * @return the complex conjugate of A.
+     */
+    public static BigDecimalComplex CCON(BigDecimalComplex A) {
+        if (A == null) {
+            return null;
+        }
+        return A.conjugate();
+    }
+
+
+    /* arithmetic operations: conjugate, absolut value 
+     */
+
+    /**
+     * Complex number conjugate.
+     * @return the complex conjugate of this.
+     */
+    public BigDecimalComplex conjugate() {
+        return new BigDecimalComplex(re, im.negate());
+    }
+
+
+    /**
+     * Complex number norm.
+     * @see edu.jas.structure.StarRingElem#norm()
+     * @return ||this||.
+     */
+    public BigDecimalComplex norm() {
+        // this.multiply(this.conjugate());
+        BigDecimal v = re.multiply(re);
+        if (!im.isZERO()) {
+            v = v.sum(im.multiply(im));
+        }
+        return new BigDecimalComplex(v);
+    }
+
+
+    /**
+     * Complex number absolute value.
+     * @see edu.jas.structure.RingElem#abs()
+     * @return |this|.
+     */
+    public BigDecimalComplex abs() {
+        if (im.isZERO()) {
+            return new BigDecimalComplex(re.abs());
+        }
+        BigDecimalComplex n = norm();
+        BigDecimal d = Roots.sqrt(n.re);
+        if (logger.isDebugEnabled()) {
+            logger.debug("sqrt(re) = " + d);
+        }
+        return new BigDecimalComplex(d);
+    }
+
+
+    /**
+     * Complex number absolute value.
+     * @param A is a complex number.
+     * @return the absolute value of A, a rational number. Note: The square root
+     *         is not jet implemented.
+     */
+    public static BigDecimal CABS(BigDecimalComplex A) {
+        if (A == null) {
+            return null;
+        }
+        return A.abs().re;
+    }
+
+
+    /**
+     * Complex number product.
+     * @param A and B are complex numbers.
+     * @return A*B.
+     */
+    public static BigDecimalComplex CPROD(BigDecimalComplex A, BigDecimalComplex B) {
+        if (A == null) {
+            return null;
+        }
+        return A.multiply(B);
+    }
+
+
+    /* arithmetic operations: *, inverse, / 
+     */
+
+
+    /**
+     * Complex number product.
+     * @param B is a complex number.
+     * @return this*B.
+     */
+    public BigDecimalComplex multiply(BigDecimalComplex B) {
+        return new BigDecimalComplex(re.multiply(B.re).subtract(im.multiply(B.im)), re.multiply(B.im).sum(
+                        im.multiply(B.re)));
+    }
+
+
+    /**
+     * Complex number inverse.
+     * @param A is a non-zero complex number.
+     * @return S with S*A = 1.
+     */
+    public static BigDecimalComplex CINV(BigDecimalComplex A) {
+        if (A == null) {
+            return null;
+        }
+        return A.inverse();
+    }
+
+
+    /**
+     * Complex number inverse.
+     * @return S with S*this = 1.
+     * @see edu.jas.structure.RingElem#inverse()
+     */
+    public BigDecimalComplex inverse() {
+        BigDecimal a = norm().re.inverse();
+        return new BigDecimalComplex(re.multiply(a), im.multiply(a.negate()));
+    }
+
+
+    /**
+     * Complex number inverse.
+     * @param S is a complex number.
+     * @return 0.
+     */
+    public BigDecimalComplex remainder(BigDecimalComplex S) {
+        if (S.isZERO()) {
+            throw new ArithmeticException("division by zero");
+        }
+        return ZERO;
+    }
+
+
+    /**
+     * Complex number quotient.
+     * @param A and B are complex numbers, B non-zero.
+     * @return A/B.
+     */
+    public static BigDecimalComplex CQ(BigDecimalComplex A, BigDecimalComplex B) {
+        if (A == null) {
+            return null;
+        }
+        return A.divide(B);
+    }
+
+
+    /**
+     * Complex number divide.
+     * @param B is a complex number, non-zero.
+     * @return this/B.
+     */
+    public BigDecimalComplex divide(BigDecimalComplex B) {
+        return this.multiply(B.inverse());
+    }
+
+
+    /**
+     * Quotient and remainder by division of this by S.
+     * @param S a complex number
+     * @return [this/S, this - (this/S)*S].
+     */
+    public BigDecimalComplex[] quotientRemainder(BigDecimalComplex S) {
+        return new BigDecimalComplex[] { divide(S), ZERO };
+    }
+
+
+    /**
+     * Complex number, random. Random rational numbers A and B are generated
+     * using random(n). Then R is the complex number with real part A and
+     * imaginary part B.
+     * @param n such that 0 &le; A, B &le; (2<sup>n</sup>-1).
+     * @return R.
+     */
+    public BigDecimalComplex random(int n) {
+        return random(n, random);
+    }
+
+
+    /**
+     * Complex number, random. Random rational numbers A and B are generated
+     * using random(n). Then R is the complex number with real part A and
+     * imaginary part B.
+     * @param n such that 0 &le; A, B &le; (2<sup>n</sup>-1).
+     * @param rnd is a source for random bits.
+     * @return R.
+     */
+    public BigDecimalComplex random(int n, Random rnd) {
+        BigDecimal r = BigDecimal.ONE.random(n, rnd);
+        BigDecimal i = BigDecimal.ONE.random(n, rnd);
+        return new BigDecimalComplex(r, i);
+    }
+
+
+    /**
+     * Complex number, random. Random rational numbers A and B are generated
+     * using random(n). Then R is the complex number with real part A and
+     * imaginary part B.
+     * @param n such that 0 &le; A, B &le; (2<sup>n</sup>-1).
+     * @return R.
+     */
+    public static BigDecimalComplex CRAND(int n) {
+        return ONE.random(n, random);
+    }
+
+
+    /**
+     * Parse complex number from string.
+     * @param s String.
+     * @return BigDecimalComplex from s.
+     */
+    public BigDecimalComplex parse(String s) {
+        return new BigDecimalComplex(s);
+    }
+
+
+    /**
+     * Parse complex number from Reader.
+     * @param r Reader.
+     * @return next BigDecimalComplex from r.
+     */
+    public BigDecimalComplex parse(Reader r) {
+        return parse(StringUtil.nextString(r));
+    }
+
+
+    /**
+     * Complex number greatest common divisor.
+     * @param S BigDecimalComplex.
+     * @return gcd(this,S).
+     */
+    public BigDecimalComplex gcd(BigDecimalComplex S) {
+        if (S == null || S.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return S;
+        }
+        return ONE;
+    }
+
+
+    /**
+     * BigDecimalComplex extended greatest common divisor.
+     * @param S BigDecimalComplex.
+     * @return [ gcd(this,S), a, b ] with a*this + b*S = gcd(this,S).
+     */
+    public BigDecimalComplex[] egcd(BigDecimalComplex S) {
+        BigDecimalComplex[] ret = new BigDecimalComplex[3];
+        ret[0] = null;
+        ret[1] = null;
+        ret[2] = null;
+        if (S == null || S.isZERO()) {
+            ret[0] = this;
+            return ret;
+        }
+        if (this.isZERO()) {
+            ret[0] = S;
+            return ret;
+        }
+        BigDecimalComplex half = fromInteger(2).inverse();
+        ret[0] = ONE;
+        ret[1] = this.inverse().multiply(half);
+        ret[2] = S.inverse().multiply(half);
+        return ret;
+    }
+
+
+    /**
+     * Returns the number of bits in the representation of this
+     * BigDecimalComplex, including a sign bit. It is equivalent to
+     * {@code re.bitLength() + im.bitLength()}.)
+     * @return number of bits in the representation of this BigDecimalComplex,
+     *         including a sign bit.
+     */
+    public long bitLength() {
+        return re.bitLength() + im.bitLength();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/BigInteger.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/BigInteger.java
@@ -1,0 +1,893 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.arith;
+
+
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+
+import edu.jas.kern.StringUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.NotInvertibleException;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * BigInteger class to make java.math.BigInteger available with RingElem
+ * respectively the GcdRingElem interface. Objects of this class are immutable.
+ * The SAC2 static methods are also provided.
+ * @author Heinz Kredel
+ * @see java.math.BigInteger
+ */
+
+public final class BigInteger
+                implements GcdRingElem<BigInteger>, RingFactory<BigInteger>, Iterable<BigInteger>, Rational {
+
+
+    /**
+     * The data structure.
+     */
+    public final java.math.BigInteger val;
+
+
+    private final static Random random = new Random();
+
+
+    /**
+     * The constant 0.
+     */
+    public final static BigInteger ZERO = new BigInteger(java.math.BigInteger.ZERO);
+
+
+    /**
+     * The constant 1.
+     */
+    public final static BigInteger ONE = new BigInteger(java.math.BigInteger.ONE);
+
+
+    /**
+     * The constant 2.
+     */
+    public final static BigInteger TWO = new BigInteger(2);
+
+
+    /**
+     * Constructor for BigInteger from math.BigInteger.
+     * @param a java.math.BigInteger.
+     */
+    public BigInteger(java.math.BigInteger a) {
+        val = a;
+    }
+
+
+    /**
+     * Constructor for BigInteger from long.
+     * @param a long.
+     */
+    public BigInteger(long a) {
+        val = new java.math.BigInteger(String.valueOf(a));
+    }
+
+
+    /**
+     * Constructor for BigInteger from String.
+     * @param s String.
+     */
+    public BigInteger(String s) {
+        val = new java.math.BigInteger(s.trim());
+    }
+
+
+    /**
+     * Constructor for BigInteger without parameters.
+     */
+    public BigInteger() {
+        val = java.math.BigInteger.ZERO;
+    }
+
+
+    /**
+     * Get the value.
+     * @return val java.math.BigInteger.
+     */
+    public java.math.BigInteger getVal() {
+        return val;
+    }
+
+
+    /**
+     * Get the value as long.
+     * @return val as long.
+     */
+    public long longValue() {
+        return val.longValue();
+    }
+
+
+    /**
+     * Get the value as long.
+     * @return val as long if val fits in long.
+     */
+    public long longValueExact() {
+        return val.longValueExact();
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public BigInteger factory() {
+        return this;
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     * @see edu.jas.structure.ElemFactory#generators()
+     */
+    public List<BigInteger> generators() {
+        List<BigInteger> g = new ArrayList<BigInteger>(1);
+        g.add(getONE());
+        return g;
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite()
+     */
+    public boolean isFinite() {
+        return false;
+    }
+
+
+    /**
+     * Clone this.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public BigInteger copy() {
+        return new BigInteger(val);
+    }
+
+
+    /**
+     * Copy BigInteger element c.
+     * @param c BigInteger.
+     * @return a copy of c.
+     */
+    public BigInteger copy(BigInteger c) {
+        return new BigInteger(c.val);
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0.
+     */
+    public BigInteger getZERO() {
+        return ZERO;
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1.
+     */
+    public BigInteger getONE() {
+        return ONE;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true.
+     */
+    public boolean isCommutative() {
+        return true;
+    }
+
+
+    /**
+     * Query if this ring is associative.
+     * @return true.
+     */
+    public boolean isAssociative() {
+        return true;
+    }
+
+
+    /**
+     * Query if this ring is a field.
+     * @return false.
+     */
+    public boolean isField() {
+        return false;
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic() {
+        return java.math.BigInteger.ZERO;
+    }
+
+
+    /**
+     * Get a BigInteger element from a math.BigInteger.
+     * @param a math.BigInteger.
+     * @return a as BigInteger.
+     */
+    public BigInteger fromInteger(java.math.BigInteger a) {
+        return new BigInteger(a);
+    }
+
+
+    /**
+     * Get a BigInteger element from a math.BigInteger.
+     * @param a math.BigInteger.
+     * @return a as BigInteger.
+     */
+    public static BigInteger valueOf(java.math.BigInteger a) {
+        return new BigInteger(a);
+    }
+
+
+    /**
+     * Get a BigInteger element from long.
+     * @param a long.
+     * @return a as BigInteger.
+     */
+    public BigInteger fromInteger(long a) {
+        return new BigInteger(a);
+    }
+
+
+    /**
+     * Get a BigInteger element from long.
+     * @param a long.
+     * @return a as BigInteger.
+     */
+    public static BigInteger valueOf(long a) {
+        return new BigInteger(a);
+    }
+
+
+    /**
+     * Is BigInteger number zero.
+     * @return If this is 0 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isZERO()
+     */
+    public boolean isZERO() {
+        return val.signum() == 0; //equals(java.math.BigInteger.ZERO);
+    }
+
+
+    /**
+     * Is BigInteger number one.
+     * @see edu.jas.structure.RingElem#isONE()
+     */
+    public boolean isONE() {
+        return val.equals(java.math.BigInteger.ONE);
+    }
+
+
+    /**
+     * Is BigInteger number unit.
+     * @see edu.jas.structure.RingElem#isUnit()
+     */
+    public boolean isUnit() {
+        return (this.isONE() || this.negate().isONE());
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return val.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        return toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python case
+        return "ZZ()";
+    }
+
+
+    /**
+     * Compare to BigInteger b.
+     * @param b BigInteger.
+     * @return 0 if this == b, 1 if this &gt; b, -1 if this &lt; b.
+     */
+    @Override
+    public int compareTo(BigInteger b) {
+        return val.compareTo(b.val);
+    }
+
+
+    /**
+     * Integer comparison.
+     * @param A BigInteger.
+     * @param B BigInteger.
+     * @return 0 if A == B, 1 if A &gt; B, -1 if A &lt; B.
+     */
+    public static int ICOMP(BigInteger A, BigInteger B) {
+        if (A == null)
+            return -B.signum();
+        return A.compareTo(B);
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object b) {
+        if (!(b instanceof BigInteger)) {
+            return false;
+        }
+        BigInteger bi = (BigInteger) b;
+        return val.equals(bi.val);
+    }
+
+
+    /**
+     * Hash code for this BigInteger.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return val.hashCode();
+    }
+
+
+    /**
+     * Absolute value of this.
+     * @see edu.jas.structure.RingElem#abs()
+     */
+    public BigInteger abs() {
+        return new BigInteger(val.abs());
+    }
+
+
+    /**
+     * Absolute value.
+     * @param A BigInteger.
+     * @return abs(A).
+     */
+    public static BigInteger IABS(BigInteger A) {
+        if (A == null) {
+            throw new IllegalArgumentException("null A not allowed");
+        }
+        return A.abs();
+    }
+
+
+    /* Negative value of this.
+     * @see edu.jas.structure.RingElem#negate()
+     */
+    public BigInteger negate() {
+        return new BigInteger(val.negate());
+    }
+
+
+    /**
+     * Negative value.
+     * @param A BigInteger.
+     * @return -A.
+     */
+    public static BigInteger INEG(BigInteger A) {
+        if (A == null) {
+            throw new IllegalArgumentException("null A not allowed");
+        }
+        return A.negate();
+    }
+
+
+    /**
+     * signum.
+     * @see edu.jas.structure.RingElem#signum()
+     */
+    public int signum() {
+        return val.signum();
+    }
+
+
+    /**
+     * Integer signum.
+     * @param A BigInteger.
+     * @return signum(A).
+     */
+    public static int ISIGN(BigInteger A) {
+        if (A == null)
+            return 0;
+        return A.signum();
+    }
+
+
+    /**
+     * BigInteger subtract.
+     * @param S BigInteger.
+     * @return this-S.
+     */
+    public BigInteger subtract(BigInteger S) {
+        return new BigInteger(val.subtract(S.val));
+    }
+
+
+    /**
+     * BigInteger subtract.
+     * @param A BigInteger.
+     * @param B BigInteger.
+     * @return A-B.
+     */
+    public static BigInteger IDIF(BigInteger A, BigInteger B) {
+        if (A == null)
+            return B.negate();
+        return A.subtract(B);
+    }
+
+
+    /**
+     * BigInteger divide.
+     * @param S BigInteger.
+     * @return this/S.
+     */
+    public BigInteger divide(BigInteger S) {
+        return new BigInteger(val.divide(S.val));
+    }
+
+
+    /**
+     * BigInteger divide.
+     * @param A BigInteger.
+     * @param B BigInteger.
+     * @return A/B.
+     */
+    public static BigInteger IQ(BigInteger A, BigInteger B) {
+        if (A == null) {
+            throw new IllegalArgumentException("null A not allowed");
+        }
+        return A.divide(B);
+    }
+
+
+    /**
+     * Integer inverse. R is a non-zero integer. S=1/R if defined else throws
+     * not invertible exception.
+     * @see edu.jas.structure.RingElem#inverse()
+     */
+    public BigInteger inverse() {
+        if (this.isONE() || this.negate().isONE()) {
+            return this;
+        }
+        //return ZERO;
+        throw new NotInvertibleException("element not invertible " + this + " :: BigInteger");
+    }
+
+
+    /**
+     * BigInteger remainder.
+     * @param S BigInteger.
+     * @return this - (this/S)*S.
+     */
+    public BigInteger remainder(BigInteger S) {
+        return new BigInteger(val.remainder(S.val));
+    }
+
+
+    /**
+     * BigInteger remainder.
+     * @param A BigInteger.
+     * @param B BigInteger.
+     * @return A - (A/B)*B.
+     */
+    public static BigInteger IREM(BigInteger A, BigInteger B) {
+        if (A == null) {
+            throw new IllegalArgumentException("null A not allowed");
+        }
+        return A.remainder(B);
+    }
+
+
+    /**
+     * BigInteger compute quotient and remainder. Throws an exception, if S ==
+     * 0.
+     * @param S BigInteger.
+     * @return BigInteger[] { q, r } with this = q S + r and 0 &le; r &lt; |S|.
+     */
+    //@Override
+    public BigInteger[] quotientRemainder(BigInteger S) {
+        BigInteger[] qr = new BigInteger[2];
+        java.math.BigInteger[] C = val.divideAndRemainder(S.val);
+        qr[0] = new BigInteger(C[0]);
+        qr[1] = new BigInteger(C[1]);
+        return qr;
+    }
+
+
+    /**
+     * Integer quotient and remainder. A and B are integers, B ne 0. Q is the
+     * quotient, integral part of A/B, and R is the remainder A-B*Q. Throws an
+     * exception, if B == 0.
+     * @param A BigInteger.
+     * @param B BigInteger.
+     * @return BigInteger[] { q, r } with A = q B + r and 0 &le; r &lt; |B|
+     */
+    public static BigInteger[] IQR(BigInteger A, BigInteger B) {
+        if (A == null) {
+            throw new IllegalArgumentException("null A not allowed");
+        }
+        return A.quotientRemainder(B);
+    }
+
+
+    /**
+     * BigInteger greatest common divisor.
+     * @param S BigInteger.
+     * @return gcd(this,S).
+     */
+    public BigInteger gcd(BigInteger S) {
+        return new BigInteger(val.gcd(S.val));
+    }
+
+
+    /**
+     * BigInteger extended greatest common divisor.
+     * @param S BigInteger.
+     * @return [ gcd(this,S), a, b ] with a*this + b*S = gcd(this,S).
+     */
+    public BigInteger[] egcd(BigInteger S) {
+        BigInteger[] ret = new BigInteger[3];
+        ret[0] = null;
+        ret[1] = null;
+        ret[2] = null;
+        if (S == null || S.isZERO()) {
+            ret[0] = this;
+            return ret;
+        }
+        if (this.isZERO()) {
+            ret[0] = S;
+            return ret;
+        }
+        //System.out.println("this = " + this + ", S = " + S);
+        BigInteger[] qr;
+        BigInteger q = this;
+        BigInteger r = S;
+        BigInteger c1 = ONE;
+        BigInteger d1 = ZERO;
+        BigInteger c2 = ZERO;
+        BigInteger d2 = ONE;
+        BigInteger x1;
+        BigInteger x2;
+        while (!r.isZERO()) {
+            qr = q.quotientRemainder(r);
+            q = qr[0];
+            x1 = c1.subtract(q.multiply(d1));
+            x2 = c2.subtract(q.multiply(d2));
+            c1 = d1;
+            c2 = d2;
+            d1 = x1;
+            d2 = x2;
+            q = r;
+            r = qr[1];
+        }
+        //System.out.println("q = " + q + "\n c1 = " + c1 + "\n c2 = " + c2);
+        if (q.signum() < 0) {
+            q = q.negate();
+            c1 = c1.negate();
+            c2 = c2.negate();
+        }
+        ret[0] = q;
+        ret[1] = c1;
+        ret[2] = c2;
+        return ret;
+    }
+
+
+    /**
+     * BigInteger greatest common divisor.
+     * @param A BigInteger.
+     * @param B BigInteger.
+     * @return gcd(A,B).
+     */
+    public static BigInteger IGCD(BigInteger A, BigInteger B) {
+        if (A == null) {
+            throw new IllegalArgumentException("null A not allowed");
+        }
+        return A.gcd(B);
+    }
+
+
+    /**
+     * BigInteger random.
+     * @param n such that 0 &le; r &le; (2<sup>n</sup>-1).
+     * @return r, a random BigInteger.
+     */
+    public BigInteger random(int n) {
+        return random(n, random);
+    }
+
+
+    /**
+     * BigInteger random.
+     * @param n such that 0 &le; r &le; (2<sup>n</sup>-1).
+     * @param rnd is a source for random bits.
+     * @return r, a random BigInteger.
+     */
+    public BigInteger random(int n, Random rnd) {
+        java.math.BigInteger r = new java.math.BigInteger(n, rnd);
+        if (rnd.nextBoolean()) {
+            r = r.negate();
+        }
+        return new BigInteger(r);
+    }
+
+
+    /**
+     * BigInteger random.
+     * @param NL such that 0 &le; r &le; (2<sup>n</sup>-1).
+     * @return r, a random BigInteger.
+     */
+    public static BigInteger IRAND(int NL) {
+        return ONE.random(NL, random);
+    }
+
+
+    /**
+     * BigInteger multiply.
+     * @param S BigInteger.
+     * @return this*S.
+     */
+    public BigInteger multiply(BigInteger S) {
+        return new BigInteger(val.multiply(S.val));
+    }
+
+
+    /**
+     * BigInteger shift left.
+     * @param n bits to shift.
+     * @return this &lt;&lt; n.
+     */
+    public BigInteger shiftLeft(int n) {
+        return new BigInteger(val.shiftLeft(n));
+    }
+
+
+    /**
+     * BigInteger multiply.
+     * @param A BigInteger.
+     * @param B BigInteger.
+     * @return A*B.
+     */
+    public static BigInteger IPROD(BigInteger A, BigInteger B) {
+        if (A == null) {
+            throw new IllegalArgumentException("null A not allowed");
+        }
+        return A.multiply(B);
+    }
+
+
+    /**
+     * BigInteger summation.
+     * @param S BigInteger.
+     * @return this+S.
+     */
+    public BigInteger sum(BigInteger S) {
+        return new BigInteger(val.add(S.val));
+    }
+
+
+    /**
+     * BigInteger addition.
+     * @param A BigInteger.
+     * @param B BigInteger.
+     * @return A+B.
+     */
+    public static BigInteger ISUM(BigInteger A, BigInteger B) {
+        if (A == null) {
+            throw new IllegalArgumentException("null A not allowed");
+        }
+        return A.sum(B);
+    }
+
+
+    /**
+     * BigInteger parse from String.
+     * @param s String.
+     * @return Biginteger from s.
+     */
+    public BigInteger parse(String s) {
+        return new BigInteger(s);
+    }
+
+
+    /**
+     * BigInteger parse from Reader.
+     * @param r Reader.
+     * @return next Biginteger from r.
+     */
+    public BigInteger parse(Reader r) {
+        return parse(StringUtil.nextString(r));
+    }
+
+
+    /**
+     * Get the decimal representation.
+     * @return decimal.
+     */
+    public BigDecimal getDecimal() {
+        return new BigDecimal(val);
+    }
+
+
+    /**
+     * Return a BigRational approximation of this Element.
+     * @return a BigRational approximation of this.
+     */
+    public BigRational getRational() {
+        return new BigRational(val);
+    }
+
+
+    /**
+     * Returns the number of bits in the representation of this BigInteger,
+     * including a sign bit. For positive BigIntegers, this is equivalent to
+     * {@code (ceil(log2(this+1))+1)}.)
+     * @return number of bits in the representation of this BigInteger,
+     *         including a sign bit.
+     */
+    public long bitLength() {
+        long n = val.bitLength();
+        //System.out.println("sign(val) = " + val.signum());
+        if (val.signum() < 0) {
+            n++;
+        }
+        return ++n;
+    }
+
+
+    /**
+     * Returns the number of bits in the representation of a Long, including a
+     * sign bit.
+     * @param v value.
+     * @return number of bits in the representation of a Long, including a sign
+     *         bit.
+     */
+    public static long bitLength(long v) { // compare BigInteger.bitLengthForInt
+        long n = 64 - Long.numberOfLeadingZeros(v);
+        return ++n;
+    }
+
+
+    private boolean nonNegative = true;
+
+
+    /**
+     * Set the iteration algorithm to all elements.
+     */
+    public void setAllIterator() {
+        nonNegative = false;
+    }
+
+
+    /**
+     * Set the iteration algorithm to non-negative elements.
+     */
+    public void setNonNegativeIterator() {
+        nonNegative = true;
+    }
+
+
+    /**
+     * Get a BigInteger iterator.
+     * @return a iterator over all integers.
+     */
+    public Iterator<BigInteger> iterator() {
+        return new BigIntegerIterator(nonNegative);
+    }
+
+}
+
+
+/**
+ * Big integer iterator.
+ * @author Heinz Kredel
+ */
+class BigIntegerIterator implements Iterator<BigInteger> {
+
+
+    /**
+     * data structure.
+     */
+    java.math.BigInteger curr;
+
+
+    final boolean nonNegative;
+
+
+    /**
+     * BigInteger iterator constructor.
+     */
+    public BigIntegerIterator() {
+        this(false);
+    }
+
+
+    /**
+     * BigInteger iterator constructor.
+     * @param nn true for an iterator over non-negative longs, false for all
+     *            elements iterator.
+     */
+    public BigIntegerIterator(boolean nn) {
+        curr = java.math.BigInteger.ZERO;
+        nonNegative = nn;
+    }
+
+
+    /**
+     * Test for availability of a next element.
+     * @return true if the iteration has more elements, else false.
+     */
+    public boolean hasNext() {
+        return true;
+    }
+
+
+    /**
+     * Get next integer.
+     * @return next integer.
+     */
+    public synchronized BigInteger next() {
+        BigInteger i = new BigInteger(curr);
+        if (nonNegative) {
+            curr = curr.add(java.math.BigInteger.ONE);
+        } else if (curr.signum() > 0 && !nonNegative) {
+            curr = curr.negate();
+        } else {
+            curr = curr.negate().add(java.math.BigInteger.ONE);
+        }
+        return i;
+    }
+
+
+    /**
+     * Remove an element if allowed.
+     */
+    public void remove() {
+        throw new UnsupportedOperationException("cannnot remove elements");
+    }
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/BigOctonion.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/BigOctonion.java
@@ -1,0 +1,885 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.arith;
+
+
+import java.io.Reader;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.kern.StringUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.structure.StarRingElem;
+
+
+/**
+ * BigOctonion class based on BigRational implementing the RingElem interface
+ * and with the familiar MAS static method names. Objects of this class are
+ * immutable.
+ * @author Heinz Kredel
+ */
+
+public final class BigOctonion
+                implements StarRingElem<BigOctonion>, GcdRingElem<BigOctonion>, RingFactory<BigOctonion> {
+
+
+    /**
+     * First part of the data structure.
+     */
+    public final BigQuaternion or;
+
+
+    /**
+     * Second part of the data structure.
+     */
+    public final BigQuaternion oi;
+
+
+    private final static Random random = new Random();
+
+
+    private static final Logger logger = LogManager.getLogger(BigOctonion.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor for a BigOctonion from Quaternions.
+     * @param r BigQuaternion.
+     * @param i BigQuaternion.
+     */
+    public BigOctonion(BigQuaternion r, BigQuaternion i) {
+        if (i == null) {
+            throw new IllegalArgumentException("null i not allowed");
+        }
+        this.or = r;
+        this.oi = i;
+        //if (ZERO == null) {
+        //ZERO = new BigOctonion(r.ring.ZERO, i.ring.ZERO);
+        //ONE = new BigOctonion(r.ring.ONE, i.ring.ZERO);
+        //I = new BigOctonion(r.ring.ZERO, i.ring.ONE);
+        //}
+    }
+
+
+    /**
+     * Constructor for a BigOctonion from BigQuaternion.
+     * @param r BigQuaternion.
+     */
+    public BigOctonion(BigQuaternion r) {
+        this(r, r.ring.ZERO);
+    }
+
+
+    /**
+     * Constructor for a BigOctonion from BigComplex.
+     * @param fac BigQuaternionRing.
+     * @param r BigComplex.
+     */
+    public BigOctonion(BigQuaternionRing fac, BigComplex r) {
+        this(new BigQuaternion(fac, r));
+    }
+
+
+    /**
+     * Constructor for a BigOctonion from BigRational.
+     * @param fac BigQuaternionRing.
+     * @param r BigRational.
+     */
+    public BigOctonion(BigQuaternionRing fac, BigRational r) {
+        this(new BigQuaternion(fac, r));
+    }
+
+
+    /**
+     * Constructor for a BigOctonion from long.
+     * @param fac BigQuaternionRing.
+     * @param r long.
+     */
+    public BigOctonion(BigQuaternionRing fac, long r) {
+        this(new BigQuaternion(fac, r));
+    }
+
+
+    /**
+     * Constructor for a BigOctonion with no arguments.
+     * @param fac BigQuaternionRing.
+     */
+    public BigOctonion(BigQuaternionRing fac) {
+        this(new BigQuaternion(fac));
+    }
+
+
+    /**
+     * The BigOctonion string constructor accepts the following formats: empty
+     * string, "quaternion", or "quat o quat" with no blanks around o if used as
+     * polynoial coefficient.
+     * @param fac BigQuaternionRing.
+     * @param s String.
+     * @throws NumberFormatException
+     */
+    public BigOctonion(BigQuaternionRing fac, String s) throws NumberFormatException {
+        if (s == null || s.length() == 0) {
+            or = getZERO().or;
+            oi = getZERO().oi;
+            return;
+        }
+        s = s.trim();
+        int o = s.indexOf("o");
+        if (o == -1) {
+            or = new BigQuaternion(fac, s);
+            oi = getZERO().oi;
+            return;
+        }
+        String sr = s.substring(0, o - 1);
+        String so = s.substring(o + 1, s.length());
+        or = new BigQuaternion(fac, sr.trim());
+        oi = new BigQuaternion(fac, so.trim());
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public BigOctonion factory() {
+        return this;
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     * @see edu.jas.structure.ElemFactory#generators()
+     */
+    public List<BigOctonion> generators() {
+        List<BigQuaternion> qg = or.ring.generators();
+        List<BigOctonion> g = new ArrayList<BigOctonion>(qg.size() * 2);
+        for (BigQuaternion q : qg) {
+            g.add(new BigOctonion(q));
+            g.add(new BigOctonion(or.ring.ZERO, q));
+        }
+        return g;
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite()
+     */
+    public boolean isFinite() {
+        return false;
+    }
+
+
+    /**
+     * Clone this.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public BigOctonion copy() {
+        return new BigOctonion(or, oi);
+    }
+
+
+    /**
+     * Copy BigOctonion element c.
+     * @param c BigOctonion.
+     * @return a copy of c.
+     */
+    public BigOctonion copy(BigOctonion c) {
+        if (c == null) {
+            throw new IllegalArgumentException("copy of null not allowed");
+        }
+        return new BigOctonion(c.or, c.oi);
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as BigOctonion.
+     */
+    public BigOctonion getZERO() {
+        if (ZERO == null) {
+            ZERO = new BigOctonion(or.ring.ZERO, or.ring.ZERO);
+            I = new BigOctonion(or.ring.ZERO, or.ring.ONE);
+        }
+        return ZERO;
+    }
+
+
+    /**
+     * Get the one element.
+     * @return q as BigOctonion.
+     */
+    public BigOctonion getONE() {
+        if (ONE == null) {
+            ONE = new BigOctonion(or.ring.ONE, or.ring.ZERO);
+        }
+        return ONE;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return false.
+     */
+    public boolean isCommutative() {
+        return false;
+    }
+
+
+    /**
+     * Query if this ring is associative.
+     * @return false.
+     */
+    public boolean isAssociative() {
+        return false;
+    }
+
+
+    /**
+     * Query if this ring is a field.
+     * @return true.
+     */
+    public boolean isField() {
+        return true;
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic() {
+        return java.math.BigInteger.ZERO;
+    }
+
+
+    /**
+     * Get a BigOctonion element from a BigInteger.
+     * @param a BigInteger.
+     * @return a BigOctonion.
+     */
+    public BigOctonion fromInteger(BigInteger a) {
+        return new BigOctonion(or.ring.fromInteger(a));
+    }
+
+
+    /**
+     * Get a BigOctonion element from a long.
+     * @param a long.
+     * @return a BigOctonion.
+     */
+    public BigOctonion fromInteger(long a) {
+        return new BigOctonion(or.ring.fromInteger(a));
+    }
+
+
+    /**
+     * The constant 0.
+     */
+    public BigOctonion ZERO; // = new BigOctonion(or.ring);
+
+
+    /**
+     * The constant 1.
+     */
+    public BigOctonion ONE; // = new BigOctonion(or.ring.ONE);
+
+
+    /**
+     * The constant i.
+     */
+    public BigOctonion I; // = new BigOctonion(or.ring.ZERO, oi.ring.ONE);
+
+
+    /**
+     * Get the or part.
+     * @return or.
+     */
+    public BigQuaternion getR() {
+        return or;
+    }
+
+
+    /**
+     * Get the oi part.
+     * @return oi.
+     */
+    public BigQuaternion getI() {
+        return oi;
+    }
+
+
+    /**
+     * Get the string representation. Is compatible with the string constructor.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        String s = or.toString();
+        boolean i = oi.isZERO();
+        if (debug) {
+            logger.debug("compareTo " + i + " ? 0 = " + oi);
+        }
+        if (i) {
+            return s;
+        }
+        s += "o" + oi;
+        return s;
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        boolean i = oi.isZERO();
+        if (i && or.isZERO()) {
+            return "0 ";
+        }
+        StringBuffer s = new StringBuffer();
+        if (!or.isZERO()) {
+            String rs = or.toScript();
+            rs = rs.replaceAll("Q", "OR");
+            s.append(rs);
+            s.append(" ");
+        }
+        if (!i) {
+            if (s.length() > 0) {
+                s.append("+ ");
+            }
+            String is = oi.toScript();
+            is = is.replaceAll("Q", "OI");
+            s.append(is);
+        }
+        return s.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python case
+        return "Oct()";
+    }
+
+
+    /**
+     * Is Octonion number zero.
+     * @param A BigOctonion.
+     * @return true if A is 0, else false.
+     */
+    public static boolean isOZERO(BigOctonion A) {
+        if (A == null)
+            return false;
+        return A.isZERO();
+    }
+
+
+    /**
+     * Is BigOctonion number zero.
+     * @return true if this is 0, else false.
+     * @see edu.jas.structure.RingElem#isZERO()
+     */
+    public boolean isZERO() {
+        return or.isZERO() && oi.isZERO();
+    }
+
+
+    /**
+     * Is BigOctonion number one.
+     * @param A is a quaternion number.
+     * @return true if A is 1, else false.
+     */
+    public static boolean isOONE(BigOctonion A) {
+        if (A == null)
+            return false;
+        return A.isONE();
+    }
+
+
+    /**
+     * Is BigOctonion number one.
+     * @see edu.jas.structure.RingElem#isONE()
+     * @return true if this is 1, else false.
+     */
+    public boolean isONE() {
+        return or.isONE() && oi.isZERO();
+    }
+
+
+    /**
+     * Is BigOctonion imaginary one.
+     * @return true if this is i, else false.
+     */
+    public boolean isIMAG() {
+        return or.isZERO() && oi.isONE();
+    }
+
+
+    /**
+     * Is BigOctonion unit element.
+     * @return If this is a unit then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isUnit()
+     */
+    public boolean isUnit() {
+        return !isZERO();
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object b) {
+        if (!(b instanceof BigOctonion))
+            return false;
+        BigOctonion B = (BigOctonion) b;
+        return or.equals(B.or) && oi.equals(B.oi);
+    }
+
+
+    /**
+     * Hash code for this BigOctonion.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h = 41 * or.hashCode();
+        h += oi.hashCode();
+        return h;
+    }
+
+
+    /**
+     * Since quaternion numbers are unordered, we use lexicographical order of
+     * re, im, jm and km.
+     * @param b BigOctonion.
+     * @return 0 if b is equal to this, 1 if this is greater b and -1 else.
+     */
+    @Override
+    public int compareTo(BigOctonion b) {
+        int s = or.compareTo(b.or);
+        if (s != 0) {
+            return s;
+        }
+        return oi.compareTo(b.oi);
+    }
+
+
+    /**
+     * Since quaternion numbers are unordered, we use lexicographical order of
+     * re, im, jm and km.
+     * @return 0 if this is equal to 0; 1 if or &gt; 0, or or == 0 and oi &gt;
+     *         0; -1 if or &lt; 0, or or == 0 and oi &lt; 0.
+     * @see edu.jas.structure.RingElem#signum()
+     */
+    public int signum() {
+        int s = or.signum();
+        if (s != 0) {
+            return s;
+        }
+        return oi.signum();
+    }
+
+
+    /* arithmetic operations: +, -, -
+     */
+
+    /**
+     * BigOctonion summation.
+     * @param B BigOctonion.
+     * @return this+B.
+     */
+    public BigOctonion sum(BigOctonion B) {
+        return new BigOctonion(or.sum(B.or), oi.sum(B.oi));
+    }
+
+
+    /**
+     * Octonion number sum.
+     * @param A BigOctonion.
+     * @param B BigOctonion.
+     * @return A+B.
+     */
+    public static BigOctonion OSUM(BigOctonion A, BigOctonion B) {
+        if (A == null)
+            return null;
+        return A.sum(B);
+    }
+
+
+    /**
+     * Octonion number difference.
+     * @param A BigOctonion.
+     * @param B BigOctonion.
+     * @return A-B.
+     */
+    public static BigOctonion ODIF(BigOctonion A, BigOctonion B) {
+        if (A == null)
+            return null;
+        return A.subtract(B);
+    }
+
+
+    /**
+     * BigOctonion subtraction.
+     * @param B BigOctonion.
+     * @return this-B.
+     */
+    public BigOctonion subtract(BigOctonion B) {
+        return new BigOctonion(or.subtract(B.or), oi.subtract(B.oi));
+    }
+
+
+    /**
+     * Octonion number negative.
+     * @param A is a octonion number
+     * @return -A.
+     */
+    public static BigOctonion ONEG(BigOctonion A) {
+        if (A == null)
+            return null;
+        return A.negate();
+    }
+
+
+    /**
+     * BigOctonion number negative.
+     * @return -this.
+     * @see edu.jas.structure.RingElem#negate()
+     */
+    public BigOctonion negate() {
+        return new BigOctonion(or.negate(), oi.negate());
+    }
+
+
+    /**
+     * Octonion number conjugate.
+     * @param A is a quaternion number.
+     * @return the quaternion conjugate of A.
+     */
+    public static BigOctonion OCON(BigOctonion A) {
+        if (A == null)
+            return null;
+        return A.conjugate();
+    }
+
+
+    /* arithmetic operations: conjugate, absolute value 
+     */
+
+    /**
+     * BigOctonion conjugate.
+     * @return conjugate(this).
+     */
+    public BigOctonion conjugate() {
+        return new BigOctonion(or.conjugate(), oi.negate());
+    }
+
+
+    /**
+     * Octonion number norm.
+     * @see edu.jas.structure.StarRingElem#norm()
+     * @return ||this||.
+     */
+    public BigOctonion norm() {
+        // this.multiply(this.conjugate());
+        BigQuaternion v = or.norm();
+        v = v.sum(oi.norm());
+        return new BigOctonion(v);
+    }
+
+
+    /**
+     * Octonion number absolute value.
+     * @see edu.jas.structure.RingElem#abs()
+     * @return |this|.
+     */
+    public BigOctonion abs() {
+        BigOctonion n = norm();
+        BigRational r = Roots.sqrt(n.or.re);
+        //logger.error("abs() square root missing");
+        return new BigOctonion(new BigQuaternion(n.or.ring, r));
+    }
+
+
+    /**
+     * Octonion number absolute value.
+     * @param A is a quaternion number.
+     * @return the absolute value of A, a rational number. Note: The square root
+     *         is not jet implemented.
+     */
+    public static BigRational OABS(BigOctonion A) {
+        if (A == null)
+            return null;
+        return A.abs().or.re;
+    }
+
+
+    /**
+     * Octonion number product.
+     * @param A BigOctonion.
+     * @param B BigOctonion.
+     * @return A*B.
+     */
+    public static BigOctonion OPROD(BigOctonion A, BigOctonion B) {
+        if (A == null)
+            return null;
+        return A.multiply(B);
+    }
+
+
+    /* arithmetic operations: *, inverse, / 
+     */
+
+    /**
+     * BigOctonion multiply.
+     * @param B BigOctonion.
+     * @return this*B.
+     */
+    public BigOctonion multiply(BigOctonion B) {
+        // (r1,i1)(r2,i2) = ( r1 r2 - i2 i1^, r1^ i2 + r2 i1 ) Baez, jas
+        // (r1,i1)(r2,i2) = ( r1 r2 - i2^ i1, i1 r2^ + i2 r1 ) Dieudonne, mas
+        BigQuaternion r = or.multiply(B.or);
+        r = r.subtract(B.oi.multiply(oi.conjugate()));
+        BigQuaternion i = or.conjugate().multiply(B.oi);
+        i = i.sum(B.or.multiply(oi));
+        return new BigOctonion(r, i);
+    }
+
+
+    /**
+     * Octonion number inverse.
+     * @param A is a non-zero quaternion number.
+     * @return S with S * A = 1.
+     */
+    public static BigOctonion OINV(BigOctonion A) {
+        if (A == null)
+            return null;
+        return A.inverse();
+    }
+
+
+    /**
+     * BigOctonion inverse.
+     * @return S with S * this = 1.
+     * @see edu.jas.structure.RingElem#inverse()
+     */
+    public BigOctonion inverse() {
+        BigRational a = norm().or.re;
+        return conjugate().divide(a);
+    }
+
+
+    /**
+     * BigOctonion remainder.
+     * @param S BigOctonion.
+     * @return 0.
+     */
+    public BigOctonion remainder(BigOctonion S) {
+        if (S.isZERO()) {
+            throw new ArithmeticException("division by zero");
+        }
+        return ZERO;
+    }
+
+
+    /**
+     * Octonion number quotient.
+     * @param A BigOctonion.
+     * @param B BigOctonion.
+     * @return R/S.
+     */
+    public static BigOctonion OQ(BigOctonion A, BigOctonion B) {
+        if (A == null)
+            return null;
+        return A.divide(B);
+    }
+
+
+    /**
+     * BigOctonion divide.
+     * @param b BigOctonion.
+     * @return this * b**(-1).
+     */
+    public BigOctonion divide(BigOctonion b) {
+        return rightDivide(b);
+    }
+
+
+    /**
+     * BigOctonion right divide.
+     * @param b BigOctonion.
+     * @return this * b**(-1).
+     */
+    public BigOctonion rightDivide(BigOctonion b) {
+        return this.multiply(b.inverse());
+    }
+
+
+    /**
+     * BigOctonion left divide.
+     * @param b BigOctonion.
+     * @return b**(-1) * this.
+     */
+    public BigOctonion leftDivide(BigOctonion b) {
+        return b.inverse().multiply(this);
+    }
+
+
+    /**
+     * BigOctonion divide.
+     * @param b BigRational.
+     * @return this/b.
+     */
+    public BigOctonion divide(BigRational b) {
+        BigRational bi = b.inverse();
+        return new BigOctonion(or.multiply(bi), oi.multiply(bi));
+    }
+
+
+    /**
+     * Quotient and remainder by division of this by S.
+     * @param S a octonion number
+     * @return [this/S, this - (this/S)*S].
+     */
+    public BigOctonion[] quotientRemainder(BigOctonion S) {
+        return new BigOctonion[] { divide(S), ZERO };
+    }
+
+
+    /**
+     * BigOctonion random. Random rational numbers A, B, C and D are generated
+     * using random(n). Then R is the quaternion number with real part A and
+     * imaginary parts B, C and D.
+     * @param n such that 0 &le; A, B, C, D &le; (2<sup>n</sup>-1).
+     * @return R, a random BigOctonion.
+     */
+    public BigOctonion random(int n) {
+        return random(n, random);
+    }
+
+
+    /**
+     * BigOctonion random. Random rational numbers A, B, C and D are generated
+     * using RNRAND(n). Then R is the quaternion number with real part A and
+     * imaginary parts B, C and D.
+     * @param n such that 0 &le; A, B, C, D &le; (2<sup>n</sup>-1).
+     * @param rnd is a source for random bits.
+     * @return R, a random BigOctonion.
+     */
+    public BigOctonion random(int n, Random rnd) {
+        BigQuaternion rr = or.ring.random(n, rnd);
+        BigQuaternion ir = oi.ring.random(n, rnd);
+        return new BigOctonion(rr, ir);
+    }
+
+
+    /*
+     * Octonion number, random. Random rational numbers A, B, C and D are
+     * generated using RNRAND(n). Then R is the quaternion number with real part
+     * A and imaginary parts B, C and D.
+     * @param n such that 0 &le; A, B, C, D &le; (2<sup>n</sup>-1).
+     * @return R, a random BigOctonion.
+    public static BigOctonion ORAND(int n) {
+        return random(n, random);
+    }
+    */
+
+    /**
+     * Parse quaternion number from String.
+     * @param s String.
+     * @return BigOctonion from s.
+     */
+    public BigOctonion parse(String s) {
+        return new BigOctonion(or.ring, s);
+    }
+
+
+    /**
+     * Parse quaternion number from Reader.
+     * @param r Reader.
+     * @return next BigOctonion from r.
+     */
+    public BigOctonion parse(Reader r) {
+        return parse(StringUtil.nextString(r));
+    }
+
+
+    /**
+     * Octonion number greatest common divisor.
+     * @param S BigOctonion.
+     * @return gcd(this,S).
+     */
+    public BigOctonion gcd(BigOctonion S) {
+        if (S == null || S.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return S;
+        }
+        return ONE;
+    }
+
+
+    /**
+     * BigOctonion extended greatest common divisor.
+     * @param S BigOctonion.
+     * @return [ gcd(this,S), a, b ] with a*this + b*S = gcd(this,S).
+     */
+    public BigOctonion[] egcd(BigOctonion S) {
+        BigOctonion[] ret = new BigOctonion[3];
+        ret[0] = null;
+        ret[1] = null;
+        ret[2] = null;
+        if (S == null || S.isZERO()) {
+            ret[0] = this;
+            return ret;
+        }
+        if (this.isZERO()) {
+            ret[0] = S;
+            return ret;
+        }
+        BigOctonion half = new BigOctonion(or.ring, new BigRational(1, 2));
+        ret[0] = ONE;
+        ret[1] = this.inverse().multiply(half);
+        ret[2] = S.inverse().multiply(half);
+        return ret;
+    }
+
+
+    /**
+     * Returns the number of bits in the representation of this BigOctonion,
+     * including a sign bit. It is equivalent to
+     * {@code or.bitLength() + oi.bitLength()}.)
+     * @return number of bits in the representation of this BigOctonion,
+     *         including a sign bit.
+     */
+    public long bitLength() {
+        return or.bitLength() + oi.bitLength();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/BigQuaternion.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/BigQuaternion.java
@@ -1,0 +1,1021 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.arith;
+
+
+import java.util.List;
+import java.util.Random;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.StarRingElem;
+
+
+/**
+ * BigQuaternion class based on BigRational implementing the RingElem interface
+ * and with the familiar MAS static method names. Objects of this class are
+ * immutable. The integer quaternion methods are implemented after
+ * https://de.wikipedia.org/wiki/Hurwitzquaternion see also
+ * https://en.wikipedia.org/wiki/Hurwitz_quaternion
+ * @author Heinz Kredel
+ */
+
+public /*final*/ class BigQuaternion implements StarRingElem<BigQuaternion>, GcdRingElem<BigQuaternion> {
+
+
+    /**
+     * Real part of the data structure.
+     */
+    public final BigRational re; // real part
+
+
+    /**
+     * Imaginary part i of the data structure.
+     */
+    public final BigRational im; // i imaginary part
+
+
+    /**
+     * Imaginary part j of the data structure.
+     */
+    public final BigRational jm; // j imaginary part
+
+
+    /**
+     * Imaginary part k of the data structure.
+     */
+    public final BigRational km; // k imaginary part
+
+
+    /**
+     * Corresponding BigQuaternion ring.
+     */
+    public final BigQuaternionRing ring;
+
+
+    protected final static Random random = new Random();
+
+
+    private static final Logger logger = LogManager.getLogger(BigQuaternion.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor for a BigQuaternion from BigRationals.
+     * @param fac BigQuaternionRing.
+     * @param r BigRational.
+     * @param i BigRational.
+     * @param j BigRational.
+     * @param k BigRational.
+     */
+    public BigQuaternion(BigQuaternionRing fac, BigRational r, BigRational i, BigRational j, BigRational k) {
+        ring = fac;
+        re = r;
+        im = i;
+        jm = j;
+        km = k;
+    }
+
+
+    /**
+     * Constructor for a BigQuaternion from BigRationals.
+     * @param fac BigQuaternionRing.
+     * @param r BigRational.
+     * @param i BigRational.
+     * @param j BigRational.
+     */
+    public BigQuaternion(BigQuaternionRing fac, BigRational r, BigRational i, BigRational j) {
+        this(fac, r, i, j, BigRational.ZERO);
+    }
+
+
+    /**
+     * Constructor for a BigQuaternion from BigRationals.
+     * @param fac BigQuaternionRing.
+     * @param r BigRational.
+     * @param i BigRational.
+     */
+    public BigQuaternion(BigQuaternionRing fac, BigRational r, BigRational i) {
+        this(fac, r, i, BigRational.ZERO);
+    }
+
+
+    /**
+     * Constructor for a BigQuaternion from BigRationals.
+     * @param fac BigQuaternionRing.
+     * @param r BigRational.
+     */
+    public BigQuaternion(BigQuaternionRing fac, BigRational r) {
+        this(fac, r, BigRational.ZERO);
+    }
+
+
+    /**
+     * Constructor for a BigQuaternion from BigComplex.
+     * @param fac BigQuaternionRing.
+     * @param r BigComplex.
+     */
+    public BigQuaternion(BigQuaternionRing fac, BigComplex r) {
+        this(fac, r.re, r.im);
+    }
+
+
+    /**
+     * Constructor for a BigQuaternion from long.
+     * @param fac BigQuaternionRing.
+     * @param r long.
+     */
+    public BigQuaternion(BigQuaternionRing fac, long r) {
+        this(fac, new BigRational(r), BigRational.ZERO);
+    }
+
+
+    /**
+     * Constructor for a BigQuaternion with no arguments.
+     * @param fac BigQuaternionRing.
+     */
+    public BigQuaternion(BigQuaternionRing fac) {
+        this(fac, BigRational.ZERO);
+    }
+
+
+    /**
+     * The BigQuaternion string constructor accepts the following formats: empty
+     * string, "rational", or "rat i rat j rat k rat" with no blanks around i, j
+     * or k if used as polynoial coefficient.
+     * @param fac BigQuaternionRing.
+     * @param s String.
+     * @throws NumberFormatException
+     */
+    public BigQuaternion(BigQuaternionRing fac, String s) throws NumberFormatException {
+        ring = fac;
+        if (s == null || s.length() == 0) {
+            re = BigRational.ZERO;
+            im = BigRational.ZERO;
+            jm = BigRational.ZERO;
+            km = BigRational.ZERO;
+            return;
+        }
+        //System.out.println("init: s = " + s);
+        s = s.trim();
+        int r = s.indexOf("i") + s.indexOf("j") + s.indexOf("k");
+        if (r == -3) {
+            re = new BigRational(s);
+            im = BigRational.ZERO;
+            jm = BigRational.ZERO;
+            km = BigRational.ZERO;
+            return;
+        }
+
+        s = s.replaceAll("~", "-"); // when used with GenPolynomialTokenizer
+        int i = s.indexOf("i");
+        String sr = "";
+        if (i > 0) {
+            sr = s.substring(0, i);
+        } else if (i < 0) {
+            throw new NumberFormatException("BigQuaternion missing i: " + s);
+        }
+        String si = "";
+        if (i < s.length()) {
+            s = s.substring(i + 1, s.length());
+        }
+        int j = s.indexOf("j");
+        if (j > 0) {
+            si = s.substring(0, j);
+        } else if (j < 0) {
+            throw new NumberFormatException("BigQuaternion missing j: " + s);
+        }
+        String sj = "";
+        if (j < s.length()) {
+            s = s.substring(j + 1, s.length());
+        }
+        int k = s.indexOf("k");
+        if (k > 0) {
+            sj = s.substring(0, k);
+        } else if (k < 0) {
+            throw new NumberFormatException("BigQuaternion missing k: " + s);
+        }
+        String sk = "";
+        if (k < s.length()) {
+            s = s.substring(k + 1, s.length());
+        }
+        sk = s;
+
+        re = new BigRational(sr.trim());
+        im = new BigRational(si.trim());
+        jm = new BigRational(sj.trim());
+        km = new BigRational(sk.trim());
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public BigQuaternionRing factory() {
+        return ring;
+    }
+
+
+    /**
+     * Clone this.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public BigQuaternion copy() {
+        return new BigQuaternion(ring, re, im, jm, km);
+    }
+
+
+    /**
+     * Get the real part.
+     * @return re.
+     */
+    public BigRational getRe() {
+        return re;
+    }
+
+
+    /**
+     * Get the imaginary part im.
+     * @return im.
+     */
+    public BigRational getIm() {
+        return im;
+    }
+
+
+    /**
+     * Get the imaginary part jm.
+     * @return jm.
+     */
+    public BigRational getJm() {
+        return jm;
+    }
+
+
+    /**
+     * Get the imaginary part km.
+     * @return km.
+     */
+    public BigRational getKm() {
+        return km;
+    }
+
+
+    /**
+     * Get the string representation. Is compatible with the string constructor.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer(re.toString());
+        int i = im.compareTo(BigRational.ZERO);
+        int j = jm.compareTo(BigRational.ZERO);
+        int k = km.compareTo(BigRational.ZERO);
+        if (debug) {
+            logger.debug("compareTo " + im + " ? 0 = " + i);
+            logger.debug("compareTo " + jm + " ? 0 = " + j);
+            logger.debug("compareTo " + km + " ? 0 = " + k);
+        }
+        if (i == 0 && j == 0 && k == 0) {
+            return sb.toString();
+        }
+        sb.append("i" + im);
+        sb.append("j" + jm);
+        sb.append("k" + km);
+        String s = sb.toString();
+        //s = s.replaceAll("-","~"); 
+        return s;
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        StringBuffer s = new StringBuffer();
+        boolean i = im.isZERO();
+        boolean j = jm.isZERO();
+        boolean k = km.isZERO();
+        if (i && j && k) {
+            if (re.isZERO()) {
+                return "0 ";
+            }
+            if (!re.isONE()) {
+                s.append(re.toScript() + "*");
+            }
+            s.append("oneQ ");
+            return s.toString();
+        }
+        if (!re.isZERO()) {
+            if (!re.isONE()) {
+                s.append(re.toScript() + "*");
+            }
+            s.append("oneQ ");
+        }
+        if (!i) {
+            if (s.length() > 0) {
+                s.append("+ ");
+            }
+            if (!im.isONE()) {
+                s.append(im.toScript() + "*");
+            }
+            s.append("IQ ");
+        }
+        if (!j) {
+            if (s.length() > 0) {
+                s.append("+ ");
+            }
+            if (!jm.isONE()) {
+                s.append(jm.toScript() + "*");
+            }
+            s.append("JQ ");
+        }
+        if (!k) {
+            if (s.length() > 0) {
+                s.append("+ ");
+            }
+            if (!km.isONE()) {
+                s.append(km.toScript() + "*");
+            }
+            s.append("KQ ");
+        }
+        return s.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python case
+        return ring.toScript();
+    }
+
+
+    /**
+     * Is Quaternion number zero.
+     * @param A BigQuaternion.
+     * @return true if A is 0, else false.
+     */
+    public static boolean isQZERO(BigQuaternion A) {
+        if (A == null)
+            return false;
+        return A.isZERO();
+    }
+
+
+    /**
+     * Is BigQuaternion number zero.
+     * @return true if this is 0, else false.
+     * @see edu.jas.structure.RingElem#isZERO()
+     */
+    public boolean isZERO() {
+        return re.isZERO() && im.isZERO() && jm.isZERO() && km.isZERO();
+    }
+
+
+    /**
+     * Is BigQuaternion number one.
+     * @param A is a quaternion number.
+     * @return true if A is 1, else false.
+     */
+    public static boolean isQONE(BigQuaternion A) {
+        if (A == null)
+            return false;
+        return A.isONE();
+    }
+
+
+    /**
+     * Is BigQuaternion number one.
+     * @see edu.jas.structure.RingElem#isONE()
+     * @return true if this is 1, else false.
+     */
+    public boolean isONE() {
+        return re.isONE() && im.isZERO() && jm.isZERO() && km.isZERO();
+    }
+
+
+    /**
+     * Is BigQuaternion imaginary one.
+     * @return true if this is i, else false.
+     */
+    public boolean isIMAG() {
+        return re.isZERO() && im.isONE() && jm.isZERO() && km.isZERO();
+    }
+
+
+    /**
+     * Is BigQuaternion unit element.
+     * @return If this is a unit then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isUnit()
+     */
+    public boolean isUnit() {
+        //if (ring.integral) { not meaningful to test
+        //    System.out.println("*** entier isUnit case not implemented ***");
+        //}
+        return !isZERO();
+    }
+
+
+    /**
+     * Is BigQuaternion entier element.
+     * @return If this is an integer Hurwitz element then true is returned, else
+     *         false.
+     */
+    public boolean isEntier() {
+        if (re.isEntier() && im.isEntier() && jm.isEntier() && km.isEntier()) {
+            return true;
+        }
+        java.math.BigInteger TWO = BigInteger.TWO.val;
+        return re.den.equals(TWO) && im.den.equals(TWO) && jm.den.equals(TWO) && km.den.equals(TWO);
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object b) {
+        if (!(b instanceof BigQuaternion)) {
+            return false;
+        }
+        BigQuaternion B = (BigQuaternion) b;
+        // ring == B.ring ?
+        return re.equals(B.re) && im.equals(B.im) && jm.equals(B.jm) && km.equals(B.km);
+    }
+
+
+    /**
+     * Hash code for this BigQuaternion.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h = re.hashCode();
+        h += h * 37 + im.hashCode();
+        h += h * 37 + jm.hashCode();
+        h += h * 37 + km.hashCode();
+        return h;
+    }
+
+
+    /**
+     * Since quaternion numbers are unordered, we use lexicographical order of
+     * re, im, jm and km.
+     * @param b BigQuaternion.
+     * @return 0 if b is equal to this, 1 if this is greater b and -1 else.
+     */
+    @Override
+    public int compareTo(BigQuaternion b) {
+        int s = re.compareTo(b.re);
+        if (s != 0) {
+            return s;
+        }
+        s = im.compareTo(b.im);
+        if (s != 0) {
+            return s;
+        }
+        s = jm.compareTo(b.jm);
+        if (s != 0) {
+            return s;
+        }
+        return km.compareTo(b.km);
+    }
+
+
+    /**
+     * Since quaternion numbers are unordered, we use lexicographical order of
+     * re, im, jm and km.
+     * @return 0 if this is equal to 0; 1 if re &gt; 0, or re == 0 and im &gt;
+     *         0, or ...; -1 if re &lt; 0, or re == 0 and im &lt; 0, or ...
+     * @see edu.jas.structure.RingElem#signum()
+     */
+    public int signum() {
+        int s = re.signum();
+        if (s != 0) {
+            return s;
+        }
+        s = im.signum();
+        if (s != 0) {
+            return s;
+        }
+        s = jm.signum();
+        if (s != 0) {
+            return s;
+        }
+        return km.signum();
+    }
+
+
+    /* arithmetic operations: +, -, -
+     */
+
+    /**
+     * BigQuaternion summation.
+     * @param B BigQuaternion.
+     * @return this+B.
+     */
+    public BigQuaternion sum(BigQuaternion B) {
+        return new BigQuaternion(ring, re.sum(B.re), im.sum(B.im), jm.sum(B.jm), km.sum(B.km));
+    }
+
+
+    /**
+     * Quaternion number sum.
+     * @param A BigQuaternion.
+     * @param B BigQuaternion.
+     * @return A+B.
+     */
+    public static BigQuaternion QSUM(BigQuaternion A, BigQuaternion B) {
+        if (A == null)
+            return null;
+        return A.sum(B);
+    }
+
+
+    /**
+     * Quaternion number difference.
+     * @param A BigQuaternion.
+     * @param B BigQuaternion.
+     * @return A-B.
+     */
+    public static BigQuaternion QDIF(BigQuaternion A, BigQuaternion B) {
+        if (A == null)
+            return null;
+        return A.subtract(B);
+    }
+
+
+    /**
+     * BigQuaternion subtraction.
+     * @param B BigQuaternion.
+     * @return this-B.
+     */
+    public BigQuaternion subtract(BigQuaternion B) {
+        return new BigQuaternion(ring, re.subtract(B.re), im.subtract(B.im), jm.subtract(B.jm),
+                        km.subtract(B.km));
+    }
+
+
+    /**
+     * Quaternion number negative.
+     * @param A is a quaternion number
+     * @return -A.
+     */
+    public static BigQuaternion QNEG(BigQuaternion A) {
+        if (A == null)
+            return null;
+        return A.negate();
+    }
+
+
+    /**
+     * BigQuaternion number negative.
+     * @return -this.
+     * @see edu.jas.structure.RingElem#negate()
+     */
+    public BigQuaternion negate() {
+        return new BigQuaternion(ring, re.negate(), im.negate(), jm.negate(), km.negate());
+    }
+
+
+    /**
+     * Quaternion number conjugate.
+     * @param A is a quaternion number.
+     * @return the quaternion conjugate of A.
+     */
+    public static BigQuaternion QCON(BigQuaternion A) {
+        if (A == null)
+            return null;
+        return A.conjugate();
+    }
+
+
+    /* arithmetic operations: conjugate, absolute value 
+     */
+
+    /**
+     * BigQuaternion conjugate.
+     * @return conjugate(this).
+     */
+    public BigQuaternion conjugate() {
+        return new BigQuaternion(ring, re, im.negate(), jm.negate(), km.negate());
+    }
+
+
+    /**
+     * Quaternion number norm.
+     * @see edu.jas.structure.StarRingElem#norm()
+     * @return ||this||.
+     */
+    public BigQuaternion norm() {
+        // this.multiply(this.conjugate());
+        BigRational v = re.multiply(re);
+        v = v.sum(im.multiply(im));
+        v = v.sum(jm.multiply(jm));
+        v = v.sum(km.multiply(km));
+        return new BigQuaternion(ring, v);
+    }
+
+
+    /**
+     * Quaternion number absolute value.
+     * @see edu.jas.structure.RingElem#abs()
+     * @return |this|.
+     */
+    public BigQuaternion abs() {
+        BigQuaternion n = norm();
+        BigRational r = Roots.sqrt(n.re);
+        //logger.error("abs() square root missing");
+        return new BigQuaternion(ring, r);
+    }
+
+
+    /**
+     * Quaternion number absolute value.
+     * @param A is a quaternion number.
+     * @return the absolute value of A, a rational number. Note: The square root
+     *         is not jet implemented.
+     */
+    public static BigRational QABS(BigQuaternion A) {
+        if (A == null)
+            return null;
+        return A.abs().re;
+    }
+
+
+    /**
+     * Quaternion number product.
+     * @param A BigQuaternion.
+     * @param B BigQuaternion.
+     * @return A*B.
+     */
+    public static BigQuaternion QPROD(BigQuaternion A, BigQuaternion B) {
+        if (A == null)
+            return null;
+        return A.multiply(B);
+    }
+
+
+    /* arithmetic operations: *, inverse, / 
+     */
+
+    /**
+     * BigQuaternion multiply with BigRational.
+     * @param b BigRational.
+     * @return this*b.
+     */
+    public BigQuaternion multiply(BigRational b) {
+        BigRational r = re.multiply(b);
+        BigRational i = im.multiply(b);
+        BigRational j = jm.multiply(b);
+        BigRational k = km.multiply(b);
+        return new BigQuaternion(ring, r, i, j, k);
+    }
+
+
+    /**
+     * BigQuaternion multiply.
+     * @param B BigQuaternion.
+     * @return this*B.
+     */
+    public BigQuaternion multiply(BigQuaternion B) {
+        BigRational r = re.multiply(B.re);
+        r = r.subtract(im.multiply(B.im));
+        r = r.subtract(jm.multiply(B.jm));
+        r = r.subtract(km.multiply(B.km));
+
+        BigRational i = re.multiply(B.im);
+        i = i.sum(im.multiply(B.re));
+        i = i.sum(jm.multiply(B.km));
+        i = i.subtract(km.multiply(B.jm));
+
+        BigRational j = re.multiply(B.jm);
+        j = j.subtract(im.multiply(B.km));
+        j = j.sum(jm.multiply(B.re));
+        j = j.sum(km.multiply(B.im));
+
+        BigRational k = re.multiply(B.km);
+        k = k.sum(im.multiply(B.jm));
+        k = k.subtract(jm.multiply(B.im));
+        k = k.sum(km.multiply(B.re));
+
+        return new BigQuaternion(ring, r, i, j, k);
+    }
+
+
+    /**
+     * Quaternion number inverse.
+     * @param A is a non-zero quaternion number.
+     * @return S with S * A = A * S = 1.
+     */
+    public static BigQuaternion QINV(BigQuaternion A) {
+        if (A == null)
+            return null;
+        return A.inverse();
+    }
+
+
+    /**
+     * BigQuaternion inverse.
+     * @return S with S * this = this * S = 1.
+     * @see edu.jas.structure.RingElem#inverse()
+     */
+    public BigQuaternion inverse() {
+        BigRational a = norm().re.inverse();
+        return new BigQuaternion(ring, re.multiply(a), im.negate().multiply(a), jm.negate().multiply(a),
+                        km.negate().multiply(a));
+    }
+
+
+    /**
+     * BigQuaternion remainder.
+     * @param S BigQuaternion.
+     * @return 0.
+     */
+    public BigQuaternion remainder(BigQuaternion S) {
+        if (S.isZERO()) {
+            throw new ArithmeticException("division by zero");
+        }
+        if (ring.integral) {
+            //System.out.println(
+            //       "*** entier right remainder(" + this + ", " + S + "): " + ring + " ***");
+            BigQuaternionInteger c = new BigQuaternionInteger(ring, this);
+            BigQuaternionInteger d = new BigQuaternionInteger(ring, S);
+            return c.rightRemainder(d);
+        }
+        return ring.getZERO();
+    }
+
+
+    /**
+     * Quaternion number quotient.
+     * @param A BigQuaternion.
+     * @param B BigQuaternion.
+     * @return R/S.
+     */
+    public static BigQuaternion QQ(BigQuaternion A, BigQuaternion B) {
+        if (A == null)
+            return null;
+        return A.divide(B);
+    }
+
+
+    /**
+     * BigQuaternion right divide.
+     * @param b BigQuaternion.
+     * @return this * b**(-1).
+     */
+    public BigQuaternion divide(BigQuaternion b) {
+        return rightDivide(b);
+    }
+
+
+    /**
+     * BigQuaternion right divide.
+     * @param b BigQuaternion.
+     * @return this * b**(-1).
+     */
+    @Override
+    public BigQuaternion rightDivide(BigQuaternion b) {
+        if (ring.integral) {
+            //System.out.println("*** entier right divide(" + this + ", " + b + "): " + ring + " ***");
+            BigQuaternionInteger c = new BigQuaternionInteger(ring, this);
+            BigQuaternionInteger d = new BigQuaternionInteger(ring, b);
+            return c.rightDivide(d);
+        }
+        return this.multiply(b.inverse());
+    }
+
+
+    /**
+     * BigQuaternion left divide.
+     * @param b BigQuaternion.
+     * @return b**(-1) * this.
+     */
+    @Override
+    public BigQuaternion leftDivide(BigQuaternion b) {
+        if (ring.integral) {
+            //System.out.println("*** entier left divide(" + this + ", " + b + "): " + ring + " ***");
+            BigQuaternionInteger c = new BigQuaternionInteger(ring, this);
+            BigQuaternionInteger d = new BigQuaternionInteger(ring, b);
+            return c.leftDivide(d);
+        }
+        return b.inverse().multiply(this);
+    }
+
+
+    /**
+     * BigQuaternion divide.
+     * @param b BigRational.
+     * @return this/b.
+     */
+    public BigQuaternion divide(BigRational b) {
+        BigRational bi = b.inverse();
+        return new BigQuaternion(ring, re.multiply(bi), im.multiply(bi), jm.multiply(bi), km.multiply(bi));
+    }
+
+
+    /**
+     * Quotient and remainder by division of this by S.
+     * @param S a quaternion number
+     * @return [this*S**(-1), this - (this*S**(-1))*S].
+     */
+    public BigQuaternion[] quotientRemainder(BigQuaternion S) {
+        if (ring.integral) {
+            //System.out.println(
+            //     "*** entier left quotient remainder(" + this + ", " + S + "): " + ring + " ***");
+            BigQuaternionInteger c = new BigQuaternionInteger(ring, this);
+            BigQuaternionInteger d = new BigQuaternionInteger(ring, S);
+            return c.rightQuotientAndRemainder(d);
+        }
+        return new BigQuaternion[] { divide(S), ring.getZERO() };
+    }
+
+
+    /**
+     * Quaternion number greatest common divisor.
+     * @param S BigQuaternion.
+     * @return gcd(this,S).
+     */
+    public BigQuaternion gcd(BigQuaternion S) {
+        return leftGcd(S);
+    }
+
+
+    /**
+     * Quaternion number greatest common divisor.
+     * @param S BigQuaternion.
+     * @return leftCcd(this,S).
+     */
+    public BigQuaternion leftGcd(BigQuaternion S) {
+        if (S == null || S.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return S;
+        }
+        if (ring.integral) {
+            //System.out.println("*** entier left gcd(" + this + ", " + S + "): " + ring + " ***");
+            BigQuaternionInteger a = new BigQuaternionInteger(ring, this);
+            BigQuaternionInteger b = new BigQuaternionInteger(ring, S);
+            return a.leftGcd(b);
+        }
+        return ring.getONE();
+    }
+
+
+    /**
+     * Quaternion number greatest common divisor.
+     * @param S BigQuaternion.
+     * @return rightCcd(this,S).
+     */
+    public BigQuaternion rightGcd(BigQuaternion S) {
+        if (S == null || S.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return S;
+        }
+        if (ring.integral) {
+            //System.out.println("*** entier right gcd(" + this + ", " + S + "): " + ring + " ***");
+            BigQuaternionInteger a = new BigQuaternionInteger(ring, this);
+            BigQuaternionInteger b = new BigQuaternionInteger(ring, S);
+            return a.rightGcd(b);
+        }
+        return ring.getONE();
+    }
+
+
+    /**
+     * BigQuaternion extended greatest common divisor.
+     * @param S BigQuaternion.
+     * @return [ gcd(this,S), a, b ] with a*this + b*S = gcd(this,S).
+     */
+    public BigQuaternion[] egcd(BigQuaternion S) {
+        if (ring.integral) {
+            System.out.println("*** entier egcd case not implemented ***");
+        }
+        BigQuaternion[] ret = new BigQuaternion[3];
+        ret[0] = null;
+        ret[1] = null;
+        ret[2] = null;
+        if (S == null || S.isZERO()) {
+            ret[0] = this;
+            return ret;
+        }
+        if (this.isZERO()) {
+            ret[0] = S;
+            return ret;
+        }
+        BigQuaternion half = new BigQuaternion(ring, new BigRational(1, 2));
+        ret[0] = ring.getONE();
+        ret[1] = this.inverse().multiply(half);
+        ret[2] = S.inverse().multiply(half);
+        return ret;
+    }
+
+
+    /**
+     * Returns the number of bits in the representation of this BigQuaternion,
+     * including a sign bit. It is equivalent to
+     * {@code re.bitLength()+im.bitLength()+jm.bitLength()+km.bitLength()}.)
+     * @return number of bits in the representation of this BigQuaternion,
+     *         including a sign bit.
+     */
+    public long bitLength() {
+        return re.bitLength() + im.bitLength() + jm.bitLength() + km.bitLength();
+    }
+
+
+    /**
+     * BigQuaternion ceiling, component wise.
+     * @return ceiling of this.
+     */
+    public BigQuaternion ceil() {
+        BigRational r = new BigRational(re.ceil());
+        BigRational i = new BigRational(im.ceil());
+        BigRational j = new BigRational(jm.ceil());
+        BigRational k = new BigRational(km.ceil());
+        return new BigQuaternion(ring, r, i, j, k);
+    }
+
+
+    /**
+     * BigQuaternion floor, component wise.
+     * @return floor of this.
+     */
+    public BigQuaternion floor() {
+        BigRational r = new BigRational(re.floor());
+        BigRational i = new BigRational(im.floor());
+        BigRational j = new BigRational(jm.floor());
+        BigRational k = new BigRational(km.floor());
+        return new BigQuaternion(ring, r, i, j, k);
+    }
+
+
+    /**
+     * BigQuaternion round to next Lipschitz integer. BigQuaternion with all
+     * integer components.
+     * @return Lipschitz integer of this.
+     */
+    public BigQuaternionInteger roundToLipschitzian() {
+        BigRational half = BigRational.HALF;
+        BigRational r = new BigRational(re.sum(half).floor());
+        BigRational i = new BigRational(im.sum(half).floor());
+        BigRational j = new BigRational(jm.sum(half).floor());
+        BigRational k = new BigRational(km.sum(half).floor());
+        return new BigQuaternionInteger(ring, r, i, j, k);
+    }
+
+
+    /**
+     * BigQuaternion round to next Hurwitz integer. BigQuaternion with all
+     * integer or all 1/2 times integer components.
+     * @return Hurwitz integer near this.
+     */
+    public BigQuaternionInteger roundToHurwitzian() {
+        if (isEntier()) {
+            //System.out.println("*** short cut to round ***");
+            return new BigQuaternionInteger(ring, this);
+        }
+        BigQuaternionInteger g = this.roundToLipschitzian();
+        BigQuaternion d = ring.getZERO();
+        //BigRational half = BigRational.HALF;
+        BigQuaternion s = this.subtract(g).norm();
+        //System.out.println("s = " + s.toScript());
+        //if (s.re.compareTo(half) < 0) { // wrong
+        List<BigQuaternion> units = ring.unitsOfHurwitzian();
+        BigQuaternion t = null;
+        for (BigQuaternion ue : units) {
+            //t = this.subtract(g).sum(ue).norm(); // bug
+            t = this.subtract(g.sum(ue)).norm();
+            if (t.re.compareTo(s.re) < 0) {
+                s = t;
+                d = ue;
+            }
+        }
+        //System.out.println("ring = " + ring);
+        g = new BigQuaternionInteger(ring, g.sum(d));
+        return g;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/BigQuaternionInteger.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/BigQuaternionInteger.java
@@ -1,0 +1,447 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.arith;
+
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+
+/**
+ * Integer BigQuaternion class based on BigRational implementing the RingElem
+ * interface and with the familiar MAS static method names. Objects of this
+ * class are immutable. The integer quaternion methods are implemented after
+ * https://de.wikipedia.org/wiki/Hurwitzquaternion see also
+ * https://en.wikipedia.org/wiki/Hurwitz_quaternion
+ * @author Heinz Kredel
+ */
+
+public final class BigQuaternionInteger extends BigQuaternion
+// implements StarRingElem<BigQuaternion>, GcdRingElem<BigQuaternion> 
+{
+
+
+    private static final Logger logger = LogManager.getLogger(BigQuaternionInteger.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor for a BigQuaternion from BigRationals.
+     * @param fac BigQuaternionRing.
+     * @param r BigRational.
+     * @param i BigRational.
+     * @param j BigRational.
+     * @param k BigRational.
+     */
+    public BigQuaternionInteger(BigQuaternionRing fac, BigRational r, BigRational i, BigRational j,
+                    BigRational k) {
+        super(fac, r, i, j, k);
+    }
+
+
+    /**
+     * Constructor for a BigQuaternion from BigRationals.
+     * @param fac BigQuaternionRing.
+     * @param r BigRational.
+     * @param i BigRational.
+     * @param j BigRational.
+     */
+    public BigQuaternionInteger(BigQuaternionRing fac, BigRational r, BigRational i, BigRational j) {
+        this(fac, r, i, j, BigRational.ZERO);
+    }
+
+
+    /**
+     * Constructor for a BigQuaternion from BigRationals.
+     * @param fac BigQuaternionRing.
+     * @param r BigRational.
+     * @param i BigRational.
+     */
+    public BigQuaternionInteger(BigQuaternionRing fac, BigRational r, BigRational i) {
+        this(fac, r, i, BigRational.ZERO);
+    }
+
+
+    /**
+     * Constructor for a BigQuaternion from BigRationals.
+     * @param fac BigQuaternionRing.
+     * @param r BigRational.
+     */
+    public BigQuaternionInteger(BigQuaternionRing fac, BigRational r) {
+        this(fac, r, BigRational.ZERO);
+    }
+
+
+    /**
+     * Constructor for a BigQuaternion from BigComplex.
+     * @param fac BigQuaternionRing.
+     * @param r BigComplex.
+     */
+    public BigQuaternionInteger(BigQuaternionRing fac, BigComplex r) {
+        this(fac, r.re, r.im);
+    }
+
+
+    /**
+     * Constructor for a BigQuaternionInteger from BigQuaternion.
+     * @param fac BigQuaternionRing.
+     * @param q BigQuaternion.
+     */
+    public BigQuaternionInteger(BigQuaternionRing fac, BigQuaternion q) {
+        this(fac, q.re, q.im, q.jm, q.km);
+    }
+
+
+    /**
+     * Constructor for a BigQuaternion from long.
+     * @param fac BigQuaternionRing.
+     * @param r long.
+     */
+    public BigQuaternionInteger(BigQuaternionRing fac, long r) {
+        this(fac, new BigRational(r), BigRational.ZERO);
+    }
+
+
+    /**
+     * Constructor for a BigQuaternion with no arguments.
+     * @param fac BigQuaternionRing.
+     */
+    public BigQuaternionInteger(BigQuaternionRing fac) {
+        this(fac, BigRational.ZERO);
+    }
+
+
+    /**
+     * The BigQuaternion string constructor accepts the following formats: empty
+     * string, "rational", or "rat i rat j rat k rat" with no blanks around i, j
+     * or k if used as polynoial coefficient.
+     * @param fac BigQuaternionRing.
+     * @param s String.
+     * @throws NumberFormatException
+     */
+    public BigQuaternionInteger(BigQuaternionRing fac, String s) throws NumberFormatException {
+        super(fac, s);
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    @Override
+    public BigQuaternionRing factory() {
+        return ring;
+    }
+
+
+    /**
+     * Clone this.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public BigQuaternionInteger copy() {
+        return new BigQuaternionInteger(ring, re, im, jm, km);
+    }
+
+
+    /* arithmetic operations: +, -, -
+     */
+
+
+    /* arithmetic operations: *, inverse, / 
+     */
+
+
+    /**
+     * Quaternion number absolute value.
+     * @see edu.jas.structure.RingElem#abs()
+     * @return |this|**2. Note: returns the norm(this).
+     */
+    public BigQuaternion abs() {
+        BigQuaternion n = norm();
+        //BigRational r = Roots.sqrt(n.re);
+        logger.error("abs() square root missing");
+        return n;
+    }
+
+    
+    /**
+     * Quaternion number inverse.
+     * @param A is a non-zero quaternion number.
+     * @return S with S * A = A * S = 1.
+     */
+    public static BigQuaternion QINV(BigQuaternion A) {
+        if (A == null)
+            return null;
+        return A.inverse();
+    }
+
+
+    /**
+     * BigQuaternion inverse.
+     * @return S with S * this = this * S = 1.
+     * @see edu.jas.structure.RingElem#inverse()
+     */
+    @Override
+    public BigQuaternion inverse() {
+        if (!isUnit()) {
+            logger.info("ring = " + ring);
+            throw new ArithmeticException("not invertible: " + this);
+        }
+        return super.inverse();
+    }
+
+
+    /**
+     * BigQuaternion remainder.
+     * @param S BigQuaternion.
+     * @return this - this * b**(-1).
+     */
+    @Override
+    public BigQuaternion remainder(BigQuaternion S) {
+        return rightRemainder(S);
+    }
+
+
+    /**
+     * Quaternion number quotient.
+     * @param A BigQuaternion.
+     * @param B BigQuaternion.
+     * @return R * B**(-1).
+     */
+    public static BigQuaternion QQ(BigQuaternion A, BigQuaternion B) {
+        if (A == null)
+            return null;
+        return A.divide(B);
+    }
+
+
+    /**
+     * BigQuaternion right divide.
+     * @param b BigQuaternion.
+     * @return this * b**(-1).
+     */
+    @Override
+    public BigQuaternion divide(BigQuaternion b) {
+        return rightDivide(b);
+    }
+
+
+    /**
+     * BigQuaternion right divide.
+     * @param b BigQuaternion.
+     * @return this * b**(-1).
+     */
+    @Override
+    public BigQuaternion rightDivide(BigQuaternion b) {
+        return rightQuotientAndRemainder(b)[0];
+    }
+
+
+    /**
+     * BigQuaternion left divide.
+     * @param b BigQuaternion.
+     * @return b**(-1) * this.
+     */
+    @Override
+    public BigQuaternion leftDivide(BigQuaternion b) {
+        return leftQuotientAndRemainder(b)[0];
+    }
+
+
+    /**
+     * BigQuaternion divide.
+     * @param b BigRational.
+     * @return this/b.
+     */
+    @Override
+    public BigQuaternion divide(BigRational b) {
+        BigQuaternion d = super.divide(b);
+        if (!d.isEntier()) {
+            throw new ArithmeticException("not divisible: " + this + " / " + b);
+        }
+        return d;
+    }
+
+
+    /**
+     * Quotient and remainder by division of this by S.
+     * @param S a quaternion number
+     * @return [this*S**(-1), this - (this*S**(-1))*S].
+     */
+    @Override
+    public BigQuaternion[] quotientRemainder(BigQuaternion S) {
+        return new BigQuaternion[] { divide(S), remainder(S) };
+    }
+
+
+    /**
+     * Quaternion number greatest common divisor.
+     * @param S BigQuaternion.
+     * @return gcd(this,S).
+     */
+    @Override
+    public BigQuaternion gcd(BigQuaternion S) {
+        return rightGcd(S);
+    }
+
+
+    /**
+     * BigQuaternion extended greatest common divisor.
+     * @param S BigQuaternion.
+     * @return [ gcd(this,S), a, b ] with a*this + b*S = gcd(this,S).
+     */
+    @Override
+    public BigQuaternion[] egcd(BigQuaternion S) {
+        throw new UnsupportedOperationException("not implemented: egcd");
+        /*
+        BigQuaternion[] ret = new BigQuaternion[3];
+        ret[0] = null;
+        ret[1] = null;
+        ret[2] = null;
+        if (S == null || S.isZERO()) {
+           ret[0] = this;
+           return ret;
+        }
+        if (this.isZERO()) {
+           ret[0] = S;
+           return ret;
+        }
+        BigQuaternion half = new BigQuaternion(ring, new BigRational(1, 2));
+        ret[0] = ring.getONE();
+        ret[1] = this.inverse().multiply(half);
+        ret[2] = S.inverse().multiply(half);
+        return ret;
+        */
+    }
+
+
+    /**
+     * Integral quotient and remainder by left division of this by S. This must
+     * be also an integral (Hurwitz) quaternion number.
+     * @param b an integral (Hurwitz) quaternion number
+     * @return [round(b**(-1)) this, this - b * (round(b**(-1)) this)].
+     */
+    public BigQuaternion[] leftQuotientAndRemainder(BigQuaternion b) {
+        //System.out.println("left QR = " + this + ", " + b);
+        if (!this.isEntier() || !b.isEntier()) {
+            throw new IllegalArgumentException("entier elements required");
+        }
+        BigQuaternion bi = b.inverse();
+        BigQuaternion m = bi.multiply(this); // left divide
+        //System.out.println("m = " + m.toScript());
+        BigQuaternionInteger mh = m.roundToHurwitzian();
+        //System.out.println("mh = " + mh.toScript());
+        BigQuaternion n = this.subtract(b.multiply(mh));
+        BigQuaternion[] ret = new BigQuaternion[2];
+        ret[0] = mh;
+        ret[1] = n;
+        return ret;
+    }
+
+
+    /**
+     * Integral quotient and remainder by right division of this by S. This must
+     * be also an integral (Hurwitz) quaternion number.
+     * @param b an integral (Hurwitz) quaternion number
+     * @return [this round(b**(-1)), this - this (round(b**(-1)) b)].
+     */
+    public BigQuaternion[] rightQuotientAndRemainder(BigQuaternion b) {
+        //System.out.println("right QR = " + this + ", " + b);
+        if (!this.isEntier() || !b.isEntier()) {
+            throw new IllegalArgumentException("entier elements required");
+        }
+        BigQuaternion bi = b.inverse();
+        BigQuaternion m = this.multiply(bi); // right divide
+        //System.out.println("m = " + m.toScript());
+        BigQuaternionInteger mh = m.roundToHurwitzian();
+        //System.out.println("mh = " + mh.toScript());
+        BigQuaternion n = this.subtract(mh.multiply(b));
+        BigQuaternion[] ret = new BigQuaternion[2];
+        ret[0] = mh;
+        ret[1] = n;
+        return ret;
+    }
+
+
+    /**
+     * Left remainder.
+     * @param a element.
+     * @return r = this - (a/left) * a, where left * a = this.
+     */
+    @Override
+    public BigQuaternion leftRemainder(BigQuaternion a) {
+        return leftQuotientAndRemainder(a)[1];
+    }
+
+
+    /**
+     * Right remainder.
+     * @param a element.
+     * @return r = this - a * (a/right), where a * right = this.
+     */
+    @Override
+    public BigQuaternion rightRemainder(BigQuaternion a) {
+        return rightQuotientAndRemainder(a)[1];
+    }
+
+
+    /**
+     * Integer quaternion number left greatest common divisor.
+     * @param S integer BigQuaternion.
+     * @return leftGcd(this,S).
+     */
+    @Override
+    public BigQuaternion leftGcd(BigQuaternion S) {
+        if (S == null || S.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return S;
+        }
+        BigQuaternionInteger q;
+        BigQuaternion r;
+        q = this;
+        r = S;
+        while (!r.isZERO()) {
+            BigQuaternion u = q.leftQuotientAndRemainder(r)[1];
+            //System.out.println("u = " + u.toScript());
+            q = new BigQuaternionInteger(ring, r);
+            r = u;
+        }
+        return q;
+    }
+
+
+    /**
+     * Integer quaternion number right greatest common divisor.
+     * @param S integer BigQuaternion.
+     * @return rightGcd(this,S).
+     */
+    @Override
+    public BigQuaternion rightGcd(BigQuaternion S) {
+        if (S == null || S.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return S;
+        }
+        BigQuaternionInteger q;
+        BigQuaternion r;
+        q = this;
+        r = S;
+        while (!r.isZERO()) {
+            BigQuaternion u = q.rightQuotientAndRemainder(r)[1];
+            //System.out.println("u = " + u.toScript());
+            q = new BigQuaternionInteger(ring, r);
+            r = u;
+        }
+        return q;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/BigQuaternionRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/BigQuaternionRing.java
@@ -1,0 +1,377 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.arith;
+
+
+import java.io.Reader;
+// import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.kern.StringUtil;
+import edu.jas.kern.Scripting;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * BigQuaternion ring class based on BigRational implementing the RingElem
+ * interface.
+ * @author Heinz Kredel
+ */
+
+public final class BigQuaternionRing implements RingFactory<BigQuaternion> {
+
+
+    /**
+     * List of all 24 integral units.
+     */
+    static List<BigQuaternion> entierUnits = null; //later: unitsOfHurwitzian();
+
+
+    /**
+     * Flag to signal if this ring is integral.
+     */
+    protected boolean integral = false;
+
+
+    protected final static Random random = new Random();
+
+
+    private static final Logger logger = LogManager.getLogger(BigQuaternionRing.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor for a BigQuaternion ring.
+     */
+    public BigQuaternionRing() {
+        this(false);
+    }
+
+
+    /**
+     * Constructor for a BigQuaternion ring.
+     */
+    public BigQuaternionRing(boolean i) {
+        integral = i;
+        logger.info("integral = " + integral);
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     * @see edu.jas.structure.ElemFactory#generators()
+     */
+    public List<BigQuaternion> generators() {
+        List<BigQuaternion> g = new ArrayList<BigQuaternion>(4);
+        g.add(getONE());
+        g.add(I);
+        g.add(J);
+        g.add(K);
+        return g;
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite()
+     */
+    public boolean isFinite() {
+        return false;
+    }
+
+
+    /**
+     * Copy BigQuaternion element c.
+     * @param c BigQuaternion.
+     * @return a copy of c.
+     */
+    public BigQuaternion copy(BigQuaternion c) {
+        return new BigQuaternion(this, c.re, c.im, c.jm, c.km);
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as BigQuaternion.
+     */
+    public BigQuaternion getZERO() {
+        return ZERO;
+    }
+
+
+    /**
+     * Get the one element.
+     * @return q as BigQuaternion.
+     */
+    public BigQuaternion getONE() {
+        return ONE;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return false.
+     */
+    public boolean isCommutative() {
+        return false;
+    }
+
+
+    /**
+     * Query if this ring is associative.
+     * @return true.
+     */
+    public boolean isAssociative() {
+        return true;
+    }
+
+
+    /**
+     * Query if this ring is a field.
+     * @return true.
+     */
+    public boolean isField() {
+        return !integral;
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic() {
+        return java.math.BigInteger.ZERO;
+    }
+
+
+    /**
+     * Get a BigQuaternion element from a BigInteger.
+     * @param a BigInteger.
+     * @return a BigQuaternion.
+     */
+    public BigQuaternion fromInteger(java.math.BigInteger a) {
+        return new BigQuaternion(this, new BigRational(a));
+    }
+
+
+    /**
+     * Get a BigQuaternion element from a long.
+     * @param a long.
+     * @return a BigQuaternion.
+     */
+    public BigQuaternion fromInteger(long a) {
+        return new BigQuaternion(this, new BigRational(a));
+    }
+
+
+    /**
+     * Get a BigQuaternion element from a long vector.
+     * @param a long vector.
+     * @return a BigQuaternion.
+     */
+    public BigQuaternion fromInteger(long[] a) {
+        return new BigQuaternion(this, new BigRational(a[0]), new BigRational(a[1]), new BigRational(a[2]),
+                        new BigRational(a[3]));
+    }
+
+
+    /**
+     * The constant 0.
+     */
+    public final BigQuaternion ZERO = new BigQuaternion(this);
+
+
+    /**
+     * The constant 1.
+     */
+    public final BigQuaternion ONE = new BigQuaternion(this, BigRational.ONE);
+
+
+    /**
+     * The constant i.
+     */
+    public final BigQuaternion I = new BigQuaternion(this, BigRational.ZERO, BigRational.ONE);
+
+
+    /**
+     * The constant j.
+     */
+    public final BigQuaternion J = new BigQuaternion(this, BigRational.ZERO, BigRational.ZERO,
+                    BigRational.ONE);
+
+
+    /**
+     * The constant k.
+     */
+    public final BigQuaternion K = new BigQuaternion(this, BigRational.ZERO, BigRational.ZERO,
+                    BigRational.ZERO, BigRational.ONE);
+
+
+    /**
+     * Get the string representation. Is compatible with the string constructor.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        String s = "BigQuaternionRing(" + integral + ")";
+        return s;
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        StringBuffer s = new StringBuffer("Quat(");
+        switch (Scripting.getLang()) {
+        case Ruby:
+            s.append((integral ? "true" : "" ));
+            break;
+        case Python:
+        default:
+            s.append((integral ? "True" : "" ));
+        }
+        s.append(")");
+        return s.toString();
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object b) {
+        if (!(b instanceof BigQuaternionRing)) {
+            return false;
+        }
+        BigQuaternionRing B = (BigQuaternionRing) b;
+        return this.integral == B.integral;
+    }
+
+
+    /**
+     * Hash code for this BigQuaternionRing.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h = 4711;
+        return h;
+    }
+
+
+    /**
+     * BigQuaternion units of the Hurwitzian integers. BigQuaternion units with
+     * all integer or all 1/2 times integer components.
+     * @return list of all 24 units.
+     */
+    public List<BigQuaternion> unitsOfHurwitzian() {
+        if (entierUnits != null) {
+            return entierUnits;
+        }
+        BigRational half = BigRational.HALF;
+        // Lipschitz integer units
+        List<BigQuaternion> units = generators();
+        List<BigQuaternion> u = new ArrayList<BigQuaternion>(units);
+        for (BigQuaternion ue : u) {
+            units.add(ue.negate());
+        }
+        // Hurwitz integer units
+        long[][] comb = new long[][] { { 1, 1, 1, 1 }, { -1, 1, 1, 1 }, { 1, -1, 1, 1 }, { -1, -1, 1, 1 },
+                { 1, 1, -1, 1 }, { -1, 1, -1, 1 }, { 1, -1, -1, 1 }, { -1, -1, -1, 1 }, { 1, 1, 1, -1 },
+                { -1, 1, 1, -1 }, { 1, -1, 1, -1 }, { -1, -1, 1, -1 }, { 1, 1, -1, -1 }, { -1, 1, -1, -1 },
+                { 1, -1, -1, -1 }, { -1, -1, -1, -1 } };
+        for (long[] row : comb) {
+            BigQuaternion ue = fromInteger(row);
+            ue = ue.multiply(half);
+            units.add(ue);
+        }
+        //System.out.println("units = " + units);
+        //for (BigQuaternion ue : units) {
+        //System.out.println("unit = " + ue + ", norm = " + ue.norm());
+        //}
+        entierUnits = units;
+        return units;
+    }
+
+
+    /**
+     * BigQuaternion random. Random rational numbers A, B, C and D are generated
+     * using random(n). Then R is the quaternion number with real part A and
+     * imaginary parts B, C and D.
+     * @param n such that 0 &le; A, B, C, D &le; (2<sup>n</sup>-1).
+     * @return R, a random BigQuaternion.
+     */
+    public BigQuaternion random(int n) {
+        return random(n, random);
+    }
+
+
+    /**
+     * BigQuaternion random. Random rational numbers A, B, C and D are generated
+     * using RNRAND(n). Then R is the quaternion number with real part A and
+     * imaginary parts B, C and D.
+     * @param n such that 0 &le; A, B, C, D &le; (2<sup>n</sup>-1).
+     * @param rnd is a source for random bits.
+     * @return R, a random BigQuaternion.
+     */
+    public BigQuaternion random(int n, Random rnd) {
+        BigRational r = BigRational.ONE.random(n, rnd);
+        BigRational i = BigRational.ONE.random(n, rnd);
+        BigRational j = BigRational.ONE.random(n, rnd);
+        BigRational k = BigRational.ONE.random(n, rnd);
+        BigQuaternion q = new BigQuaternion(this, r, i, j, k);
+        if (integral) {
+            q = q.roundToHurwitzian();
+        }
+        return q;
+    }
+
+
+    /*
+     * Quaternion number, random. Random rational numbers A, B, C and D are
+     * generated using RNRAND(n). Then R is the quaternion number with real part
+     * A and imaginary parts B, C and D.
+     * @param n such that 0 &le; A, B, C, D &le; (2<sup>n</sup>-1).
+     * @return R, a random BigQuaternion.
+    public static BigQuaternion QRAND(int n) {
+        return ONE.random(n, random);
+    }
+     */
+
+
+    /**
+     * Parse quaternion number from String.
+     * @param s String.
+     * @return BigQuaternion from s.
+     */
+    public BigQuaternion parse(String s) {
+        return new BigQuaternion(this, s);
+    }
+
+
+    /**
+     * Parse quaternion number from Reader.
+     * @param r Reader.
+     * @return next BigQuaternion from r.
+     */
+    public BigQuaternion parse(Reader r) {
+        return parse(StringUtil.nextString(r));
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/BigRational.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/BigRational.java
@@ -1,0 +1,1505 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.arith;
+
+
+import java.io.Reader;
+import java.math.BigInteger;
+import java.math.MathContext;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+import edu.jas.kern.Scripting;
+import edu.jas.kern.StringUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Immutable arbitrary-precision rational numbers. BigRational class based on
+ * BigInteger and implementing the RingElem interface. BigInteger is from
+ * java.math in the implementation. The SAC2 static methods are also provided.
+ * @author Heinz Kredel
+ */
+
+public final class BigRational implements GcdRingElem<BigRational>, RingFactory<BigRational>, Rational,
+                Iterable<BigRational> {
+
+
+    /**
+     * Numerator part of the data structure.
+     */
+    public final BigInteger num;
+
+
+    /**
+     * Denominator part of the data structure.
+     */
+    public final BigInteger den;
+
+
+    /**
+     * The Constant 0.
+     */
+    public final static BigRational ZERO = new BigRational(BigInteger.ZERO);
+
+
+    /**
+     * The Constant 1.
+     */
+    public final static BigRational ONE = new BigRational(BigInteger.ONE);
+
+
+    /**
+     * The Constant 1/2.
+     */
+    public final static BigRational HALF = new BigRational(1, 2);
+
+
+    private final static Random random = new Random();
+
+
+    /**
+     * Constructor for a BigRational from math.BigIntegers.
+     * @param n math.BigInteger.
+     * @param d math.BigInteger.
+     */
+    protected BigRational(BigInteger n, BigInteger d) {
+        // assert gcd(n,d) == 1
+        num = n;
+        den = d;
+    }
+
+
+    /**
+     * Constructor for a BigRational from math.BigIntegers.
+     * @param n math.BigInteger.
+     */
+    public BigRational(BigInteger n) {
+        num = n;
+        den = BigInteger.ONE; // be aware of static initialization order
+    }
+
+
+    /**
+     * Constructor for a BigRational from jas.arith.BigIntegers.
+     * @param n edu.jas.arith.BigInteger.
+     */
+    public BigRational(edu.jas.arith.BigInteger n) {
+        this(n.getVal());
+    }
+
+
+    /**
+     * Constructor for a BigRational from jas.arith.BigIntegers.
+     * @param n edu.jas.arith.BigInteger.
+     * @param d edu.jas.arith.BigInteger.
+     */
+    public BigRational(edu.jas.arith.BigInteger n, edu.jas.arith.BigInteger d) {
+        BigInteger nu = n.getVal();
+        BigInteger de = d.getVal();
+        BigRational r = RNRED(nu, de);
+        num = r.num;
+        den = r.den;
+    }
+
+
+    /**
+     * Constructor for a BigRational from longs.
+     * @param n long.
+     * @param d long.
+     */
+    public BigRational(long n, long d) {
+        BigInteger nu = BigInteger.valueOf(n);
+        BigInteger de = BigInteger.valueOf(d);
+        BigRational r = RNRED(nu, de);
+        num = r.num;
+        den = r.den;
+    }
+
+
+    /**
+     * Constructor for a BigRational from longs.
+     * @param n long.
+     */
+    public BigRational(long n) {
+        num = BigInteger.valueOf(n);
+        den = BigInteger.ONE;
+    }
+
+
+    /**
+     * Constructor for a BigRational with no arguments.
+     */
+    public BigRational() {
+        num = BigInteger.ZERO;
+        den = BigInteger.ONE;
+    }
+
+
+    /**
+     * Constructor for a BigRational from String.
+     * @param s String.
+     * @throws NumberFormatException
+     */
+    public BigRational(String s) throws NumberFormatException {
+        if (s == null) {
+            num = BigInteger.ZERO;
+            den = BigInteger.ONE;
+            return;
+        }
+        if (s.length() == 0) {
+            num = BigInteger.ZERO;
+            den = BigInteger.ONE;
+            return;
+        }
+        BigInteger n;
+        BigInteger d;
+        s = s.trim();
+        int i = s.indexOf('/');
+        if (i < 0) {
+            i = s.indexOf('.');
+            if (i < 0) {
+                num = new BigInteger(s);
+                den = BigInteger.ONE;
+                return;
+            }
+            if (s.charAt(0) == '-') { // case -0.11111
+                n = new BigInteger(s.substring(1, i));
+            } else {
+                n = new BigInteger(s.substring(0, i));
+            }
+            BigRational r = new BigRational(n);
+            d = new BigInteger(s.substring(i + 1, s.length()));
+            int j = s.length() - i - 1;
+            //System.out.println("j = " + j);
+            //System.out.println("n = " + n);
+            //System.out.println("d = " + d);
+            BigRational z = new BigRational(1, 10);
+            z = z.power(j); //Power.<BigRational> positivePower(z, j);
+            BigRational f = new BigRational(d);
+            f = f.multiply(z);
+            r = r.sum(f);
+            if (s.charAt(0) == '-') {
+                num = r.num.negate();
+            } else {
+                num = r.num;
+            }
+            den = r.den;
+        } else {
+            String sn = s.substring(0, i);
+            String sd = s.substring(i + 1, s.length());
+            BigRational r;
+            if (s.indexOf(".") < 0) { // all integers
+                n = new BigInteger(sn);
+                d = new BigInteger(sd);
+                r = RNRED(n, d);
+            } else { // integers or decimal fractions
+                BigRational rn = new BigRational(sn);
+                BigRational rd = new BigRational(sd);
+                r = rn.divide(rd);
+            }
+            num = r.num;
+            den = r.den;
+            return;
+        }
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public BigRational factory() {
+        return this;
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     * @see edu.jas.structure.ElemFactory#generators()
+     */
+    public List<BigRational> generators() {
+        List<BigRational> g = new ArrayList<BigRational>(1);
+        g.add(getONE());
+        return g;
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite()
+     */
+    public boolean isFinite() {
+        return false;
+    }
+
+
+    /**
+     * Clone this.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public BigRational copy() {
+        return new BigRational(num, den);
+    }
+
+
+    /**
+     * Copy BigRational element c.
+     * @param c BigRational.
+     * @return a copy of c.
+     */
+    public BigRational copy(BigRational c) {
+        return new BigRational(c.num, c.den);
+    }
+
+
+    /**
+     * Return a BigRational approximation of this Element.
+     * @return a BigRational approximation of this.
+     * @see edu.jas.arith.Rational#getRational()
+     */
+    public BigRational getRational() {
+        return this;
+    }
+
+
+    /**
+     * Get the numerator.
+     * @return num.
+     */
+    public BigInteger numerator() {
+        return num;
+    }
+
+
+    /**
+     * Get the denominator.
+     * @return den.
+     */
+    public BigInteger denominator() {
+        return den;
+    }
+
+
+    /**
+     * Get the string representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        if (Scripting.getPrecision() >= 0) {
+            return toString(Scripting.getPrecision());
+        }
+        StringBuffer s = new StringBuffer();
+        s.append(num);
+        if (!den.equals(BigInteger.ONE)) {
+            s.append("/").append(den);
+        }
+        return s.toString();
+    }
+
+
+    /**
+     * Get the decimal string representation with given precision.
+     * @param n precision.
+     * @return decimal approximation.
+     */
+    public String toString(int n) {
+        if (n < 0) {
+            return toString();
+        }
+        java.math.MathContext mc = new java.math.MathContext(n);
+        BigDecimal d = new BigDecimal(this, mc);
+        return d.toString();
+    }
+
+
+    /**
+     * Get the decimal representation.
+     * @return decimal.
+     */
+    public BigDecimal getDecimal() {
+        BigDecimal d = new BigDecimal(this);
+        return d;
+    }
+
+
+    /**
+     * Get this as a <tt>double</tt>.
+     * @return this as a <tt>double</tt>
+     * @see java.lang.Number#doubleValue()
+     */
+    public double doubleValue() {
+        BigDecimal d = new BigDecimal(this, MathContext.DECIMAL64);
+        return d.doubleValue();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case: (num,den) or num 
+        // Ruby case: num/den or num 
+        StringBuffer s = new StringBuffer();
+        if (den.equals(BigInteger.ONE)) {
+            s.append(num.toString());
+            return s.toString();
+        }
+        if (Scripting.getPrecision() >= 0) {
+            return toString(Scripting.getPrecision());
+        }
+        switch (Scripting.getLang()) {
+        case Python:
+            s.append("(");
+            s.append(num.toString());
+            s.append(",");
+            s.append(den.toString());
+            s.append(")");
+            break;
+        case Ruby:
+        default:
+            s.append(num.toString());
+            s.append("/");
+            s.append(den.toString());
+        }
+        return s.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python and Ruby case
+        return "QQ()";
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as BigRational.
+     */
+    public BigRational getZERO() {
+        return ZERO;
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as BigRational.
+     */
+    public BigRational getONE() {
+        return ONE;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true.
+     */
+    public boolean isCommutative() {
+        return true;
+    }
+
+
+    /**
+     * Query if this ring is associative.
+     * @return true.
+     */
+    public boolean isAssociative() {
+        return true;
+    }
+
+
+    /**
+     * Query if this ring is a field.
+     * @return true.
+     */
+    public boolean isField() {
+        return true;
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic() {
+        return BigInteger.ZERO;
+    }
+
+
+    /**
+     * Get a BigRational element from a math.BigInteger.
+     * @param a math.BigInteger.
+     * @return BigRational from a.
+     */
+    public BigRational fromInteger(BigInteger a) {
+        return new BigRational(a);
+    }
+
+
+    /**
+     * Get a BigRational element from a arith.BigInteger.
+     * @param a arith.BigInteger.
+     * @return BigRational from a.
+     */
+    public BigRational fromInteger(edu.jas.arith.BigInteger a) {
+        return new BigRational(a);
+    }
+
+
+    /**
+     * Get a BigRational element from a math.BigInteger.
+     * @param a math.BigInteger.
+     * @return BigRational from a.
+     */
+    public static BigRational valueOf(BigInteger a) {
+        return new BigRational(a);
+    }
+
+
+    /**
+     * Get a BigRational element from a long.
+     * @param a long.
+     * @return BigRational from a.
+     */
+    public BigRational fromInteger(long a) {
+        return new BigRational(a);
+    }
+
+
+    /**
+     * Get a BigRational element from a long.
+     * @param a long.
+     * @return BigRational from a.
+     */
+    public static BigRational valueOf(long a) {
+        return new BigRational(a);
+    }
+
+
+    /**
+     * Is BigRational zero.
+     * @return If this is 0 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isZERO()
+     */
+    public boolean isZERO() {
+        return num.signum() == 0; //equals(BigInteger.ZERO);
+    }
+
+
+    /**
+     * Is BigRational one.
+     * @return If this is 1 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isONE()
+     */
+    public boolean isONE() {
+        return num.equals(den);
+    }
+
+
+    /**
+     * Is BigRational unit.
+     * @return If this is a unit then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isUnit()
+     */
+    public boolean isUnit() {
+        return !isZERO();
+    }
+
+
+    /**
+     * Is BigRational entier.
+     * @return If this is an integer then true is returned, else false.
+     */
+    public boolean isEntier() {
+        return isZERO() || den.equals(BigInteger.ONE);
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object b) {
+        if (!(b instanceof BigRational)) {
+            return false;
+        }
+        BigRational br = (BigRational) b;
+        return num.equals(br.num) && den.equals(br.den);
+    }
+
+
+    /**
+     * Hash code for this BigRational.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return 37 * num.hashCode() + den.hashCode();
+    }
+
+
+    /**
+     * Rational number reduction to lowest terms.
+     * @param n BigInteger.
+     * @param d BigInteger.
+     * @return a/b ~ n/d, gcd(a,b) = 1, b &gt; 0.
+     */
+    public static BigRational RNRED(BigInteger n, BigInteger d) {
+        BigInteger num;
+        BigInteger den;
+        if (n.equals(BigInteger.ZERO)) {
+            num = n;
+            den = BigInteger.ONE;
+            return new BigRational(num, den);
+        }
+        if (n.equals(d)) {
+            num = BigInteger.ONE;
+            den = BigInteger.ONE;
+            return new BigRational(num, den);
+        }
+        BigInteger c = n.gcd(d);
+        if (c.equals(BigInteger.ONE)) {
+            num = n;
+            den = d;
+        } else {
+            num = n.divide(c);
+            den = d.divide(c);
+        }
+        if (den.signum() < 0) {
+            num = num.negate();
+            den = den.negate();
+        }
+        return new BigRational(num, den);
+    }
+
+
+    /**
+     * Rational number reduction to lowest terms.
+     * @param n BigInteger.
+     * @param d BigInteger.
+     * @return a/b ~ n/d, gcd(a,b) = 1, b &gt; 0.
+     */
+    public static BigRational reduction(BigInteger n, BigInteger d) {
+        return RNRED(n, d);
+    }
+
+
+    /**
+     * Rational number absolute value.
+     * @return the absolute value of this.
+     * @see edu.jas.structure.RingElem#abs()
+     */
+    public BigRational abs() {
+        if (this.signum() >= 0) {
+            return this;
+        }
+        return this.negate();
+    }
+
+
+    /**
+     * Rational number absolute value.
+     * @param R is a rational number.
+     * @return the absolute value of R.
+     */
+    public static BigRational RNABS(BigRational R) {
+        if (R == null)
+            return null;
+        return R.abs();
+    }
+
+
+    /**
+     * Rational number comparison.
+     * @param S BigRational.
+     * @return SIGN(this-S).
+     */
+    @Override
+    public int compareTo(BigRational S) {
+        BigInteger J2Y;
+        BigInteger J3Y;
+        BigInteger R1;
+        BigInteger R2;
+        BigInteger S1;
+        BigInteger S2;
+        int J1Y;
+        int SL;
+        int TL;
+        int RL;
+        if (this.equals(ZERO)) {
+            return -S.signum();
+        }
+        if (S.equals(ZERO)) {
+            return this.signum();
+        }
+        R1 = num; //this.numerator(); 
+        R2 = den; //this.denominator();
+        S1 = S.num;
+        S2 = S.den;
+        RL = R1.signum();
+        SL = S1.signum();
+        J1Y = (RL - SL);
+        TL = (J1Y / 2);
+        if (TL != 0) {
+            return TL;
+        }
+        J3Y = R1.multiply(S2);
+        J2Y = R2.multiply(S1);
+        TL = J3Y.compareTo(J2Y);
+        return TL;
+    }
+
+
+    /**
+     * Rational number comparison.
+     * @param R BigRational.
+     * @param S BigRational.
+     * @return SIGN(R-S).
+     */
+    public static int RNCOMP(BigRational R, BigRational S) {
+        if (R == null)
+            return Integer.MAX_VALUE;
+        return R.compareTo(S);
+    }
+
+
+    /**
+     * Rational number denominator.
+     * @param R BigRational.
+     * @return R.denominator().
+     */
+    public static BigInteger RNDEN(BigRational R) {
+        if (R == null)
+            return null;
+        return R.den;
+    }
+
+
+    /**
+     * Rational number difference.
+     * @param S BigRational.
+     * @return this-S.
+     */
+    public BigRational subtract(BigRational S) {
+        return this.sum(S.negate());
+    }
+
+
+    /**
+     * Rational number difference.
+     * @param R BigRational.
+     * @param S BigRational.
+     * @return R-S.
+     */
+    public static BigRational RNDIF(BigRational R, BigRational S) {
+        if (R == null)
+            return S.negate();
+        return R.subtract(S);
+    }
+
+
+    /**
+     * Rational number decimal write. R is a rational number. n is a
+     * non-negative integer. R is approximated by a decimal fraction D with n
+     * decimal digits following the decimal point and D is written in the output
+     * stream. The inaccuracy of the approximation is at most (1/2)*10**-n.
+     * @param R
+     * @param NL
+     */
+    // If ABS(D) is greater than ABS(R) then the last digit is
+    // followed by a minus sign, if ABS(D) is less than ABS(R) then by a
+    // plus sign. 
+    public static void RNDWR(BigRational R, int NL) {
+        //BigInteger num = R.num;
+        //BigInteger den = R.den;
+        java.math.MathContext mc = new java.math.MathContext(NL);
+        BigDecimal d = new BigDecimal(R, mc);
+        System.out.print(d.toString());
+        return;
+    }
+
+
+    /**
+     * Rational number from integer.
+     * @param A BigInteger.
+     * @return A/1.
+     */
+    public static BigRational RNINT(BigInteger A) {
+        return new BigRational(A);
+    }
+
+
+    /**
+     * Rational number inverse.
+     * @return 1/this.
+     * @see edu.jas.structure.RingElem#inverse()
+     */
+    public BigRational inverse() {
+        BigInteger R1 = num;
+        BigInteger R2 = den;
+        BigInteger S1;
+        BigInteger S2;
+        if (R1.signum() >= 0) {
+            S1 = R2;
+            S2 = R1;
+        } else {
+            S1 = R2.negate();
+            S2 = R1.negate();
+        }
+        return new BigRational(S1, S2);
+    }
+
+
+    /**
+     * Rational number inverse.
+     * @param R BigRational.
+     * @return 1/R.
+     */
+    public static BigRational RNINV(BigRational R) {
+        if (R == null)
+            return null;
+        return R.inverse();
+    }
+
+
+    /**
+     * Rational number negative.
+     * @return -this.
+     * @see edu.jas.structure.RingElem#negate()
+     */
+    public BigRational negate() {
+        BigInteger n = num.negate();
+        return new BigRational(n, den);
+    }
+
+
+    /**
+     * Rational number negative.
+     * @param R BigRational.
+     * @return -R.
+     */
+    public static BigRational RNNEG(BigRational R) {
+        if (R == null)
+            return null;
+        return R.negate();
+    }
+
+
+    /**
+     * Rational number numerator.
+     * @param R BigRational.
+     * @return R.numerator().
+     */
+    public static BigInteger RNNUM(BigRational R) {
+        if (R == null)
+            return null;
+        return R.num;
+    }
+
+
+    /**
+     * Rational number product.
+     * @param S BigRational.
+     * @return this*S.
+     */
+    public BigRational multiply(BigRational S) {
+        BigInteger D1 = null;
+        BigInteger D2 = null;
+        BigInteger R1 = null;
+        BigInteger R2 = null;
+        BigInteger RB1 = null;
+        BigInteger RB2 = null;
+        BigInteger S1 = null;
+        BigInteger S2 = null;
+        BigInteger SB1 = null;
+        BigInteger SB2 = null;
+        BigRational T;
+        BigInteger T1;
+        BigInteger T2;
+        if (this.equals(ZERO) || S.equals(ZERO)) {
+            T = ZERO;
+            return T;
+        }
+        R1 = num; //this.numerator(); 
+        R2 = den; //this.denominator();
+        S1 = S.num;
+        S2 = S.den;
+        if (R2.equals(BigInteger.ONE) && S2.equals(BigInteger.ONE)) {
+            T1 = R1.multiply(S1);
+            T = new BigRational(T1, BigInteger.ONE);
+            return T;
+        }
+        if (R2.equals(BigInteger.ONE)) {
+            if (R1.equals(S2)) {
+                D1 = R1;
+            } else {
+                D1 = R1.gcd(S2);
+            }
+            RB1 = R1.divide(D1);
+            SB2 = S2.divide(D1);
+            T1 = RB1.multiply(S1);
+            T = new BigRational(T1, SB2);
+            return T;
+        }
+        if (S2.equals(BigInteger.ONE)) {
+            if (S1.equals(R2)) {
+                D2 = S1;
+            } else {
+                D2 = S1.gcd(R2);
+            }
+            SB1 = S1.divide(D2);
+            RB2 = R2.divide(D2);
+            T1 = SB1.multiply(R1);
+            T = new BigRational(T1, RB2);
+            return T;
+        }
+        if (R1.equals(S2)) {
+            D1 = R1;
+        } else {
+            D1 = R1.gcd(S2);
+        }
+        RB1 = R1.divide(D1);
+        SB2 = S2.divide(D1);
+        if (S1.equals(R2)) {
+            D2 = S1;
+        } else {
+            D2 = S1.gcd(R2);
+        }
+        SB1 = S1.divide(D2);
+        RB2 = R2.divide(D2);
+        T1 = RB1.multiply(SB1);
+        T2 = RB2.multiply(SB2);
+        T = new BigRational(T1, T2);
+        return T;
+    }
+
+
+    /**
+     * Rational number product.
+     * @param R BigRational.
+     * @param S BigRational.
+     * @return R*S.
+     */
+    public static BigRational RNPROD(BigRational R, BigRational S) {
+        if (R == null) {
+            return R;
+        }
+        return R.multiply(S);
+    }
+
+
+    /**
+     * Rational number quotient.
+     * @param S BigRational.
+     * @return this/S.
+     */
+    public BigRational divide(BigRational S) {
+        return multiply(S.inverse());
+    }
+
+
+    /**
+     * Rational number quotient.
+     * @param R BigRational.
+     * @param S BigRational.
+     * @return R/S.
+     */
+    public static BigRational RNQ(BigRational R, BigRational S) {
+        if (R == null) {
+            return R;
+        }
+        return R.divide(S);
+    }
+
+
+    /**
+     * Rational number remainder.
+     * @param S BigRational.
+     * @return this-(this/S)*S
+     */
+    public BigRational remainder(BigRational S) {
+        if (S.isZERO()) {
+            throw new ArithmeticException("division by zero");
+        }
+        return ZERO;
+    }
+
+
+    /**
+     * Quotient and remainder by division of this by S.
+     * @param S a rational number
+     * @return [this/S, this - (this/S)*S].
+     */
+    public BigRational[] quotientRemainder(BigRational S) {
+        return new BigRational[] { divide(S), ZERO };
+    }
+
+
+    /**
+     * Rational number, random. Random integers A, B and a random sign s are
+     * generated using BigInteger(n,random) and random.nextBoolen(). Then R =
+     * s*A/(B+1), reduced to lowest terms.
+     * @param n such that 0 &le; A, B &le; (2<sup>n</sup>-1).
+     * @return a random BigRational.
+     */
+    public BigRational random(int n) {
+        return random(n, random);
+    }
+
+
+    /**
+     * Rational number, random. Random integers A, B and a random sign s are
+     * generated using BigInteger(n,random) and random.nextBoolen(). Then R =
+     * s*A/(B+1), reduced to lowest terms.
+     * @param n such that 0 &le; A, B &le; (2<sup>n</sup>-1).
+     * @param rnd is a source for random bits.
+     * @return a random BigRational.
+     */
+    public BigRational random(int n, Random rnd) {
+        BigInteger A;
+        BigInteger B;
+        A = new BigInteger(n, rnd); // always positive
+        if (rnd.nextBoolean()) {
+            A = A.negate();
+        }
+        B = new BigInteger(n, rnd); // always positive
+        B = B.add(BigInteger.ONE);
+        return RNRED(A, B);
+    }
+
+
+    /**
+     * Rational number, random. Random integers A, B and a random sign s are
+     * generated using BigInteger(n,random) and random.nextBoolen(). Then R =
+     * s*A/(B+1), reduced to lowest terms.
+     * @param NL such that 0 &le; A, B &le; (2<sup>n</sup>-1).
+     * @return a random BigRational.
+     */
+    public static BigRational RNRAND(int NL) {
+        return ONE.random(NL, random);
+    }
+
+
+    /**
+     * Rational number sign.
+     * @see edu.jas.structure.RingElem#signum()
+     */
+    public int signum() {
+        return num.signum();
+    }
+
+
+    /**
+     * Rational number sign.
+     * @param R BigRational.
+     * @return R.signum().
+     */
+    public static int RNSIGN(BigRational R) {
+        if (R == null) {
+            return 0;
+        }
+        return R.signum();
+    }
+
+
+    /**
+     * Rational number sum.
+     * @param S BigRational.
+     * @return this+S.
+     */
+    public BigRational sum(BigRational S) {
+        BigInteger D = null;
+        BigInteger E, J1Y, J2Y;
+        BigRational T;
+        BigInteger R1 = null;
+        BigInteger R2 = null;
+        BigInteger RB2 = null;
+        BigInteger S1 = null;
+        BigInteger S2 = null;
+        BigInteger SB2 = null;
+        BigInteger T1;
+        BigInteger T2;
+        if (this.equals(ZERO)) {
+            return S;
+        }
+        if (S.equals(ZERO)) {
+            return this;
+        }
+        R1 = num; //this.numerator(); 
+        R2 = den; //this.denominator();
+        S1 = S.num;
+        S2 = S.den;
+        if (R2.equals(BigInteger.ONE) && S2.equals(BigInteger.ONE)) {
+            T1 = R1.add(S1);
+            T = new BigRational(T1, BigInteger.ONE);
+            return T;
+        }
+        if (R2.equals(BigInteger.ONE)) {
+            T1 = R1.multiply(S2);
+            T1 = T1.add(S1);
+            T = new BigRational(T1, S2);
+            return T;
+        }
+        if (S2.equals(BigInteger.ONE)) {
+            T1 = R2.multiply(S1);
+            T1 = T1.add(R1);
+            T = new BigRational(T1, R2);
+            return T;
+        }
+        if (R2.equals(S2)) {
+            D = R2;
+        } else {
+            D = R2.gcd(S2);
+        }
+        if (D.equals(BigInteger.ONE)) {
+            RB2 = R2;
+            SB2 = S2;
+        } else {
+            RB2 = R2.divide(D);
+            SB2 = S2.divide(D);
+        }
+        J1Y = R1.multiply(SB2);
+        J2Y = RB2.multiply(S1);
+        T1 = J1Y.add(J2Y);
+        if (T1.equals(BigInteger.ZERO)) {
+            return ZERO;
+        }
+        if (!D.equals(BigInteger.ONE)) {
+            if (T1.equals(D)) {
+                E = D;
+            } else {
+                E = T1.gcd(D);
+            }
+            if (!E.equals(BigInteger.ONE)) {
+                T1 = T1.divide(E);
+                R2 = R2.divide(E);
+            }
+        }
+        T2 = R2.multiply(SB2);
+        T = new BigRational(T1, T2);
+        return T;
+    }
+
+
+    /**
+     * Rational number sum.
+     * @param R BigRational.
+     * @param S BigRational.
+     * @return R+S.
+     */
+    public static BigRational RNSUM(BigRational R, BigRational S) {
+        if (R == null) {
+            return S;
+        }
+        return R.sum(S);
+    }
+
+
+    /**
+     * Parse rational number from String.
+     * @param s String.
+     * @return BigRational from s.
+     */
+    public BigRational parse(String s) {
+        return new BigRational(s);
+    }
+
+
+    /**
+     * Parse rational number from Reader.
+     * @param r Reader.
+     * @return next BigRational from r.
+     */
+    public BigRational parse(Reader r) {
+        return parse(StringUtil.nextString(r));
+    }
+
+
+    /**
+     * Rational number greatest common divisor.
+     * @param S BigRational.
+     * @return gcd(this,S).
+     */
+    public BigRational gcd(BigRational S) {
+        if (S == null || S.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return S;
+        }
+        return ONE;
+    }
+
+
+    /**
+     * BigRational extended greatest common divisor.
+     * @param S BigRational.
+     * @return [ gcd(this,S), a, b ] with a*this + b*S = gcd(this,S).
+     */
+    public BigRational[] egcd(BigRational S) {
+        BigRational[] ret = new BigRational[3];
+        ret[0] = null;
+        ret[1] = null;
+        ret[2] = null;
+        if (S == null || S.isZERO()) {
+            ret[0] = this;
+            return ret;
+        }
+        if (this.isZERO()) {
+            ret[0] = S;
+            return ret;
+        }
+        BigRational half = new BigRational(1, 2);
+        ret[0] = ONE;
+        ret[1] = this.inverse().multiply(half);
+        ret[2] = S.inverse().multiply(half);
+        return ret;
+    }
+
+
+    /**
+     * BigRational ceiling.
+     * @return ceiling of this.
+     */
+    public BigInteger ceil() {
+        if (isEntier()) {
+            return num;
+        }
+        BigInteger[] qr = num.divideAndRemainder(den);
+        //System.out.println("ceil: " + this + ", q = " + qr[0] + ", r = " +qr[1]);
+        BigInteger q = qr[0];
+        if (qr[1].signum() > 0) {
+            q = q.add(BigInteger.ONE);
+        }
+        return q;
+    }
+
+
+    /**
+     * BigRational floor.
+     * @return floor of this.
+     */
+    public BigInteger floor() {
+        if (isEntier()) {
+            return num;
+        }
+        BigInteger[] qr = num.divideAndRemainder(den);
+        //System.out.println("floor: " + this + ", q = " + qr[0] + ", r = " +qr[1]);
+        BigInteger q = qr[0];
+        if (qr[1].signum() < 0) {
+            q = q.subtract(BigInteger.ONE);
+        }
+        return q;
+    }
+
+
+    /**
+     * Returns the number of bits in the representation of this BigRational,
+     * including a sign bit. For positive BigRational, this is equivalent to
+     * {@code num.bitLength()+den.bitLength()}.)
+     * @return number of bits in the representation of this BigRational,
+     *         including a sign bit.
+     */
+    public long bitLength() {
+        long n = num.bitLength();
+        if (num.signum() < 0) {
+            n++;
+        }
+        n++;
+        n += den.bitLength();
+        // den.signum() > 0
+        n++;
+        return n;
+    }
+
+
+    private boolean nonNegative = true;
+
+
+    private boolean duplicates = true;
+
+
+    /**
+     * Set the iteration algorithm to all elements.
+     */
+    public void setAllIterator() {
+        nonNegative = false;
+    }
+
+
+    /**
+     * Set the iteration algorithm to non-negative elements.
+     */
+    public void setNonNegativeIterator() {
+        nonNegative = true;
+    }
+
+
+    /**
+     * Set the iteration algorithm to no duplicate elements.
+     */
+    public void setNoDuplicatesIterator() {
+        duplicates = false;
+    }
+
+
+    /**
+     * Set the iteration algorithm to allow duplicate elements.
+     */
+    public void setDuplicatesIterator() {
+        duplicates = true;
+    }
+
+
+    /**
+     * Get a BigRational iterator.
+     * @return a iterator over all rationals.
+     */
+    public Iterator<BigRational> iterator() {
+        if (duplicates) {
+            return new BigRationalIterator(nonNegative);
+        }
+        return new BigRationalUniqueIterator(new BigRationalIterator(nonNegative));
+    }
+
+
+    /**
+     * Get a BigRational iterator with no duplicates.
+     * @return a iterator over all rationals without duplicates.
+     */
+    public Iterator<BigRational> uniqueIterator() {
+        return new BigRationalUniqueIterator(new BigRationalIterator(nonNegative));
+    }
+
+}
+
+
+/**
+ * Big rational iterator. Uses Cantors diagonal enumeration.
+ * @author Heinz Kredel
+ */
+class BigRationalIterator implements Iterator<BigRational> {
+
+
+    /**
+     * data structure.
+     */
+    BigRational curr;
+
+
+    edu.jas.arith.BigInteger den;
+
+
+    edu.jas.arith.BigInteger num;
+
+
+    Iterator<edu.jas.arith.BigInteger> denit;
+
+
+    Iterator<edu.jas.arith.BigInteger> numit;
+
+
+    List<edu.jas.arith.BigInteger> denlist;
+
+
+    List<edu.jas.arith.BigInteger> numlist;
+
+
+    Iterator<edu.jas.arith.BigInteger> denlistit;
+
+
+    Iterator<edu.jas.arith.BigInteger> numlistit;
+
+
+    final boolean nonNegative;
+
+
+    protected long level;
+
+
+    /**
+     * BigRational iterator constructor.
+     */
+    public BigRationalIterator() {
+        this(false);
+    }
+
+
+    /**
+     * BigRational iterator constructor.
+     * @param nn indicator for a non-negative iterator, if true, false for an
+     *            all iterator
+     */
+    public BigRationalIterator(boolean nn) {
+        nonNegative = nn;
+        curr = edu.jas.arith.BigRational.ZERO;
+        level = 0;
+        den = new edu.jas.arith.BigInteger(); // ZERO
+        num = edu.jas.arith.BigInteger.ONE.copy();
+        if (nonNegative) {
+            den.setNonNegativeIterator();
+        } else {
+            den.setAllIterator();
+        }
+        num.setNonNegativeIterator();
+        denit = den.iterator();
+        numit = num.iterator();
+        denlist = new ArrayList<edu.jas.arith.BigInteger>();
+        numlist = new ArrayList<edu.jas.arith.BigInteger>();
+        edu.jas.arith.BigInteger unused = denit.next(); // skip zero denominator
+        unused = numit.next();
+        if (unused == null) { // use for findbugs
+            System.out.println("unused is null");
+        }
+        denlist.add(denit.next());
+        numlist.add(numit.next());
+        denlistit = denlist.iterator();
+        numlistit = numlist.iterator();
+    }
+
+
+    /**
+     * Test for availability of a next element.
+     * @return true if the iteration has more elements, else false.
+     */
+    public boolean hasNext() {
+        return true;
+    }
+
+
+    /**
+     * Get next rational.
+     * @return next rational.
+     */
+    public synchronized BigRational next() {
+        BigRational r = curr;
+        if (denlistit.hasNext() && numlistit.hasNext()) {
+            BigInteger d = denlistit.next().val;
+            BigInteger n = numlistit.next().val;
+            //System.out.println(d + "//" + n);
+            curr = BigRational.reduction(d, n);
+            return r;
+        }
+        level++;
+        if (level % 2 == 1) {
+            Collections.reverse(denlist);
+        } else {
+            Collections.reverse(numlist);
+        }
+        denlist.add(denit.next());
+        numlist.add(numit.next());
+        if (level % 2 == 0) {
+            Collections.reverse(denlist);
+        } else {
+            Collections.reverse(numlist);
+        }
+        //System.out.println("denlist = " + denlist);
+        //System.out.println("numlist = " + numlist);
+        denlistit = denlist.iterator();
+        numlistit = numlist.iterator();
+        BigInteger d = denlistit.next().val;
+        BigInteger n = numlistit.next().val;
+        //System.out.println(d + "//" + n);
+        curr = BigRational.reduction(d, n);
+        return r;
+    }
+
+
+    /**
+     * Remove an element if allowed.
+     */
+    public void remove() {
+        throw new UnsupportedOperationException("cannnot remove elements");
+    }
+}
+
+
+/**
+ * Big rational unique iterator. Uses Cantors diagonal enumeration, produces
+ * distinct elements.
+ * @author Heinz Kredel
+ */
+class BigRationalUniqueIterator implements Iterator<BigRational> {
+
+
+    /**
+     * data structure.
+     */
+    final Set<BigRational> unique;
+
+
+    final Iterator<BigRational> ratit;
+
+
+    /**
+     * BigRational iterator constructor.
+     */
+    public BigRationalUniqueIterator() {
+        this(BigRational.ONE.iterator());
+    }
+
+
+    /**
+     * BigRational iterator constructor.
+     * @param rit backing rational iterator of non unique elements
+     */
+    public BigRationalUniqueIterator(Iterator<BigRational> rit) {
+        ratit = rit;
+        unique = new HashSet<BigRational>();
+    }
+
+
+    /**
+     * Test for availability of a next element.
+     * @return true if the iteration has more elements, else false.
+     */
+    public synchronized boolean hasNext() {
+        return ratit.hasNext();
+    }
+
+
+    /**
+     * Get next rational.
+     * @return next rational.
+     */
+    public synchronized BigRational next() {
+        BigRational r = ratit.next();
+        while (unique.contains(r)) {
+            //System.out.println("duplicate " + r);
+            r = ratit.next();
+        }
+        unique.add(r);
+        return r;
+    }
+
+
+    /**
+     * Remove an element if allowed.
+     */
+    public void remove() {
+        throw new UnsupportedOperationException("cannnot remove elements");
+    }
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/Combinatoric.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/Combinatoric.java
@@ -1,0 +1,89 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.arith;
+
+
+/**
+ * Combinatoric algorithms. Similar to ALDES/SAC2 SACCOMB module.
+ * @author Heinz Kredel
+ */
+public class Combinatoric {
+
+
+    /**
+     * Integer binomial coefficient induction. n and k are integers with 0
+     * less than or equal to k less than or equal to n. A is the binomial
+     * coefficient n over k. B is the binomial coefficient n over k+1.
+     * @param A previous induction result.
+     * @param n long.
+     * @param k long.
+     * @return the binomial coefficient n over k+1.
+     */
+    public static BigInteger binCoeffInduction(BigInteger A, long n, long k) {
+        BigInteger kp, np;
+        np = new BigInteger(n - k);
+        kp = new BigInteger(k + 1);
+        BigInteger B = A.multiply(np).divide(kp);
+        return B;
+    }
+
+
+    /**
+     * Integer binomial coefficient. n and k are integers with 0 less than
+     * or equal to k less than or equal to n. A is the binomial coefficient n
+     * over k.
+     * @param n long.
+     * @param k long.
+     * @return the binomial coefficient n over k+1.
+     */
+    public static BigInteger binCoeff(int n, int k) {
+        BigInteger A = BigInteger.ONE;
+        int kp = (k < n - k ? k : n - k);
+        for (int j = 0; j < kp; j++) {
+            A = binCoeffInduction(A, n, j);
+        }
+        return A;
+    }
+
+
+    /**
+     * Integer binomial coefficient partial sum. n and k are integers, 0 le k le
+     * n. A is the sum on i, from 0 to k, of the binomial coefficient n over i.
+     * @param n long.
+     * @param k long.
+     * @return the binomial coefficient partial sum n over i.
+     */
+    public static BigInteger binCoeffSum(int n, int k) {
+        BigInteger B, S;
+        S = BigInteger.ONE;
+        B = BigInteger.ONE;
+        for (int j = 0; j < k; j++) {
+            B = binCoeffInduction(B, n, j);
+            S = S.sum(B);
+        }
+        return S;
+    }
+
+
+    /**
+     * Factorial.
+     * @param n integer.
+     * @return n!, with 0! = 1.
+     */
+    public static BigInteger factorial(long n) {
+        if (n <= 1) {
+            return BigInteger.ONE;
+        }
+        BigInteger f = BigInteger.ONE;
+        if (n >= Integer.MAX_VALUE) {
+            throw new UnsupportedOperationException(n + " >= Integer.MAX_VALUE = " + Integer.MAX_VALUE);
+        }
+        for (int i = 2; i <= n; i++) {
+            f = f.multiply(new BigInteger(i));
+        }
+        return f;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/ModInt.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/ModInt.java
@@ -1,0 +1,614 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.arith;
+
+
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.NotInvertibleException;
+
+
+/**
+ * ModInt class with RingElem interface. Objects of this class are immutable.
+ * @author Heinz Kredel
+ * @see ModInteger
+ */
+
+public final class ModInt implements GcdRingElem<ModInt>, Modular {
+
+
+    /**
+     * ModIntRing reference.
+     */
+    public final ModIntRing ring;
+
+
+    /**
+     * Value part of the element data structure.
+     */
+    public final int val;
+
+
+    /**
+     * The constructor creates a ModInt object from a ModIntRing and a value
+     * part.
+     * @param m ModIntRing.
+     * @param a math.BigInteger.
+     */
+    public ModInt(ModIntRing m, java.math.BigInteger a) {
+        this(m, a.mod(m.getModul()).intValue());
+    }
+
+
+    /**
+     * The constructor creates a ModInt object from a ModIntRing and a int value
+     * part.
+     * @param m ModIntRing.
+     * @param a int.
+     */
+    public ModInt(ModIntRing m, int a) {
+        ring = m;
+        int v = a % ring.modul;
+        val = (v >= 0 ? v : v + ring.modul);
+    }
+
+
+    /**
+     * The constructor creates a ModInt object from a ModIntRing and a long
+     * value part.
+     * @param m ModIntRing.
+     * @param a long.
+     */
+    public ModInt(ModIntRing m, long a) {
+        ring = m;
+        int v = (int) (a % (long)ring.modul);
+        val = (v >= 0 ? v : v + ring.modul);
+    }
+
+
+    /**
+     * The constructor creates a ModInt object from a ModIntRing and a Int value
+     * part.
+     * @param m ModIntRing.
+     * @param a Int.
+     */
+    public ModInt(ModIntRing m, Integer a) {
+        this(m, a.intValue());
+    }
+
+
+    /**
+     * The constructor creates a ModInt object from a ModIntRing and a Long
+     * value part.
+     * @param m ModIntRing.
+     * @param a long.
+     */
+    public ModInt(ModIntRing m, Long a) {
+        this(m, a.longValue());
+    }
+
+
+    /**
+     * The constructor creates a ModInt object from a ModIntRing and a String
+     * value part.
+     * @param m ModIntRing.
+     * @param s String.
+     */
+    public ModInt(ModIntRing m, String s) {
+        this(m, Integer.valueOf(s.trim()));
+    }
+
+
+    /**
+     * The constructor creates a 0 ModInt object from a given ModIntRing.
+     * @param m ModIntRing.
+     */
+    public ModInt(ModIntRing m) {
+        this(m, 0);
+    }
+
+
+    /**
+     * Get the value part.
+     * @return val.
+     */
+    public int getVal() {
+        return val;
+    }
+
+
+    /**
+     * Get the module part.
+     * @return modul.
+     */
+    public int getModul() {
+        return ring.modul;
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public ModIntRing factory() {
+        return ring;
+    }
+
+
+    /**
+     * Get the symmetric value part.
+     * @return val with -modul/2 &le; val &lt; modul/2.
+     */
+    public int getSymmetricVal() {
+        if ((val + val) > ring.modul) {
+            // val > m/2 as 2*val > m, make symmetric to 0
+            return val - ring.modul;
+        }
+        return val;
+    }
+
+
+    /**
+     * Return a BigInteger from this Element.
+     * @return a BigInteger of this.
+     */
+    public BigInteger getInteger() {
+        return new BigInteger(val);
+    }
+
+
+    /**
+     * Return a symmetric BigInteger from this Element.
+     * @return a symmetric BigInteger of this.
+     */
+    public BigInteger getSymmetricInteger() {
+        int v = val;
+        if ((val + val) > ring.modul) {
+            // val > m/2 as 2*val > m, make symmetric to 0
+            v = val - ring.modul;
+        }
+        return new BigInteger(v);
+    }
+
+
+    /**
+     * Clone this.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public ModInt copy() {
+        return new ModInt(ring, val);
+    }
+
+
+    /**
+     * Is ModInt number zero.
+     * @return If this is 0 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isZERO()
+     */
+    public boolean isZERO() {
+        return val == 0;
+    }
+
+
+    /**
+     * Is ModInt number one.
+     * @return If this is 1 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isONE()
+     */
+    public boolean isONE() {
+        return val == 1L;
+    }
+
+
+    /**
+     * Is ModInt number a unit.
+     * @return If this is a unit then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isUnit()
+     */
+    public boolean isUnit() {
+        if (isZERO()) {
+            return false;
+        }
+        if (ring.isField()) {
+            return true;
+        }
+        int g = gcd(ring.modul, val);
+        return (g == 1L || g == -1L);
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return Integer.toString(val);
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        return toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python case
+        return factory().toScript();
+    }
+
+
+    /**
+     * ModInt comparison.
+     * @param b ModInt.
+     * @return sign(this-b).
+     */
+    @Override
+    public int compareTo(ModInt b) {
+        int v = b.val;
+        if (ring != b.ring) {
+            v = v % ring.modul;
+        }
+        if (val > v) {
+            return 1;
+        }
+        return (val < v ? -1 : 0);
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object b) {
+        if (!(b instanceof ModInt)) {
+            return false;
+        }
+        return (0 == compareTo((ModInt) b));
+    }
+
+
+    /**
+     * Hash code for this ModInt.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return val;
+    }
+
+
+    /**
+     * ModInt absolute value.
+     * @return the absolute value of this.
+     * @see edu.jas.structure.RingElem#abs()
+     */
+    public ModInt abs() {
+        return new ModInt(ring, (val < 0 ? -val : val));
+    }
+
+
+    /**
+     * ModInt negative.
+     * @see edu.jas.structure.RingElem#negate()
+     * @return -this.
+     */
+    public ModInt negate() {
+        return new ModInt(ring, -val);
+    }
+
+
+    /**
+     * ModInt signum.
+     * @see edu.jas.structure.RingElem#signum()
+     * @return signum(this).
+     */
+    public int signum() {
+        if (val > 0) {
+            return 1;
+        }
+        return (val < 0 ? -1 : 0);
+    }
+
+
+    /**
+     * ModInt subtraction.
+     * @param S ModInt.
+     * @return this-S.
+     */
+    public ModInt subtract(ModInt S) {
+        return new ModInt(ring, val - S.val);
+    }
+
+
+    /**
+     * ModInt divide.
+     * @param S ModInt.
+     * @return this/S.
+     */
+    public ModInt divide(ModInt S) {
+        try {
+            return multiply(S.inverse());
+        } catch (NotInvertibleException e) {
+            try {
+                if ((val % S.val) == 0) {
+                    return new ModInt(ring, val / S.val);
+                }
+                throw new NotInvertibleException(e.getCause());
+            } catch (ArithmeticException a) {
+                throw new NotInvertibleException(a.getCause());
+            }
+        }
+    }
+
+
+    /**
+     * ModInt inverse.
+     * @see edu.jas.structure.RingElem#inverse()
+     * @throws NotInvertibleException if the element is not invertible.
+     * @return S with S=1/this if defined.
+     */
+    public ModInt inverse() /*throws NotInvertibleException*/ {
+        try {
+            return new ModInt(ring, modInverse(val, ring.modul));
+        } catch (ArithmeticException e) {
+            int g = gcd(val, ring.modul);
+            int f = ring.modul / g;
+            throw new ModularNotInvertibleException(e, new BigInteger(ring.modul), new BigInteger(g),
+                            new BigInteger(f));
+        }
+    }
+
+
+    /**
+     * ModInt remainder.
+     * @param S ModInt.
+     * @return remainder(this,S).
+     */
+    public ModInt remainder(ModInt S) {
+        if (S == null || S.isZERO()) {
+            throw new ArithmeticException("division by zero");
+        }
+        if (S.isONE()) {
+            return ring.getZERO();
+        }
+        if (S.isUnit()) {
+            return ring.getZERO();
+        }
+        return new ModInt(ring, val % S.val);
+    }
+
+
+    /**
+     * ModInt multiply.
+     * @param S ModInt.
+     * @return this*S.
+     */
+    public ModInt multiply(ModInt S) {
+        return new ModInt(ring, val * S.val);
+    }
+
+
+    /**
+     * ModInt summation.
+     * @param S ModInt.
+     * @return this+S.
+     */
+    public ModInt sum(ModInt S) {
+        return new ModInt(ring, val + S.val);
+    }
+
+
+    /**
+     * ModInteger greatest common divisor.
+     * @param S ModInteger.
+     * @return [ gcd(this,S), a, b ] with a*this + b*S = gcd(this,S).
+     */
+    public ModInt gcd(ModInt S) {
+        if (S.isZERO()) {
+            return this;
+        }
+        if (isZERO()) {
+            return S;
+        }
+        if (isUnit() || S.isUnit()) {
+            return ring.getONE();
+        }
+        return new ModInt(ring, gcd(val, S.val));
+    }
+
+
+    /**
+     * ModInteger extended greatest common divisor.
+     * @param S ModInteger.
+     * @return [ gcd(this,S), a, b ] with a*this + b*S = gcd(this,S).
+     */
+    public ModInt[] egcd(ModInt S) {
+        ModInt[] ret = new ModInt[3];
+        ret[0] = null;
+        ret[1] = null;
+        ret[2] = null;
+        if (S == null || S.isZERO()) {
+            ret[0] = this;
+            return ret;
+        }
+        if (isZERO()) {
+            ret[0] = S;
+            return ret;
+        }
+        if (isUnit() || S.isUnit()) {
+            ret[0] = ring.getONE();
+            if (isUnit() && S.isUnit()) {
+                //ModInt half = (new ModInt(ring, 2L)).inverse();
+                //ret[1] = this.inverse().multiply(half);
+                //ret[2] = S.inverse().multiply(half);
+                // (1-1*this)/S
+                ret[1] = ring.getONE();
+                ModInt x = ret[0].subtract(ret[1].multiply(this));
+                ret[2] = x.divide(S);
+                return ret;
+            }
+            if (isUnit()) {
+                // oder inverse(S-1)?
+                ret[1] = this.inverse();
+                ret[2] = ring.getZERO();
+                return ret;
+            }
+            // if ( s.isUnit() ) {
+            // oder inverse(this-1)?
+            ret[1] = ring.getZERO();
+            ret[2] = S.inverse();
+            return ret;
+            //}
+        }
+        //System.out.println("this = " + this + ", S = " + S);
+        int q = this.val;
+        int r = S.val;
+        int c1 = 1; // BigInteger.ONE.val;
+        int d1 = 0; // BigInteger.ZERO.val;
+        int c2 = 0; // BigInteger.ZERO.val;
+        int d2 = 1; // BigInteger.ONE.val;
+        int x1;
+        int x2;
+        while (r != 0) {
+            //qr = q.divideAndRemainder(r);
+            int a = q / r;
+            int b = q % r;
+            q = a;
+            x1 = c1 - q * d1;
+            x2 = c2 - q * d2;
+            c1 = d1;
+            c2 = d2;
+            d1 = x1;
+            d2 = x2;
+            q = r;
+            r = b;
+        }
+        //System.out.println("q = " + q + "\n c1 = " + c1 + "\n c2 = " + c2);
+        ret[0] = new ModInt(ring, q);
+        ret[1] = new ModInt(ring, c1);
+        ret[2] = new ModInt(ring, c2);
+        return ret;
+    }
+
+
+    /**
+     * Int greatest common divisor.
+     * @param T int.
+     * @param S int.
+     * @return gcd(T,S).
+     */
+    public int gcd(int T, int S) {
+        if (S == 0) {
+            return T;
+        }
+        if (T == 0) {
+            return S;
+        }
+        int a = T;
+        int b = S;
+        while (b != 0) {
+            int r = a % b;
+            a = b;
+            b = r;
+        }
+        return a;
+    }
+
+
+    /**
+     * Int half extended greatest common divisor.
+     * @param T int.
+     * @param S int.
+     * @return [ gcd(T,S), a ] with a*T + b*S = gcd(T,S).
+     */
+    public int[] hegcd(int T, int S) {
+        int[] ret = new int[2];
+        if (S == 0) {
+            ret[0] = T;
+            ret[1] = 1;
+            return ret;
+        }
+        if (T == 0) {
+            ret[0] = S;
+            ret[1] = 0;
+            return ret;
+        }
+        //System.out.println("hegcd, T = " + T + ", S = " + S);
+        int a = T;
+        int b = S;
+        int a1 = 1;
+        int b1 = 0;
+        while (b != 0) {
+            int q = a / b;
+            int r = a % b;
+            a = b;
+            b = r;
+            int r1 = a1 - q * b1;
+            a1 = b1;
+            b1 = r1;
+        }
+        if (a1 < 0) {
+            a1 += S;
+        }
+        ret[0] = a;
+        ret[1] = a1;
+        return ret;
+    }
+
+
+    /**
+     * Int modular inverse.
+     * @param T int.
+     * @param m int.
+     * @return a with with a*T = 1 mod m.
+     */
+    public int modInverse(int T, int m) {
+        if (T == 0) {
+            throw new NotInvertibleException("zero is not invertible");
+        }
+        int[] hegcd = hegcd(T, m);
+        int a = hegcd[0];
+        if (!(a == 1L || a == -1L)) { // gcd != 1
+            throw new ModularNotInvertibleException("element not invertible, gcd != 1", new BigInteger(m),
+                            new BigInteger(a), new BigInteger(m / a));
+        }
+        int b = hegcd[1];
+        if (b == 0) { // when m divides this, e.g. m.isUnit()
+            throw new NotInvertibleException("element not invertible, divisible by modul");
+        }
+        if (b < 0) {
+            b += m;
+        }
+        return b;
+    }
+
+
+    /**
+     * Returns the number of bits in the representation of this ModInt,
+     * including a sign bit.
+     * @return number of bits in the representation of this ModInt, including a
+     *         sign bit.
+     */
+    public int bitLength() {
+        return (int) BigInteger.bitLength(val);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/ModIntRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/ModIntRing.java
@@ -1,0 +1,545 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.arith;
+
+
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+
+import edu.jas.kern.StringUtil;
+
+
+/**
+ * ModIntRing factory with RingFactory interface. Effectively immutable.
+ * @author Heinz Kredel
+ */
+
+public final class ModIntRing implements ModularRingFactory<ModInt>, Iterable<ModInt> {
+
+
+    /**
+     * Module part of the factory data structure.
+     */
+    public final int modul;
+
+
+    /**
+     * Random number generator.
+     */
+    private final static Random random = new Random();
+
+
+    /**
+     * Indicator if this ring is a field.
+     */
+    private int isField = -1; // initially unknown
+
+
+    /*
+     * Certainty if module is probable prime.
+     */
+    //private final int certainty = 10;
+
+
+    /**
+     * maximal representable integer.
+     */
+    public final static java.math.BigInteger MAX_INT = new java.math.BigInteger(
+                    String.valueOf(Short.MAX_VALUE)); // not larger!
+
+
+    /**
+     * The constructor creates a ModIntRing object from a int integer as module
+     * part.
+     * @param m int integer.
+     */
+    public ModIntRing(int m) {
+        modul = m;
+    }
+
+
+    /**
+     * The constructor creates a ModIntRing object from a int integer as module
+     * part.
+     * @param m int integer.
+     * @param isField indicator if m is prime.
+     */
+    public ModIntRing(int m, boolean isField) {
+        modul = m;
+        this.isField = (isField ? 1 : 0);
+    }
+
+
+    /**
+     * The constructor creates a ModIntRing object from a Int integer as module
+     * part.
+     * @param m Int integer.
+     */
+    public ModIntRing(Integer m) {
+        this(m.intValue());
+    }
+
+
+    /**
+     * The constructor creates a ModIntRing object from a Int integer as module
+     * part.
+     * @param m Int integer.
+     * @param isField indicator if m is prime.
+     */
+    public ModIntRing(Integer m, boolean isField) {
+        this(m.intValue(), isField);
+    }
+
+
+    /**
+     * The constructor creates a ModIntRing object from a BigInteger converted
+     * to int as module part.
+     * @param m java.math.BigInteger.
+     */
+    public ModIntRing(java.math.BigInteger m) {
+        this(m.intValueExact());
+        if (MAX_INT.compareTo(m) < 0) { // m > max
+            //System.out.println("modul to large for int " + m + ",max=" + MAX_INT);
+            throw new IllegalArgumentException("modul to large for int " + m + ", max=" + MAX_INT);
+        }
+    }
+
+
+    /**
+     * The constructor creates a ModIntRing object from a BigInteger converted
+     * to int as module part.
+     * @param m java.math.BigInteger.
+     * @param isField indicator if m is prime.
+     */
+    public ModIntRing(java.math.BigInteger m, boolean isField) {
+        this(m.intValueExact(), isField);
+        if (MAX_INT.compareTo(m) < 0) { // m > max
+            //System.out.println("modul to large for int " + m + ",max=" + MAX_INT);
+            throw new IllegalArgumentException("modul to large for int " + m + ", max=" + MAX_INT);
+        }
+    }
+
+
+    /**
+     * The constructor creates a ModIntRing object from a String object as
+     * module part.
+     * @param m String.
+     */
+    public ModIntRing(String m) {
+        this(Integer.valueOf(m.trim()));
+    }
+
+
+    /**
+     * The constructor creates a ModIntRing object from a String object as
+     * module part.
+     * @param m String.
+     * @param isField indicator if m is prime.
+     */
+    public ModIntRing(String m, boolean isField) {
+        this(Integer.valueOf(m.trim()), isField);
+    }
+
+
+    /**
+     * Get the module part as BigInteger.
+     * @return modul.
+     */
+    public java.math.BigInteger getModul() {
+        return new java.math.BigInteger(Integer.toString(modul));
+    }
+
+
+    /**
+     * Get the module part as int.
+     * @return modul.
+     */
+    public int getIntModul() {
+        return modul;
+    }
+
+
+    /**
+     * Get the module part as BigInteger.
+     * @return modul.
+     */
+    public BigInteger getIntegerModul() {
+        return new BigInteger(modul);
+    }
+
+
+    /**
+     * Create ModInt element c.
+     * @param c
+     * @return a ModInt of c.
+     */
+    public ModInt create(java.math.BigInteger c) {
+        return new ModInt(this, c);
+    }
+
+
+    /**
+     * Create ModInt element c.
+     * @param c
+     * @return a ModInt of c.
+     */
+    public ModInt create(int c) {
+        return new ModInt(this, c);
+    }
+
+
+    /**
+     * Create ModInt element c.
+     * @param c
+     * @return a ModInt of c.
+     */
+    public ModInt create(String c) {
+        return parse(c);
+    }
+
+
+    /**
+     * Copy ModInt element c.
+     * @param c
+     * @return a copy of c.
+     */
+    public ModInt copy(ModInt c) {
+        return new ModInt(this, c.val);
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as ModInt.
+     */
+    public ModInt getZERO() {
+        return new ModInt(this, 0);
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as ModInt.
+     */
+    public ModInt getONE() {
+        return new ModInt(this, 1);
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     * @see edu.jas.structure.ElemFactory#generators()
+     */
+    public List<ModInt> generators() {
+        List<ModInt> g = new ArrayList<ModInt>(1);
+        g.add(getONE());
+        return g;
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite()
+     */
+    public boolean isFinite() {
+        return true;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true.
+     */
+    public boolean isCommutative() {
+        return true;
+    }
+
+
+    /**
+     * Query if this ring is associative.
+     * @return true.
+     */
+    public boolean isAssociative() {
+        return true;
+    }
+
+
+    /**
+     * Query if this ring is a field.
+     * @return true if module is prime, else false.
+     */
+    public boolean isField() {
+        if (isField > 0) {
+            return true;
+        }
+        if (isField == 0) {
+            return false;
+        }
+        //System.out.println("isProbablePrime " + modul + " = " + modul.isProbablePrime(certainty));
+        java.math.BigInteger m = new java.math.BigInteger(Integer.toString(modul));
+        if (m.isProbablePrime(m.bitLength())) {
+            isField = 1;
+            return true;
+        }
+        isField = 0;
+        return false;
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic() {
+        return new java.math.BigInteger(Integer.toString(modul));
+    }
+
+
+    /**
+     * Get a ModInt element from a BigInteger value.
+     * @param a BigInteger.
+     * @return a ModInt.
+     */
+    public ModInt fromInteger(java.math.BigInteger a) {
+        return new ModInt(this, a);
+    }
+
+
+    /**
+     * Get a ModInt element from a int value.
+     * @param a int.
+     * @return a ModInt.
+     */
+    public ModInt fromInteger(int a) {
+        return new ModInt(this, a);
+    }
+
+
+    /**
+     * Get a ModInt element from a long value.
+     * @param a lon.
+     * @return a ModInt.
+     */
+    public ModInt fromInteger(long a) {
+        return new ModInt(this, a);
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return " mod(" + modul + ")"; //",max="  + MAX_INT + ")";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.ElemFactory#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python and Ruby case
+        if (isField()) {
+            return "GFI(" + modul + ")";
+        }
+        return "ZMI(" + modul + ")";
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object b) {
+        if (!(b instanceof ModIntRing)) {
+            return false;
+        }
+        ModIntRing m = (ModIntRing) b;
+        return (modul == m.modul);
+    }
+
+
+    /**
+     * Hash code for this ModIntRing.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return modul;
+    }
+
+
+    /**
+     * ModInt random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @return a random integer mod modul.
+     */
+    public ModInt random(int n) {
+        return random(n, random);
+    }
+
+
+    /**
+     * ModInt random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @param rnd is a source for random bits.
+     * @return a random integer mod modul.
+     */
+    public ModInt random(int n, Random rnd) {
+        java.math.BigInteger v = new java.math.BigInteger(n, rnd);
+        return new ModInt(this, v); // rnd.nextInt() not ok
+    }
+
+
+    /**
+     * Parse ModInt from String.
+     * @param s String.
+     * @return ModInt from s.
+     */
+    public ModInt parse(String s) {
+        return new ModInt(this, s);
+    }
+
+
+    /**
+     * Parse ModInt from Reader.
+     * @param r Reader.
+     * @return next ModInt from r.
+     */
+    public ModInt parse(Reader r) {
+        return parse(StringUtil.nextString(r));
+    }
+
+
+    /**
+     * ModInt chinese remainder algorithm. This is a factory method. Assert
+     * c.modul &ge; a.modul and c.modul * a.modul = this.modul.
+     * @param c ModInt.
+     * @param ci inverse of c.modul in ring of a.
+     * @param a other ModInt.
+     * @return S, with S mod c.modul == c and S mod a.modul == a.
+     */
+    public ModInt chineseRemainder(ModInt c, ModInt ci, ModInt a) {
+        //if (true) { 
+        //    if (c.ring.modul < a.ring.modul) {
+        //        System.out.println("ModInt error " + c.ring + ", " + a.ring);
+        //    }
+        //}
+        ModInt b = a.ring.fromInteger(c.val); // c mod a.modul
+        ModInt d = a.subtract(b); // a-c mod a.modul
+        if (d.isZERO()) {
+            return new ModInt(this, c.val);
+        }
+        b = d.multiply(ci); // b = (a-c)*ci mod a.modul
+        // (c.modul*b)+c mod this.modul = c mod c.modul = 
+        // (c.modul*ci*(a-c)+c) mod a.modul = a mod a.modul
+        int s = c.ring.modul * b.val;
+        s = s + c.val;
+        return new ModInt(this, s);
+    }
+
+
+    /**
+     * Modular digit list chinese remainder algorithm. m1 and m2 are positive
+     * beta-integers, with GCD(m1,m2)=1 and m=m1*m2 less than beta. L1 and L2
+     * are lists of elements of Z(m1) and Z(m2) respectively. L is a list of all
+     * a in Z(m) such that a is congruent to a1 modulo m1 and a is congruent to
+     * a2 modulo m2 with a1 in L1 and a2 in L2. This is a factory method. Assert
+     * c.modul &ge; a.modul and c.modul * a.modul = this.modul.
+     * @param m1 ModInt.
+     * @param m2 other ModInt.
+     * @return L list of congruences.
+     */
+    public static List<ModInt> chineseRemainder(ModInt m1, ModInt m2, List<ModInt> L1, List<ModInt> L2) {
+        int mm = m1.ring.modul * m2.ring.modul;
+        ModIntRing m = new ModIntRing(mm);
+        ModInt m21 = m2.ring.fromInteger(m1.ring.modul);
+        ModInt mi1 = m21.inverse();
+
+        List<ModInt> L = new ArrayList<ModInt>();
+        for (ModInt a : L1) {
+            for (ModInt b : L2) {
+                ModInt c = m.chineseRemainder(a, mi1, b);
+                L.add(c);
+            }
+        }
+        return L;
+    }
+
+
+    /**
+     * Get a ModInt iterator.
+     * @return a iterator over all modular integers in this ring.
+     */
+    public Iterator<ModInt> iterator() {
+        return new ModIntIterator(this);
+    }
+
+}
+
+
+/**
+ * Modular integer iterator.
+ * @author Heinz Kredel
+ */
+class ModIntIterator implements Iterator<ModInt> {
+
+
+    /**
+     * data structure.
+     */
+    int curr;
+
+
+    final ModIntRing ring;
+
+
+    /**
+     * ModInt iterator constructor.
+     * @param fac modular integer factory;
+     */
+    public ModIntIterator(ModIntRing fac) {
+        curr = 0;
+        ring = fac;
+    }
+
+
+    /**
+     * Test for availability of a next element.
+     * @return true if the iteration has more elements, else false.
+     */
+    public synchronized boolean hasNext() {
+        return curr < ring.modul;
+    }
+
+
+    /**
+     * Get next integer.
+     * @return next integer.
+     */
+    public synchronized ModInt next() {
+        ModInt i = new ModInt(ring, curr);
+        curr++;
+        return i;
+    }
+
+
+    /**
+     * Remove an element if allowed.
+     */
+    public void remove() {
+        throw new UnsupportedOperationException("cannnot remove elements");
+    }
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/ModInteger.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/ModInteger.java
@@ -1,0 +1,670 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.arith;
+
+
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.NotInvertibleException;
+
+
+/**
+ * ModInteger class with GcdRingElem interface. Objects of this class are
+ * immutable. The SAC2 static methods are also provided.
+ * @author Heinz Kredel
+ * @see java.math.BigInteger
+ */
+
+public final class ModInteger implements GcdRingElem<ModInteger>, Modular {
+
+
+    /**
+     * ModIntegerRing reference.
+     */
+    public final ModIntegerRing ring;
+
+
+    /**
+     * Value part of the element data structure.
+     */
+    public final java.math.BigInteger val;
+
+
+    /**
+     * The constructor creates a ModInteger object from a ModIntegerRing and a
+     * value part.
+     * @param m ModIntegerRing.
+     * @param a math.BigInteger.
+     */
+    public ModInteger(ModIntegerRing m, java.math.BigInteger a) {
+        ring = m;
+        val = a.mod(ring.modul);
+    }
+
+
+    /**
+     * The constructor creates a ModInteger object from a ModIntegerRing and a
+     * long value part.
+     * @param m ModIntegerRing.
+     * @param a long.
+     */
+    public ModInteger(ModIntegerRing m, long a) {
+        this(m, new java.math.BigInteger(String.valueOf(a)));
+    }
+
+
+    /**
+     * The constructor creates a ModInteger object from a ModIntegerRing and a
+     * String value part.
+     * @param m ModIntegerRing.
+     * @param s String.
+     */
+    public ModInteger(ModIntegerRing m, String s) {
+        this(m, new java.math.BigInteger(s.trim()));
+    }
+
+
+    /**
+     * The constructor creates a 0 ModInteger object from a given
+     * ModIntegerRing.
+     * @param m ModIntegerRing.
+     */
+    public ModInteger(ModIntegerRing m) {
+        this(m, java.math.BigInteger.ZERO);
+    }
+
+
+    /**
+     * Get the value part.
+     * @return val.
+     */
+    public java.math.BigInteger getVal() {
+        return val;
+    }
+
+
+    /**
+     * Get the module part.
+     * @return modul.
+     */
+    public java.math.BigInteger getModul() {
+        return ring.modul;
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public ModIntegerRing factory() {
+        return ring;
+    }
+
+
+    /**
+     * Get the symmetric value part.
+     * @return val with -modul/2 &le; val &lt; modul/2.
+     */
+    public java.math.BigInteger getSymmetricVal() {
+        if (val.add(val).compareTo(ring.modul) > 0) {
+            // val > m/2 as 2*val > m, make symmetric to 0
+            return val.subtract(ring.modul);
+        }
+        return val;
+    }
+
+
+    /**
+     * Return a BigInteger from this Element.
+     * @return a BigInteger of this.
+     */
+    public BigInteger getInteger() {
+        return new BigInteger(val);
+    }
+
+
+    /**
+     * Return a symmetric BigInteger from this Element.
+     * @return a symmetric BigInteger of this.
+     */
+    public BigInteger getSymmetricInteger() {
+        java.math.BigInteger v = val;
+        if (val.add(val).compareTo(ring.modul) > 0) {
+            // val > m/2 as 2*val > m, make symmetric to 0
+            v = val.subtract(ring.modul);
+        }
+        return new BigInteger(v);
+    }
+
+
+    /**
+     * Clone this.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public ModInteger copy() {
+        return new ModInteger(ring, val);
+    }
+
+
+    /**
+     * Is ModInteger number zero.
+     * @return If this is 0 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isZERO()
+     */
+    public boolean isZERO() {
+        return val.signum() == 0;
+    }
+
+
+    /**
+     * Is ModInteger number one.
+     * @return If this is 1 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isONE()
+     */
+    public boolean isONE() {
+        return val.equals(java.math.BigInteger.ONE);
+    }
+
+
+    /**
+     * Is ModInteger number a unit.
+     * @return If this is a unit then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isUnit()
+     */
+    public boolean isUnit() {
+        if (isZERO()) {
+            return false;
+        }
+        if (ring.isField()) {
+            return true;
+        }
+        java.math.BigInteger g = ring.modul.gcd(val).abs();
+        return (g.equals(java.math.BigInteger.ONE));
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return val.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        return toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python case
+        return factory().toScript();
+    }
+
+
+    /**
+     * ModInteger comparison.
+     * @param b ModInteger.
+     * @return sign(this-b).
+     */
+    @Override
+    public int compareTo(ModInteger b) {
+        java.math.BigInteger v = b.val;
+        if (ring != b.ring) {
+            v = v.mod(ring.modul);
+        }
+        return val.compareTo(v);
+    }
+
+
+    /**
+     * ModInteger comparison.
+     * @param A ModInteger.
+     * @param B ModInteger.
+     * @return sign(this-b).
+     */
+    public static int MICOMP(ModInteger A, ModInteger B) {
+        if (A == null)
+            return -B.signum();
+        return A.compareTo(B);
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object b) {
+        if (!(b instanceof ModInteger)) {
+            return false;
+        }
+        return (0 == compareTo((ModInteger) b));
+    }
+
+
+    /**
+     * Hash code for this ModInteger.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        //return 37 * val.hashCode();
+        return val.hashCode();
+    }
+
+
+    /**
+     * ModInteger absolute value.
+     * @return the absolute value of this.
+     * @see edu.jas.structure.RingElem#abs()
+     */
+    public ModInteger abs() {
+        return new ModInteger(ring, val.abs());
+    }
+
+
+    /**
+     * ModInteger absolute value.
+     * @param A ModInteger.
+     * @return the absolute value of A.
+     */
+    public static ModInteger MIABS(ModInteger A) {
+        if (A == null)
+            return null;
+        return A.abs();
+    }
+
+
+    /**
+     * ModInteger negative.
+     * @see edu.jas.structure.RingElem#negate()
+     * @return -this.
+     */
+    public ModInteger negate() {
+        return new ModInteger(ring, val.negate());
+    }
+
+
+    /**
+     * ModInteger negative.
+     * @param A ModInteger.
+     * @return -A.
+     */
+    public static ModInteger MINEG(ModInteger A) {
+        if (A == null)
+            return null;
+        return A.negate();
+    }
+
+
+    /**
+     * ModInteger signum.
+     * @see edu.jas.structure.RingElem#signum()
+     * @return signum(this).
+     */
+    public int signum() {
+        return val.signum();
+    }
+
+
+    /**
+     * ModInteger signum.
+     * @param A ModInteger
+     * @return signum(A).
+     */
+    public static int MISIGN(ModInteger A) {
+        if (A == null)
+            return 0;
+        return A.signum();
+    }
+
+
+    /**
+     * ModInteger subtraction.
+     * @param S ModInteger.
+     * @return this-S.
+     */
+    public ModInteger subtract(ModInteger S) {
+        return new ModInteger(ring, val.subtract(S.val));
+    }
+
+
+    /**
+     * ModInteger subtraction.
+     * @param A ModInteger.
+     * @param B ModInteger.
+     * @return A-B.
+     */
+    public static ModInteger MIDIF(ModInteger A, ModInteger B) {
+        if (A == null)
+            return B.negate();
+        return A.subtract(B);
+    }
+
+
+    /**
+     * ModInteger divide.
+     * @param S ModInteger.
+     * @return this/S.
+     */
+    public ModInteger divide(ModInteger S) {
+        try {
+            return multiply(S.inverse());
+        } catch (NotInvertibleException e) {
+            try {
+                if (val.remainder(S.val).equals(java.math.BigInteger.ZERO)) {
+                    return new ModInteger(ring, val.divide(S.val));
+                }
+                throw new NotInvertibleException(e);
+            } catch (ArithmeticException a) {
+                throw new NotInvertibleException(a);
+            }
+        }
+    }
+
+
+    /**
+     * ModInteger quotient.
+     * @param A ModInteger.
+     * @param B ModInteger.
+     * @return A/B.
+     */
+    public static ModInteger MIQ(ModInteger A, ModInteger B) {
+        if (A == null)
+            return null;
+        return A.divide(B);
+    }
+
+
+    /**
+     * ModInteger inverse.
+     * @see edu.jas.structure.RingElem#inverse()
+     * @throws NotInvertibleException if the element is not invertible.
+     * @return S with S=1/this if defined.
+     */
+    public ModInteger inverse() /*throws NotInvertibleException*/ {
+        try {
+            return new ModInteger(ring, val.modInverse(ring.modul));
+        } catch (ArithmeticException e) {
+            java.math.BigInteger g = val.gcd(ring.modul);
+            java.math.BigInteger f = ring.modul.divide(g);
+            throw new ModularNotInvertibleException(e, new BigInteger(ring.modul), new BigInteger(g),
+                            new BigInteger(f));
+        }
+    }
+
+
+    /**
+     * ModInteger inverse.
+     * @param A is a non-zero integer.
+     * @see edu.jas.structure.RingElem#inverse()
+     * @return S with S=1/A if defined.
+     */
+    public static ModInteger MIINV(ModInteger A) {
+        if (A == null)
+            return null;
+        return A.inverse();
+    }
+
+
+    /**
+     * ModInteger remainder.
+     * @param S ModInteger.
+     * @return remainder(this,S).
+     */
+    public ModInteger remainder(ModInteger S) {
+        if (S == null || S.isZERO()) {
+            throw new ArithmeticException("division by zero");
+        }
+        if (S.isONE()) {
+            return ring.getZERO();
+        }
+        if (S.isUnit()) {
+            return ring.getZERO();
+        }
+        return new ModInteger(ring, val.remainder(S.val));
+    }
+
+
+    /**
+     * ModInteger remainder.
+     * @param A ModInteger.
+     * @param B ModInteger.
+     * @return A - (A/B)*B.
+     */
+    public static ModInteger MIREM(ModInteger A, ModInteger B) {
+        if (A == null)
+            return null;
+        return A.remainder(B);
+    }
+
+
+    /**
+     * Quotient and remainder by division of this by S.
+     * @param S a modular integer
+     * @return [this/S, this - (this/S)*S].
+     */
+    public ModInteger[] quotientRemainder(ModInteger S) {
+        return new ModInteger[] { divide(S), remainder(S) };
+    }
+
+
+    /**
+     * ModInteger multiply.
+     * @param S ModInteger.
+     * @return this*S.
+     */
+    public ModInteger multiply(ModInteger S) {
+        return new ModInteger(ring, val.multiply(S.val));
+    }
+
+
+    /**
+     * ModInteger product.
+     * @param A ModInteger.
+     * @param B ModInteger.
+     * @return A*B.
+     */
+    public static ModInteger MIPROD(ModInteger A, ModInteger B) {
+        if (A == null)
+            return null;
+        return A.multiply(B);
+    }
+
+
+    /**
+     * ModInteger summation.
+     * @param S ModInteger.
+     * @return this+S.
+     */
+    public ModInteger sum(ModInteger S) {
+        return new ModInteger(ring, val.add(S.val));
+    }
+
+
+    /**
+     * ModInteger summation.
+     * @param A ModInteger.
+     * @param B ModInteger.
+     * @return A+B.
+     */
+    public static ModInteger MISUM(ModInteger A, ModInteger B) {
+        if (A == null)
+            return null;
+        return A.sum(B);
+    }
+
+
+    /**
+     * ModInteger greatest common divisor.
+     * @param S ModInteger.
+     * @return gcd(this,S).
+     */
+    public ModInteger gcd(ModInteger S) {
+        if (S.isZERO()) {
+            return this;
+        }
+        if (isZERO()) {
+            return S;
+        }
+        if (isUnit() || S.isUnit()) {
+            return ring.getONE();
+        }
+        return new ModInteger(ring, val.gcd(S.val));
+    }
+
+
+    /**
+     * ModInteger half extended greatest common divisor.
+     * @param S ModInteger.
+     * @return [ gcd(this,S), a ] with a*this + b*S = gcd(this,S) for some b.
+     */
+    public ModInteger[] hegcd(ModInteger S) {
+        ModInteger[] ret = new ModInteger[2];
+        ret[0] = null;
+        ret[1] = null;
+        if (S == null || S.isZERO()) {
+            ret[0] = this;
+            ret[1] = this.ring.getONE();
+            return ret;
+        }
+        if (isZERO()) {
+            ret[0] = S;
+            return ret;
+        }
+        //System.out.println("this = " + this + ", S = " + S);
+        java.math.BigInteger[] qr;
+        java.math.BigInteger q = this.val;
+        java.math.BigInteger r = S.val;
+        java.math.BigInteger c1 = BigInteger.ONE.val;
+        java.math.BigInteger d1 = BigInteger.ZERO.val;
+        java.math.BigInteger x1;
+        while (!r.equals(java.math.BigInteger.ZERO)) {
+            qr = q.divideAndRemainder(r);
+            q = qr[0];
+            x1 = c1.subtract(q.multiply(d1));
+            c1 = d1;
+            d1 = x1;
+            q = r;
+            r = qr[1];
+        }
+        //System.out.println("q = " + q + "\n c1 = " + c1 + "\n c2 = " + c2);
+        ret[0] = new ModInteger(ring, q);
+        ret[1] = new ModInteger(ring, c1);
+        //assert ( ((c1.multiply(this)).remainder(S).equals(q) )); 
+        return ret;
+    }
+
+
+    /**
+     * ModInteger extended greatest common divisor.
+     * @param S ModInteger.
+     * @return [ gcd(this,S), a, b ] with a*this + b*S = gcd(this,S).
+     */
+    public ModInteger[] egcd(ModInteger S) {
+        ModInteger[] ret = new ModInteger[3];
+        ret[0] = null;
+        ret[1] = null;
+        ret[2] = null;
+        if (S == null || S.isZERO()) {
+            ret[0] = this;
+            return ret;
+        }
+        if (isZERO()) {
+            ret[0] = S;
+            return ret;
+        }
+        if (this.isUnit() || S.isUnit()) {
+            ret[0] = ring.getONE();
+            if (this.isUnit() && S.isUnit()) {
+                //ModInteger half = ring.fromInteger(2).inverse();
+                //ret[1] = this.inverse().multiply(half);
+                //ret[2] = S.inverse().multiply(half);
+                //System.out.println("gcd = " + (ret[1].multiply(this).sum(ret[2].multiply(S))));
+                // (1-1*this)/S
+                ret[1] = ring.getONE();
+                ModInteger x = ret[0].subtract(ret[1].multiply(this));
+                ret[2] = x.divide(S);
+                //System.out.println("gcd, a, b = " + (ret[1]) + ", " + ret[2]);
+                //System.out.println("gcd = " + (ret[1].multiply(this).sum(ret[2].multiply(S))));
+                return ret;
+            }
+            if (this.isUnit()) {
+                // oder inverse(S-1)?
+                ret[1] = this.inverse();
+                ret[2] = ring.getZERO();
+                return ret;
+            }
+            // if ( S.isUnit() ) {
+            // oder inverse(this-1)?
+            ret[1] = ring.getZERO();
+            ret[2] = S.inverse();
+            return ret;
+            //}
+        }
+        //System.out.println("this = " + this + ", S = " + S);
+        java.math.BigInteger[] qr;
+        java.math.BigInteger q = this.val;
+        java.math.BigInteger r = S.val;
+        java.math.BigInteger c1 = BigInteger.ONE.val;
+        java.math.BigInteger d1 = BigInteger.ZERO.val;
+        java.math.BigInteger c2 = BigInteger.ZERO.val;
+        java.math.BigInteger d2 = BigInteger.ONE.val;
+        java.math.BigInteger x1;
+        java.math.BigInteger x2;
+        while (!r.equals(java.math.BigInteger.ZERO)) {
+            qr = q.divideAndRemainder(r);
+            q = qr[0];
+            x1 = c1.subtract(q.multiply(d1));
+            x2 = c2.subtract(q.multiply(d2));
+            c1 = d1;
+            c2 = d2;
+            d1 = x1;
+            d2 = x2;
+            q = r;
+            r = qr[1];
+        }
+        //System.out.println("q = " + q + "\n c1 = " + c1 + "\n c2 = " + c2);
+        ret[0] = new ModInteger(ring, q);
+        ret[1] = new ModInteger(ring, c1);
+        ret[2] = new ModInteger(ring, c2);
+        return ret;
+    }
+
+
+    /**
+     * Returns the number of bits in the representation of this ModInteger,
+     * including a sign bit. For positive ModIntegers, this is equivalent to
+     * {@code val.bitLength()}.)
+     * @return number of bits in the representation of this ModInteger,
+     *         including a sign bit.
+     */
+    public long bitLength() {
+        long n = val.bitLength();
+        if (val.signum() < 0) {
+            n++;
+        }
+        n++;
+        return n;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/ModIntegerRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/ModIntegerRing.java
@@ -1,0 +1,488 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.arith;
+
+
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+
+import edu.jas.kern.StringUtil;
+
+
+/**
+ * ModIntegerRing factory with RingFactory interface. Effectively immutable.
+ * @author Heinz Kredel
+ */
+
+public final class ModIntegerRing implements ModularRingFactory<ModInteger>, Iterable<ModInteger> {
+
+
+    /**
+     * Module part of the factory data structure.
+     */
+    public final java.math.BigInteger modul;
+
+
+    private final static Random random = new Random();
+
+
+    /**
+     * Indicator if this ring is a field.
+     */
+    private int isField = -1; // initially unknown
+
+
+    /*
+     * Certainty if module is probable prime.
+     */
+    //private int certainty = 10;
+
+
+    /**
+     * The constructor creates a ModIntegerRing object from a BigInteger object
+     * as module part.
+     * @param m math.BigInteger.
+     */
+    public ModIntegerRing(java.math.BigInteger m) {
+        modul = m;
+    }
+
+
+    /**
+     * The constructor creates a ModIntegerRing object from a BigInteger object
+     * as module part.
+     * @param m math.BigInteger.
+     * @param isField indicator if m is prime.
+     */
+    public ModIntegerRing(java.math.BigInteger m, boolean isField) {
+        modul = m;
+        this.isField = (isField ? 1 : 0);
+    }
+
+
+    /**
+     * The constructor creates a ModIntegerRing object from a long as module
+     * part.
+     * @param m long.
+     */
+    public ModIntegerRing(long m) {
+        this(new java.math.BigInteger(String.valueOf(m)));
+    }
+
+
+    /**
+     * The constructor creates a ModIntegerRing object from a long as module
+     * part.
+     * @param m long.
+     * @param isField indicator if m is prime.
+     */
+    public ModIntegerRing(long m, boolean isField) {
+        this(new java.math.BigInteger(String.valueOf(m)), isField);
+    }
+
+
+    /**
+     * The constructor creates a ModIntegerRing object from a String object as
+     * module part.
+     * @param m String.
+     */
+    public ModIntegerRing(String m) {
+        this(new java.math.BigInteger(m.trim()));
+    }
+
+
+    /**
+     * The constructor creates a ModIntegerRing object from a String object as
+     * module part.
+     * @param m String.
+     * @param isField indicator if m is prime.
+     */
+    public ModIntegerRing(String m, boolean isField) {
+        this(new java.math.BigInteger(m.trim()), isField);
+    }
+
+
+    /**
+     * Get the module part.
+     * @return modul.
+     */
+    public java.math.BigInteger getModul() {
+        return modul;
+    }
+
+
+    /**
+     * Get the module part as BigInteger.
+     * @return modul.
+     */
+    public BigInteger getIntegerModul() {
+        return new BigInteger(modul);
+    }
+
+
+    /**
+     * Create ModInteger element c.
+     * @param c
+     * @return a ModInteger of c.
+     */
+    public ModInteger create(java.math.BigInteger c) {
+        return new ModInteger(this, c);
+    }
+
+
+    /**
+     * Create ModInteger element c.
+     * @param c
+     * @return a ModInteger of c.
+     */
+    public ModInteger create(long c) {
+        return new ModInteger(this, c);
+    }
+
+
+    /**
+     * Create ModInteger element c.
+     * @param c
+     * @return a ModInteger of c.
+     */
+    public ModInteger create(String c) {
+        return parse(c);
+    }
+
+
+    /**
+     * Copy ModInteger element c.
+     * @param c
+     * @return a copy of c.
+     */
+    public ModInteger copy(ModInteger c) {
+        return new ModInteger(this, c.val);
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as ModInteger.
+     */
+    public ModInteger getZERO() {
+        return new ModInteger(this, java.math.BigInteger.ZERO);
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as ModInteger.
+     */
+    public ModInteger getONE() {
+        return new ModInteger(this, java.math.BigInteger.ONE);
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     * @see edu.jas.structure.ElemFactory#generators()
+     */
+    public List<ModInteger> generators() {
+        List<ModInteger> g = new ArrayList<ModInteger>(1);
+        g.add(getONE());
+        return g;
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite()
+     */
+    public boolean isFinite() {
+        return true;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true.
+     */
+    public boolean isCommutative() {
+        return true;
+    }
+
+
+    /**
+     * Query if this ring is associative.
+     * @return true.
+     */
+    public boolean isAssociative() {
+        return true;
+    }
+
+
+    /**
+     * Query if this ring is a field.
+     * @return true if module is prime, else false.
+     */
+    public boolean isField() {
+        if (isField > 0) {
+            return true;
+        }
+        if (isField == 0) {
+            return false;
+        }
+        //System.out.println("isProbablePrime " + modul + " = " + modul.isProbablePrime(certainty));
+        // if ( modul.isProbablePrime(certainty) ) {
+        if (modul.isProbablePrime(modul.bitLength())) {
+            isField = 1;
+            return true;
+        }
+        isField = 0;
+        return false;
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic() {
+        return modul;
+    }
+
+
+    /**
+     * Get a ModInteger element from a BigInteger value.
+     * @param a BigInteger.
+     * @return a ModInteger.
+     */
+    public ModInteger fromInteger(java.math.BigInteger a) {
+        return new ModInteger(this, a);
+    }
+
+
+    /**
+     * Get a ModInteger element from a long value.
+     * @param a long.
+     * @return a ModInteger.
+     */
+    public ModInteger fromInteger(long a) {
+        return new ModInteger(this, a);
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return " bigMod(" + modul.toString() + ")";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.ElemFactory#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python and Ruby case
+        if (isField()) {
+            return "GF(" + modul.toString() + ")";
+        }
+        return "ZM(" + modul.toString() + ")";
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object b) {
+        if (!(b instanceof ModIntegerRing)) {
+            return false;
+        }
+        ModIntegerRing m = (ModIntegerRing) b;
+        return (0 == modul.compareTo(m.modul));
+    }
+
+
+    /**
+     * Hash code for this ModIntegerRing.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return modul.hashCode();
+    }
+
+
+    /**
+     * ModInteger random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @return a random integer mod modul.
+     */
+    public ModInteger random(int n) {
+        return random(n, random);
+    }
+
+
+    /**
+     * ModInteger random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @param rnd is a source for random bits.
+     * @return a random integer mod modul.
+     */
+    public ModInteger random(int n, Random rnd) {
+        java.math.BigInteger v = new java.math.BigInteger(n, rnd);
+        return new ModInteger(this, v);
+    }
+
+
+    /**
+     * Parse ModInteger from String.
+     * @param s String.
+     * @return ModInteger from s.
+     */
+    public ModInteger parse(String s) {
+        return new ModInteger(this, s);
+    }
+
+
+    /**
+     * Parse ModInteger from Reader.
+     * @param r Reader.
+     * @return next ModInteger from r.
+     */
+    public ModInteger parse(Reader r) {
+        return parse(StringUtil.nextString(r));
+    }
+
+
+    /**
+     * ModInteger chinese remainder algorithm. This is a factory method. Assert
+     * c.modul &ge; a.modul and c.modul * a.modul = this.modul.
+     * @param c ModInteger.
+     * @param ci inverse of c.modul in ring of a.
+     * @param a other ModInteger.
+     * @return S, with S mod c.modul == c and S mod a.modul == a.
+     */
+    public ModInteger chineseRemainder(ModInteger c, ModInteger ci, ModInteger a) {
+        //if (false) { // debug
+        //    if (c.ring.modul.compareTo(a.ring.modul) < 1) {
+        //        System.out.println("ModInteger error " + c + ", " + a);
+        //    }
+        //}
+        ModInteger b = a.ring.fromInteger(c.val); // c mod a.modul
+        ModInteger d = a.subtract(b); // a-c mod a.modul
+        if (d.isZERO()) {
+            return fromInteger(c.val);
+        }
+        b = d.multiply(ci); // b = (a-c)*ci mod a.modul
+        // (c.modul*b)+c mod this.modul = c mod c.modul = 
+        // (c.modul*ci*(a-c)+c) mod a.modul = a mod a.modul
+        java.math.BigInteger s = c.ring.modul.multiply(b.val);
+        s = s.add(c.val);
+        return fromInteger(s);
+    }
+
+
+    /**
+     * Modular integer list chinese remainder algorithm. m1 and m2 are positive
+     * integers, with GCD(m1,m2)=1 and m=m1*m2 less than beta. L1 and L2 are
+     * lists of elements of Z(m1) and Z(m2) respectively. L is a list of all a
+     * in Z(m) such that a is congruent to a1 modulo m1 and a is congruent to a2
+     * modulo m2 with a1 in L1 and a2 in L2. This is a factory method. Assert
+     * c.modul &ge; a.modul and c.modul * a.modul = this.modul.
+     * @param m1 modular integer.
+     * @param m2 other modular integer.
+     * @return L list of congruences.
+     */
+    public static List<ModInteger> chineseRemainder(ModInteger m1, ModInteger m2, List<ModInteger> L1,
+                    List<ModInteger> L2) {
+        java.math.BigInteger mm = m1.ring.modul.multiply(m2.ring.modul);
+        ModIntegerRing m = new ModIntegerRing(mm);
+        ModInteger m21 = m2.ring.fromInteger(m1.ring.modul);
+        ModInteger mi1 = m21.inverse();
+
+        List<ModInteger> L = new ArrayList<ModInteger>();
+        for (ModInteger a : L1) {
+            for (ModInteger b : L2) {
+                ModInteger c = m.chineseRemainder(a, mi1, b);
+                L.add(c);
+            }
+        }
+        return L;
+    }
+
+
+    /**
+     * Get a ModInteger iterator.
+     * @return a iterator over all modular integers in this ring.
+     */
+    public Iterator<ModInteger> iterator() {
+        return new ModIntegerIterator(this);
+    }
+
+}
+
+
+/**
+ * Modular integer iterator.
+ * @author Heinz Kredel
+ */
+class ModIntegerIterator implements Iterator<ModInteger> {
+
+
+    /**
+     * data structure.
+     */
+    java.math.BigInteger curr;
+
+
+    final ModIntegerRing ring;
+
+
+    /**
+     * ModInteger iterator constructor.
+     * @param fac modular integer factory;
+     */
+    public ModIntegerIterator(ModIntegerRing fac) {
+        curr = java.math.BigInteger.ZERO;
+        ring = fac;
+    }
+
+
+    /**
+     * Test for availability of a next element.
+     * @return true if the iteration has more elements, else false.
+     */
+    public synchronized boolean hasNext() {
+        return curr.compareTo(ring.modul) < 0;
+    }
+
+
+    /**
+     * Get next integer.
+     * @return next integer.
+     */
+    public synchronized ModInteger next() {
+        ModInteger i = new ModInteger(ring, curr);
+        curr = curr.add(java.math.BigInteger.ONE);
+        return i;
+    }
+
+
+    /**
+     * Remove an element if allowed.
+     */
+    public void remove() {
+        throw new UnsupportedOperationException("cannnot remove elements");
+    }
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/ModLong.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/ModLong.java
@@ -1,0 +1,590 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.arith;
+
+
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.NotInvertibleException;
+
+
+/**
+ * ModLong class with RingElem interface. Objects of this class are immutable.
+ * @author Heinz Kredel
+ * @see ModInteger
+ */
+
+public final class ModLong implements GcdRingElem<ModLong>, Modular {
+
+
+    /**
+     * ModLongRing reference.
+     */
+    public final ModLongRing ring;
+
+
+    /**
+     * Value part of the element data structure.
+     */
+    public final long val;
+
+
+    /**
+     * The constructor creates a ModLong object from a ModLongRing and a value
+     * part.
+     * @param m ModLongRing.
+     * @param a math.BigInteger.
+     */
+    public ModLong(ModLongRing m, java.math.BigInteger a) {
+        this(m, a.mod(m.getModul()).longValue());
+    }
+
+
+    /**
+     * The constructor creates a ModLong object from a ModLongRing and a long
+     * value part.
+     * @param m ModLongRing.
+     * @param a long.
+     */
+    public ModLong(ModLongRing m, long a) {
+        ring = m;
+        long v = a % ring.modul;
+        val = (v >= 0L ? v : v + ring.modul);
+    }
+
+
+    /**
+     * The constructor creates a ModLong object from a ModLongRing and a Long
+     * value part.
+     * @param m ModLongRing.
+     * @param a Long.
+     */
+    public ModLong(ModLongRing m, Long a) {
+        this(m, a.longValue());
+    }
+
+
+    /**
+     * The constructor creates a ModLong object from a ModLongRing and a String
+     * value part.
+     * @param m ModLongRing.
+     * @param s String.
+     */
+    public ModLong(ModLongRing m, String s) {
+        this(m, Long.valueOf(s.trim()));
+    }
+
+
+    /**
+     * The constructor creates a 0 ModLong object from a given ModLongRing.
+     * @param m ModLongRing.
+     */
+    public ModLong(ModLongRing m) {
+        this(m, 0L);
+    }
+
+
+    /**
+     * Get the value part.
+     * @return val.
+     */
+    public long getVal() {
+        return val;
+    }
+
+
+    /**
+     * Get the module part.
+     * @return modul.
+     */
+    public long getModul() {
+        return ring.modul;
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public ModLongRing factory() {
+        return ring;
+    }
+
+
+    /**
+     * Get the symmetric value part.
+     * @return val with -modul/2 &le; val &lt; modul/2.
+     */
+    public long getSymmetricVal() {
+        if ((val + val) > ring.modul) {
+            // val > m/2 as 2*val > m, make symmetric to 0
+            return val - ring.modul;
+        }
+        return val;
+    }
+
+
+    /**
+     * Return a BigInteger from this Element.
+     * @return a BigInteger of this.
+     */
+    public BigInteger getInteger() {
+        return new BigInteger(val);
+    }
+
+
+    /**
+     * Return a symmetric BigInteger from this Element.
+     * @return a symmetric BigInteger of this.
+     */
+    public BigInteger getSymmetricInteger() {
+        long v = val;
+        if ((val + val) > ring.modul) {
+            // val > m/2 as 2*val > m, make symmetric to 0
+            v = val - ring.modul;
+        }
+        return new BigInteger(v);
+    }
+
+
+    /**
+     * Clone this.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public ModLong copy() {
+        return new ModLong(ring, val);
+    }
+
+
+    /**
+     * Is ModLong number zero.
+     * @return If this is 0 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isZERO()
+     */
+    public boolean isZERO() {
+        return val == 0L;
+    }
+
+
+    /**
+     * Is ModLong number one.
+     * @return If this is 1 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isONE()
+     */
+    public boolean isONE() {
+        return val == 1L;
+    }
+
+
+    /**
+     * Is ModLong number a unit.
+     * @return If this is a unit then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isUnit()
+     */
+    public boolean isUnit() {
+        if (isZERO()) {
+            return false;
+        }
+        if (ring.isField()) {
+            return true;
+        }
+        long g = gcd(ring.modul, val);
+        return (g == 1L || g == -1L);
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return Long.toString(val);
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        return toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python case
+        return factory().toScript();
+    }
+
+
+    /**
+     * ModLong comparison.
+     * @param b ModLong.
+     * @return sign(this-b).
+     */
+    @Override
+    public int compareTo(ModLong b) {
+        long v = b.val;
+        if (ring != b.ring) {
+            v = v % ring.modul;
+        }
+        if (val > v) {
+            return 1;
+        }
+        return (val < v ? -1 : 0);
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object b) {
+        if (!(b instanceof ModLong)) {
+            return false;
+        }
+        return (0 == compareTo((ModLong) b));
+    }
+
+
+    /**
+     * Hash code for this ModLong.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return (int) val;
+    }
+
+
+    /**
+     * ModLong absolute value.
+     * @return the absolute value of this.
+     * @see edu.jas.structure.RingElem#abs()
+     */
+    public ModLong abs() {
+        return new ModLong(ring, (val < 0 ? -val : val));
+    }
+
+
+    /**
+     * ModLong negative.
+     * @see edu.jas.structure.RingElem#negate()
+     * @return -this.
+     */
+    public ModLong negate() {
+        return new ModLong(ring, -val);
+    }
+
+
+    /**
+     * ModLong signum.
+     * @see edu.jas.structure.RingElem#signum()
+     * @return signum(this).
+     */
+    public int signum() {
+        if (val > 0L) {
+            return 1;
+        }
+        return (val < 0L ? -1 : 0);
+    }
+
+
+    /**
+     * ModLong subtraction.
+     * @param S ModLong.
+     * @return this-S.
+     */
+    public ModLong subtract(ModLong S) {
+        return new ModLong(ring, val - S.val);
+    }
+
+
+    /**
+     * ModLong divide.
+     * @param S ModLong.
+     * @return this/S.
+     */
+    public ModLong divide(ModLong S) {
+        try {
+            return multiply(S.inverse());
+        } catch (NotInvertibleException e) {
+            try {
+                if ((val % S.val) == 0L) {
+                    return new ModLong(ring, val / S.val);
+                }
+                throw new NotInvertibleException(e.getCause());
+            } catch (ArithmeticException a) {
+                throw new NotInvertibleException(a.getCause());
+            }
+        }
+    }
+
+
+    /**
+     * ModLong inverse.
+     * @see edu.jas.structure.RingElem#inverse()
+     * @throws NotInvertibleException if the element is not invertible.
+     * @return S with S=1/this if defined.
+     */
+    public ModLong inverse() /*throws NotInvertibleException*/ {
+        try {
+            return new ModLong(ring, modInverse(val, ring.modul));
+        } catch (ArithmeticException e) {
+            long g = gcd(val, ring.modul);
+            long f = ring.modul / g;
+            throw new ModularNotInvertibleException(e, new BigInteger(ring.modul), new BigInteger(g),
+                            new BigInteger(f));
+        }
+    }
+
+
+    /**
+     * ModLong remainder.
+     * @param S ModLong.
+     * @return remainder(this,S).
+     */
+    public ModLong remainder(ModLong S) {
+        if (S == null || S.isZERO()) {
+            throw new ArithmeticException("division by zero");
+        }
+        if (S.isONE()) {
+            return ring.getZERO();
+        }
+        if (S.isUnit()) {
+            return ring.getZERO();
+        }
+        return new ModLong(ring, val % S.val);
+    }
+
+
+    /**
+     * ModLong multiply.
+     * @param S ModLong.
+     * @return this*S.
+     */
+    public ModLong multiply(ModLong S) {
+        return new ModLong(ring, val * S.val);
+    }
+
+
+    /**
+     * ModLong summation.
+     * @param S ModLong.
+     * @return this+S.
+     */
+    public ModLong sum(ModLong S) {
+        return new ModLong(ring, val + S.val);
+    }
+
+
+    /**
+     * ModInteger greatest common divisor.
+     * @param S ModInteger.
+     * @return [ gcd(this,S), a, b ] with a*this + b*S = gcd(this,S).
+     */
+    public ModLong gcd(ModLong S) {
+        if (S.isZERO()) {
+            return this;
+        }
+        if (isZERO()) {
+            return S;
+        }
+        if (isUnit() || S.isUnit()) {
+            return ring.getONE();
+        }
+        return new ModLong(ring, gcd(val, S.val));
+    }
+
+
+    /**
+     * ModInteger extended greatest common divisor.
+     * @param S ModInteger.
+     * @return [ gcd(this,S), a, b ] with a*this + b*S = gcd(this,S).
+     */
+    public ModLong[] egcd(ModLong S) {
+        ModLong[] ret = new ModLong[3];
+        ret[0] = null;
+        ret[1] = null;
+        ret[2] = null;
+        if (S == null || S.isZERO()) {
+            ret[0] = this;
+            return ret;
+        }
+        if (isZERO()) {
+            ret[0] = S;
+            return ret;
+        }
+        if (isUnit() || S.isUnit()) {
+            ret[0] = ring.getONE();
+            if (isUnit() && S.isUnit()) {
+                //ModLong half = (new ModLong(ring, 2L)).inverse();
+                //ret[1] = this.inverse().multiply(half);
+                //ret[2] = S.inverse().multiply(half);
+                // (1-1*this)/S
+                ret[1] = ring.getONE();
+                ModLong x = ret[0].subtract(ret[1].multiply(this));
+                ret[2] = x.divide(S);
+                return ret;
+            }
+            if (isUnit()) {
+                // oder inverse(S-1)?
+                ret[1] = this.inverse();
+                ret[2] = ring.getZERO();
+                return ret;
+            }
+            // if ( s.isUnit() ) {
+            // oder inverse(this-1)?
+            ret[1] = ring.getZERO();
+            ret[2] = S.inverse();
+            return ret;
+            //}
+        }
+        //System.out.println("this = " + this + ", S = " + S);
+        long q = this.val;
+        long r = S.val;
+        long c1 = 1L; // BigInteger.ONE.val;
+        long d1 = 0L; // BigInteger.ZERO.val;
+        long c2 = 0L; // BigInteger.ZERO.val;
+        long d2 = 1L; // BigInteger.ONE.val;
+        long x1;
+        long x2;
+        while (r != 0L) {
+            //qr = q.divideAndRemainder(r);
+            long a = q / r;
+            long b = q % r;
+            q = a;
+            x1 = c1 - q * d1;
+            x2 = c2 - q * d2;
+            c1 = d1;
+            c2 = d2;
+            d1 = x1;
+            d2 = x2;
+            q = r;
+            r = b;
+        }
+        //System.out.println("q = " + q + "\n c1 = " + c1 + "\n c2 = " + c2);
+        ret[0] = new ModLong(ring, q);
+        ret[1] = new ModLong(ring, c1);
+        ret[2] = new ModLong(ring, c2);
+        return ret;
+    }
+
+
+    /**
+     * Long greatest common divisor.
+     * @param T long.
+     * @param S long.
+     * @return gcd(T,S).
+     */
+    public long gcd(long T, long S) {
+        if (S == 0L) {
+            return T;
+        }
+        if (T == 0L) {
+            return S;
+        }
+        long a = T;
+        long b = S;
+        while (b != 0L) {
+            long r = a % b;
+            a = b;
+            b = r;
+        }
+        return a;
+    }
+
+
+    /**
+     * Long half extended greatest common divisor.
+     * @param T long.
+     * @param S long.
+     * @return [ gcd(T,S), a ] with a*T + b*S = gcd(T,S).
+     */
+    public long[] hegcd(long T, long S) {
+        long[] ret = new long[2];
+        if (S == 0L) {
+            ret[0] = T;
+            ret[1] = 1L;
+            return ret;
+        }
+        if (T == 0L) {
+            ret[0] = S;
+            ret[1] = 0L;
+            return ret;
+        }
+        //System.out.println("hegcd, T = " + T + ", S = " + S);
+        long a = T;
+        long b = S;
+        long a1 = 1L;
+        long b1 = 0L;
+        while (b != 0L) {
+            long q = a / b;
+            long r = a % b;
+            a = b;
+            b = r;
+            long r1 = a1 - q * b1;
+            a1 = b1;
+            b1 = r1;
+        }
+        if (a1 < 0L) {
+            a1 += S;
+        }
+        ret[0] = a;
+        ret[1] = a1;
+        return ret;
+    }
+
+
+    /**
+     * Long modular inverse.
+     * @param T long.
+     * @param m long.
+     * @return a with with a*T = 1 mod m.
+     */
+    public long modInverse(long T, long m) {
+        if (T == 0L) {
+            throw new NotInvertibleException("zero is not invertible");
+        }
+        long[] hegcd = hegcd(T, m);
+        long a = hegcd[0];
+        if (!(a == 1L || a == -1L)) { // gcd != 1
+            throw new ModularNotInvertibleException("element not invertible, gcd != 1", new BigInteger(m),
+                            new BigInteger(a), new BigInteger(m / a));
+        }
+        long b = hegcd[1];
+        if (b == 0L) { // when m divides this, e.g. m.isUnit()
+            throw new NotInvertibleException("element not invertible, divisible by modul");
+        }
+        if (b < 0L) {
+            b += m;
+        }
+        return b;
+    }
+
+
+    /**
+     * Returns the number of bits in the representation of this ModLong,
+     * including a sign bit.
+     * @return number of bits in the representation of this ModLong, including a
+     *         sign bit.
+     */
+    public long bitLength() {
+        return BigInteger.bitLength(val);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/ModLongRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/ModLongRing.java
@@ -1,0 +1,535 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.arith;
+
+
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+
+import edu.jas.kern.StringUtil;
+
+
+/**
+ * ModLongRing factory with RingFactory interface. Effectively immutable.
+ * @author Heinz Kredel
+ */
+
+public final class ModLongRing implements ModularRingFactory<ModLong>, Iterable<ModLong> {
+
+
+    /**
+     * Module part of the factory data structure.
+     */
+    public final long modul;
+
+
+    /**
+     * Random number generator.
+     */
+    private final static Random random = new Random();
+
+
+    /**
+     * Indicator if this ring is a field.
+     */
+    private int isField = -1; // initially unknown
+
+
+    /*
+     * Certainty if module is probable prime.
+     */
+    //private final int certainty = 10;
+
+
+    /**
+     * maximal representable integer.
+     */
+    public final static java.math.BigInteger MAX_LONG = new java.math.BigInteger(
+                    String.valueOf(Integer.MAX_VALUE)); // not larger!
+
+
+    /**
+     * The constructor creates a ModLongRing object from a long integer as
+     * module part.
+     * @param m long integer.
+     */
+    public ModLongRing(long m) {
+        modul = m;
+    }
+
+
+    /**
+     * The constructor creates a ModLongRing object from a long integer as
+     * module part.
+     * @param m long integer.
+     * @param isField indicator if m is prime.
+     */
+    public ModLongRing(long m, boolean isField) {
+        modul = m;
+        this.isField = (isField ? 1 : 0);
+    }
+
+
+    /**
+     * The constructor creates a ModLongRing object from a Long integer as
+     * module part.
+     * @param m Long integer.
+     */
+    public ModLongRing(Long m) {
+        this(m.longValue());
+    }
+
+
+    /**
+     * The constructor creates a ModLongRing object from a Long integer as
+     * module part.
+     * @param m Long integer.
+     * @param isField indicator if m is prime.
+     */
+    public ModLongRing(Long m, boolean isField) {
+        this(m.longValue(), isField);
+    }
+
+
+    /**
+     * The constructor creates a ModLongRing object from a BigInteger converted
+     * to long as module part.
+     * @param m java.math.BigInteger.
+     */
+    public ModLongRing(java.math.BigInteger m) {
+        this(m.longValueExact());
+        if (MAX_LONG.compareTo(m) < 0) { // m > max
+            //System.out.println("modul to large for long " + m + ",max=" + MAX_LONG);
+            throw new IllegalArgumentException("modul to large for long " + m + ", max=" + MAX_LONG);
+        }
+    }
+
+
+    /**
+     * The constructor creates a ModLongRing object from a BigInteger converted
+     * to long as module part.
+     * @param m java.math.BigInteger.
+     * @param isField indicator if m is prime.
+     */
+    public ModLongRing(java.math.BigInteger m, boolean isField) {
+        this(m.longValueExact(), isField);
+        if (MAX_LONG.compareTo(m) < 0) { // m > max
+            //System.out.println("modul to large for long " + m + ",max=" + MAX_LONG);
+            throw new IllegalArgumentException("modul to large for long " + m + ", max=" + MAX_LONG);
+        }
+    }
+
+
+    /**
+     * The constructor creates a ModLongRing object from a String object as
+     * module part.
+     * @param m String.
+     */
+    public ModLongRing(String m) {
+        this(Long.valueOf(m.trim()));
+    }
+
+
+    /**
+     * The constructor creates a ModLongRing object from a String object as
+     * module part.
+     * @param m String.
+     * @param isField indicator if m is prime.
+     */
+    public ModLongRing(String m, boolean isField) {
+        this(Long.valueOf(m.trim()), isField);
+    }
+
+
+    /**
+     * Get the module part as BigInteger.
+     * @return modul.
+     */
+    public java.math.BigInteger getModul() {
+        return new java.math.BigInteger(Long.toString(modul));
+    }
+
+
+    /**
+     * Get the module part as long.
+     * @return modul.
+     */
+    public long getLongModul() {
+        return modul;
+    }
+
+
+    /**
+     * Get the module part as BigInteger.
+     * @return modul.
+     */
+    public BigInteger getIntegerModul() {
+        return new BigInteger(modul);
+    }
+
+
+    /**
+     * Create ModLong element c.
+     * @param c
+     * @return a ModLong of c.
+     */
+    public ModLong create(java.math.BigInteger c) {
+        return new ModLong(this, c);
+    }
+
+
+    /**
+     * Create ModLong element c.
+     * @param c
+     * @return a ModLong of c.
+     */
+    public ModLong create(long c) {
+        return new ModLong(this, c);
+    }
+
+
+    /**
+     * Create ModLong element c.
+     * @param c
+     * @return a ModLong of c.
+     */
+    public ModLong create(String c) {
+        return parse(c);
+    }
+
+
+    /**
+     * Copy ModLong element c.
+     * @param c
+     * @return a copy of c.
+     */
+    public ModLong copy(ModLong c) {
+        return new ModLong(this, c.val);
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as ModLong.
+     */
+    public ModLong getZERO() {
+        return new ModLong(this, 0L);
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as ModLong.
+     */
+    public ModLong getONE() {
+        return new ModLong(this, 1L);
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     * @see edu.jas.structure.ElemFactory#generators()
+     */
+    public List<ModLong> generators() {
+        List<ModLong> g = new ArrayList<ModLong>(1);
+        g.add(getONE());
+        return g;
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite()
+     */
+    public boolean isFinite() {
+        return true;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true.
+     */
+    public boolean isCommutative() {
+        return true;
+    }
+
+
+    /**
+     * Query if this ring is associative.
+     * @return true.
+     */
+    public boolean isAssociative() {
+        return true;
+    }
+
+
+    /**
+     * Query if this ring is a field.
+     * @return true if module is prime, else false.
+     */
+    public boolean isField() {
+        if (isField > 0) {
+            return true;
+        }
+        if (isField == 0) {
+            return false;
+        }
+        //System.out.println("isProbablePrime " + modul + " = " + modul.isProbablePrime(certainty));
+        java.math.BigInteger m = new java.math.BigInteger(Long.toString(modul));
+        if (m.isProbablePrime(m.bitLength())) {
+            isField = 1;
+            return true;
+        }
+        isField = 0;
+        return false;
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic() {
+        return new java.math.BigInteger(Long.toString(modul));
+    }
+
+
+    /**
+     * Get a ModLong element from a BigInteger value.
+     * @param a BigInteger.
+     * @return a ModLong.
+     */
+    public ModLong fromInteger(java.math.BigInteger a) {
+        return new ModLong(this, a);
+    }
+
+
+    /**
+     * Get a ModLong element from a long value.
+     * @param a long.
+     * @return a ModLong.
+     */
+    public ModLong fromInteger(long a) {
+        return new ModLong(this, a);
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return " mod(" + modul + ")"; //",max="  + MAX_LONG + ")";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.ElemFactory#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python and Ruby case
+        if (isField()) {
+            return "GFL(" + modul + ")";
+        }
+        return "ZML(" + modul + ")";
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object b) {
+        if (!(b instanceof ModLongRing)) {
+            return false;
+        }
+        ModLongRing m = (ModLongRing) b;
+        return (modul == m.modul);
+    }
+
+
+    /**
+     * Hash code for this ModLongRing.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return (int) modul;
+    }
+
+
+    /**
+     * ModLong random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @return a random integer mod modul.
+     */
+    public ModLong random(int n) {
+        return random(n, random);
+    }
+
+
+    /**
+     * ModLong random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @param rnd is a source for random bits.
+     * @return a random integer mod modul.
+     */
+    public ModLong random(int n, Random rnd) {
+        java.math.BigInteger v = new java.math.BigInteger(n, rnd);
+        return new ModLong(this, v); // rnd.nextLong() not ok
+    }
+
+
+    /**
+     * Parse ModLong from String.
+     * @param s String.
+     * @return ModLong from s.
+     */
+    public ModLong parse(String s) {
+        return new ModLong(this, s);
+    }
+
+
+    /**
+     * Parse ModLong from Reader.
+     * @param r Reader.
+     * @return next ModLong from r.
+     */
+    public ModLong parse(Reader r) {
+        return parse(StringUtil.nextString(r));
+    }
+
+
+    /**
+     * ModLong chinese remainder algorithm. This is a factory method. Assert
+     * c.modul &ge; a.modul and c.modul * a.modul = this.modul.
+     * @param c ModLong.
+     * @param ci inverse of c.modul in ring of a.
+     * @param a other ModLong.
+     * @return S, with S mod c.modul == c and S mod a.modul == a.
+     */
+    public ModLong chineseRemainder(ModLong c, ModLong ci, ModLong a) {
+        //if (true) { 
+        //    if (c.ring.modul < a.ring.modul) {
+        //        System.out.println("ModLong error " + c.ring + ", " + a.ring);
+        //    }
+        //}
+        ModLong b = a.ring.fromInteger(c.val); // c mod a.modul
+        ModLong d = a.subtract(b); // a-c mod a.modul
+        if (d.isZERO()) {
+            return new ModLong(this, c.val);
+        }
+        b = d.multiply(ci); // b = (a-c)*ci mod a.modul
+        // (c.modul*b)+c mod this.modul = c mod c.modul = 
+        // (c.modul*ci*(a-c)+c) mod a.modul = a mod a.modul
+        long s = c.ring.modul * b.val;
+        s = s + c.val;
+        return new ModLong(this, s);
+    }
+
+
+    /**
+     * Modular digit list chinese remainder algorithm. m1 and m2 are positive
+     * beta-integers, with GCD(m1,m2)=1 and m=m1*m2 less than beta. L1 and L2
+     * are lists of elements of Z(m1) and Z(m2) respectively. L is a list of all
+     * a in Z(m) such that a is congruent to a1 modulo m1 and a is congruent to
+     * a2 modulo m2 with a1 in L1 and a2 in L2. This is a factory method. Assert
+     * c.modul &ge; a.modul and c.modul * a.modul = this.modul.
+     * @param m1 ModLong.
+     * @param m2 other ModLong.
+     * @return L list of congruences.
+     */
+    public static List<ModLong> chineseRemainder(ModLong m1, ModLong m2, List<ModLong> L1, List<ModLong> L2) {
+        long mm = m1.ring.modul * m2.ring.modul;
+        ModLongRing m = new ModLongRing(mm);
+        ModLong m21 = m2.ring.fromInteger(m1.ring.modul);
+        ModLong mi1 = m21.inverse();
+
+        List<ModLong> L = new ArrayList<ModLong>();
+        for (ModLong a : L1) {
+            for (ModLong b : L2) {
+                ModLong c = m.chineseRemainder(a, mi1, b);
+                L.add(c);
+            }
+        }
+        return L;
+    }
+
+
+    /**
+     * Get a ModLong iterator.
+     * @return a iterator over all modular integers in this ring.
+     */
+    public Iterator<ModLong> iterator() {
+        return new ModLongIterator(this);
+    }
+
+}
+
+
+/**
+ * Modular integer iterator.
+ * @author Heinz Kredel
+ */
+class ModLongIterator implements Iterator<ModLong> {
+
+
+    /**
+     * data structure.
+     */
+    long curr;
+
+
+    final ModLongRing ring;
+
+
+    /**
+     * ModLong iterator constructor.
+     * @param fac modular integer factory;
+     */
+    public ModLongIterator(ModLongRing fac) {
+        curr = 0L;
+        ring = fac;
+    }
+
+
+    /**
+     * Test for availability of a next element.
+     * @return true if the iteration has more elements, else false.
+     */
+    public synchronized boolean hasNext() {
+        return curr < ring.modul;
+    }
+
+
+    /**
+     * Get next integer.
+     * @return next integer.
+     */
+    public synchronized ModLong next() {
+        ModLong i = new ModLong(ring, curr);
+        curr++;
+        return i;
+    }
+
+
+    /**
+     * Remove an element if allowed.
+     */
+    public void remove() {
+        throw new UnsupportedOperationException("cannnot remove elements");
+    }
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/Modular.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/Modular.java
@@ -1,0 +1,29 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.arith;
+
+
+/**
+ * Interface with getInteger and getSymmetricInteger methods.
+ * @author Heinz Kredel
+ */
+
+public interface Modular {
+
+
+    /**
+     * Return a BigInteger from this Element.
+     * @return a BigInteger of this.
+     */
+    public BigInteger getInteger();
+
+
+    /**
+     * Return a symmetric BigInteger from this Element.
+     * @return a symmetric BigInteger of this.
+     */
+    public BigInteger getSymmetricInteger();
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/ModularNotInvertibleException.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/ModularNotInvertibleException.java
@@ -1,0 +1,120 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.arith;
+
+
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.NotInvertibleException;
+
+
+/**
+ * Modular integer NotInvertibleException class. Runtime Exception to be thrown
+ * for not invertible modular integers. Container for the non-trivial factors
+ * found by the inversion algorithm. <b>Note: </b> cannot be generic because of
+ * Throwable.
+ * @author Heinz Kredel
+ */
+public class ModularNotInvertibleException extends NotInvertibleException {
+
+
+    public final GcdRingElem f; // = f1 * f2
+
+
+    public final GcdRingElem f1;
+
+
+    public final GcdRingElem f2;
+
+
+    public ModularNotInvertibleException() {
+        this(null, null, null);
+    }
+
+
+    public ModularNotInvertibleException(String c) {
+        this(c, null, null, null);
+    }
+
+
+    public ModularNotInvertibleException(String c, Throwable t) {
+        this(c, t, null, null, null);
+    }
+
+
+    public ModularNotInvertibleException(Throwable t) {
+        this(t, null, null, null);
+    }
+
+
+    /**
+     * Constructor.
+     * @param f gcd ring element with f = f1 * f2.
+     * @param f1 gcd ring element.
+     * @param f2 gcd ring element.
+     */
+    public ModularNotInvertibleException(GcdRingElem f, GcdRingElem f1, GcdRingElem f2) {
+        super("ModularNotInvertibleException");
+        this.f = f;
+        this.f1 = f1;
+        this.f2 = f2;
+    }
+
+
+    /**
+     * Constructor.
+     * @param f gcd ring element with f = f1 * f2.
+     * @param f1 gcd ring element.
+     * @param f2 gcd ring element.
+     */
+    public ModularNotInvertibleException(String c, GcdRingElem f, GcdRingElem f1, GcdRingElem f2) {
+        super(c);
+        this.f = f;
+        this.f1 = f1;
+        this.f2 = f2;
+    }
+
+
+    /**
+     * Constructor.
+     * @param f gcd ring element with f = f1 * f2.
+     * @param f1 gcd ring element.
+     * @param f2 gcd ring element.
+     */
+    public ModularNotInvertibleException(String c, Throwable t, GcdRingElem f, GcdRingElem f1, GcdRingElem f2) {
+        super(c, t);
+        this.f = f;
+        this.f1 = f1;
+        this.f2 = f2;
+    }
+
+
+    /**
+     * Constructor.
+     * @param f gcd ring element with f = f1 * f2.
+     * @param f1 gcd ring element.
+     * @param f2 gcd ring element.
+     */
+    public ModularNotInvertibleException(Throwable t, GcdRingElem f, GcdRingElem f1, GcdRingElem f2) {
+        super("ModularNotInvertibleException", t);
+        this.f = f;
+        this.f1 = f1;
+        this.f2 = f2;
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        String s = super.toString();
+        if (f != null || f1 != null || f2 != null) {
+            s += ", f = " + f + ", f1 = " + f1 + ", f2 = " + f2;
+        }
+        return s;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/ModularRingFactory.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/ModularRingFactory.java
@@ -1,0 +1,40 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.arith;
+
+
+import java.lang.Iterable;
+
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Modular ring factory interface. Defines Chinese remainder method and get
+ * modul method.
+ * @author Heinz Kredel
+ */
+
+public interface ModularRingFactory<C extends RingElem<C> & Modular> extends RingFactory<C>, Iterable<C> {
+
+
+    /**
+     * Return the BigInteger modul for the factory.
+     * @return a BigInteger of this.modul.
+     */
+    public BigInteger getIntegerModul();
+
+
+    /**
+     * Chinese remainder algorithm. Assert c.modul &ge; a.modul and c.modul *
+     * a.modul = this.modul.
+     * @param c modular.
+     * @param ci inverse of c.modul in ring of a.
+     * @param a other ModLong.
+     * @return S, with S mod c.modul == c and S mod a.modul == a.
+     */
+    public C chineseRemainder(C c, C ci, C a);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/PrimeInteger.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/PrimeInteger.java
@@ -1,0 +1,1098 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.arith;
+
+
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+
+/**
+ * Integer prime factorization. Code from ALDES/SAC2 and MAS module SACPRIM.
+ * 
+ * See ALDES/SAC2 or MAS code in SACPRIM.
+ * See Symja <code>org/matheclipse/core/expression/Primality.java</code> for Pollard
+ *      algorithm.
+ * @author Heinz Kredel
+ */
+
+public final class PrimeInteger {
+
+
+    private static final Logger logger = LogManager.getLogger(PrimeInteger.class);
+
+
+    /**
+     * Maximal long, which can be factored by IFACT(long). Has nothing to do
+     * with SAC2.BETA.
+     */
+    final public static long BETA = PrimeList.getLongPrime(61, 1).longValue();
+
+
+    /**
+     * Medium prime divisor range.
+     */
+    //final static long IMPDS_MIN = 1000;  // SAC2/Aldes 
+    //final static long IMPDS_MAX = 5000;  // "
+    //final static long IMPDS_MIN = 2000;  
+    //final static long IMPDS_MAX = 10000; 
+    final static long IMPDS_MIN = 10000;
+
+
+    final static long IMPDS_MAX = 128000;
+
+
+    /**
+     * List of small prime numbers.
+     */
+    final public static List<Long> SMPRM = smallPrimes(2, (int) (IMPDS_MIN >> 1));
+
+
+    /**
+     * List of units of Z mod 210.
+     */
+    final public static List<Long> UZ210 = getUZ210();
+
+
+    /**
+     * Digit prime generator. K and m are positive beta-integers. L is the list
+     * (p(1),...,p(r)) of all prime numbers p such that m le p lt m+2*K, with
+     * p(1) lt p(2) lt ... lt p(r).
+     * See also SACPRIM.DPGEN.
+     * @param m start integer
+     * @param K number of integers
+     * @return the list L of prime numbers p with m &le; p &lt; m + 2*K.
+     */
+    public static List<Long> smallPrimes(long m, int K) {
+        int k;
+        long ms;
+        ms = m;
+        if (ms <= 1) {
+            ms = 1;
+        }
+        m = ms;
+        if (m % 2 == 0) {
+            m++;
+            K--;
+        }
+        //if (kp % 2 == 0) { 
+        //    k = kp/2; 
+        //} else { 
+        //    k = (kp+1)/2; 
+        //}
+        k = K;
+
+        /* init */
+        long h = 2L * ((long)k - 1L);
+        long m2 = m + h; // mp    
+        BitSet p = new BitSet(k);
+        p.set(0, k);
+        //for (int i = 0; i < k; i++) { 
+        //    p.set(i); 
+        //}
+
+        /* compute */
+        int r, d = 0;
+        int i, c = 0;
+        while (true) {
+            switch (c) {
+            /* mark multiples of d for d=3 and d=6n-/+1 with d**2<=m2 */
+            case 2:
+                d += 2;
+                c = 3;
+                break;
+            case 3:
+                d += 4;
+                c = 2;
+                break;
+            case 0:
+                d = 3;
+                c = 1;
+                break;
+            case 1:
+                d = 5;
+                c = 2;
+                break;
+             default: 
+                throw new RuntimeException("this should not happen");
+            }
+            if (d > (m2 / d)) {
+                break;
+            }
+            r = (int) (m % d);
+            if (r + h >= d || r == 0) {
+                if (r == 0) {
+                    i = 0;
+                } else {
+                    if (r % 2 == 0) {
+                        i = d - (r / 2);
+                    } else {
+                        i = (d - r) / 2;
+                    }
+                }
+                if (m <= d) {
+                    i += d;
+                }
+                while (i < k) {
+                    p.set(i, false);
+                    i += d;
+                }
+            }
+        }
+        /* output */
+        int l = p.cardinality(); // l = 0
+        //for (i=0; i<k; i++) { 
+        //    if (p.get(i)) { 
+        //         l++;
+        //     } 
+        //}
+        if (ms <= 2) {
+            l++;
+        }
+        //if (ms <= 1) { 
+        //}
+        List<Long> po = new ArrayList<Long>(l);
+        if (l == 0) {
+            return po;
+        }
+        //l = 0;
+        if (ms == 1) {
+            //po.add(2); 
+            //l++; 
+            p.set(0, false);
+        }
+        if (ms <= 2) {
+            po.add(2L);
+            //l++; 
+        }
+        long pl = m;
+        //System.out.println("pl = " + pl + " p[0] = " + p[0]);
+        //System.out.println("k-1 = " + (k-1) + " p[k-1] = " + p[k-1]);
+        for (i = 0; i < k; i++) {
+            if (p.get(i)) {
+                po.add(pl);
+                //l++; 
+            }
+            pl += 2;
+        }
+        //System.out.println("SMPRM = " + po);
+        return po;
+    }
+
+
+    /**
+     * Integer small prime divisors. n is a positive integer. F is a list of
+     * primes (q(1),q(2),...,q(h)), h non-negative, q(1) le q(2) le ... lt q(h),
+     * such that n is equal to m times the product of the q(i) and m is not
+     * divisible by any prime in SMPRM. Either m=1 or m gt 1,000,000. 
+     * <br /> In JAS F is a map and m=1 or m &gt; 4.000.000.
+     * See also SACPRIM.ISPD.
+     * @param n integer to factor.
+     * @param F a map of pairs of prime numbers and multiplicities (p,e) with p**e
+     *            divides n and e maximal, F is modified.
+     * @return n/F a factor of n not divisible by any prime number in SMPRM.
+     */
+    public static long smallPrimeDivisors(long n, SortedMap<Long, Integer> F) {
+        //SortedMap<Long, Integer> F = new TreeMap<Long, Integer>();
+        List<Long> LP;
+        long QL = 0;
+        long PL;
+        long RL = 0;
+        boolean TL;
+
+        long ML = n;
+        LP = SMPRM; //smallPrimes(2, 500); //SMPRM;
+        TL = false;
+        int i = 0;
+        do {
+            PL = LP.get(i);
+            QL = ML / PL;
+            RL = ML % PL;
+            if (RL == 0) {
+                Integer e = F.get(PL);
+                if (e == null) {
+                    e = 1;
+                } else {
+                    e++;
+                }
+                F.put(PL, e);
+                ML = QL;
+            } else {
+                i++;
+            }
+            TL = (QL <= PL);
+        } while (!(TL || (i >= LP.size())));
+        //System.out.println("TL = " + TL + ", ML = " + ML + ", PL = " + PL + ", QL = " + QL);
+        if (TL && (ML != 1L)) {
+            Integer e = F.get(ML);
+            if (e == null) {
+                e = 1;
+            } else {
+                e = e + 1;
+            }
+            F.put(ML, e);
+            ML = 1;
+        }
+        //F.put(ML, 0); // hack
+        return ML;
+    }
+
+
+    /**
+     * Integer small prime divisors. n is a positive integer. F is a list of
+     * primes (q(1),q(2),...,q(h)), h non-negative, q(1) le q(2) le ... lt q(h),
+     * such that n is equal to m times the product of the q(i) and m is not
+     * divisible by any prime in SMPRM. Either m=1 or m gt 1,000,000. 
+     * <br /> In JAS F is a map and m=1 or m &gt; 4.000.000.
+     * See also SACPRIM.ISPD.
+     * @param n integer to factor.
+     * @param F a map of pairs of prime numbers and multiplicities (p,e) with p**e
+     *            divides n and e maximal, F is modified.
+     * @return n/F a factor of n not divisible by any prime number in SMPRM.
+     */
+    public static java.math.BigInteger smallPrimeDivisors(java.math.BigInteger n, SortedMap<java.math.BigInteger, Integer> F) {
+        List<Long> LP;
+        java.math.BigInteger QL = java.math.BigInteger.ZERO;
+        java.math.BigInteger PL;
+        java.math.BigInteger RL = java.math.BigInteger.ZERO;
+        boolean TL;
+
+        java.math.BigInteger ML = n;
+        LP = SMPRM; //smallPrimes(2, 500); //SMPRM;
+        TL = false;
+        int i = 0;
+        do {
+            PL = java.math.BigInteger.valueOf( LP.get(i) );
+            java.math.BigInteger[] xx = ML.divideAndRemainder(PL);
+            QL = xx[0]; //ML.divide(PL);
+            RL = xx[1]; //ML.remainder(PL);
+            if (RL.equals(java.math.BigInteger.ZERO)) {
+                Integer e = F.get(PL);
+                if (e == null) {
+                    e = 1;
+                } else {
+                    e++;
+                }
+                F.put(PL, e);
+                ML = QL;
+            } else {
+                i++;
+            }
+            TL = (QL.compareTo(PL) <= 0);
+        } while (!(TL || (i >= LP.size())));
+        //System.out.println("TL = " + TL + ", ML = " + ML + ", PL = " + PL + ", QL = " + QL);
+        if (TL && (!ML.equals(java.math.BigInteger.ONE))) {
+            Integer e = F.get(ML);
+            if (e == null) {
+                e = 1;
+            } else {
+                e = e + 1;
+            }
+            F.put(ML, e);
+            ML = java.math.BigInteger.ONE;
+        }
+        //F.put(ML, 0); // hack
+        return ML;
+    }
+
+
+    /**
+     * Integer primality test. n is a positive integer. r is true, if n is
+     * prime, else false.
+     * @param n integer to test.
+     * @return true if n is prime, else false.
+     */
+    public static boolean isPrime(long n) {
+        java.math.BigInteger N = java.math.BigInteger.valueOf(n);
+        return isPrime(N);
+    }
+
+
+    /**
+     * Integer primality test. n is a positive integer. r is true, if n is
+     * prime, else false.
+     * @param N integer to test.
+     * @return true if N is prime, else false.
+     */
+    public static boolean isPrime(java.math.BigInteger N) {
+        if (N.isProbablePrime(N.bitLength())) {
+            return true;
+        }
+        SortedMap<java.math.BigInteger, Integer> F = factors(N);
+        return (F.size() == 1) && F.values().contains(1);
+    }
+
+
+    /**
+     * Test prime factorization. n is a positive integer. r is true, if n =
+     * product_i(pi**ei) and each pi is prime, else false.
+     * @param n integer to test.
+     * @param F a map of pairs of prime numbers (p,e) with p**e divides n.
+     * @return true if n = product_i(pi**ei) and each pi is prime, else false.
+     */
+    public static boolean isPrimeFactorization(long n, SortedMap<Long, Integer> F) {
+        long f = 1L;
+        for (Map.Entry<Long, Integer> m : F.entrySet()) {
+            long p = m.getKey();
+            if (!isPrime(p)) {
+                return false;
+            }
+            int e = m.getValue();
+            long pe = java.math.BigInteger.valueOf(p).pow(e).longValueExact();
+            f *= pe;
+        }
+        return n == f;
+    }
+
+
+    /**
+     * Test factorization. n is a positive integer. r is true, if n =
+     * product_i(pi**ei), else false.
+     * @param n integer to test.
+     * @param F a map of pairs of numbers (p,e) with p**e divides n.
+     * @return true if n = product_i(pi**ei), else false.
+     */
+    public static boolean isFactorization(long n, SortedMap<Long, Integer> F) {
+        long f = 1L;
+        for (Map.Entry<Long, Integer> m : F.entrySet()) {
+            long p = m.getKey();
+            int e = m.getValue();
+            long pe = java.math.BigInteger.valueOf(p).pow(e).longValueExact();
+            f *= pe;
+        }
+        return n == f;
+    }
+
+
+    /**
+     * Integer factorization. n is a positive integer. F is a list (q(1),
+     * q(2),...,q(h)) of the prime factors of n, q(1) le q(2) le ... le q(h),
+     * with n equal to the product of the q(i). <br /> In JAS F is a map.
+     * See also SACPRIM.IFACT.
+     * @param n integer to factor.
+     * @return a map of pairs of numbers (p,e) with p**e divides n.
+     */
+    public static SortedMap<Long, Integer> factors(long n) {
+        if (n > BETA) {
+            throw new UnsupportedOperationException("factors(long) only for longs less than BETA: " + BETA);
+        }
+        long ML, PL, AL, BL, CL, MLP, RL, SL;
+        SortedMap<Long, Integer> F = new TreeMap<Long, Integer>();
+        SortedMap<Long, Integer> FP = null;
+        // search small prime factors
+        ML = smallPrimeDivisors(n, F); // , F, ML
+        if (ML == 1L) {
+            return F;
+        }
+        //System.out.println("F = " + F);
+        // search medium prime factors
+        AL = IMPDS_MIN;
+        do {
+            MLP = ML - 1;
+            RL = (new ModLong(new ModLongRing(ML), 3)).power(MLP).getVal(); //(3**MLP) mod ML; 
+            if (RL == 1L) {
+                FP = factors(MLP);
+                SL = primalityTestSelfridge(ML, MLP, FP);
+                if (SL == 1) {
+                    logger.info("primalityTestSelfridge: FP = " + FP);
+                    Integer e = F.get(ML);
+                    if (e == null) {
+                        e = 1;
+                    } else { // will not happen
+                        e = e + 1;
+                    }
+                    F.put(ML, e); 
+                    return F;
+                }
+            }
+            CL = Roots.sqrtInt(new BigInteger(ML)).getVal().longValue(); //SACI.ISQRT( ML, CL, TL );
+            //System.out.println("CL = " + CL + ", ML = " + ML + ", CL^2 = " + (CL*CL));
+            BL = Math.max(IMPDS_MAX, CL / 3L);
+            if (AL > BL) {
+                PL = 1L;
+            } else {
+                logger.info("mediumPrimeDivisorSearch: a = " + AL + ", b = " + BL);
+                PL = mediumPrimeDivisorSearch(ML, AL, BL); //, PL, ML );
+                //System.out.println("PL = " + PL);
+                if (PL != 1L) {
+                    AL = PL;
+                    Integer e = F.get(PL);
+                    if (e == null) {
+                        e = 1;
+                    } else {
+                        e = e + 1;
+                    }
+                    F.put(PL, e); 
+                    ML = ML / PL;
+                }
+            }
+        } while (PL != 1L);
+        // fixed: the ILPDS should also be in the while loop, was already wrong in SAC2/Aldes and MAS
+        // seems to be okay for integers smaller than beta
+        java.math.BigInteger N = java.math.BigInteger.valueOf(ML);
+        if (N.isProbablePrime(N.bitLength())) {
+            F.put(ML, 1);
+            return F;
+        }
+        AL = BL;
+        BL = CL;
+        logger.info("largePrimeDivisorSearch: a = " + AL + ", b = " + BL + ", m = " + ML);
+        // search large prime factors
+        do {
+            //ILPDS( ML, AL, BL, PL, ML );
+            PL = largePrimeDivisorSearch(ML, AL, BL);
+            if (PL != 1L) {
+                Integer e = F.get(PL);
+                if (e == null) {
+                    e = 1;
+                } else {
+                    e++;
+                }
+                F.put(PL, e);
+                ML = ML / PL;
+                AL = PL;
+                CL = Roots.sqrtInt(BigInteger.valueOf(ML)).getVal().longValue(); //SACI.ISQRT( ML, CL, TL );
+                //System.out.println("CL = " + CL + ", ML = " + ML + ", CL^2 = " + (CL*CL));
+                BL = Math.min(BL, CL);
+                if (AL > BL) {
+                    PL = 1L;
+                }
+            }
+        } while (PL != 1L);
+        //System.out.println("PL = " + PL + ", ML = " + ML);
+        if (ML != 1L) {
+            Integer e = F.get(ML);
+            if (e == null) {
+                e = 1;
+            } else {
+                e = e + 1;
+            }
+            F.put(ML, e);
+        }
+        return F;
+    }
+
+
+    /**
+     * Integer factorization, Pollard rho algorithm. n is a positive integer. F
+     * is a list (q(1), q(2),...,q(h)) of the prime factors of n, q(1) le q(2)
+     * le ... le q(h), with n equal to the product of the q(i). <br /> In
+     * JAS F is a map.
+     * See also SACPRIM.IFACT.
+     * @param n integer to factor.
+     * @return a map F of pairs of numbers (p,e) with p**e divides n and p
+     *            probable prime.
+     */
+    public static SortedMap<Long, Integer> factorsPollard(long n) {
+        if (n > BETA) {
+            throw new UnsupportedOperationException("factors(long) only for longs less than BETA: " + BETA);
+        }
+        SortedMap<Long, Integer> F = new TreeMap<Long, Integer>();
+        factorsPollardRho(n, F); 
+        return F;
+    }
+
+
+    /**
+     * Integer medium prime divisor search. n, a and b are positive integers
+     * such that a le b le n and n has no positive divisors less than a. If n
+     * has a prime divisor in the closed interval from a to b then p is the
+     * least such prime and q=n/p. Otherwise p=1 and q=n.
+     * See also SACPRIM.IMPDS.
+     * @param n integer to factor.
+     * @param a lower bound.
+     * @param b upper bound.
+     * @return p a prime factor of n, with a &le; p &le; b &lt; n.
+     */
+    public static long mediumPrimeDivisorSearch(long n, long a, long b) {
+        List<Long> LP;
+        long R, J1Y, RL1, RL2, RL, PL;
+
+        RL = a % 210;
+        LP = UZ210;
+        long ll = LP.size();
+        int i = 0;
+        while (RL > LP.get(i)) {
+            i++; 
+        }
+        RL1 = LP.get(i); 
+        PL = a + (RL1 - RL); 
+        //System.out.println("PL = " + PL + ", BL = " + BL);
+        while (PL <= b) {
+            R = n % PL; //SACI.IQR( NL, PL, QL, R );
+            if (R == 0) {
+                return PL;
+            }
+            i++; 
+            if (i >= ll) { 
+                LP = UZ210;
+                RL2 = (RL1 - 210L);
+                i = 0;
+            } else {
+                RL2 = RL1;
+            }
+            RL1 = LP.get(i); 
+            J1Y = (RL1 - RL2);
+            PL = PL + J1Y; 
+        }
+        PL = 1L; //SACI.IONE;
+        //QL = NL;
+        return PL;
+    }
+
+
+    /**
+     * Integer selfridge primality test. m is an integer greater than or equal
+     * to 3. mp=m-1. F is a list (q(1),q(2),...,q(k)), q(1) le q(2) le ... le
+     * q(k), of the prime factors of mp, with mp equal to the product of the
+     * q(i). An attempt is made to find a root of unity modulo m of order m-1.
+     * If the existence of such a root is discovered then m is prime and s=1. If
+     * it is discovered that no such root exists then m is not a prime and s=-1.
+     * Otherwise the primality of m remains uncertain and s=0.
+     * See also SACPRIM.ISPT.
+     * @param m integer to test.
+     * @param mp integer m-1.
+     * @param F a map of pairs (p,e), with primes p, multiplicity e and with
+     *            p**e divides mp and e maximal.
+     * @return s = -1 (not prime), 0 (unknown) or 1 (prime).
+     */
+    public static int primalityTestSelfridge(long m, long mp, SortedMap<Long, Integer> F) {
+        long AL, BL, QL, QL1, MLPP, PL1, PL;
+        int SL;
+        //List<Long> SMPRM = smallPrimes(2, 500); //SMPRM;
+        List<Long> PP;
+
+        List<Map.Entry<Long, Integer>> FP = new ArrayList<Map.Entry<Long, Integer>>(F.entrySet());
+        QL1 = 1L; //SACI.IONE;
+        PL1 = 1L;
+        int i = 0;
+        while (true) {
+            do {
+                if (i == FP.size()) { 
+                    logger.info("SL=1: m = " + m);
+                    SL = 1;
+                    return SL;
+                }
+                QL = FP.get(i).getKey();
+                i++; 
+            } while (!(QL > QL1));
+            QL1 = QL;
+            PP = SMPRM;
+            int j = 0;
+            do {
+                if (j == PP.size()) {
+                    logger.info("SL=0: m = " + m);
+                    SL = 0;
+                    return SL;
+                }
+                PL = PP.get(j); 
+                j++; 
+                if (PL > PL1) {
+                    PL1 = PL;
+                    AL = (new ModLong(new ModLongRing(m), PL)).power(mp).getVal(); //(PL**MLP) mod ML; 
+                    if (AL != 1) {
+                        logger.info("SL=-1: m = " + m);
+                        SL = (-1);
+                        return SL;
+                    }
+                }
+                MLPP = mp / QL; 
+                BL = (new ModLong(new ModLongRing(m), PL)).power(MLPP).getVal(); //(PL**MLPP) mod ML; 
+            } while (BL == 1L);
+        }
+    }
+
+
+    /**
+     * Integer large prime divisor search. n is a positive integer with no prime
+     * divisors less than 17. 1 le a le b le n. A search is made for a divisor p
+     * of the integer n, with a le p le b. If such a p is found then np=n/p,
+     * otherwise p=1 and np=n. A modular version of Fermats method is used, and
+     * the search goes from a to b.
+     * See also SACPRIM.ILPDS.
+     * @param n integer to factor.
+     * @param a lower bound.
+     * @param b upper bound.
+     * @return p a prime factor of n, with a &le; p &le; b &lt; n.
+     */
+    public static long largePrimeDivisorSearch(long n, long a, long b) { // return PL, NLP ignored
+        if (n > BETA) {
+            throw new UnsupportedOperationException(
+                            "largePrimeDivisorSearch only for longs less than BETA: " + BETA);
+        }
+        List<ModLong> L = null;
+        List<ModLong> LP;
+        long RL1, RL2, J1Y, r, PL, TL;
+        long RL, J2Y, XL1, XL2, QL, XL, YL, YLP;
+        long ML = 0L;
+        long SL = 0L;
+        QL = n / b;
+        RL = n % b;
+        XL1 = b + QL;
+        SL = XL1 % 2L;
+        XL1 = XL1 / 2L; // after SL
+        if ((RL != 0) || (SL != 0)) {
+            XL1 = XL1 + 1L;
+        }
+        QL = n / a;
+        XL2 = a + QL;
+        XL2 = XL2 / 2L;
+        L = residueListFermat(n); //FRESL( NL, ML, L ); // ML not returned
+        if (L.isEmpty()) {
+            return n;
+        }
+        ML = L.get(0).ring.getModul().longValue(); // sic
+        // check is okay: sort: L = SACSET.LBIBMS( L ); revert: L = MASSTOR.INV( L );
+        Collections.sort(L);
+        Collections.reverse(L);
+        //System.out.println("FRESL: " + L);
+        r = XL2 % ML;
+        LP = L;
+        int i = 0;
+        while (i < LP.size() && r < LP.get(i).getVal()) {
+            i++; 
+        }
+        if (i == LP.size()) {
+            i = 0; //LP = L;
+            SL = ML;
+        } else {
+            SL = 0L;
+        }
+        RL1 = LP.get(i).getVal(); 
+        i++; 
+        SL = ((SL + r) - RL1);
+        XL = XL2 - SL;
+        TL = 0L;
+        while (XL >= XL1) {
+            J2Y = XL * XL;
+            YLP = J2Y - n;
+            //System.out.println("YLP = " + YLP + ", J2Y = " + J2Y);
+            YL = Roots.sqrtInt(BigInteger.valueOf(YLP)).getVal().longValue(); // SACI.ISQRT( YLP, YL, TL );
+            //System.out.println("YL = sqrt(YLP) = " + YL);
+            TL = YLP - YL * YL;
+            if (TL == 0L) {
+                PL = XL - YL;
+                return PL;
+            }
+            if (i < LP.size()) {
+                RL2 = LP.get(i).getVal(); 
+                i++; 
+                SL = (RL1 - RL2);
+            } else {
+                i = 0;
+                RL2 = LP.get(i).getVal(); 
+                i++; 
+                J1Y = (ML + RL1);
+                SL = (J1Y - RL2);
+            }
+            RL1 = RL2;
+            XL = XL - SL;
+        }
+        PL = 1L; 
+        // unused NLP = NL;
+        return PL;
+    }
+
+
+    /**
+     * Fermat residue list, single modulus. m is a positive beta-integer. a
+     * belongs to Z(m). L is a list of the distinct b in Z(m) such that b**2-a
+     * is a square in Z(m).
+     * See also SACPRIM.FRLSM.
+     * @param m integer to factor.
+     * @param a element of Z mod m.
+     * @return Lp a list of Fermat residues for modul m.
+     */
+    public static List<ModLong> residueListFermatSingle(long m, long a) {
+        List<ModLong> Lp;
+        SortedSet<ModLong> L;
+        List<ModLong> S, SP;
+        int MLP;
+        ModLong SL, SLP, SLPP;
+
+        ModLongRing ring = new ModLongRing(m);
+        ModLong am = ring.fromInteger(a);
+        MLP = (int) (m / 2L);
+        S = new ArrayList<ModLong>();
+        for (int i = 0; i <= MLP; i++) {
+            SL = ring.fromInteger(i);
+            SL = SL.multiply(SL); //SACM.MDPROD( ML, IL, IL );
+            S.add(SL); 
+        }
+        L = new TreeSet<ModLong>();
+        SP = S;
+        for (int i = MLP; i >= 0; i -= 1) {
+            SL = SP.get(i); 
+            SLP = SL.subtract(am); //SACM.MDDIF( ML, SL, AL );
+            int j = S.indexOf(SLP); 
+            if (j >= 0) { // != 0
+                SLP = ring.fromInteger(i);
+                L.add(SLP); 
+                SLPP = SLP.negate(); 
+                if (!SLPP.equals(SLP)) {
+                    L.add(SLPP); 
+                }
+            }
+        }
+        Lp = new ArrayList<ModLong>(L);
+        return Lp;
+    }
+
+
+    /**
+     * Fermat residue list. n is a positive integer with no prime divisors less
+     * than 17. m is a positive beta-integer and L is an ordered list of the
+     * elements of Z(m) such that if x**2-n is a square then x is congruent to a
+     * (modulo m) for some a in L.
+     * See also SACPRIM.FRESL.
+     * @param n integer to factor.
+     * @return Lp a list of Fermat residues for different modules.
+     */
+    public static List<ModLong> residueListFermat(long n) {
+        List<ModLong> L, L1;
+        List<Long> H, M;
+        long AL1, AL2, AL3, AL4, BL1, HL, J1Y, J2Y, KL, KL1, ML1, ML;
+        //too large: long BETA = Long.MAX_VALUE - 1L; 
+
+        // modulus 2**5.
+        BL1 = 0L;
+        AL1 = n % 32L; 
+        AL2 = AL1 % 16L; 
+        AL3 = AL2 % 8L; 
+        AL4 = AL3 % 4L; 
+        if (AL4 == 3L) {
+            ML = 4L;
+            if (AL3 == 3L) {
+                BL1 = 2L;
+            } else {
+                BL1 = 0L;
+            }
+        } else {
+            if (AL3 == 1L) {
+                ML = 8L;
+                if (AL2 == 1L) {
+                    BL1 = 1L;
+                } else {
+                    BL1 = 3L;
+                }
+            } else {
+                ML = 16L;
+                switch ((short) (AL1 / 8L)) {
+                case (short) 0: 
+                    BL1 = 3L;
+                    break;
+                case (short) 1: 
+                    BL1 = 7L;
+                    break;
+                case (short) 2: 
+                    BL1 = 5L;
+                    break;
+                case (short) 3: 
+                    BL1 = 1L;
+                    break;
+                default: 
+                    throw new RuntimeException("this should not happen");
+                }
+            }
+        }
+        L = new ArrayList<ModLong>();
+        ModLongRing ring = new ModLongRing(ML);
+        ModLongRing ring2;
+        if (ML == 4L) {
+            L.add(ring.fromInteger(BL1));
+        } else {
+            J1Y = ML - BL1;
+            L.add(ring.fromInteger(BL1));
+            L.add(ring.fromInteger(J1Y));
+        }
+        KL = L.size();
+
+        // modulus 3**3.
+        AL1 = n % 27L; 
+        AL2 = AL1 % 3L; 
+        if (AL2 == 2L) {
+            ML1 = 3L;
+            ring2 = new ModLongRing(ML1);
+            KL1 = 1L;
+            L1 = new ArrayList<ModLong>();
+            L1.add(ring2.fromInteger(0));
+        } else {
+            ML1 = 27L;
+            ring2 = new ModLongRing(ML1);
+            KL1 = 4L;
+            L1 = residueListFermatSingle(ML1, AL1);
+            // ring2 == L1.get(0).ring
+        }
+        //L = SACM.MDLCRA( ML, ML1, L, L1 );
+        L = ModLongRing.chineseRemainder(ring.getONE(), ring2.getONE(), L, L1);
+        ML = (ML * ML1);
+        ring = new ModLongRing(ML); // == L.get(0).ring
+        KL = (KL * KL1);
+        //System.out.println("FRESL: L = " + L + ", ring = " + ring.toScript());
+
+        // modulus 5**2.
+        AL1 = n % 25L; 
+        AL2 = AL1 % 5L; 
+        if ((AL2 == 2L) || (AL2 == 3L)) {
+            ML1 = 5L;
+            ring2 = new ModLongRing(ML1);
+            J1Y = (AL2 - 1L);
+            J2Y = (6L - AL2);
+            L1 = new ArrayList<ModLong>();
+            L1.add(ring2.fromInteger(J1Y));
+            L1.add(ring2.fromInteger(J2Y));
+            KL1 = 2L;
+        } else {
+            ML1 = 25L;
+            ring2 = new ModLongRing(ML1);
+            L1 = residueListFermatSingle(ML1, AL1);
+            KL1 = 7L;
+        }
+        if (ML1 >= BETA / ML) {
+            return L;
+        }
+        //L = SACM.MDLCRA( ML, ML1, L, L1 );
+        L = ModLongRing.chineseRemainder(ring.getONE(), ring2.getONE(), L, L1);
+        ML = (ML * ML1);
+        ring = new ModLongRing(ML);
+        KL = (KL * KL1);
+        //System.out.println("FRESL: L = " + L + ", ring = " + ring.toScript());
+
+        // moduli 7,11,13.
+        L1 = new ArrayList<ModLong>();
+        M = new ArrayList<Long>(3);
+        H = new ArrayList<Long>(3);
+        //M = MASSTOR.COMPi( 7, MASSTOR.COMPi( 11, 13 ) );
+        M.add(7L);
+        M.add(11L);
+        M.add(13L);
+        //H = MASSTOR.COMPi( 64, MASSTOR.COMPi( 48, 0 ) );
+        H.add(64L);
+        H.add(48L);
+        H.add(0L);
+        int i = 0;
+        while (true) {
+            ML1 = M.get(i); 
+            if (ML1 >= BETA / ML) {
+                return L;
+            }
+            ring2 = new ModLongRing(ML1);
+            AL1 = n % ML1; 
+            L1 = residueListFermatSingle(ML1, AL1);
+            KL1 = L1.size(); 
+            //L = SACM.MDLCRA( ML, ML1, L, L1 );
+            L = ModLongRing.chineseRemainder(ring.getONE(), ring2.getONE(), L, L1);
+            ML = (ML * ML1);
+            ring = new ModLongRing(ML);
+            KL = (KL * KL1);
+            //System.out.println("FRESL: L = " + L + ", ring = " + ring.toScript());
+            HL = H.get(i); 
+            i++;
+            if (KL > HL) {
+                return L;
+            }
+        }
+        // return ?
+    }
+
+
+    /**
+     * Compute units of Z sub 210.
+     * See also SACPRIM.UZ210.
+     * @return list of units of Z sub 210.
+     */
+    public static List<Long> getUZ210() {
+        List<Long> UZ = new ArrayList<Long>();
+        java.math.BigInteger z210 = java.math.BigInteger.valueOf(210);
+        //for (int i = 209; i >= 1; i -= 2) {
+        for (long i = 1; i <= 209; i += 2) {
+            if (z210.gcd(java.math.BigInteger.valueOf(i)).equals(java.math.BigInteger.ONE)) {
+                UZ.add(i);
+            }
+        }
+        return UZ;
+    }
+
+
+    /**
+     * Integer factorization. n is a positive integer. F is a list (q(1),
+     * q(2),...,q(h)) of the prime factors of n, q(1) le q(2) le ... le q(h),
+     * with n equal to the product of the q(i). <br /> In JAS F is a map.
+     * See also SACPRIM.IFACT, uses Pollards rho method.
+     * @param n integer to factor.
+     * @return a map of pairs of numbers (p,e) with p**e divides n.
+     */
+    public static SortedMap<java.math.BigInteger, Integer> factors(java.math.BigInteger n) {
+        java.math.BigInteger b = java.math.BigInteger.valueOf(BETA);
+        SortedMap<java.math.BigInteger, Integer> F = new TreeMap<java.math.BigInteger, Integer>();
+        if (n.compareTo(b) > 0) {
+            n = smallPrimeDivisors(n, F);
+            if (n.compareTo(b) > 0) {
+                logger.info("run factorsPollardRho on n = " + n);
+                factorsPollardRho(n, F); 
+                return F;
+            }
+        }
+        // n <= beta
+        long s = n.longValue();
+        SortedMap<Long, Integer> ff = factors(s); // useless 2nd smallPrimeDiv search
+        for (Map.Entry<Long, Integer> m : ff.entrySet()) {
+            java.math.BigInteger mm = java.math.BigInteger.valueOf(m.getKey());
+            F.put(mm, m.getValue());            
+        }
+        return F;
+    }
+
+
+    /**
+     * Integer factorization using Pollards rho algorithm. n is a positive
+     * integer. F is a list (q(1), q(2),...,q(h)) of the prime factors of n,
+     * q(1) le q(2) le ... le q(h), with n equal to the product of the q(i).
+     * <br /> In JAS F is a map.
+     * @param n integer to factor.
+     * @param F a map of pairs of numbers (p,e) with p**e divides n and p is
+     *            probable prime, F is modified.
+     */
+    public static void factorsPollardRho(java.math.BigInteger n, SortedMap<java.math.BigInteger, Integer> F) {
+        java.math.BigInteger factor;
+        java.math.BigInteger temp = n;
+        int iterationCounter = 0;
+        Integer count;
+        while (!temp.isProbablePrime(32)) {
+            factor = rho(temp);
+            if (factor.equals(temp)) {
+                if (iterationCounter++ > 4) {
+                    break;
+                }
+            } else {
+                iterationCounter = 1;
+            }
+            count = F.get(factor);
+            if (count == null) {
+                F.put(factor, 1);
+            } else {
+                F.put(factor, count + 1);
+            }
+            temp = temp.divide(factor);
+        }
+        count = F.get(temp);
+        if (count == null) {
+            F.put(temp, 1);
+        } else {
+            F.put(temp, count + 1);
+        }
+    }
+
+
+    /**
+     * Random number generator.
+     */
+    //final static SecureRandom random = new SecureRandom();
+    final static Random random = new Random();
+
+
+    /**
+     * Search cycle with Pollards rho algorithm x**2 + c mod n. n is a positive
+     * integer. <br />
+     * @param n integer test.
+     * @return x-y with gcd(x-y, n) = 1.
+     */
+    static java.math.BigInteger rho(java.math.BigInteger n) {
+        java.math.BigInteger divisor;
+        java.math.BigInteger c = new java.math.BigInteger(n.bitLength(), random);
+        java.math.BigInteger x = new java.math.BigInteger(n.bitLength(), random);
+        java.math.BigInteger xx = x;
+        do {
+            x = x.multiply(x).mod(n).add(c).mod(n);
+            xx = xx.multiply(xx).mod(n).add(c).mod(n);
+            xx = xx.multiply(xx).mod(n).add(c).mod(n);
+            divisor = x.subtract(xx).gcd(n);
+        } while (divisor.equals(java.math.BigInteger.ONE));
+        return divisor;
+    }
+
+
+    /**
+     * Integer factorization using Pollards rho algorithm. n is a positive
+     * integer. F is a list (q(1), q(2),...,q(h)) of the prime factors of n,
+     * q(1) le q(2) le ... le q(h), with n equal to the product of the q(i).
+     * <br /> In JAS F is a map.
+     * @param n integer to factor.
+     * @param F a map of pairs of numbers (p,e) with p**e divides n and p is
+     *            probable prime, F is modified.
+     */
+    public static void factorsPollardRho(long n, SortedMap<Long, Integer> F) {
+        long factor;
+        long temp = n;
+        int iterationCounter = 0;
+        Integer count;
+        while (!java.math.BigInteger.valueOf(temp).isProbablePrime(32)) {
+            factor = rho(temp);
+            if (factor == temp) {
+                if (iterationCounter++ > 4) {
+                    break;
+                }
+            } else {
+                iterationCounter = 1;
+            }
+            count = F.get(factor);
+            if (count == null) {
+                F.put(factor, 1);
+            } else {
+                F.put(factor, count + 1);
+            }
+            temp = temp / factor;
+        }
+        count = F.get(temp);
+        if (count == null) {
+            F.put(temp, 1);
+        } else {
+            F.put(temp, count + 1);
+        }
+        //System.out.println("random = " + random.getAlgorithm());
+    }
+
+
+    /**
+     * Search cycle with Pollards rho algorithm x**2 + c mod n. n is a positive
+     * integer. c is a random constant.
+     * @param n integer test.
+     * @return x-y with gcd(x-y, n) == 1.
+     */
+    static long rho(long n) {
+        long divisor;
+        int bl = java.math.BigInteger.valueOf(n).bitLength();
+        long c = new java.math.BigInteger(bl, random).longValue(); // .abs()
+        long x = new java.math.BigInteger(bl, random).longValue(); // .abs()
+        ModLongRing ring = new ModLongRing(n);
+        ModLong cm = new ModLong(ring, c);
+        ModLong xm = new ModLong(ring, x);
+        ModLong xxm = xm;
+        do {
+            xm = xm.multiply(xm).sum(cm);
+            xxm = xxm.multiply(xxm).sum(cm);
+            xxm = xxm.multiply(xxm).sum(cm);
+            divisor = gcd(xm.getVal() - xxm.getVal(), n);
+        } while (divisor == 1L);
+        return divisor;
+    }
+
+
+    static long gcd(long a, long b) {
+        return BigInteger.valueOf(a).gcd(BigInteger.valueOf(b)).getVal().longValue();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/PrimeList.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/PrimeList.java
@@ -1,0 +1,415 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.arith;
+
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+
+/**
+ * List of big primes. Provides an Iterator for generating prime numbers.
+ * Similar to ALDES/SAC2 SACPOL.PRIME list.
+ * See Knuth vol 2, page 390, for list of known primes. See also ALDES/SAC2
+ *      SACPOL.PRIME
+ * 
+ * @author Heinz Kredel
+ */
+
+public final class PrimeList implements Iterable<java.math.BigInteger> {
+
+
+    /**
+     * Range of probable primes.
+     */
+    public static enum Range {
+        small, low, medium, large, mersenne
+    };
+
+
+    /**
+     * Cache the val list for different size
+     */
+    private volatile static List<java.math.BigInteger> SMALL_LIST = null;
+
+
+    private volatile static List<java.math.BigInteger> LOW_LIST = null;
+
+
+    private volatile static List<java.math.BigInteger> MEDIUM_LIST = null;
+
+
+    private volatile static List<java.math.BigInteger> LARGE_LIST = null;
+
+
+    private volatile static List<java.math.BigInteger> MERSENNE_LIST = null;
+
+
+    /**
+     * The list of probable primes in requested range.
+     */
+    private List<java.math.BigInteger> val = null;
+
+
+    /**
+     * The last prime in the list.
+     */
+    private java.math.BigInteger last;
+
+
+    /**
+     * Constructor for PrimeList.
+     */
+    public PrimeList() {
+        this(Range.medium);
+    }
+
+
+    /**
+     * Constructor for PrimeList.
+     * 
+     * @param r size range for primes.
+     */
+    public PrimeList(Range r) {
+        // initialize with some known primes, see knuth (2,390)
+        switch (r) {
+        case small:
+            if (SMALL_LIST != null) {
+                val = SMALL_LIST;
+            } else {
+                val = new ArrayList<java.math.BigInteger>(50);
+                addSmall();
+                SMALL_LIST = val;
+            }
+            break;
+        case low:
+            if (LOW_LIST != null) {
+                val = LOW_LIST;
+            } else {
+                val = new ArrayList<java.math.BigInteger>(50);
+                addLow();
+                LOW_LIST = val;
+            }
+            break;
+        default:
+        case medium:
+            if (MEDIUM_LIST != null) {
+                val = MEDIUM_LIST;
+            } else {
+                val = new ArrayList<java.math.BigInteger>(50);
+                addMedium();
+                MEDIUM_LIST = val;
+            }
+            break;
+        case large:
+            if (LARGE_LIST != null) {
+                val = LARGE_LIST;
+            } else {
+                val = new ArrayList<java.math.BigInteger>(50);
+                addLarge();
+                LARGE_LIST = val;
+            }
+            break;
+        case mersenne:
+            if (MERSENNE_LIST != null) {
+                val = MERSENNE_LIST;
+            } else {
+                val = new ArrayList<java.math.BigInteger>(50);
+                addMersenne();
+                MERSENNE_LIST = val;
+            }
+            break;
+        }
+        last = get(size() - 1);
+    }
+
+
+    /**
+     * Add small primes.
+     */
+    private void addSmall() {
+        // really small
+        val.add(java.math.BigInteger.valueOf(2L));
+        val.add(java.math.BigInteger.valueOf(3L));
+        val.add(java.math.BigInteger.valueOf(5L));
+        val.add(java.math.BigInteger.valueOf(7L));
+        val.add(java.math.BigInteger.valueOf(11L));
+        val.add(java.math.BigInteger.valueOf(13L));
+        val.add(java.math.BigInteger.valueOf(17L));
+        val.add(java.math.BigInteger.valueOf(19L));
+        val.add(java.math.BigInteger.valueOf(23L));
+        val.add(java.math.BigInteger.valueOf(29L));
+    }
+
+
+    /**
+     * Add low sized primes.
+     */
+    private void addLow() {
+        // 2^15-x
+        val.add(getLongPrime(15, 19));
+        val.add(getLongPrime(15, 49));
+        val.add(getLongPrime(15, 51));
+        val.add(getLongPrime(15, 55));
+        val.add(getLongPrime(15, 61));
+        val.add(getLongPrime(15, 75));
+        val.add(getLongPrime(15, 81));
+        val.add(getLongPrime(15, 115));
+        val.add(getLongPrime(15, 121));
+        val.add(getLongPrime(15, 135));
+        // 2^16-x
+        val.add(getLongPrime(16, 15));
+        val.add(getLongPrime(16, 17));
+        val.add(getLongPrime(16, 39));
+        val.add(getLongPrime(16, 57));
+        val.add(getLongPrime(16, 87));
+        val.add(getLongPrime(16, 89));
+        val.add(getLongPrime(16, 99));
+        val.add(getLongPrime(16, 113));
+        val.add(getLongPrime(16, 117));
+        val.add(getLongPrime(16, 123));
+    }
+
+
+    /**
+     * Add medium sized primes.
+     */
+    private void addMedium() {
+        // 2^28-x
+        val.add(getLongPrime(28, 57));
+        val.add(getLongPrime(28, 89));
+        val.add(getLongPrime(28, 95));
+        val.add(getLongPrime(28, 119));
+        val.add(getLongPrime(28, 125));
+        val.add(getLongPrime(28, 143));
+        val.add(getLongPrime(28, 165));
+        val.add(getLongPrime(28, 183));
+        val.add(getLongPrime(28, 213));
+        val.add(getLongPrime(28, 273));
+        // 2^29-x
+        val.add(getLongPrime(29, 3));
+        val.add(getLongPrime(29, 33));
+        val.add(getLongPrime(29, 43));
+        val.add(getLongPrime(29, 63));
+        val.add(getLongPrime(29, 73));
+        val.add(getLongPrime(29, 75));
+        val.add(getLongPrime(29, 93));
+        val.add(getLongPrime(29, 99));
+        val.add(getLongPrime(29, 121));
+        val.add(getLongPrime(29, 133));
+        // 2^32-x
+        val.add(getLongPrime(32, 5));
+        val.add(getLongPrime(32, 17));
+        val.add(getLongPrime(32, 65));
+        val.add(getLongPrime(32, 99));
+        val.add(getLongPrime(32, 107));
+        val.add(getLongPrime(32, 135));
+        val.add(getLongPrime(32, 153));
+        val.add(getLongPrime(32, 185));
+        val.add(getLongPrime(32, 209));
+        val.add(getLongPrime(32, 267));
+    }
+
+
+    /**
+     * Add large sized primes.
+     */
+    private void addLarge() {
+        // 2^59-x
+        val.add(getLongPrime(59, 55));
+        val.add(getLongPrime(59, 99));
+        val.add(getLongPrime(59, 225));
+        val.add(getLongPrime(59, 427));
+        val.add(getLongPrime(59, 517));
+        val.add(getLongPrime(59, 607));
+        val.add(getLongPrime(59, 649));
+        val.add(getLongPrime(59, 687));
+        val.add(getLongPrime(59, 861));
+        val.add(getLongPrime(59, 871));
+        // 2^60-x
+        val.add(getLongPrime(60, 93));
+        val.add(getLongPrime(60, 107));
+        val.add(getLongPrime(60, 173));
+        val.add(getLongPrime(60, 179));
+        val.add(getLongPrime(60, 257));
+        val.add(getLongPrime(60, 279));
+        val.add(getLongPrime(60, 369));
+        val.add(getLongPrime(60, 395));
+        val.add(getLongPrime(60, 399));
+        val.add(getLongPrime(60, 453));
+        // 2^63-x
+        val.add(getLongPrime(63, 25));
+        val.add(getLongPrime(63, 165));
+        val.add(getLongPrime(63, 259));
+        val.add(getLongPrime(63, 301));
+        val.add(getLongPrime(63, 375));
+        val.add(getLongPrime(63, 387));
+        val.add(getLongPrime(63, 391));
+        val.add(getLongPrime(63, 409));
+        val.add(getLongPrime(63, 457));
+        val.add(getLongPrime(63, 471));
+        // 2^64-x not possible
+    }
+
+
+    /**
+     * Add Mersenne sized primes.
+     */
+    private void addMersenne() {
+        // 2^n-1
+        val.add(getMersennePrime(2));
+        val.add(getMersennePrime(3));
+        val.add(getMersennePrime(5));
+        val.add(getMersennePrime(7));
+        val.add(getMersennePrime(13));
+        val.add(getMersennePrime(17));
+        val.add(getMersennePrime(19));
+        val.add(getMersennePrime(31));
+        val.add(getMersennePrime(61));
+        val.add(getMersennePrime(89));
+        val.add(getMersennePrime(107));
+        val.add(getMersennePrime(127));
+        val.add(getMersennePrime(521));
+        val.add(getMersennePrime(607));
+        val.add(getMersennePrime(1279));
+        val.add(getMersennePrime(2203));
+        val.add(getMersennePrime(2281));
+        val.add(getMersennePrime(3217));
+        val.add(getMersennePrime(4253));
+        val.add(getMersennePrime(4423));
+        val.add(getMersennePrime(9689));
+        val.add(getMersennePrime(9941));
+        val.add(getMersennePrime(11213));
+        val.add(getMersennePrime(19937));
+    }
+
+
+    /**
+     * Method to compute a prime as 2**n - m.
+     * @param n power for 2.
+     * @param m for 2**n - m.
+     * @return 2**n - m
+     */
+    public static java.math.BigInteger getLongPrime(int n, int m) {
+        if (n < 30) {
+            return java.math.BigInteger.valueOf((1 << n) - m);
+        }
+        return java.math.BigInteger.ONE.shiftLeft(n).subtract(java.math.BigInteger.valueOf(m));
+    }
+
+
+    /**
+     * Method to compute a Mersenne prime as 2**n - 1.
+     * @param n power for 2.
+     * @return 2**n - 1
+     */
+    public static java.math.BigInteger getMersennePrime(int n) {
+        return java.math.BigInteger.ONE.shiftLeft(n).subtract(java.math.BigInteger.ONE);
+    }
+
+
+    /**
+     * Check if the list contains really prime numbers.
+     * @return true if all checked numbers are prime
+     */
+    protected boolean checkPrimes() {
+        return checkPrimes(size());
+    }
+
+
+    /**
+     * Check if the list contains really prime numbers.
+     * @param n number of primes to check.
+     * @return true if all checked numbers are prime
+     */
+    protected boolean checkPrimes(int n) {
+        boolean isPrime;
+        int i = 0;
+        for (java.math.BigInteger p : val) {
+            if (i++ >= n) {
+                break;
+            }
+            isPrime = p.isProbablePrime(63);
+            if (!isPrime) {
+                System.out.println("not prime = " + p);
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return val.toString();
+    }
+
+
+    /**
+     * Size of current list.
+     * @return current size of list.
+     */
+    public int size() {
+        return val.size();
+    }
+
+
+    /**
+     * Get prime at index i.
+     * @param i index to get element.
+     * @return prime at index i.
+     */
+    public java.math.BigInteger get(int i) {
+        java.math.BigInteger p;
+        if (i < size()) {
+            p = val.get(i);
+        } else if (i == size()) {
+            p = last.nextProbablePrime();
+            val.add(p);
+            last = p;
+        } else {
+            p = get(i - 1);
+            p = last.nextProbablePrime();
+            val.add(p);
+            last = p;
+        }
+        return p;
+    }
+
+
+    /**
+     * Iterator. 
+     * Always has next, will generate new primes if required.
+     * @return iterator over the prime list.
+     */
+    public Iterator<java.math.BigInteger> iterator() {
+        return new Iterator<java.math.BigInteger>() {
+
+
+            int index = -1;
+
+
+            public boolean hasNext() {
+                return true;
+            }
+
+
+            public void remove() {
+                throw new UnsupportedOperationException("remove not implemented");
+            }
+
+
+            public java.math.BigInteger next() {
+                index++;
+                return get(index);
+            }
+        };
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/Product.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/Product.java
@@ -1,0 +1,814 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.arith;
+
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.structure.NotInvertibleException;
+import edu.jas.structure.RegularRingElem;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Direct product element based on RingElem. Objects of this class are (nearly)
+ * immutable.
+ * @author Heinz Kredel
+ */
+public class Product<C extends RingElem<C>> implements RegularRingElem<Product<C>> {
+
+
+    private static final Logger logger = LogManager.getLogger(Product.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Product class factory data structure.
+     */
+    public final ProductRing<C> ring;
+
+
+    /**
+     * Value part of the element data structure.
+     */
+    public final SortedMap<Integer, C> val;
+
+
+    /**
+     * Flag to remember if this product element is a unit in each cmponent. -1
+     * is unknown, 1 is unit, 0 not a unit.
+     */
+    protected int isunit = -1; // initially unknown
+
+
+    /**
+     * The constructor creates a Product object from a ring factory.
+     * @param r ring factory.
+     */
+    public Product(ProductRing<C> r) {
+        this(r, new TreeMap<Integer, C>(), 0);
+    }
+
+
+    /**
+     * The constructor creates a Product object from a ring factory and a ring
+     * element.
+     * @param r ring factory.
+     * @param a ring element.
+     */
+    public Product(ProductRing<C> r, SortedMap<Integer, C> a) {
+        this(r, a, -1);
+    }
+
+
+    /**
+     * The constructor creates a Product object from a ring factory, a ring
+     * element and an indicator if a is a unit.
+     * @param r ring factory.
+     * @param a ring element.
+     * @param u isunit indicator, -1, 0, 1.
+     */
+    public Product(ProductRing<C> r, SortedMap<Integer, C> a, int u) {
+        ring = r;
+        val = a;
+        isunit = u;
+    }
+
+
+    /**
+     * Get component.
+     * @param i index of component.
+     * @return val(i).
+     */
+    public C get(int i) {
+        return val.get(i); // auto-boxing
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public ProductRing<C> factory() {
+        return ring;
+    }
+
+
+    /**
+     * Clone this.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public Product<C> copy() {
+        return new Product<C>(ring, val, isunit);
+    }
+
+
+    /**
+     * Is Product zero.
+     * @return If this is 0 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isZERO()
+     */
+    public boolean isZERO() {
+        return val.size() == 0;
+    }
+
+
+    /**
+     * Is Product one.
+     * @return If this is 1 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isONE()
+     */
+    public boolean isONE() {
+        if (val.size() != ring.length()) {
+            return false;
+        }
+        for (C e : val.values()) {
+            if (!e.isONE()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Is Product full.
+     * @return If every component is non-zero, then true is returned, else
+     *         false.
+     */
+    public boolean isFull() {
+        if (val.size() != ring.length()) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Is Product unit.
+     * @return If this is a unit then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isUnit()
+     */
+    public boolean isUnit() {
+        if (isunit > 0) {
+            return true;
+        }
+        if (isunit == 0) {
+            return false;
+        }
+        if (isZERO()) {
+            isunit = 0;
+            return false;
+        }
+        for (C e : val.values()) {
+            if (!e.isUnit()) {
+                isunit = 0;
+                return false;
+            }
+        }
+        isunit = 1;
+        return true;
+    }
+
+
+    /**
+     * Is Product idempotent.
+     * @return If this is a idempotent element then true is returned, else
+     *         false.
+     */
+    public boolean isIdempotent() {
+        for (C e : val.values()) {
+            if (!e.isONE()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Get the String representation as RingElem.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return val.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        StringBuffer s = new StringBuffer("( ");
+        boolean first = true;
+        for (Map.Entry<Integer, C> me : val.entrySet()) {
+            Integer i = me.getKey();
+            C v = me.getValue();
+            if (first) {
+                first = false;
+            } else {
+                if (v.signum() < 0) {
+                    s.append(" - ");
+                    v = v.negate();
+                } else {
+                    s.append(" + ");
+                }
+            }
+            if (!v.isONE()) {
+                s.append(v.toScript() + "*");
+            }
+            s.append("pg" + i);
+        }
+        s.append(" )");
+        return s.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python case
+        return factory().toScript();
+    }
+
+
+    /**
+     * Product comparison.
+     * @param b Product.
+     * @return sign(this-b).
+     */
+    @Override
+    public int compareTo(Product<C> b) {
+        if (!ring.equals(b.ring)) {
+            logger.info("other ring " + b.ring);
+            throw new IllegalArgumentException("rings not comparable " + this);
+        }
+        SortedMap<Integer, C> v = b.val;
+        Iterator<Map.Entry<Integer, C>> ti = val.entrySet().iterator();
+        Iterator<Map.Entry<Integer, C>> bi = v.entrySet().iterator();
+        int s;
+        while (ti.hasNext() && bi.hasNext()) {
+            Map.Entry<Integer, C> te = ti.next();
+            Map.Entry<Integer, C> be = bi.next();
+            s = te.getKey().compareTo(be.getKey());
+            if (s != 0) {
+                return s;
+            }
+            s = te.getValue().compareTo(be.getValue());
+            if (s != 0) {
+                return s;
+            }
+        }
+        if (ti.hasNext()) {
+            return -1;
+        }
+        if (bi.hasNext()) {
+            return 1;
+        }
+        return 0;
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean equals(Object b) {
+        if (b == null) {
+            return false;
+        }
+        if (!(b instanceof Product)) {
+            return false;
+        }
+        Product<C> a = (Product<C>) b;
+        return (0 == compareTo(a));
+    }
+
+
+    /**
+     * Hash code for this local.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h = ring.hashCode();
+        h = 37 * h + val.hashCode();
+        return h;
+    }
+
+
+    /**
+     * Product extend. Add new component j with value of component i.
+     * @param i from index.
+     * @param j to index.
+     * @return the extended value of this.
+     */
+    public Product<C> extend(int i, int j) {
+        RingFactory<C> rf = ring.getFactory(j);
+        SortedMap<Integer, C> elem = new TreeMap<Integer, C>(val);
+        C v = val.get(i);
+        C w = rf.copy(v); // valueOf
+        if (!w.isZERO()) {
+            elem.put(j, w);
+        }
+        return new Product<C>(ring, elem, isunit);
+    }
+
+
+    /**
+     * Product absolute value.
+     * @return the absolute value of this.
+     * @see edu.jas.structure.RingElem#abs()
+     */
+    public Product<C> abs() {
+        SortedMap<Integer, C> elem = new TreeMap<Integer, C>();
+        for (Map.Entry<Integer, C> e : val.entrySet()) {
+            Integer i = e.getKey();
+            C v = e.getValue().abs();
+            elem.put(i, v);
+        }
+        return new Product<C>(ring, elem, isunit);
+    }
+
+
+    /**
+     * Product summation.
+     * @param S Product.
+     * @return this+S.
+     */
+    public Product<C> sum(Product<C> S) {
+        if (S == null || S.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return S;
+        }
+        SortedMap<Integer, C> elem = new TreeMap<Integer, C>(val); // clone
+        SortedMap<Integer, C> sel = S.val;
+        for (Map.Entry<Integer, C> is : sel.entrySet()) {
+            Integer i = is.getKey();
+            C x = elem.get(i);
+            C y = is.getValue(); //sel.get( i ); // assert y != null
+            if (x != null) {
+                x = x.sum(y);
+                if (!x.isZERO()) {
+                    elem.put(i, x);
+                } else {
+                    elem.remove(i);
+                }
+            } else {
+                elem.put(i, y);
+            }
+        }
+        return new Product<C>(ring, elem);
+    }
+
+
+    /**
+     * Product negate.
+     * @return -this.
+     * @see edu.jas.structure.RingElem#negate()
+     */
+    public Product<C> negate() {
+        SortedMap<Integer, C> elem = new TreeMap<Integer, C>();
+        for (Map.Entry<Integer, C> me : val.entrySet()) {
+            Integer i = me.getKey();
+            C v = me.getValue().negate();
+            elem.put(i, v);
+        }
+        return new Product<C>(ring, elem, isunit);
+    }
+
+
+    /**
+     * Product signum.
+     * @see edu.jas.structure.RingElem#signum()
+     * @return signum of first non-zero component.
+     */
+    public int signum() {
+        if (val.size() == 0) {
+            return 0;
+        }
+        C v = val.get(val.firstKey());
+        return v.signum();
+    }
+
+
+    /**
+     * Product subtraction.
+     * @param S Product.
+     * @return this-S.
+     */
+    public Product<C> subtract(Product<C> S) {
+        return sum(S.negate());
+    }
+
+
+    /**
+     * Product quasi-inverse.
+     * @see edu.jas.structure.RingElem#inverse()
+     * @return S with S = 1/this if defined.
+     */
+    public Product<C> inverse() {
+        if (this.isZERO()) {
+            return this;
+        }
+        int isu = 0;
+        SortedMap<Integer, C> elem = new TreeMap<Integer, C>();
+        for (Map.Entry<Integer, C> me : val.entrySet()) {
+            Integer i = me.getKey();
+            C x = me.getValue(); // is non zero
+            try {
+                x = x.inverse();
+            } catch (NotInvertibleException e) {
+                // could happen for e.g. ModInteger or AlgebraicNumber
+                x = null; //ring.getFactory(i).getZERO();
+            }
+            if (x != null && !x.isZERO()) { // can happen
+                elem.put(i, x);
+                isu = 1;
+            }
+        }
+        return new Product<C>(ring, elem, isu);
+    }
+
+
+    /**
+     * Product idempotent.
+     * @return smallest S with this*S = this.
+     */
+    public Product<C> idempotent() {
+        if (this.isZERO()) {
+            return this;
+        }
+        SortedMap<Integer, C> elem = new TreeMap<Integer, C>();
+        for (Integer i : val.keySet()) {
+            RingFactory<C> f = ring.getFactory(i);
+            C x = f.getONE();
+            elem.put(i, x);
+        }
+        return new Product<C>(ring, elem, 1);
+    }
+
+
+    /**
+     * Product idempotent complement.
+     * @return 1-this.idempotent().
+     */
+    public Product<C> idemComplement() {
+        if (this.isZERO()) {
+            return ring.getONE();
+        }
+        int isu = 0;
+        SortedMap<Integer, C> elem = new TreeMap<Integer, C>();
+        for (int i = 0; i < ring.length(); i++) {
+            C v = val.get(i);
+            if (v == null) {
+                RingFactory<C> f = ring.getFactory(i);
+                C x = f.getONE();
+                elem.put(i, x);
+                isu = 1;
+            }
+        }
+        return new Product<C>(ring, elem, isu);
+    }
+
+
+    /**
+     * Product idempotent and.
+     * @param S Product.
+     * @return this.idempotent() and S.idempotent().
+     */
+    public Product<C> idempotentAnd(Product<C> S) {
+        if (this.isZERO() && S.isZERO()) {
+            return this;
+        }
+        int isu = 0;
+        SortedMap<Integer, C> elem = new TreeMap<Integer, C>();
+        for (int i = 0; i < ring.length(); i++) {
+            C v = val.get(i);
+            C w = S.val.get(i);
+            if (v != null && w != null) {
+                RingFactory<C> f = ring.getFactory(i);
+                C x = f.getONE();
+                elem.put(i, x);
+                isu = 1;
+            }
+        }
+        return new Product<C>(ring, elem, isu);
+    }
+
+
+    /**
+     * Product idempotent or.
+     * @param S Product.
+     * @return this.idempotent() or S.idempotent().
+     */
+    public Product<C> idempotentOr(Product<C> S) {
+        if (this.isZERO() && S.isZERO()) {
+            return this;
+        }
+        int isu = 0;
+        SortedMap<Integer, C> elem = new TreeMap<Integer, C>();
+        for (int i = 0; i < ring.length(); i++) {
+            C v = val.get(i);
+            C w = S.val.get(i);
+            if (v != null || w != null) {
+                RingFactory<C> f = ring.getFactory(i);
+                C x = f.getONE();
+                elem.put(i, x);
+                isu = 1;
+            }
+        }
+        return new Product<C>(ring, elem, isu);
+    }
+
+
+    /**
+     * Product fill with idempotent.
+     * @param S Product.
+     * @return fill this with S.idempotent().
+     */
+    public Product<C> fillIdempotent(Product<C> S) {
+        if (S.isZERO()) {
+            return this;
+        }
+        SortedMap<Integer, C> elem = new TreeMap<Integer, C>(val);
+        for (int i = 0; i < ring.length(); i++) {
+            C v = elem.get(i);
+            if (v != null) {
+                continue;
+            }
+            C w = S.val.get(i);
+            if (w != null) {
+                RingFactory<C> f = ring.getFactory(i);
+                C x = f.getONE();
+                elem.put(i, x);
+            }
+        }
+        return new Product<C>(ring, elem, isunit);
+    }
+
+
+    /**
+     * Product fill with one.
+     * @return fill this with one.
+     */
+    public Product<C> fillOne() {
+        if (this.isFull()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return ring.getONE();
+        }
+        SortedMap<Integer, C> elem = new TreeMap<Integer, C>(val);
+        for (int i = 0; i < ring.length(); i++) {
+            C v = elem.get(i);
+            if (v != null) {
+                continue;
+            }
+            RingFactory<C> f = ring.getFactory(i);
+            C x = f.getONE();
+            elem.put(i, x);
+        }
+        return new Product<C>(ring, elem, isunit);
+    }
+
+
+    /**
+     * Product quasi-division.
+     * @param S Product.
+     * @return this/S.
+     */
+    public Product<C> divide(Product<C> S) {
+        if (S == null) {
+            return ring.getZERO();
+        }
+        if (S.isZERO()) {
+            return S;
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        SortedMap<Integer, C> elem = new TreeMap<Integer, C>();
+        SortedMap<Integer, C> sel = S.val;
+        for (Map.Entry<Integer, C> me : val.entrySet()) {
+            Integer i = me.getKey();
+            C y = sel.get(i);
+            if (y != null) {
+                C x = me.getValue();
+                try {
+                    x = x.divide(y);
+                } catch (NotInvertibleException e) {
+                    // should not happen any more
+                    System.out.println("product divide error: x = " + x + ", y = " + y);
+                    // could happen for e.g. ModInteger or AlgebraicNumber
+                    x = null; //ring.getFactory(i).getZERO();
+                }
+                if (x != null && !x.isZERO()) { // can happen
+                    elem.put(i, x);
+                }
+            }
+        }
+        return new Product<C>(ring, elem);
+    }
+
+
+    /**
+     * Product quasi-remainder.
+     * @param S Product.
+     * @return this - (this/S)*S.
+     */
+    public Product<C> remainder(Product<C> S) {
+        if (S == null) {
+            return this; //ring.getZERO();
+        }
+        if (S.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        SortedMap<Integer, C> elem = new TreeMap<Integer, C>();
+        SortedMap<Integer, C> sel = S.val;
+        for (Map.Entry<Integer, C> me : val.entrySet()) {
+            Integer i = me.getKey();
+            C y = sel.get(i);
+            if (y != null) {
+                C x = me.getValue();
+                x = x.remainder(y);
+                if (x != null && !x.isZERO()) { // can happen
+                    elem.put(i, x);
+                }
+            }
+        }
+        return new Product<C>(ring, elem);
+    }
+
+
+    /**
+     * Quotient and remainder by division of this by S.
+     * @param S a product
+     * @return [this/S, this - (this/S)*S].
+     */
+    @SuppressWarnings("unchecked")
+    public Product<C>[] quotientRemainder(Product<C> S) {
+        return new Product[] { divide(S), remainder(S) };
+    }
+
+
+    /**
+     * Product multiplication.
+     * @param S Product.
+     * @return this*S.
+     */
+    public Product<C> multiply(Product<C> S) {
+        if (S == null) {
+            return ring.getZERO();
+        }
+        if (S.isZERO()) {
+            return S;
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        SortedMap<Integer, C> elem = new TreeMap<Integer, C>();
+        SortedMap<Integer, C> sel = S.val;
+        for (Map.Entry<Integer, C> me : val.entrySet()) {
+            Integer i = me.getKey();
+            C y = sel.get(i);
+            if (y != null) {
+                C x = me.getValue();
+                x = x.multiply(y);
+                if (x != null && !x.isZERO()) {
+                    elem.put(i, x);
+                }
+            }
+        }
+        return new Product<C>(ring, elem);
+    }
+
+
+    /**
+     * Product multiply by coefficient.
+     * @param c coefficient.
+     * @return this*c.
+     */
+    public Product<C> multiply(C c) {
+        SortedMap<Integer, C> elem = new TreeMap<Integer, C>();
+        for (Map.Entry<Integer, C> me : val.entrySet()) {
+            Integer i = me.getKey();
+            C v = me.getValue().multiply(c);
+            if (v != null && !v.isZERO()) {
+                elem.put(i, v);
+            }
+        }
+        return new Product<C>(ring, elem);
+    }
+
+
+    /**
+     * Greatest common divisor.
+     * @param S other element.
+     * @return gcd(this,S).
+     */
+    public Product<C> gcd(Product<C> S) {
+        if (S == null || S.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return S;
+        }
+        SortedMap<Integer, C> elem = new TreeMap<Integer, C>(val); // clone
+        SortedMap<Integer, C> sel = S.val;
+        for (Map.Entry<Integer, C> is : sel.entrySet()) {
+            Integer i = is.getKey();
+            C x = elem.get(i);
+            C y = is.getValue(); //sel.get( i ); // assert y != null
+            if (x != null) {
+                x = x.gcd(y);
+                if (x != null && !x.isZERO()) {
+                    elem.put(i, x);
+                } else {
+                    elem.remove(i);
+                }
+            } else {
+                elem.put(i, y);
+            }
+        }
+        return new Product<C>(ring, elem);
+    }
+
+
+    /**
+     * Extended greatest common divisor.
+     * @param S other element.
+     * @return [ gcd(this,S), c1, c2 ] with c1*this + c2*b = gcd(this,S).
+     */
+    @SuppressWarnings("unchecked")
+    public Product<C>[] egcd(Product<C> S) {
+        Product<C>[] ret = new Product[3];
+        ret[0] = null;
+        ret[1] = null;
+        ret[2] = null;
+        if (S == null || S.isZERO()) {
+            ret[0] = this;
+            return ret;
+        }
+        if (this.isZERO()) {
+            ret[0] = S;
+            return ret;
+        }
+        SortedMap<Integer, C> elem = new TreeMap<Integer, C>(val); // clone
+        SortedMap<Integer, C> elem1 = this.idempotent().val; // init with 1
+        SortedMap<Integer, C> elem2 = new TreeMap<Integer, C>(); // zero
+        SortedMap<Integer, C> sel = S.val;
+        for (Map.Entry<Integer, C> is : sel.entrySet()) {
+            Integer i = is.getKey();
+            C x = elem.get(i);
+            C y = is.getValue(); //sel.get( i ); // assert y != null
+            if (x != null) {
+                C[] g = x.egcd(y);
+                if (!g[0].isZERO()) {
+                    elem.put(i, g[0]);
+                    elem1.put(i, g[1]);
+                    elem2.put(i, g[2]);
+                } else {
+                    elem.remove(i);
+                }
+            } else {
+                elem.put(i, y);
+                elem2.put(i, ring.getFactory(i).getONE());
+            }
+        }
+        ret[0] = new Product<C>(ring, elem);
+        ret[1] = new Product<C>(ring, elem1);
+        ret[2] = new Product<C>(ring, elem2);
+        return ret;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/ProductRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/ProductRing.java
@@ -1,0 +1,590 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.arith;
+
+
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Direct product ring factory based on RingElem and RingFactory module. Objects
+ * of this class are <b>mutable</b>.
+ * @author Heinz Kredel
+ */
+public class ProductRing<C extends RingElem<C>> implements RingFactory<Product<C>> {
+
+
+    private static final Logger logger = LogManager.getLogger(ProductRing.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Ring factory is n copies.
+     */
+    protected int nCopies;
+
+
+    /**
+     * One Ring factory.
+     */
+    protected final RingFactory<C> ring;
+
+
+    /**
+     * Ring factory list.
+     */
+    protected final List<RingFactory<C>> ringList;
+
+
+    /**
+     * A default random sequence generator.
+     */
+    protected final static Random random = new Random();
+
+
+    /**
+     * The constructor creates a ProductRing object from an ring factory and a
+     * modul.
+     * @param r ring factory.
+     * @param n number of copies.
+     */
+    public ProductRing(RingFactory<C> r, int n) {
+        ring = r;
+        nCopies = n;
+        ringList = null;
+    }
+
+
+    /**
+     * The constructor creates a ProductRing object from an ring factory and a
+     * modul.
+     * @param l list of ring factories.
+     */
+    public ProductRing(List<RingFactory<C>> l) {
+        ringList = l;
+        ring = null;
+        nCopies = 0;
+    }
+
+
+    /**
+     * Get ring factory at index i.
+     * @param i index.
+     * @return RingFactory_i.
+     */
+    public RingFactory<C> getFactory(int i) {
+        if (nCopies != 0) {
+            if (0 <= i && i < nCopies) {
+                return ring;
+            }
+            logger.info("index: " + i);
+            throw new IllegalArgumentException("index out of bound " + this);
+        }
+        return ringList.get(i);
+    }
+
+
+    /**
+     * Add a ring factory.
+     * @param rf new ring factory.
+     */
+    public synchronized void addFactory(RingFactory<C> rf) {
+        if (nCopies != 0) {
+            if (ring.equals(rf)) {
+                nCopies++;
+            }
+            throw new IllegalArgumentException("wrong RingFactory: " + rf);
+        }
+        ringList.add(rf);
+    }
+
+
+    /**
+     * Contains a ring factory.
+     * @param rf ring factory.
+     * @return true, if rf is contained in this, else false.
+     */
+    public boolean containsFactory(RingFactory<C> rf) {
+        if (nCopies != 0) {
+            if (ring.equals(rf)) {
+                return true;
+            }
+            return false; // misleading
+        }
+        return ringList.contains(rf);
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite()
+     */
+    public boolean isFinite() {
+        if (nCopies != 0) {
+            return ring.isFinite();
+        }
+        for (RingFactory<C> f : ringList) {
+            boolean b = f.isFinite();
+            if (!b) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Copy Product element c.
+     * @param c
+     * @return a copy of c.
+     */
+    public Product<C> copy(Product<C> c) {
+        return new Product<C>(c.ring, c.val, c.isunit);
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as Product.
+     */
+    public Product<C> getZERO() {
+        return new Product<C>(this);
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as Product.
+     */
+    public Product<C> getONE() {
+        SortedMap<Integer, C> elem = new TreeMap<Integer, C>();
+        if (nCopies != 0) {
+            for (int i = 0; i < nCopies; i++) {
+                elem.put(i, ring.getONE());
+            }
+        } else {
+            int i = 0;
+            for (RingFactory<C> f : ringList) {
+                elem.put(i, f.getONE());
+                i++;
+            }
+        }
+        return new Product<C>(this, elem, 1);
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     * @see edu.jas.structure.ElemFactory#generators()
+     */
+    public List<Product<C>> generators() {
+        List<Product<C>> gens = new ArrayList<Product<C>>(/*nCopies*ring.generators.size()*/);
+        int n = nCopies;
+        if (n == 0) {
+            n = ringList.size();
+        }
+        for (int i = 0; i < n; i++) {
+            //System.out.println("i = " + i + ", n = " + n);
+            RingFactory<C> f = getFactory(i);
+            List<? extends C> rgens = f.generators();
+            for (C c : rgens) {
+                SortedMap<Integer, C> elem = new TreeMap<Integer, C>();
+                elem.put(i, c);
+                Product<C> g = new Product<C>(this, elem);
+                //g = g.fillOne();
+                gens.add(g);
+            }
+        }
+        return gens;
+    }
+
+
+    /**
+     * Get an atomic element.
+     * @param i index.
+     * @return e_i as Product.
+     */
+    public Product<C> getAtomic(int i) {
+        if (i < 0 || i >= length()) {
+            throw new IllegalArgumentException("index out of bounds " + i);
+        }
+        SortedMap<Integer, C> elem = new TreeMap<Integer, C>();
+        if (nCopies != 0) {
+            elem.put(i, ring.getONE());
+        } else {
+            RingFactory<C> f = ringList.get(i);
+            elem.put(i, f.getONE());
+        }
+        return new Product<C>(this, elem, 1);
+    }
+
+
+    /**
+     * Get the number of factors of this ring.
+     * @return nCopies or ringList.size().
+     */
+    public int length() {
+        if (nCopies != 0) {
+            return nCopies;
+        }
+        return ringList.size();
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true if this ring is commutative, else false.
+     */
+    public boolean isCommutative() {
+        if (nCopies != 0) {
+            return ring.isCommutative();
+        }
+        for (RingFactory<C> f : ringList) {
+            if (!f.isCommutative()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Query if this ring is associative.
+     * @return true if this ring is associative, else false.
+     */
+    public boolean isAssociative() {
+        if (nCopies != 0) {
+            return ring.isAssociative();
+        }
+        for (RingFactory<C> f : ringList) {
+            if (!f.isAssociative()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Query if this ring is a field.
+     * @return true or false.
+     */
+    public boolean isField() {
+        if (nCopies != 0) {
+            if (nCopies == 1) {
+                return ring.isField();
+            }
+        } else {
+            if (ringList.size() == 1) {
+                return ringList.get(0).isField();
+            }
+        }
+        return false;
+    }
+
+
+    /**
+     * Query if this ring consists only of fields.
+     * @return true or false.
+     */
+    public boolean onlyFields() {
+        if (nCopies != 0) {
+            return ring.isField();
+        }
+        for (RingFactory<C> f : ringList) {
+            if (!f.isField()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return minimal characteristic of ring component.
+     */
+    public java.math.BigInteger characteristic() {
+        if (nCopies != 0) {
+            return ring.characteristic();
+        }
+        java.math.BigInteger c = null;
+        java.math.BigInteger d;
+        for (RingFactory<C> f : ringList) {
+            if (c == null) {
+                c = f.characteristic();
+            } else {
+                d = f.characteristic();
+                if (c.compareTo(d) > 0) { // c > d
+                    c = d;
+                }
+            }
+        }
+        return c;
+    }
+
+
+    /**
+     * Get a Product element from a BigInteger value.
+     * @param a BigInteger.
+     * @return a Product.
+     */
+    public Product<C> fromInteger(java.math.BigInteger a) {
+        SortedMap<Integer, C> elem = new TreeMap<Integer, C>();
+        if (nCopies != 0) {
+            C c = ring.fromInteger(a);
+            for (int i = 0; i < nCopies; i++) {
+                elem.put(i, c);
+            }
+        } else {
+            int i = 0;
+            for (RingFactory<C> f : ringList) {
+                elem.put(i, f.fromInteger(a));
+                i++;
+            }
+        }
+        return new Product<C>(this, elem);
+    }
+
+
+    /**
+     * Get a Product element from a long value.
+     * @param a long.
+     * @return a Product.
+     */
+    public Product<C> fromInteger(long a) {
+        return fromInteger(new java.math.BigInteger("" + a));
+    }
+
+
+    /**
+     * Get the String representation as RingFactory.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        if (nCopies != 0) {
+            String cf = ring.toString();
+            if (cf.matches("[0-9].*")) {
+                cf = ring.getClass().getSimpleName();
+            }
+            return "ProductRing[ " + cf + "^" + nCopies + " ]";
+        }
+        StringBuffer sb = new StringBuffer("ProductRing[ ");
+        int i = 0;
+        for (RingFactory<C> f : ringList) {
+            if (i != 0) {
+                sb.append(", ");
+            }
+            String cf = f.toString();
+            if (cf.matches("[0-9].*")) {
+                cf = f.getClass().getSimpleName();
+            }
+            sb.append(cf);
+            i++;
+        }
+        sb.append(" ]");
+        return sb.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.ElemFactory#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        StringBuffer s = new StringBuffer("RR( [ ");
+        for (int i = 0; i < length(); i++) {
+            if (i > 0) {
+                s.append(", ");
+            }
+            RingFactory<C> v = getFactory(i);
+            String f = null;
+            try {
+                f = ((RingElem<C>) v).toScriptFactory(); // sic
+            } catch (Exception e) {
+                f = v.toScript();
+            }
+            s.append(f);
+        }
+        s.append(" ] )");
+        return s.toString();
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (b == null) {
+            return false;
+        }
+        if (!(b instanceof ProductRing)) {
+            return false;
+        }
+        ProductRing<C> a = (ProductRing<C>) b;
+        if (nCopies != 0) {
+            if (nCopies != a.nCopies || !ring.equals(a.ring)) {
+                return false;
+            }
+        } else {
+            if (ringList.size() != a.ringList.size()) {
+                return false;
+            }
+            int i = 0;
+            for (RingFactory<C> f : ringList) {
+                if (!f.equals(a.ringList.get(i))) {
+                    return false;
+                }
+                i++;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Hash code for this product ring.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h = 0;
+        if (nCopies != 0) {
+            h = ring.hashCode();
+            h = 37 * h + nCopies;
+        } else {
+            for (RingFactory<C> f : ringList) {
+                h = 37 * h + f.hashCode();
+            }
+        }
+        return h;
+    }
+
+
+    /**
+     * Product random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @return a random product element v.
+     */
+    public Product<C> random(int n) {
+        return random(n, 0.5f);
+    }
+
+
+    /**
+     * Product random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @param q density of nozero entries.
+     * @return a random product element v.
+     */
+    public Product<C> random(int n, float q) {
+        return random(n, q, random);
+    }
+
+
+    /**
+     * Product random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @param rnd is a source for random bits.
+     * @return a random product element v.
+     */
+    public Product<C> random(int n, Random rnd) {
+        return random(n, 0.5f, random);
+    }
+
+
+    /**
+     * Product random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @param q density of nozero entries.
+     * @param rnd is a source for random bits.
+     * @return a random product element v.
+     */
+    public Product<C> random(int n, float q, Random rnd) {
+        SortedMap<Integer, C> elem = new TreeMap<Integer, C>();
+        float d;
+        if (nCopies != 0) {
+            for (int i = 0; i < nCopies; i++) {
+                d = rnd.nextFloat();
+                if (d < q) {
+                    C r = ring.random(n, rnd);
+                    if (!r.isZERO()) {
+                        elem.put(i, r);
+                    }
+                }
+            }
+        } else {
+            int i = 0;
+            for (RingFactory<C> f : ringList) {
+                d = rnd.nextFloat();
+                if (d < q) {
+                    C r = f.random(n, rnd);
+                    if (!r.isZERO()) {
+                        elem.put(i, r);
+                    }
+                }
+                i++;
+            }
+        }
+        return new Product<C>(this, elem);
+    }
+
+
+    /**
+     * Parse Product from String.
+     * @param s String.
+     * @return Product from s.
+     */
+    public Product<C> parse(String s) {
+        StringReader sr = new StringReader(s);
+        return parse(sr);
+    }
+
+
+    /**
+     * Parse Product from Reader. Syntax: p1 ... pn (no commas)
+     * @param r Reader.
+     * @return next Product from r.
+     */
+    public Product<C> parse(Reader r) {
+        SortedMap<Integer, C> elem = new TreeMap<Integer, C>();
+        if (nCopies != 0) {
+            for (int i = 0; i < nCopies; i++) {
+                elem.put(i, ring.parse(r));
+            }
+        } else {
+            int i = 0;
+            for (RingFactory<C> f : ringList) {
+                elem.put(i, f.parse(r));
+                i++;
+            }
+        }
+        return new Product<C>(this, elem);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/Rational.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/Rational.java
@@ -1,0 +1,22 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.arith;
+
+
+/**
+ * Interface with method to get a BigRational (approximation).
+ * @author Heinz Kredel
+ */
+
+public interface Rational {
+
+
+    /**
+     * Return a BigRational approximation of this Element.
+     * @return a BigRational approximation of this.
+     */
+    public BigRational getRational();
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/Roots.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/Roots.java
@@ -1,0 +1,333 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.arith;
+
+
+import java.math.MathContext;
+
+
+/**
+ * Root computation algorithms. Roots for BigInteger and BigDecimals.
+ * @author Heinz Kredel
+ */
+public class Roots {
+
+
+    /**
+     * Integer n-th root. Uses BigDecimal and newton iteration. R is the n-th
+     * root of A.
+     * @param A big integer.
+     * @param n long.
+     * @return the n-th root of A.
+     */
+    public static BigInteger root(BigInteger A, int n) {
+        if (n == 1) {
+            return A;
+        }
+        if (n == 2) {
+            return sqrt(A);
+        }
+        if (n < 1) {
+            throw new IllegalArgumentException("negative root not defined");
+        }
+        if (A == null || A.isZERO() || A.isONE()) {
+            return A;
+        }
+        if (A.signum() < 0) {
+            throw new ArithmeticException("root of negative not defined: " + A);
+        }
+        // ensure enough precision
+        int s = A.val.bitLength() + 2;
+        MathContext mc = new MathContext(s);
+        //System.out.println("mc = " + mc);
+        BigDecimal Ap = new BigDecimal(A.val, mc);
+        //System.out.println("Ap = " + Ap);
+        BigDecimal Ar = root(Ap, n);
+        //System.out.println("Ar = " + Ar);
+        java.math.BigInteger RP = Ar.val.toBigInteger();
+        BigInteger R = new BigInteger(RP);
+        while (true) {
+            BigInteger P = R.power(n); //Power.positivePower(R, n);
+            //System.out.println("P = " + P);
+            if (A.compareTo(P) >= 0) {
+                break;
+            }
+            R = R.subtract(BigInteger.ONE);
+        }
+        return R;
+    }
+
+
+    /**
+     * Integer square root. Uses BigDecimal and newton iteration. R is the
+     * square root of A.
+     * @param A big integer.
+     * @return the square root of A.
+     */
+    public static BigInteger sqrt(BigInteger A) {
+        if (A == null || A.isZERO() || A.isONE()) {
+            return A;
+        }
+        if (A.signum() < 0) {
+            throw new ArithmeticException("root of negative not defined: " + A);
+        }
+        // ensure enough precision
+        int s = A.val.bitLength() + 2;
+        MathContext mc = new MathContext(s);
+        //System.out.println("mc = " + mc);
+        // newton iteration
+        BigDecimal Ap = new BigDecimal(A.val, mc);
+        //System.out.println("Ap = " + Ap);
+        BigDecimal Ar = sqrt(Ap);
+        //System.out.println("Ar = " + Ar);
+        java.math.BigInteger RP = Ar.val.toBigInteger();
+        BigInteger R = new BigInteger(RP);
+        while (true) {
+            BigInteger P = R.multiply(R);
+            //System.out.println("P = " + P);
+            if (A.compareTo(P) >= 0) {
+                break;
+            }
+            R = R.subtract(BigInteger.ONE);
+        }
+        return R;
+    }
+
+
+    /**
+     * Integer square root. Uses BigInteger only. R is the square root of A.
+     * @param A big integer.
+     * @return the square root of A.
+     */
+    public static BigInteger sqrtInt(BigInteger A) {
+        if (A == null || A.isZERO() || A.isONE()) {
+            return A;
+        }
+        int s = A.signum();
+        if (s < 0) {
+            throw new ArithmeticException("root of negative not defined: " + A);
+        }
+        BigInteger R, R1, d;
+        int log2 = A.val.bitLength();
+        //System.out.println("A = " + A + ", log2 = " + log2);
+        int rootlog2 = log2 - log2 / 2;
+        R = new BigInteger(A.val.shiftRight(rootlog2));
+        //System.out.println("R = " + R + ", rootlog2 = " + rootlog2);
+        d = R;
+        while (!d.isZERO()) {
+            d = new BigInteger(d.val.shiftRight(1)); // div 2
+            R1 = R.sum(d);
+            s = A.compareTo(R1.multiply(R1));
+            if (s == 0) {
+                return R1;
+            }
+            if (s > 0) {
+                R = R1;
+            }
+            //System.out.println("R1 = " + R1);
+            //System.out.println("d  = " + d);
+        }
+        while (true) {
+            R1 = R.sum(BigInteger.ONE);
+            //System.out.println("R1 = " + R1);
+            s = A.compareTo(R1.multiply(R1));
+            if (s == 0) {
+                return R1;
+            }
+            if (s > 0) {
+                R = R1;
+            }
+            if (s < 0) {
+                return R;
+            }
+        }
+        //return R;
+    }
+
+
+    /**
+     * Square root. R is the square root of A.
+     * @param A big decimal.
+     * @return the square root of A.
+     */
+    public static BigDecimal sqrt(BigDecimal A) {
+        if (A == null || A.isZERO() || A.isONE()) {
+            return A;
+        }
+        if (A.signum() < 0) {
+            throw new ArithmeticException("root of negative not defined: " + A);
+        }
+        // for small A use root of inverse
+        if (A.abs().val.compareTo(BigDecimal.ONE.val) < 0) {
+            BigDecimal Ap = A.inverse();
+            Ap = sqrt(Ap);
+            Ap = Ap.inverse();
+            //System.out.println("sqrt(A).inverse() = " + Ap);
+            return Ap;
+        }
+        // ensure enough precision
+        MathContext mc = A.context;
+        BigDecimal eps = new BigDecimal("0.1");
+        int p = Math.max(mc.getPrecision(), java.math.MathContext.DECIMAL64.getPrecision());
+        //java.math.MathContext.UNLIMITED.getPrecision() == 0
+        eps = eps.power(p / 2);
+        // newton iteration
+        BigDecimal Ap = new BigDecimal(A.val, mc);
+        BigDecimal ninv = new BigDecimal(0.5, mc);
+        BigDecimal R1, R = Ap.multiply(ninv); // initial guess
+        BigDecimal d;
+        int i = 0;
+        while (true) {
+            R1 = R.sum(Ap.divide(R));
+            R1 = R1.multiply(ninv); // div n
+            d = R.subtract(R1).abs();
+            R = R1;
+            if (d.val.compareTo(eps.val) <= 0) {
+                //System.out.println("d  = " + d + ", R = " + R);
+                break;
+            }
+            if (i++ % 11 == 0) {
+                eps = eps.sum(eps);
+            }
+            //System.out.println("eps  = " + eps + ", d = " + d);
+        }
+        return R;
+    }
+
+
+    /**
+     * N-th root. R is the n-th root of A.
+     * @param A big decimal.
+     * @param n long.
+     * @return the n-th root of A.
+     */
+    public static BigDecimal root(BigDecimal A, int n) {
+        if (n == 1) {
+            return A;
+        }
+        if (n == 2) {
+            return sqrt(A);
+        }
+        if (n < 1) {
+            throw new IllegalArgumentException("negative root not defined");
+        }
+        if (A == null || A.isZERO() || A.isONE()) {
+            return A;
+        }
+        if (A.signum() < 0) {
+            throw new ArithmeticException("root of negative not defined: " + A);
+        }
+        // for small A use root of inverse
+        if (A.abs().val.compareTo(BigDecimal.ONE.val) < 0) {
+            BigDecimal Ap = A.inverse();
+            //System.out.println("A.inverse() = " + Ap);
+            Ap = root(Ap, n);
+            return Ap.inverse();
+        }
+        // ensure enough precision
+        MathContext mc = A.context;
+        BigDecimal eps = new BigDecimal("0.1");
+        int p = Math.max(mc.getPrecision(), java.math.MathContext.DECIMAL64.getPrecision());
+        //java.math.MathContext.UNLIMITED.getPrecision() == 0
+        eps = eps.power((p / 3) * 2);
+        // newton iteration
+        BigDecimal Ap = A;
+        BigDecimal N = new BigDecimal(n, mc);
+        BigDecimal ninv = new BigDecimal(1.0 / n, mc);
+        BigDecimal nsub = new BigDecimal(1.0, mc); // because of precision
+        nsub = nsub.subtract(ninv);
+        BigDecimal P, R1, R = Ap.multiply(ninv); // initial guess
+        BigDecimal d;
+        int i = 0;
+        while (true) {
+            P = R.power(n - 1); //Power.positivePower(R, n - 1);
+            R1 = Ap.divide(P.multiply(N));
+            R1 = R.multiply(nsub).sum(R1);
+            d = R.subtract(R1).abs();
+            R = R1;
+            if (d.val.compareTo(eps.val) <= 0) {
+                //System.out.println("d.val  = " + d.val);
+                break;
+            }
+            if (i++ % 11 == 0) {
+                eps = eps.sum(eps);
+            }
+        }
+        // System.out.println("eps  = " + eps + ", d = " + d);
+        return R;
+    }
+
+
+    /**
+     * Complex decimal number square root.
+     * @param a big decimal complex.
+     * @return sqrt(a).
+     */
+    public static BigDecimalComplex sqrt(BigDecimalComplex a) {
+        if (a.isZERO() || a.isONE()) {
+            return a;
+        }
+        if (a.im.isZERO() && a.re.signum() > 0) {
+            BigDecimal v = Roots.sqrt(a.re);
+            return new BigDecimalComplex(v);
+        }
+        BigDecimal r = a.re.abs().sum(a.abs().re);
+        BigDecimal t = new BigDecimal(2);
+        BigDecimal ti = new BigDecimal("0.5");
+        //BigDecimal u = r.divide(t);
+        BigDecimal u = r.multiply(ti);
+        BigDecimal v = Roots.sqrt(u);
+        //System.out.println("r = " + r + ", a = " + a);
+        //System.out.println("v = " + v + ", u = " + u);
+        if (a.re.signum() >= 0) {
+            return new BigDecimalComplex(v, a.im.divide(v.multiply(t)));
+        }
+        u = v;
+        if (a.im.signum() < 0) {
+            u = u.negate();
+        }
+        return new BigDecimalComplex(a.im.abs().divide(v.multiply(t)), u);
+    }
+
+
+    /**
+     * Square root. R is the square root approximation of A.
+     * Convert to BigDecimal and compute square root.
+     * @param A big rational.
+     * @return the square root approximation of A.
+     */
+    public static BigRational sqrt(BigRational A) {
+        if (A == null || A.isZERO() || A.isONE()) {
+            return A;
+        }
+        if (A.signum() < 0) {
+            throw new ArithmeticException("root of negative not defined: " + A);
+        }
+        BigDecimal ad = new BigDecimal(A);
+        BigDecimal s = sqrt(ad);
+        //System.out.println("s = " + s);
+        BigRational S = new BigRational(s.toString());
+        return S;
+    }
+
+
+    /**
+     * Square root. R is the square root approximation of A.
+     * Convert to BigDecimalComplex and compute square root.
+     * @param A big complex rational.
+     * @return the square root approximation of A.
+     */
+    public static BigComplex sqrt(BigComplex A) {
+        if (A == null || A.isZERO() || A.isONE()) {
+            return A;
+        }
+        BigDecimalComplex ad = new BigDecimalComplex(A);
+        BigDecimalComplex s = sqrt(ad);
+        //System.out.println("s = " + s);
+        BigComplex S = new BigComplex(s.toString());
+        return S;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/package.html
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/arith/package.html
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "../DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>Basic arithmetic package</title>
+  </head>
+
+  <body>
+    <h1>Basic arithmetic package.</h1>
+
+<p>
+  This package contains classes for arithmetic in the basic coefficient rings,
+  e.g. <code>BigRational</code>, <code>BigInteger</code>, <code>ModLong</code> or 
+  <code>ModInteger</code>.
+  All such classes implement the <code>RingElem</code> respectively the <code>GcdRingElem</code> interface.
+  The class <code>PrimeList</code> provides a list of useful prime numbers.
+  The <code>Product</code> class implements a finite product of other ring elements.
+</p>
+
+
+    <hr />
+    <address><a href="mailto:kredel at rz.uni-mannheim.de">Heinz Kredel</a></address>
+<p>
+<!-- Created: Wed Mar  1 12:29:04 CET 2006 -->
+<!-- hhmts start -->
+Last modified: Thu Dec 15 22:56:05 CET 2011
+<!-- hhmts end -->
+</p>
+<p>$Id$ 
+</p>
+  </body>
+</html>

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/FDUtil.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/FDUtil.java
@@ -1,0 +1,1215 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.fd;
+
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.GenSolvablePolynomialRing;
+import edu.jas.poly.RecSolvablePolynomial;
+import edu.jas.poly.RecSolvablePolynomialRing;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Solvable polynomials factorization domain utilities, for example recursive
+ * pseudo remainder.
+ * @author Heinz Kredel
+ */
+
+public class FDUtil {
+
+
+    private static final Logger logger = LogManager.getLogger(FDUtil.class);
+
+
+    private static final boolean debug = true; //logger.isDebugEnabled();
+
+
+    private static final boolean info = logger.isInfoEnabled();
+
+
+    /**
+     * GenSolvablePolynomial sparse pseudo remainder for univariate polynomials.
+     * @param <C> coefficient type.
+     * @param P GenSolvablePolynomial.
+     * @param S nonzero GenSolvablePolynomial.
+     * @return remainder with ore(ldcf(S)<sup>m'</sup>) P = quotient * S +
+     *         remainder. m' &le; deg(P)-deg(S)
+     * @see edu.jas.poly.GenPolynomial#remainder(edu.jas.poly.GenPolynomial).
+     */
+    @SuppressWarnings("unchecked")
+    public static <C extends GcdRingElem<C>> GenSolvablePolynomial<C> leftBaseSparsePseudoRemainder(
+                    GenSolvablePolynomial<C> P, GenSolvablePolynomial<C> S) {
+        return leftBasePseudoQuotientRemainder(P, S)[1];
+    }
+
+
+    /**
+     * GenSolvablePolynomial sparse right pseudo remainder for univariate
+     * polynomials.
+     * @param <C> coefficient type.
+     * @param P GenSolvablePolynomial.
+     * @param S nonzero GenSolvablePolynomial.
+     * @return remainder with P ore(ldcf(S)<sup>m'</sup>) = S * quotient +
+     *         remainder. m' &le; deg(P)-deg(S)
+     * @see edu.jas.poly.GenPolynomial#remainder(edu.jas.poly.GenPolynomial).
+     */
+    @SuppressWarnings("unchecked")
+    public static <C extends GcdRingElem<C>> GenSolvablePolynomial<C> rightBaseSparsePseudoRemainder(
+                    GenSolvablePolynomial<C> P, GenSolvablePolynomial<C> S) {
+        return rightBasePseudoQuotientRemainder(P, S)[1];
+    }
+
+
+    /**
+     * GenSolvablePolynomial sparse pseudo quotient for univariate polynomials
+     * or exact division.
+     * @param <C> coefficient type.
+     * @param P GenSolvablePolynomial.
+     * @param S nonzero GenSolvablePolynomial.
+     * @return quotient with ore(ldcf(S)<sup>m'</sup>) P = quotient * S +
+     *         remainder. m' &le; deg(P)-deg(S)
+     * @see edu.jas.poly.GenPolynomial#divide(edu.jas.poly.GenPolynomial).
+     */
+    public static <C extends GcdRingElem<C>> GenSolvablePolynomial<C> leftBasePseudoQuotient(
+                    GenSolvablePolynomial<C> P, GenSolvablePolynomial<C> S) {
+        return leftBasePseudoQuotientRemainder(P, S)[0];
+    }
+
+
+    /**
+     * GenSolvablePolynomial right sparse pseudo quotient for univariate
+     * polynomials or exact division.
+     * @param <C> coefficient type.
+     * @param P GenSolvablePolynomial.
+     * @param S nonzero GenSolvablePolynomial.
+     * @return quotient with P ore(ldcf(S)<sup>m'</sup>) = S * quotient +
+     *         remainder. m' &le; deg(P)-deg(S)
+     * @see edu.jas.poly.GenPolynomial#divide(edu.jas.poly.GenPolynomial).
+     */
+    public static <C extends GcdRingElem<C>> GenSolvablePolynomial<C> rightBasePseudoQuotient(
+                    GenSolvablePolynomial<C> P, GenSolvablePolynomial<C> S) {
+        return rightBasePseudoQuotientRemainder(P, S)[0];
+    }
+
+
+    /**
+     * GenSolvablePolynomial sparse pseudo quotient and remainder for univariate
+     * polynomials or exact division.
+     * @param <C> coefficient type.
+     * @param P GenSolvablePolynomial.
+     * @param S nonzero GenSolvablePolynomial.
+     * @return [ quotient, remainder ] with ore(ldcf(S)<sup>m'</sup>) P =
+     *         quotient * S + remainder. m' &le; deg(P)-deg(S)
+     * @see edu.jas.poly.GenPolynomial#divide(edu.jas.poly.GenPolynomial).
+     */
+    @SuppressWarnings("unchecked")
+    public static <C extends GcdRingElem<C>> GenSolvablePolynomial<C>[] leftBasePseudoQuotientRemainder(
+                    GenSolvablePolynomial<C> P, GenSolvablePolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            throw new ArithmeticException(P.toString() + " division by zero " + S);
+        }
+        //if (S.ring.nvar != 1) { // ok if exact division
+        //    throw new RuntimeException("univariate polynomials only");
+        //}
+        GenSolvablePolynomial<C>[] ret = new GenSolvablePolynomial[2];
+        ret[0] = null;
+        ret[1] = null;
+        if (P.isZERO() || S.isONE()) {
+            ret[0] = P;
+            ret[1] = S.ring.getZERO();
+            return ret;
+        }
+        if (P instanceof RecSolvablePolynomial) {
+            RecSolvablePolynomial<C> Pr = (RecSolvablePolynomial) P;
+            if (!Pr.ring.coeffTable.isEmpty()) {
+                throw new UnsupportedOperationException(
+                                "RecSolvablePolynomial with twisted coeffs not supported");
+            }
+        }
+        GreatestCommonDivisorAbstract<C> fd = new GreatestCommonDivisorFake<C>(P.ring.coFac);
+        ExpVector e = S.leadingExpVector();
+        GenSolvablePolynomial<C> h;
+        GenSolvablePolynomial<C> r = P;
+        GenSolvablePolynomial<C> q = S.ring.getZERO().copy();
+        while (!r.isZERO()) {
+            ExpVector f = r.leadingExpVector();
+            if (f.multipleOf(e)) {
+                C a = r.leadingBaseCoefficient();
+                f = f.subtract(e);
+                h = S.multiplyLeft(f); // coeff a
+                C c = h.leadingBaseCoefficient();
+                // need ga, gc: ga a = gc c
+                C[] oc = fd.leftOreCond(a, c);
+                C ga = oc[0];
+                C gc = oc[1];
+                r = r.multiplyLeft(ga); // coeff ga a, exp f
+                h = h.multiplyLeft(gc); // coeff gc c, exp f
+                q = q.multiplyLeft(ga); // c
+                q = (GenSolvablePolynomial<C>) q.sum(gc, f); // a
+                //System.out.println("q = " + q);
+                r = (GenSolvablePolynomial<C>) r.subtract(h);
+            } else {
+                break;
+            }
+        }
+        int sp = P.signum();
+        int ss = S.signum();
+        int sq = q.signum();
+        // sp = ss * sq
+        if (sp != ss * sq) {
+            q = (GenSolvablePolynomial<C>) q.negate();
+            r = (GenSolvablePolynomial<C>) r.negate();
+        }
+        ret[0] = q;
+        ret[1] = r;
+        return ret;
+    }
+
+
+    /**
+     * GenSolvablePolynomial sparse pseudo quotient and remainder for univariate
+     * polynomials or exact division.
+     * @param <C> coefficient type.
+     * @param P GenSolvablePolynomial.
+     * @param S nonzero GenSolvablePolynomial.
+     * @return [ quotient, remainder ] with P ore(ldcf(S)<sup>m'</sup>) = S *
+     *         quotient + remainder. m' &le; deg(P)-deg(S)
+     * @see edu.jas.poly.GenPolynomial#divide(edu.jas.poly.GenPolynomial).
+     */
+    @SuppressWarnings("unchecked")
+    public static <C extends GcdRingElem<C>> GenSolvablePolynomial<C>[] rightBasePseudoQuotientRemainder(
+                    GenSolvablePolynomial<C> P, GenSolvablePolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            throw new ArithmeticException(P.toString() + " division by zero " + S);
+        }
+        //if (S.ring.nvar != 1) { // ok if exact division
+        //    throw new RuntimeException("univariate polynomials only");
+        //}
+        GenSolvablePolynomial<C>[] ret = new GenSolvablePolynomial[2];
+        ret[0] = null;
+        ret[1] = null;
+        if (P.isZERO() || S.isONE()) {
+            ret[0] = P;
+            ret[1] = S.ring.getZERO();
+            return ret;
+        }
+        if (P instanceof RecSolvablePolynomial) {
+            RecSolvablePolynomial<C> Pr = (RecSolvablePolynomial) P;
+            if (!Pr.ring.coeffTable.isEmpty()) {
+                throw new UnsupportedOperationException(
+                                "RecSolvablePolynomial with twisted coeffs not supported");
+            }
+        }
+        GreatestCommonDivisorAbstract<C> fd = new GreatestCommonDivisorFake<C>(P.ring.coFac);
+        ExpVector e = S.leadingExpVector();
+        GenSolvablePolynomial<C> h;
+        GenSolvablePolynomial<C> r = P;
+        GenSolvablePolynomial<C> q = S.ring.getZERO().copy();
+        while (!r.isZERO()) {
+            ExpVector f = r.leadingExpVector();
+            if (f.multipleOf(e)) {
+                C a = r.leadingBaseCoefficient();
+                f = f.subtract(e);
+                h = S.multiply(f); // coeff a
+                C c = h.leadingBaseCoefficient();
+                // need ga, gc: a ga = c gc
+                C[] oc = fd.rightOreCond(a, c);
+                C ga = oc[0];
+                C gc = oc[1];
+                r = r.multiply(ga); // coeff a ga, exp f
+                h = h.multiply(gc); // coeff c gc, exp f wanted but is exp f * coeff c gc, okay for base
+                q = q.multiply(ga); // c
+                q = (GenSolvablePolynomial<C>) q.sum(gc, f); // a
+                r = (GenSolvablePolynomial<C>) r.subtract(h);
+            } else {
+                break;
+            }
+        }
+        int sp = P.signum();
+        int ss = S.signum();
+        int sq = q.signum();
+        // sp = ss * sq
+        if (sp != ss * sq) {
+            q = (GenSolvablePolynomial<C>) q.negate();
+            r = (GenSolvablePolynomial<C>) r.negate();
+        }
+        ret[0] = q;
+        ret[1] = r;
+        return ret;
+    }
+
+
+    /**
+     * Is recursive GenSolvablePolynomial pseudo quotient and remainder. For
+     * recursive polynomials.
+     * @param <C> coefficient type.
+     * @param P recursive GenSolvablePolynomial.
+     * @param S nonzero recursive GenSolvablePolynomial.
+     * @return true, if P ~= q * S + r, else false.
+     * @see edu.jas.poly.GenPolynomial#remainder(edu.jas.poly.GenPolynomial).
+     *      <b>Note:</b> not always meaningful and working
+     */
+    @SuppressWarnings("unchecked")
+    public static <C extends GcdRingElem<C>> boolean isRecursivePseudoQuotientRemainder(
+                    GenSolvablePolynomial<GenPolynomial<C>> P, GenSolvablePolynomial<GenPolynomial<C>> S,
+                    GenSolvablePolynomial<GenPolynomial<C>> q, GenSolvablePolynomial<GenPolynomial<C>> r) {
+        GenSolvablePolynomial<GenPolynomial<C>> rhs, lhs;
+        rhs = (GenSolvablePolynomial<GenPolynomial<C>>) q.multiply(S).sum(r);
+        lhs = P;
+        GenPolynomial<C> ldcf = S.leadingBaseCoefficient();
+        long d = P.degree(0) - S.degree(0) + 1;
+        d = (d > 0 ? d : -d + 2);
+        for (long i = 0; i <= d; i++) {
+            //System.out.println("lhs = " + lhs);
+            //System.out.println("rhs = " + rhs);
+            //System.out.println("lhs-rhs = " + lhs.subtract(rhs));
+            if (lhs.equals(rhs)) {
+                return true;
+            }
+            lhs = lhs.multiply(ldcf);
+        }
+        GenSolvablePolynomial<GenPolynomial<C>> Pp = P;
+        rhs = q.multiply(S);
+        //System.out.println("rhs,2 = " + rhs);
+        for (long i = 0; i <= d; i++) {
+            lhs = (GenSolvablePolynomial<GenPolynomial<C>>) Pp.subtract(r);
+            //System.out.println("lhs = " + lhs);
+            //System.out.println("rhs = " + rhs);
+            //System.out.println("lhs-rhs = " + lhs.subtract(rhs));
+            if (lhs.equals(rhs)) {
+                //System.out.println("lhs,2 = " + lhs);
+                return true;
+            }
+            Pp = Pp.multiply(ldcf);
+        }
+        GenPolynomialRing<C> cofac = (GenPolynomialRing) P.ring.coFac;
+        GreatestCommonDivisorAbstract<C> fd = new GreatestCommonDivisorSimple<C>(cofac.coFac);
+        GenSolvablePolynomial<C> a = (GenSolvablePolynomial<C>) P.leadingBaseCoefficient();
+        rhs = (GenSolvablePolynomial<GenPolynomial<C>>) q.multiply(S).sum(r);
+        GenSolvablePolynomial<C> b = (GenSolvablePolynomial<C>) rhs.leadingBaseCoefficient();
+        GenSolvablePolynomial<C>[] oc = fd.leftOreCond(a, b);
+        GenPolynomial<C> ga = oc[0];
+        GenPolynomial<C> gb = oc[1];
+        //System.out.println("FDQR: OreCond:  a = " +  a + ",  b = " +  b);
+        //System.out.println("FDQR: OreCond: ga = " + ga + ", gb = " + gb);
+        // ga a = gd d
+        GenSolvablePolynomial<GenPolynomial<C>> Pa = P.multiplyLeft(ga); // coeff ga a
+        GenSolvablePolynomial<GenPolynomial<C>> Rb = rhs.multiplyLeft(gb); // coeff gb b  
+        GenSolvablePolynomial<GenPolynomial<C>> D = (GenSolvablePolynomial<GenPolynomial<C>>) Pa.subtract(Rb);
+        if (D.isZERO()) {
+            return true;
+        }
+        if (debug) {
+            logger.info("not QR: D = " + D);
+        }
+        //System.out.println("FDQR: Pa = " + Pa);
+        //System.out.println("FDQR: Rb = " + Rb);
+        //System.out.println("FDQR: Pa-Rb = " + D);
+        return false;
+    }
+
+
+    /**
+     * GenSolvablePolynomial sparse pseudo remainder for recursive solvable
+     * polynomials.
+     * @param <C> coefficient type.
+     * @param P recursive GenSolvablePolynomial.
+     * @param S nonzero recursive GenSolvablePolynomial.
+     * @return remainder with ore(ldcf(S)<sup>m'</sup>) P = quotient * S +
+     *         remainder.
+     * @see edu.jas.poly.PolyUtil#recursiveSparsePseudoRemainder(edu.jas.poly.GenPolynomial,edu.jas.poly.GenPolynomial)
+     *      .
+     */
+    @SuppressWarnings("unchecked")
+    public static <C extends GcdRingElem<C>> GenSolvablePolynomial<GenPolynomial<C>> recursiveSparsePseudoRemainder(
+                    GenSolvablePolynomial<GenPolynomial<C>> P, GenSolvablePolynomial<GenPolynomial<C>> S) {
+        return recursivePseudoQuotientRemainder(P, S)[1];
+    }
+
+
+    /**
+     * GenSolvablePolynomial recursive pseudo quotient for recursive
+     * polynomials.
+     * @param <C> coefficient type.
+     * @param P recursive GenSolvablePolynomial.
+     * @param S nonzero recursive GenSolvablePolynomial.
+     * @return quotient with ore(ldcf(S)<sup>m'</sup>) P = quotient * S +
+     *         remainder.
+     * @see edu.jas.poly.GenPolynomial#remainder(edu.jas.poly.GenPolynomial).
+     */
+    public static <C extends GcdRingElem<C>> GenSolvablePolynomial<GenPolynomial<C>> recursivePseudoQuotient(
+                    GenSolvablePolynomial<GenPolynomial<C>> P, GenSolvablePolynomial<GenPolynomial<C>> S) {
+        return recursivePseudoQuotientRemainder(P, S)[0];
+    }
+
+
+    /**
+     * GenSolvablePolynomial recursive pseudo quotient and remainder for
+     * recursive polynomials.
+     * @param <C> coefficient type.
+     * @param P recursive GenSolvablePolynomial.
+     * @param S nonzero recursive GenSolvablePolynomial.
+     * @return [ quotient, remainder ] with ore(ldcf(S)<sup>m'</sup>) P =
+     *         quotient * S + remainder.
+     * @see edu.jas.poly.GenPolynomial#remainder(edu.jas.poly.GenPolynomial).
+     */
+    @SuppressWarnings("unchecked")
+    public static <C extends GcdRingElem<C>> GenSolvablePolynomial<GenPolynomial<C>>[] recursivePseudoQuotientRemainder(
+                    GenSolvablePolynomial<GenPolynomial<C>> P, GenSolvablePolynomial<GenPolynomial<C>> S) {
+        if (S == null || S.isZERO()) {
+            throw new ArithmeticException(P + " division by zero " + S);
+        }
+        //if (S.ring.nvar != 1) { // ok if exact division
+        //    throw new RuntimeException("univariate polynomials only");
+        //}
+        GenSolvablePolynomial<GenPolynomial<C>>[] ret = new GenSolvablePolynomial[2];
+        if (P == null || P.isZERO()) {
+            ret[0] = S.ring.getZERO();
+            ret[1] = S.ring.getZERO();
+            return ret;
+        }
+        if (S.isONE()) {
+            ret[0] = P;
+            ret[1] = S.ring.getZERO();
+            return ret;
+        }
+        GenPolynomialRing<C> cofac = (GenPolynomialRing) P.ring.coFac;
+        GreatestCommonDivisorAbstract<C> fd = new GreatestCommonDivisorSimple<C>(cofac.coFac);
+
+        ExpVector e = S.leadingExpVector();
+        GenSolvablePolynomial<GenPolynomial<C>> h;
+        GenSolvablePolynomial<GenPolynomial<C>> r = P;
+        GenSolvablePolynomial<GenPolynomial<C>> q = S.ring.getZERO().copy();
+        while (!r.isZERO()) {
+            ExpVector g = r.leadingExpVector();
+            ExpVector f = g;
+            if (f.multipleOf(e)) {
+                f = f.subtract(e);
+                h = S.multiplyLeft(f); // coeff c, exp (f/e) e
+                GenSolvablePolynomial<C> a = (GenSolvablePolynomial<C>) r.leadingBaseCoefficient();
+                GenSolvablePolynomial<C> d = (GenSolvablePolynomial<C>) h.leadingBaseCoefficient();
+                GenSolvablePolynomial<C>[] oc = fd.leftOreCond(a, d);
+                GenPolynomial<C> ga = oc[0]; // d
+                GenPolynomial<C> gd = oc[1]; // a
+                // ga a = gd d
+                r = r.multiplyLeft(ga); // coeff ga a, exp f
+                h = h.multiplyLeft(gd); // coeff gd d, exp f
+                q = q.multiplyLeft(ga); // d
+                q = (GenSolvablePolynomial<GenPolynomial<C>>) q.sum(gd, f); // a
+                r = (GenSolvablePolynomial<GenPolynomial<C>>) r.subtract(h);
+                if (!r.isZERO() && g.equals(r.leadingExpVector())) {
+                    throw new RuntimeException("degree not descending: r = " + r);
+                }
+            } else {
+                break;
+            }
+        }
+        int sp = P.signum();
+        int ss = S.signum();
+        int sq = q.signum();
+        // sp = ss * sq
+        if (sp != ss * sq) {
+            q = (GenSolvablePolynomial<GenPolynomial<C>>) q.negate();
+            r = (GenSolvablePolynomial<GenPolynomial<C>>) r.negate();
+        }
+        ret[0] = q;
+        ret[1] = r;
+        return ret;
+    }
+
+
+    /**
+     * Is recursive GenSolvablePolynomial right pseudo quotient and remainder.
+     * For recursive polynomials.
+     * @param <C> coefficient type.
+     * @param P recursive GenSolvablePolynomial.
+     * @param S nonzero recursive GenSolvablePolynomial.
+     * @return true, if P ~= S * q + r, else false.
+     * @see edu.jas.poly.GenPolynomial#remainder(edu.jas.poly.GenPolynomial).
+     *      <b>Note:</b> not always meaningful and working
+     */
+    @SuppressWarnings("unchecked")
+    public static <C extends GcdRingElem<C>> boolean isRecursiveRightPseudoQuotientRemainder(
+                    GenSolvablePolynomial<GenPolynomial<C>> P, GenSolvablePolynomial<GenPolynomial<C>> S,
+                    GenSolvablePolynomial<GenPolynomial<C>> q, GenSolvablePolynomial<GenPolynomial<C>> r) {
+        GenSolvablePolynomial<GenPolynomial<C>> rhs, lhs;
+        rhs = (GenSolvablePolynomial<GenPolynomial<C>>) S.multiply(q).sum(r);
+        lhs = P;
+        GenPolynomial<C> ldcf = S.leadingBaseCoefficient();
+        long d = P.degree(0) - S.degree(0) + 1;
+        d = (d > 0 ? d : -d + 2);
+        for (long i = 0; i <= d; i++) {
+            //System.out.println("lhs = " + lhs);
+            //System.out.println("rhs = " + rhs);
+            //System.out.println("lhs-rhs = " + lhs.subtract(rhs));
+            if (lhs.equals(rhs)) {
+                return true;
+            }
+            lhs = lhs.multiplyLeft(ldcf); // side?
+        }
+        GenSolvablePolynomial<GenPolynomial<C>> Pp = P;
+        rhs = S.multiply(q);
+        //System.out.println("rhs,2 = " + rhs);
+        for (long i = 0; i <= d; i++) {
+            lhs = (GenSolvablePolynomial<GenPolynomial<C>>) Pp.subtract(r);
+            //System.out.println("lhs = " + lhs);
+            //System.out.println("rhs = " + rhs);
+            //System.out.println("lhs-rhs = " + lhs.subtract(rhs));
+            if (lhs.equals(rhs)) {
+                //System.out.println("lhs,2 = " + lhs);
+                return true;
+            }
+            Pp = Pp.multiplyLeft(ldcf); // side?
+        }
+        GenPolynomialRing<C> cofac = (GenPolynomialRing) P.ring.coFac;
+        GreatestCommonDivisorAbstract<C> fd = new GreatestCommonDivisorSimple<C>(cofac.coFac);
+
+        //GenSolvablePolynomial<GenPolynomial<C>> pr = P.rightRecursivePolynomial();
+        RecSolvablePolynomial<C> pr = (RecSolvablePolynomial<C>) P.rightRecursivePolynomial();
+        GenSolvablePolynomial<C> a = (GenSolvablePolynomial<C>) pr.leadingBaseCoefficient();
+
+        rhs = (GenSolvablePolynomial<GenPolynomial<C>>) S.multiply(q).sum(r);
+        //GenSolvablePolynomial<GenPolynomial<C>> rr = rhs.rightRecursivePolynomial();
+        RecSolvablePolynomial<C> rr = (RecSolvablePolynomial<C>) rhs.rightRecursivePolynomial();
+        GenSolvablePolynomial<C> b = (GenSolvablePolynomial<C>) rr.leadingBaseCoefficient();
+
+        GenSolvablePolynomial<C>[] oc = fd.rightOreCond(a, b);
+        GenPolynomial<C> ga = oc[0];
+        GenPolynomial<C> gb = oc[1];
+        //System.out.println("FDQR: OreCond:  a = " +  a + ",  b = " +  b);
+        //System.out.println("FDQR: OreCond: ga = " + ga + ", gb = " + gb);
+        // a ga = d gd
+        GenSolvablePolynomial<GenPolynomial<C>> Pa = pr.multiplyRightComm(ga); // coeff a ga
+        GenSolvablePolynomial<GenPolynomial<C>> Rb = rr.multiplyRightComm(gb); // coeff b gb
+        //System.out.println("right(P)  = " +  pr + ",  P   = " +  P);
+        //System.out.println("right(rhs)= " +  rr + ",  rhs = " +  rhs);
+        //System.out.println("Pa        = " +  Pa + ",  ga  = " +  ga);
+        //System.out.println("Rb        = " +  Rb + ",  gb  = " +  gb);
+        GenSolvablePolynomial<GenPolynomial<C>> D = (GenSolvablePolynomial<GenPolynomial<C>>) Pa.subtract(Rb);
+        if (D.isZERO()) {
+            return true;
+        }
+        if (true) {
+            System.out.println("Pa = " + Pa);
+            System.out.println("Rb = " + Rb);
+            logger.info("not right QR: Pa-Rb = " + D);
+        }
+        return false;
+    }
+
+
+    /**
+     * GenSolvablePolynomial right sparse pseudo remainder for recursive
+     * solvable polynomials. <b>Note:</b> uses right multiplication of P by
+     * ldcf(S), not always applicable.
+     * @param <C> coefficient type.
+     * @param P recursive GenSolvablePolynomial.
+     * @param S nonzero recursive GenSolvablePolynomial.
+     * @return remainder with P ore(ldcf(S)<sup>m'</sup>) = quotient * S +
+     *         remainder.
+     * @see edu.jas.poly.PolyUtil#recursiveSparsePseudoRemainder(edu.jas.poly.GenPolynomial,edu.jas.poly.GenPolynomial)
+     *      .
+     */
+    public static <C extends GcdRingElem<C>> GenSolvablePolynomial<GenPolynomial<C>> recursiveRightSparsePseudoRemainder(
+                    GenSolvablePolynomial<GenPolynomial<C>> P, GenSolvablePolynomial<GenPolynomial<C>> S) {
+        return recursiveRightPseudoQuotientRemainder(P, S)[1];
+    }
+
+
+    /**
+     * GenSolvablePolynomial recursive right pseudo quotient for recursive
+     * polynomials.
+     * @param <C> coefficient type.
+     * @param P recursive GenSolvablePolynomial.
+     * @param S nonzero recursive GenSolvablePolynomial.
+     * @return quotient with P ore(ldcf(S)<sup>m'</sup>) = S * quotient +
+     *         remainder.
+     * @see edu.jas.poly.GenPolynomial#remainder(edu.jas.poly.GenPolynomial).
+     */
+    public static <C extends GcdRingElem<C>> GenSolvablePolynomial<GenPolynomial<C>> recursiveRightPseudoQuotient(
+                    GenSolvablePolynomial<GenPolynomial<C>> P, GenSolvablePolynomial<GenPolynomial<C>> S) {
+        return recursiveRightPseudoQuotientRemainder(P, S)[0];
+    }
+
+
+    /**
+     * GenSolvablePolynomial right sparse pseudo quotient and remainder for
+     * recursive solvable polynomials. <b>Note:</b> uses right multiplication of
+     * P by ldcf(S), not always applicable.
+     * @param <C> coefficient type.
+     * @param P recursive GenSolvablePolynomial.
+     * @param S nonzero recursive GenSolvablePolynomial.
+     * @return remainder with P ore(ldcf(S)<sup>m'</sup>) = S * quotient +
+     *         remainder.
+     * @see edu.jas.poly.PolyUtil#recursiveSparsePseudoRemainder(edu.jas.poly.GenPolynomial,edu.jas.poly.GenPolynomial)
+     *      .
+     */
+    @SuppressWarnings("unchecked")
+    public static <C extends GcdRingElem<C>> GenSolvablePolynomial<GenPolynomial<C>>[] recursiveRightPseudoQuotientRemainder(
+                    GenSolvablePolynomial<GenPolynomial<C>> P, GenSolvablePolynomial<GenPolynomial<C>> S) {
+        if (S == null || S.isZERO()) {
+            throw new ArithmeticException(P + " division by zero " + S);
+        }
+        GenSolvablePolynomial<GenPolynomial<C>>[] ret = new GenSolvablePolynomial[2];
+        if (P == null || P.isZERO()) {
+            ret[0] = S.ring.getZERO();
+            ret[1] = S.ring.getZERO();
+            return ret;
+        }
+        if (S.isONE()) {
+            ret[0] = P;
+            ret[1] = S.ring.getZERO();
+            return ret;
+        }
+        //if (S.isConstant()) {
+        //    ret[0] = P.ring.getZERO();
+        //    ret[1] = S.ring.getZERO();
+        //    return ret;
+        //}
+        GenPolynomialRing<C> cofac = (GenPolynomialRing) P.ring.coFac;
+        GreatestCommonDivisorAbstract<C> fd = new GreatestCommonDivisorSimple<C>(cofac.coFac);
+
+        ExpVector e = S.leadingExpVector();
+        GenSolvablePolynomial<GenPolynomial<C>> h, q, r;
+        RecSolvablePolynomial<C> hr, rr, qr;
+        r = P;
+        qr = (RecSolvablePolynomial<C>) S.ring.getZERO().copy();
+        while (!r.isZERO()) {
+            ExpVector g = r.leadingExpVector();
+            ExpVector f = g;
+            if (f.multipleOf(e)) {
+                f = f.subtract(e);
+                //System.out.println("f = " + f);
+                h = S.multiply(f); // coeff c, exp e (f/e)
+                hr = (RecSolvablePolynomial<C>) h.rightRecursivePolynomial();
+                rr = (RecSolvablePolynomial<C>) r.rightRecursivePolynomial();
+                GenSolvablePolynomial<C> a = (GenSolvablePolynomial<C>) rr.leadingBaseCoefficient();
+                GenSolvablePolynomial<C> d = (GenSolvablePolynomial<C>) hr.leadingBaseCoefficient();
+                GenSolvablePolynomial<C>[] oc = fd.rightOreCond(a, d);
+                GenPolynomial<C> ga = oc[0]; // d
+                GenPolynomial<C> gd = oc[1]; // a
+                //System.out.println("OreCond:  a = " +  a + ",  d = " +  d);
+                //System.out.println("OreCond: ga = " + ga + ", gd = " + gd);
+                // a ga = d gd
+                //rr = rr.multiply(ga);   // exp f, coeff a ga 
+                //hr = hr.multiply(gd,f); // exp f, coeff d gd
+                rr = rr.multiplyRightComm(ga); // exp f, coeff a ga 
+                hr = hr.multiplyRightComm(gd); // exp f, coeff d gd  ///.shift(f)
+                h = hr.evalAsRightRecursivePolynomial();
+                r = rr.evalAsRightRecursivePolynomial();
+                r = (GenSolvablePolynomial<GenPolynomial<C>>) r.subtract(h);
+                qr = qr.multiplyRightComm(ga); // d
+                qr = (RecSolvablePolynomial<C>) qr.sum(gd, f); // a // same for right coefficients
+                //System.out.println("q = " + qr); //.leadingMonomial());
+                if (!r.isZERO() && g.equals(r.leadingExpVector())) {
+                    throw new RuntimeException("something is wrong: g == lc(r), terms not descending " + r);
+                }
+                //System.out.println("r = " +  r + ", qr = " +  qr);
+            } else {
+                break;
+            }
+        }
+        q = qr.evalAsRightRecursivePolynomial();
+        int sp = P.signum();
+        int ss = S.signum();
+        int sq = q.signum();
+        // sp = ss * sq
+        if (sp != ss * sq) {
+            q = (GenSolvablePolynomial<GenPolynomial<C>>) q.negate();
+            r = (GenSolvablePolynomial<GenPolynomial<C>>) r.negate();
+        }
+        ret[0] = q;
+        ret[1] = r;
+        return ret;
+    }
+
+
+    // ----------------------------------------------------------------------
+
+
+    /**
+     * GenSolvablePolynomial recursive quotient for recursive polynomials and
+     * exact division by coefficient ring element.
+     * @param <C> coefficient type.
+     * @param P recursive GenSolvablePolynomial.
+     * @param s GenSolvablePolynomial.
+     * @return P/s.
+     */
+    @SuppressWarnings("unchecked")
+    public static <C extends GcdRingElem<C>> GenSolvablePolynomial<GenPolynomial<C>> recursiveDivideRightEval(
+                    GenSolvablePolynomial<GenPolynomial<C>> P, GenSolvablePolynomial<C> s) {
+        if (s.isONE()) {
+            return P;
+        }
+        GenSolvablePolynomial<GenPolynomial<C>> Pr = P.rightRecursivePolynomial();
+        GenSolvablePolynomial<GenPolynomial<C>> Qr = FDUtil.<C> recursiveLeftDivide(Pr, s); // Left/Right
+        GenSolvablePolynomial<GenPolynomial<C>> Q = Qr.evalAsRightRecursivePolynomial();
+        if (debug) {
+            if (!Qr.multiplyLeft(s).equals(Pr)) {
+                System.out.println("rDivREval: Pr   = " + Pr + ", P = " + P);
+                System.out.println("rDivREval: Qr   = " + Qr + ", Q = " + Q);
+                System.out.println("rDivREval: s*Qr = " + Qr.multiplyLeft(s) + ", s = " + s);
+                System.out.println("rDivREval: Qr*s = " + Qr.multiply(s));
+                //System.out.println("rDivREval: P.ring == Q.ring: " + P.ring.equals(Q.ring) );
+                throw new RuntimeException("rDivREval: s*Qr != Pr");
+            }
+            if (!Q.multiply(s).equals(P)) {
+                System.out.println("rDivREval: P   = " + P + ", right(P) = " + Pr);
+                System.out.println("rDivREval: Q   = " + Q + ", right(Q) = " + Qr);
+                System.out.println("rDivREval: Q*s = " + Q.multiply(s) + ", s = " + s);
+                System.out.println("rDivREval: s*Q = " + Q.multiplyLeft(s));
+                //System.out.println("rDivREval: P.ring == Q.ring: " + P.ring.equals(Q.ring) );
+                throw new RuntimeException("rDivREval: Q*s != P");
+            }
+        }
+        return Q;
+    }
+
+
+    /**
+     * GenSolvablePolynomial left recursive quotient for recursive polynomials
+     * and exact division by coefficient ring element.
+     * @param <C> coefficient type.
+     * @param P recursive GenSolvablePolynomial.
+     * @param s GenSolvablePolynomial.
+     * @return this/s.
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    public static <C extends GcdRingElem<C>> GenSolvablePolynomial<GenPolynomial<C>> recursiveDivide(
+                    GenSolvablePolynomial<GenPolynomial<C>> P, GenSolvablePolynomial<C> s) {
+        if (s == null || s.isZERO()) {
+            throw new ArithmeticException("division by zero " + P + ", " + s);
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        if (s.isONE()) {
+            return P;
+        }
+        GenSolvablePolynomialRing<GenPolynomial<C>> rfac = (GenSolvablePolynomialRing<GenPolynomial<C>>) P.ring;
+        GenSolvablePolynomial<GenPolynomial<C>> onep = rfac.getONE();
+        //ExpVector zero = rfac.evzero;
+        GenSolvablePolynomial<GenPolynomial<C>> q = rfac.getZERO();
+        GenSolvablePolynomial<GenPolynomial<C>> r;
+        GenSolvablePolynomial<GenPolynomial<C>> p = P; //.ring.getZERO().copy();
+        while (!p.isZERO()) {
+            // for (Map.Entry<ExpVector, GenPolynomial<C>> m1 : P.getMap().entrySet()) {
+            Map.Entry<ExpVector, GenPolynomial<C>> m1 = p.leadingMonomial();
+            GenSolvablePolynomial<C> c1 = (GenSolvablePolynomial<C>) m1.getValue();
+            ExpVector e1 = m1.getKey();
+            GenSolvablePolynomial<C> c = c1.divide(s);
+            if (c.isZERO()) {
+                throw new RuntimeException("something is wrong: c is zero, c1 = " + c1 + ", s = " + s);
+            }
+            r = onep.multiplyLeft(c.multiply(s), e1); // right: (c e1) * 1 * (s zero)
+            if (!c1.equals(r.leadingBaseCoefficient())) {
+                System.out.println("recRightDivide: lc(r) = " + r.leadingBaseCoefficient() + ", c1 = " + c1);
+                System.out.println("recRightDivide: lc(r) = " + c.multiply(s) + ", c = " + c + ", s = " + s);
+                throw new RuntimeException("something is wrong: lc(r) != c*s");
+            }
+            p = (RecSolvablePolynomial<C>) p.subtract(r);
+            if (!p.isZERO() && e1.compareTo(p.leadingExpVector()) == 0) {
+                System.out.println("recRightDivide: c     = " + c);
+                System.out.println("recRightDivide: lt(p) = " + p.leadingExpVector() + ", e1 = " + e1);
+                System.out.println("recRightDivide: c1/s  = " + c1.divide(s));
+                System.out.println("recRightDivide: s*c   = " + s.multiply(c));
+                System.out.println("recRightDivide: c*s   = " + c.multiply(s));
+                throw new RuntimeException("something is wrong: degree not descending");
+            }
+            q = (RecSolvablePolynomial<C>) q.sum(c, e1);
+        }
+        return q;
+    }
+
+
+    /*
+     * GenSolvablePolynomial recursive right quotient for recursive polynomials
+     * and partial right exact division by coefficient ring element.
+     * @param <C> coefficient type.
+     * @param P recursive GenSolvablePolynomial.
+     * @param s GenSolvablePolynomial.
+     * @return this/s.
+     @SuppressWarnings("unchecked")
+     public static <C extends GcdRingElem<C>> GenSolvablePolynomial<GenPolynomial<C>> recursiveRightDivide(
+     GenSolvablePolynomial<GenPolynomial<C>> P, GenSolvablePolynomial<C> s) {
+     if (s == null || s.isZERO()) {
+     throw new ArithmeticException("division by zero " + P + ", " + s);
+     }
+     if (P.isZERO()) {
+     return P;
+     }
+     if (s.isONE()) {
+     return P;
+     }
+     GenSolvablePolynomial<GenPolynomial<C>> p = P.ring.getZERO().copy();
+     GenSolvablePolynomial<GenPolynomial<C>> Pr = P.rightRecursivePolynomial();
+     logger.info("P = " + P + ", right(P) = " + Pr + ", left(s) = " + s);
+     for (Map.Entry<ExpVector, GenPolynomial<C>> m1 : Pr.getMap().entrySet()) {
+     GenSolvablePolynomial<C> c1 = (GenSolvablePolynomial<C>) m1.getValue();
+     ExpVector e1 = m1.getKey();
+     //GenSolvablePolynomial<C> c = FDUtil.<C> basePseudoQuotient(c1, s);
+     GenSolvablePolynomial<C> c = FDUtil.<C> divideRightPolynomial(c1, s);
+     //GenSolvablePolynomial<C>[] QR = FDUtil.<C> basePseudoQuotientRemainder(c1, s);
+     if (!c.isZERO()) {
+     //pv.put(e1, c); 
+     p.doPutToMap(e1, c);
+     }
+     }
+     GenSolvablePolynomial<GenPolynomial<C>> pl = p.evalAsRightRecursivePolynomial();
+     logger.info("pl = " + pl + ", p = " + p);
+     return pl;
+     }
+    */
+
+
+    /*
+     * GenSolvablePolynomial right quotient for polynomials and partial right
+     * exact division by coefficient ring element.
+     * @param <C> coefficient type.
+     * @param P GenSolvablePolynomial.
+     * @param s GenSolvablePolynomial, constant wrt. the main variable.
+     * @return P/s.
+     @SuppressWarnings("unchecked")
+     public static <C extends GcdRingElem<C>> GenSolvablePolynomial<C> divideRightPolynomial(
+     GenSolvablePolynomial<C> P, GenSolvablePolynomial<C> s) {
+     if (s == null || s.isZERO()) {
+     throw new ArithmeticException("division by zero " + P + ", " + s);
+     }
+     if (P.isZERO()) {
+     return P;
+     }
+     if (s.isONE()) {
+     return P;
+     }
+     GenSolvablePolynomialRing<C> pfac = P.ring;
+     GenSolvablePolynomial<C> q;
+     if (pfac.nvar <= 1) {
+     GenSolvablePolynomial<C>[] QR1;
+     QR1 = FDUtil.<C> leftBasePseudoQuotientRemainder(P, s);
+     q = QR1[0];
+     if (debug) {
+     if (!QR1[1].isZERO()) {
+     System.out.println("rDivPol, P = " + P);
+     System.out.println("rDivPol, s = " + s);
+     throw new RuntimeException("non zero remainder, q = " + q + ", r = " + QR1[1]);
+     }
+     }
+     return q;
+     }
+     GenSolvablePolynomialRing<GenPolynomial<C>> rfac = pfac.recursive(1);
+     GenSolvablePolynomial<GenPolynomial<C>> pr, sr, qr, rr;
+     GenSolvablePolynomial<GenPolynomial<C>>[] QR;
+     pr = (GenSolvablePolynomial<GenPolynomial<C>>) PolyUtil.<C> recursive(rfac, P);
+     sr = (GenSolvablePolynomial<GenPolynomial<C>>) PolyUtil.<C> recursive(rfac, s);
+     //qr = FDUtil.<C> recursiveDivideRightPolynomial(pr,sc);
+     QR = FDUtil.<C> recursiveRightPseudoQuotientRemainder(pr, sr);
+     //QR = FDUtil.<C> recursivePseudoQuotientRemainder(pr,sr);
+     qr = QR[0];
+     rr = QR[1];
+     if (debug) {
+     if (!rr.isZERO()) {
+     System.out.println("rDivPol, pr = " + pr);
+     System.out.println("rDivPol, sr = " + sr);
+     throw new RuntimeException("non zero remainder, q = " + qr + ", r = " + rr);
+     }
+     }
+     q = (GenSolvablePolynomial<C>) PolyUtil.<C> distribute(pfac, qr);
+     return q;
+     }
+    */
+
+
+    /**
+     * GenSolvablePolynomial recursive quotient for recursive polynomials and
+     * partial right exact division by coefficient ring element.
+     * @param <C> coefficient type.
+     * @param P recursive GenSolvablePolynomial.
+     * @param s GenSolvablePolynomial.
+     * @return Q with s * Q = P.
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    public static <C extends GcdRingElem<C>> GenSolvablePolynomial<GenPolynomial<C>> recursiveRightDivide(
+                    GenSolvablePolynomial<GenPolynomial<C>> P, GenSolvablePolynomial<C> s) {
+        if (s == null || s.isZERO()) {
+            throw new ArithmeticException("division by zero " + P + ", " + s);
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        if (s.isONE()) {
+            return P;
+        }
+        if (!(P instanceof RecSolvablePolynomial)) {
+            //return FDUtil.<C> recursiveDivide(P,s);
+        }
+        RecSolvablePolynomialRing<C> rfac = (RecSolvablePolynomialRing<C>) P.ring;
+        if (rfac.coeffTable.isEmpty()) {
+            //return FDUtil.<C> recursiveDivide(P,s);
+        }
+        RecSolvablePolynomial<C> onep = rfac.getONE();
+        //ExpVector zero = rfac.evzero;
+        RecSolvablePolynomial<C> q = rfac.getZERO();
+        RecSolvablePolynomial<C> r;
+        RecSolvablePolynomial<C> p = (RecSolvablePolynomial<C>) P;
+        //System.out.println("recRightDivide: p=P = " + p + ", s = " + s);
+        while (!p.isZERO()) {
+            Map.Entry<ExpVector, GenPolynomial<C>> m1 = p.leadingMonomial();
+            GenSolvablePolynomial<C> a = (GenSolvablePolynomial<C>) m1.getValue();
+            ExpVector f = m1.getKey();
+            GenSolvablePolynomial<C> c = (GenSolvablePolynomial<C>) a.rightDivide(s); // s * c = a
+            //System.out.println("recRightDivide: s \\ a = c: " + s + " \\ " + a + " = " + c);
+            if (c.isZERO()) {
+                //logger.info("something is wrong: c is zero, a = " + a + ", s = " + s);
+                throw new RuntimeException("something is wrong: c is zero, a = " + a + ", s = " + s);
+            }
+            r = onep.multiply(s.multiply(c), f); // left 1 * s * c * (1 f)
+            if (!a.equals(r.leadingBaseCoefficient())) {
+                System.out.println("recRightDivide: a   = " + a + ", lc(r) = " + r.leadingBaseCoefficient());
+                System.out.println("recRightDivide: c*s = " + c.multiply(s) + ", s = " + s + ", c = " + c);
+                System.out.println(
+                                "recRightDivide: s*c = " + s.multiply(c) + ", a%s = " + a.rightRemainder(s));
+                throw new RuntimeException("something is wrong: c*s != a: " + rfac.toScript());
+            }
+            p = (RecSolvablePolynomial<C>) p.subtract(r);
+            if (!p.isZERO() && f.compareTo(p.leadingExpVector()) == 0) {
+                System.out.println("recRightDivide: c     = " + c);
+                System.out.println("recRightDivide: lt(p) = " + p.leadingExpVector() + ", f = " + f);
+                System.out.println("recRightDivide: a/s   = " + a.divide(s));
+                System.out.println("recRightDivide: s*c   = " + s.multiply(c));
+                System.out.println("recRightDivide: c*s   = " + c.multiply(s));
+                throw new RuntimeException("something is wrong: degree not descending");
+            }
+            q = (RecSolvablePolynomial<C>) q.sum(c, f);
+        }
+        //System.out.println("recRightDivide: q        = " + q);
+        return q;
+    }
+
+
+    /**
+     * GenSolvablePolynomial recursive quotient for recursive polynomials and
+     * partial left exact division by coefficient ring element.
+     * @param <C> coefficient type.
+     * @param P recursive GenSolvablePolynomial.
+     * @param s GenSolvablePolynomial.
+     * @return Q with Q * s = P.
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    public static <C extends GcdRingElem<C>> GenSolvablePolynomial<GenPolynomial<C>> recursiveLeftDivide(
+                    GenSolvablePolynomial<GenPolynomial<C>> P, GenSolvablePolynomial<C> s) {
+        if (s == null || s.isZERO()) {
+            throw new ArithmeticException("division by zero " + P + ", " + s);
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        if (s.isONE()) {
+            return P;
+        }
+        if (!(P instanceof RecSolvablePolynomial)) {
+            //return FDUtil.<C> recursiveDivide(P,s);
+        }
+        RecSolvablePolynomialRing<C> rfac = (RecSolvablePolynomialRing<C>) P.ring;
+        if (rfac.coeffTable.isEmpty()) {
+            //return FDUtil.<C> recursiveDivide(P,s);
+        }
+        RecSolvablePolynomial<C> onep = rfac.getONE();
+        //ExpVector zero = rfac.evzero;
+        RecSolvablePolynomial<C> q = rfac.getZERO();
+        RecSolvablePolynomial<C> r, Pp;
+        //RecSolvablePolynomial<C> p = (RecSolvablePolynomial<C>) P;
+        RecSolvablePolynomial<C> p = (RecSolvablePolynomial<C>) P.rightRecursivePolynomial();
+        //System.out.println("recLeftDivide: P        = " + P + ", s = " + s);
+        //System.out.println("recLeftDivide: right(P) = " + p);
+        Pp = p;
+        while (!p.isZERO()) {
+            ExpVector f = p.leadingExpVector();
+            GenSolvablePolynomial<C> a = (GenSolvablePolynomial<C>) p.leadingBaseCoefficient();
+            GenSolvablePolynomial<C> c = (GenSolvablePolynomial<C>) a.divide(s); // c * s = a
+            ///GenSolvablePolynomial<C> c = (GenSolvablePolynomial<C>) a.rightDivide(s);
+            if (c.isZERO()) {
+                throw new RuntimeException("something is wrong: c is zero, a = " + a + ", s = " + s);
+            }
+            //System.out.println("recLeftDivide: a / s = c: " + a + " / " + s + " = " + c);
+            //r = onep.multiply(c, f, s, zero); // right: (c f) * 1 * (s zero)
+            r = onep.multiplyLeft(c.multiply(s), f); // right: (c*s f) * one
+            ///r = onep.multiplyLeft(s.multiply(c), f); // left: (s*c f) * one
+            if (!a.equals(r.leadingBaseCoefficient())) {
+                System.out.println("recLeftDivide: a        = " + a);
+                C ac = a.leadingBaseCoefficient();
+                C rc = r.leadingBaseCoefficient().leadingBaseCoefficient();
+                C cc = rc.inverse().multiply(ac);
+                System.out.println("recLeftDivide: cc       = " + cc);
+                c = c.multiply(cc);
+                r = onep.multiplyLeft(c.multiply(s), f); // right: (1 f) * c * s
+                //System.out.println("recLeftDivide: lc(r)    = " + r.leadingBaseCoefficient());
+                throw new RuntimeException("something is wrong: c*s != a: " + rfac.toScript());
+            }
+            p = (RecSolvablePolynomial<C>) p.subtract(r);
+            if (!p.isZERO() && f.compareTo(p.leadingExpVector()) == 0) {
+                System.out.println("recLeftDivide: P        = " + P + ", s = " + s);
+                System.out.println("recLeftDivide: right(P) = " + Pp);
+                System.out.println("recLeftDivide: c        = " + c);
+                System.out.println("recLeftDivide: lt(p)    = " + p.leadingExpVector() + ", f = " + f);
+                System.out.println("recLeftDivide: a/s      = " + a.divide(s));
+                System.out.println("recLeftDivide: a\\s      = " + a.rightDivide(s));
+                System.out.println("recLeftDivide: s*c      = " + s.multiply(c));
+                System.out.println("recLeftDivide: c*s      = " + c.multiply(s));
+                throw new RuntimeException("something is wrong: degree not descending");
+            }
+            q = (RecSolvablePolynomial<C>) q.sum(c, f);
+        }
+        //System.out.println("recLeftDivide: q        = " + q);
+        q = (RecSolvablePolynomial<C>) q.evalAsRightRecursivePolynomial();
+        //System.out.println("recLeftDivide: eval(q)  = " + q);
+        return q;
+    }
+
+
+    /**
+     * Integral solvable polynomial from solvable rational function
+     * coefficients. Represent as polynomial with integral solvable polynomial
+     * coefficients by multiplication with the lcm(??) of the numerators of the
+     * rational function coefficients.
+     * @param fac result polynomial factory.
+     * @param A polynomial with solvable rational function coefficients to be
+     *            converted.
+     * @return polynomial with integral solvable polynomial coefficients.
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    public static <C extends GcdRingElem<C>> GenSolvablePolynomial<GenPolynomial<C>> integralFromQuotientCoefficients(
+                    GenSolvablePolynomialRing<GenPolynomial<C>> fac,
+                    GenSolvablePolynomial<SolvableQuotient<C>> A) {
+        GenSolvablePolynomial<GenPolynomial<C>> B = fac.getZERO().copy();
+        if (A == null || A.isZERO()) {
+            return B;
+        }
+        GenSolvablePolynomial<C> c = null;
+        GenSolvablePolynomial<C> d;
+        GenSolvablePolynomial<C> x;
+        GenSolvablePolynomial<C> z;
+        GenPolynomialRing<C> cofac = (GenPolynomialRing) fac.coFac;
+        GreatestCommonDivisorAbstract<C> fd = new GreatestCommonDivisorPrimitive<C>(cofac.coFac);
+        int s = 0;
+        // lcm/ore of denominators ??
+        Map<ExpVector, SolvableQuotient<C>> Am = A.getMap();
+        for (SolvableQuotient<C> y : Am.values()) {
+            x = y.den;
+            // c = lcm(c,x)
+            if (c == null) {
+                c = x;
+                s = x.signum();
+            } else {
+                d = fd.leftGcd(c, x);
+                z = (GenSolvablePolynomial<C>) x.divide(d); // ??
+                c = z.multiply(c); // ?? multiplyLeft
+            }
+        }
+        if (s < 0) {
+            c = (GenSolvablePolynomial<C>) c.negate();
+        }
+        for (Map.Entry<ExpVector, SolvableQuotient<C>> y : Am.entrySet()) {
+            ExpVector e = y.getKey();
+            SolvableQuotient<C> a = y.getValue();
+            // p = n*(c/d)
+            GenPolynomial<C> b = c.divide(a.den);
+            GenPolynomial<C> p = a.num.multiply(b);
+            //B = B.sum( p, e ); // inefficient
+            B.doPutToMap(e, p);
+        }
+        return B;
+    }
+
+
+    /**
+     * Integral solvable polynomial from solvable rational function
+     * coefficients. Represent as polynomial with integral solvable polynomial
+     * coefficients by multiplication with the lcm(??) of the numerators of the
+     * solvable rational function coefficients.
+     * @param fac result polynomial factory.
+     * @param L list of polynomials with solvable rational function coefficients
+     *            to be converted.
+     * @return list of polynomials with integral solvable polynomial
+     *         coefficients.
+     */
+    @SuppressWarnings("unchecked")
+    public static <C extends GcdRingElem<C>> List<GenSolvablePolynomial<GenPolynomial<C>>> integralFromQuotientCoefficients(
+                    GenSolvablePolynomialRing<GenPolynomial<C>> fac,
+                    Collection<GenSolvablePolynomial<SolvableQuotient<C>>> L) {
+        if (L == null) {
+            return null;
+        }
+        List<GenSolvablePolynomial<GenPolynomial<C>>> list = new ArrayList<GenSolvablePolynomial<GenPolynomial<C>>>(
+                        L.size());
+        for (GenSolvablePolynomial<SolvableQuotient<C>> p : L) {
+            list.add(integralFromQuotientCoefficients(fac, p));
+        }
+        return list;
+    }
+
+
+    /**
+     * Solvable rational function from integral solvable polynomial
+     * coefficients. Represent as polynomial with type SolvableQuotient
+     * <C> coefficients.
+     * @param fac result polynomial factory.
+     * @param A polynomial with integral solvable polynomial coefficients to be
+     *            converted.
+     * @return polynomial with type SolvableQuotient<C> coefficients.
+     */
+    @SuppressWarnings("unchecked")
+    public static <C extends GcdRingElem<C>> GenSolvablePolynomial<SolvableQuotient<C>> quotientFromIntegralCoefficients(
+                    GenSolvablePolynomialRing<SolvableQuotient<C>> fac,
+                    GenSolvablePolynomial<GenPolynomial<C>> A) {
+        GenSolvablePolynomial<SolvableQuotient<C>> B = fac.getZERO().copy();
+        if (A == null || A.isZERO()) {
+            return B;
+        }
+        RingFactory<SolvableQuotient<C>> cfac = fac.coFac;
+        SolvableQuotientRing<C> qfac = (SolvableQuotientRing<C>) cfac;
+        for (Map.Entry<ExpVector, GenPolynomial<C>> y : A.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            GenSolvablePolynomial<C> a = (GenSolvablePolynomial<C>) y.getValue();
+            SolvableQuotient<C> p = new SolvableQuotient<C>(qfac, a); // can not be zero
+            if (!p.isZERO()) {
+                //B = B.sum( p, e ); // inefficient
+                B.doPutToMap(e, p);
+            }
+        }
+        return B;
+    }
+
+
+    /**
+     * Solvable rational function from integral solvable polynomial
+     * coefficients. Represent as polynomial with type SolvableQuotient
+     * <C> coefficients.
+     * @param fac result polynomial factory.
+     * @param L list of polynomials with integral solvable polynomial
+     *            coefficients to be converted.
+     * @return list of polynomials with type SolvableQuotient<C> coefficients.
+     */
+    public static <C extends GcdRingElem<C>> List<GenSolvablePolynomial<SolvableQuotient<C>>> quotientFromIntegralCoefficients(
+                    GenSolvablePolynomialRing<SolvableQuotient<C>> fac,
+                    Collection<GenSolvablePolynomial<GenPolynomial<C>>> L) {
+        if (L == null) {
+            return null;
+        }
+        List<GenSolvablePolynomial<SolvableQuotient<C>>> list = new ArrayList<GenSolvablePolynomial<SolvableQuotient<C>>>(
+                        L.size());
+        for (GenSolvablePolynomial<GenPolynomial<C>> p : L) {
+            list.add(quotientFromIntegralCoefficients(fac, p));
+        }
+        return list;
+    }
+
+
+    /**
+     * Left greatest common divisor and cofactors.
+     * @param r solvable polynomial ring.
+     * @param n first solvable polynomial.
+     * @param d second solvable polynomial.
+     * @return [ g=leftGcd(n,d), n/g, d/g ]
+     */
+    @SuppressWarnings({ "cast", "unchecked" })
+    public static <C extends GcdRingElem<C>> GenSolvablePolynomial<C>[] leftGcdCofactors(
+                    GenSolvablePolynomialRing<C> r, GenSolvablePolynomial<C> n, GenSolvablePolynomial<C> d) {
+        //GreatestCommonDivisorAbstract<C> e1 = new GreatestCommonDivisorSimple<C>(r.coFac);
+        GreatestCommonDivisorAbstract<C> e1 = new GreatestCommonDivisorPrimitive<C>(r.coFac);
+        //GreatestCommonDivisorAbstract<C> engine = new GreatestCommonDivisorFake<C>(r.coFac);
+        GreatestCommonDivisorAbstract<C> e2 = new GreatestCommonDivisorSyzygy<C>(r.coFac);
+        GreatestCommonDivisorAbstract<C> engine = new SGCDParallelProxy<C>(r.coFac, e1, e2);
+        if (info) {
+            logger.info("leftGCD_in: " + n + ", " + d);
+        }
+        GenSolvablePolynomial<C>[] res = (GenSolvablePolynomial<C>[]) new GenSolvablePolynomial[3];
+        res[0] = engine.leftGcd(n, d);
+        //res[0] = PolyModUtil.<C> syzLeftGcd(r, n, d);
+        res[1] = n;
+        res[2] = d;
+        if (res[0].isONE()) {
+            return res;
+        }
+        if (info) {
+            logger.info("leftGCD_out: " + res[0]);
+        }
+        GenSolvablePolynomial<C>[] nqr;
+        nqr = FDUtil.<C> rightBasePseudoQuotientRemainder(n, res[0]);
+        if (!nqr[1].isZERO()) {
+            res[0] = r.getONE();
+            return res;
+        }
+        GenSolvablePolynomial<C>[] dqr;
+        dqr = FDUtil.<C> rightBasePseudoQuotientRemainder(d, res[0]);
+        if (!dqr[1].isZERO()) {
+            res[0] = r.getONE();
+            return res;
+        }
+        res[1] = nqr[0];
+        res[2] = dqr[0];
+        return res;
+    }
+
+
+    /**
+     * Right greatest common divisor and cofactors.
+     * @param r solvable polynomial ring.
+     * @param n first solvable polynomial.
+     * @param d second solvable polynomial.
+     * @return [ g=rightGcd(n,d), n/g, d/g ]
+     */
+    @SuppressWarnings({ "cast", "unchecked" })
+    public static <C extends GcdRingElem<C>> GenSolvablePolynomial<C>[] rightGcdCofactors(
+                    GenSolvablePolynomialRing<C> r, GenSolvablePolynomial<C> n, GenSolvablePolynomial<C> d) {
+        //GreatestCommonDivisorAbstract<C> e1 = new GreatestCommonDivisorSimple<C>(r.coFac);
+        //GreatestCommonDivisorAbstract<C> e1 = new GreatestCommonDivisorPrimitive<C>(r.coFac);
+        GreatestCommonDivisorAbstract<C> engine = new GreatestCommonDivisorFake<C>(r.coFac);
+        //GreatestCommonDivisorAbstract<C> e2 = new GreatestCommonDivisorSyzygy<C>(r.coFac);
+        //GreatestCommonDivisorAbstract<C> engine = new SGCDParallelProxy<C>(r.coFac, e1, e2);
+        if (info) {
+            logger.info("rightGCD_in: " + n + ", " + d);
+        }
+        GenSolvablePolynomial<C>[] res = (GenSolvablePolynomial<C>[]) new GenSolvablePolynomial[3];
+        res[0] = engine.rightGcd(n, d);
+        //res[0] = PolyModUtil.<C> syzRightGcd(r, n, d);
+        res[1] = n;
+        res[2] = d;
+        if (res[0].isONE()) {
+            return res;
+        }
+        if (info) {
+            logger.info("rightGCD_out: " + res[0]);
+        }
+        GenSolvablePolynomial<C>[] nqr;
+        nqr = FDUtil.<C> leftBasePseudoQuotientRemainder(n, res[0]);
+        if (!nqr[1].isZERO()) {
+            res[0] = r.getONE();
+            return res;
+        }
+        GenSolvablePolynomial<C>[] dqr;
+        dqr = FDUtil.<C> leftBasePseudoQuotientRemainder(d, res[0]);
+        if (!dqr[1].isZERO()) {
+            res[0] = r.getONE();
+            return res;
+        }
+        res[1] = nqr[0];
+        res[2] = dqr[0];
+        return res;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/GCDcoFactors.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/GCDcoFactors.java
@@ -1,0 +1,291 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.fd;
+
+
+import java.io.Serializable;
+
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Container for the co-factors of left-right GCD computation. Invariant is left
+ * * coA * right = polyA and left * coB * right = polyB.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class GCDcoFactors<C extends GcdRingElem<C>> implements Serializable {
+
+
+    /**
+     * GCD algorithm to use for verification.
+     */
+    public final GreatestCommonDivisorAbstract<C> fd;
+
+
+    /**
+     * Original polynomial A of the GCD computation.
+     */
+    public final GenSolvablePolynomial<C> polyA;
+
+
+    /**
+     * Original polynomial B of the GCD computation.
+     */
+    public final GenSolvablePolynomial<C> polyB;
+
+
+    /**
+     * Co-factor of A.
+     */
+    public final GenSolvablePolynomial<C> coA;
+
+
+    /**
+     * Co-factor of B.
+     */
+    public final GenSolvablePolynomial<C> coB;
+
+
+    /**
+     * Left GCD of A and B.
+     */
+    public final GenSolvablePolynomial<C> left;
+
+
+    /**
+     * Right GCD of A and B.
+     */
+    public final GenSolvablePolynomial<C> right;
+
+
+    /**
+     * Constructor.
+     * @param g GCD algorithm to use for verification.
+     * @param a polynomial A.
+     * @param b polynomial B.
+     * @param ca polynomial coA.
+     * @param cb polynomial coB.
+     * @param l polynomial left GCD.
+     * @param r polynomial right GCD.
+     */
+    public GCDcoFactors(GreatestCommonDivisorAbstract<C> g, GenSolvablePolynomial<C> a,
+                    GenSolvablePolynomial<C> b, GenSolvablePolynomial<C> ca, GenSolvablePolynomial<C> cb,
+                    GenSolvablePolynomial<C> l, GenSolvablePolynomial<C> r) {
+        fd = g;
+        polyA = a;
+        polyB = b;
+        coA = ca;
+        coB = cb;
+        left = l;
+        right = r;
+    }
+
+
+    /**
+     * Test if the invariants of this are fulfilled.
+     * @return true if x * (left * coA * right) = y * (polyA), for x, y with x *
+     *         lc(left * coA * right) == y * lc(polyA) and x * (left * coB *
+     *         right) == y * (polyB), for x, y with x * lc(left * coB * right)
+     *         == y * lc(polyB).
+     */
+    public boolean isGCD() {
+        GenSolvablePolynomial<C> a, ap, bp;
+        //C l = left.leadingBaseCoefficient();
+        //C c1 = fd.leftBaseContent((GenSolvablePolynomial<C>)a.abs());
+        //C c2 = fd.leftBaseContent((GenSolvablePolynomial<C>)polyA.abs());
+        //System.out.println("c1 = " + c1 + ", c2 = " + c2 + ", c1/l = " + c1.leftDivide(l) + ", c2/l = " + c2.leftDivide(l));
+        //System.out.println("c1 = " + c1 + ", c2 = " + c2 + ", l\\c1 = " + c1.rightDivide(l) + ", l\\c2 = " + c2.rightDivide(l));
+        //System.out.println("c1%l = " + c1.leftRemainder(l) + ", c2%l = " + c2.leftRemainder(l));
+        //GenSolvablePolynomial<C> a = left.multiply(right).multiply(coA); // left right coA
+        //a = (GenSolvablePolynomial<C>)fd.leftBasePrimitivePart(a).abs();
+        //System.out.println("a = " + a);
+        //if (! a.equals(fd.leftBasePrimitivePart(polyA).abs())) {
+        //    System.out.println("a = " + a + ",\nA != " + polyA);
+        //    return false;
+        //}
+        //C d1 = fd.leftBaseContent((GenSolvablePolynomial<C>)b.abs());
+        //C d2 = fd.leftBaseContent((GenSolvablePolynomial<C>)polyB.abs());
+        //System.out.println("d1 = " + d1 + ", d2 = " + d2 + ", d1/l = " + d1.leftDivide(l) + ", d2/l = " + d2.leftDivide(l));
+        //System.out.println("d1 = " + d1 + ", d2 = " + d2 + ", l\\d1 = " + d1.rightDivide(l) + ", l\\d2 = " + d2.rightDivide(l));
+        //System.out.println("d1%l = " + d1.leftRemainder(l) + ", d2%l = " + d2.leftRemainder(l));
+        //GenSolvablePolynomial<C> b = left.multiply(right).multiply(coB);
+        //b = (GenSolvablePolynomial<C>)fd.leftBasePrimitivePart(b).abs();
+        //System.out.println("b = " + b);
+        //if (! b.abs().equals(fd.leftBasePrimitivePart(polyB).abs())) {
+        //    System.out.println("b = " + b + ",\nB != " + polyB);
+        //    return false;
+        //}
+        // check via Ore condition
+        a = left.multiply(coA).multiply(right);
+        C c1 = a.leadingBaseCoefficient();
+        C c2 = polyA.leadingBaseCoefficient();
+        C[] oc = fd.leftOreCond(c1, c2);
+        ap = a.multiplyLeft(oc[0]);
+        bp = polyA.multiplyLeft(oc[1]);
+        if (!ap.equals(bp)) {
+            //System.out.println("a: ap_l = " + ap + ", bp = " + bp);
+            oc = fd.rightOreCond(c1, c2);
+            ap = a.multiply(oc[0]);
+            bp = polyA.multiply(oc[1]);
+            if (!ap.equals(bp)) {
+                System.out.println("a: ap_r = " + ap + ", bp = " + bp);
+                return false;
+            }
+        }
+        a = left.multiply(coB).multiply(right);
+        c1 = a.leadingBaseCoefficient();
+        c2 = polyB.leadingBaseCoefficient();
+        oc = fd.leftOreCond(c1, c2);
+        ap = a.multiplyLeft(oc[0]);
+        bp = polyB.multiplyLeft(oc[1]);
+        if (!ap.equals(bp)) {
+            //System.out.println("b: ap_l = " + ap + ", bp = " + bp);
+            oc = fd.rightOreCond(c1, c2);
+            ap = a.multiply(oc[0]);
+            bp = polyB.multiply(oc[1]);
+            if (!ap.equals(bp)) {
+                System.out.println("b: ap_r = " + ap + ", bp = " + bp);
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        sb.append(left.toString());
+        sb.append(" * ");
+        sb.append(coA.toString());
+        sb.append(" * ");
+        sb.append(right.toString());
+        sb.append(" == ");
+        sb.append(polyA.toString());
+        sb.append(",\n ");
+        sb.append(left.toString());
+        sb.append(" * ");
+        sb.append(coB.toString());
+        sb.append(" * ");
+        sb.append(right.toString());
+        sb.append(" == ");
+        sb.append(polyB.toString());
+        return sb.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this container.
+     * @see edu.jas.structure.ElemFactory#toScript()
+     */
+    public String toScript() {
+        // Python case
+        StringBuffer sb = new StringBuffer();
+        sb.append(left.toScript());
+        sb.append(" * ");
+        sb.append(coA.toScript());
+        sb.append(" * ");
+        sb.append(right.toScript());
+        sb.append(" == ");
+        sb.append(polyA.toString());
+        sb.append(" && ");
+        sb.append(left.toScript());
+        sb.append(" * ");
+        sb.append(coB.toScript());
+        sb.append(" * ");
+        sb.append(right.toScript());
+        sb.append(" == ");
+        sb.append(polyB.toString());
+        sb.append(" ");
+        return sb.toString();
+    }
+
+
+    /**
+     * Hash code for this GCDcoFactors.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h = polyA.hashCode();
+        h = (h << 7);
+        h += polyB.hashCode();
+        h = (h << 7);
+        h += coA.hashCode();
+        h = (h << 7);
+        h += coB.hashCode();
+        h = (h << 7);
+        h += left.hashCode();
+        h = (h << 7);
+        h += right.hashCode();
+        return h;
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object B) {
+        if (B == null) {
+            return false;
+        }
+        if (!(B instanceof GCDcoFactors)) {
+            return false;
+        }
+        GCDcoFactors<C> a = (GCDcoFactors<C>) B;
+        return this.compareTo(a) == 0;
+    }
+
+
+    /**
+     * Comparison.
+     * @param facs gcd co-factors container.
+     * @return sign(this.polyA-facs.polyA) lexicographic &gt;
+     *         sign(this.polyB-facs.polyB) lexicographic &gt;
+     *         sign(this.coA-facs.coA) lexicographic &gt;
+     *         sign(this.coB-facs.coB) lexicographic &gt;
+     *         sign(this.left-facs.left) lexicographic &gt;
+     *         sign(this.right-facs.right).
+     */
+    public int compareTo(GCDcoFactors<C> facs) {
+        int s = polyA.compareTo(facs.polyA);
+        if (s != 0) {
+            return s;
+        }
+        s = polyB.compareTo(facs.polyB);
+        if (s != 0) {
+            return s;
+        }
+        s = coA.compareTo(facs.coA);
+        if (s != 0) {
+            return s;
+        }
+        s = coB.compareTo(facs.coB);
+        if (s != 0) {
+            return s;
+        }
+        s = left.compareTo(facs.left);
+        if (s != 0) {
+            return s;
+        }
+        s = right.compareTo(facs.right);
+        if (s != 0) {
+            return s;
+        }
+        return 0;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/GreatestCommonDivisor.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/GreatestCommonDivisor.java
@@ -1,0 +1,112 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.fd;
+
+
+import java.io.Serializable;
+import java.util.List;
+
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * (Non-unique) factorization domain greatest common divisor algorithm
+ * interface.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public interface GreatestCommonDivisor<C extends GcdRingElem<C>> extends Serializable {
+
+
+    /**
+     * GenSolvablePolynomial left greatest common divisor.
+     * @param P GenSolvablePolynomial.
+     * @param S GenSolvablePolynomial.
+     * @return gcd(P,S) with P = P'*gcd(P,S)*p and S = S'*gcd(P,S)*s, where
+     *         deg_main(p) = deg_main(s) == 0.
+     */
+    public GenSolvablePolynomial<C> leftGcd(GenSolvablePolynomial<C> P, GenSolvablePolynomial<C> S);
+
+
+    /**
+     * GenSolvablePolynomial right greatest common divisor.
+     * @param P GenSolvablePolynomial.
+     * @param S GenSolvablePolynomial.
+     * @return gcd(P,S) with P = p*gcd(P,S)*P' and S = s*gcd(P,S)*S', where
+     *         deg_main(p) = deg_main(s) == 0.
+     */
+    public GenSolvablePolynomial<C> rightGcd(GenSolvablePolynomial<C> P, GenSolvablePolynomial<C> S);
+
+
+    /**
+     * GenSolvablePolynomial left least common multiple.
+     * @param P GenSolvablePolynomial.
+     * @param S GenSolvablePolynomial.
+     * @return lcm(P,S) with lcm(P,S) = P'*P = S'*S.
+     */
+    public GenSolvablePolynomial<C> leftLcm(GenSolvablePolynomial<C> P, GenSolvablePolynomial<C> S);
+
+
+    /**
+     * GenSolvablePolynomial right least common multiple.
+     * @param P GenSolvablePolynomial.
+     * @param S GenSolvablePolynomial.
+     * @return lcm(P,S) with lcm(P,S) = P*P' = S*S'.
+     */
+    public GenSolvablePolynomial<C> rightLcm(GenSolvablePolynomial<C> P, GenSolvablePolynomial<C> S);
+
+
+    /**
+     * GenSolvablePolynomial right content.
+     * @param P GenSolvablePolynomial.
+     * @return cont(P) with pp(P)*cont(P) = P.
+     */
+    public GenSolvablePolynomial<C> rightContent(GenSolvablePolynomial<C> P);
+
+
+    /**
+     * GenSolvablePolynomial right primitive part.
+     * @param P GenSolvablePolynomial.
+     * @return pp(P) with pp(P)*cont(P) = P.
+     */
+    public GenSolvablePolynomial<C> rightPrimitivePart(GenSolvablePolynomial<C> P);
+
+
+    /**
+     * GenSolvablePolynomial left content.
+     * @param P GenSolvablePolynomial.
+     * @return cont(P) with cont(P)*pp(P) = P.
+     */
+    public GenSolvablePolynomial<C> leftContent(GenSolvablePolynomial<C> P);
+
+
+    /**
+     * GenSolvablePolynomial left primitive part.
+     * @param P GenSolvablePolynomial.
+     * @return pp(P) with cont(P)*pp(P) = P.
+     */
+    public GenSolvablePolynomial<C> leftPrimitivePart(GenSolvablePolynomial<C> P);
+
+
+    /**
+     * GenSolvablePolynomial left co-prime list.
+     * @param A list of GenSolvablePolynomials.
+     * @return B with leftGcd(b,c) = 1 for all b != c in B and for all
+     *         non-constant a in A there exists b in B with b|a. B does not
+     *         contain zero or constant polynomials.
+     */
+    public List<GenSolvablePolynomial<C>> leftCoPrime(List<GenSolvablePolynomial<C>> A);
+
+
+    /**
+     * GenSolvablePolynomial test for left co-prime list.
+     * @param A list of GenSolvablePolynomials.
+     * @return true if leftGcd(b,c) = 1 for all b != c in B, else false.
+     */
+    public boolean isLeftCoPrime(List<GenSolvablePolynomial<C>> A);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/GreatestCommonDivisorAbstract.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/GreatestCommonDivisorAbstract.java
@@ -1,0 +1,1440 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.fd;
+
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gbufd.SolvableSyzygyAbstract;
+import edu.jas.gbufd.SolvableSyzygySeq;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.GenSolvablePolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.poly.RecSolvablePolynomial;
+import edu.jas.poly.RecSolvablePolynomialRing;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.structure.StarRingElem;
+import edu.jas.ufd.GCDFactory;
+
+
+/**
+ * (Non-unique) factorization domain greatest common divisor common algorithms.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public abstract class GreatestCommonDivisorAbstract<C extends GcdRingElem<C>>
+                implements GreatestCommonDivisor<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GreatestCommonDivisorAbstract.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Engine for syzygy computation.
+     */
+    final SolvableSyzygyAbstract<C> syz;
+
+
+    /**
+     * Coefficient ring.
+     */
+    final RingFactory<C> coFac;
+
+
+    /*
+     * Engine for commutative gcd computation.
+     */
+    //edu.jas.ufd.GreatestCommonDivisorAbstract<C> cgcd;
+
+
+    /**
+     * Constructor.
+     * @param cf coefficient ring.
+     */
+    public GreatestCommonDivisorAbstract(RingFactory<C> cf) {
+        this(cf, new SolvableSyzygySeq<C>(cf));
+    }
+
+
+    /**
+     * Constructor.
+     * @param cf coefficient ring.
+     * @param s algorithm for SolvableSyzygy computation.
+     */
+    public GreatestCommonDivisorAbstract(RingFactory<C> cf, SolvableSyzygyAbstract<C> s) {
+        coFac = cf;
+        syz = s;
+        //cgcd = GCDFactory.<C> getImplementation(pfac.coFac);
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return getClass().getName();
+    }
+
+
+    /**
+     * GenSolvablePolynomial base coefficient content.
+     * @param P GenSolvablePolynomial.
+     * @return cont(P) with pp(P)*cont(P) = P.
+     */
+    public C leftBaseContent(GenSolvablePolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException("P == null");
+        }
+        if (P.isZERO()) {
+            return P.ring.getZEROCoefficient();
+        }
+        if (P.ring.coFac.isField()) { // so to make monic
+            return P.leadingBaseCoefficient();
+        }
+        C d = null;
+        for (C c : P.getMap().values()) {
+            if (d == null) {
+                d = c;
+            } else {
+                d = d.leftGcd(c);
+            }
+            if (d.isONE()) {
+                return d;
+            }
+        }
+        if (d.signum() < 0) {
+            d = d.negate();
+        }
+        return d;
+    }
+
+
+    /**
+     * GenSolvablePolynomial right base coefficient content.
+     * @param P GenSolvablePolynomial.
+     * @return cont(P) with cont(P)*pp(P) = P.
+     */
+    public C rightBaseContent(GenSolvablePolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException("P == null");
+        }
+        if (P.isZERO()) {
+            return P.ring.getZEROCoefficient();
+        }
+        if (P.ring.coFac.isField()) { // so to make monic
+            return P.leadingBaseCoefficient(); // todo check move to right
+        }
+        C d = null;
+        for (C c : P.getMap().values()) {
+            if (d == null) {
+                d = c;
+            } else {
+                d = d.rightGcd(c); // DONE does now exist
+            }
+            if (d.isONE()) {
+                return d;
+            }
+        }
+        if (d.signum() < 0) {
+            d = d.negate();
+        }
+        return d;
+    }
+
+
+    /**
+     * GenSolvablePolynomial base coefficient primitive part.
+     * @param P GenSolvablePolynomial.
+     * @return pp(P) with pp(P)*cont(P) = P.
+     */
+    public GenSolvablePolynomial<C> leftBasePrimitivePart(GenSolvablePolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException("P == null");
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        C d = leftBaseContent(P);
+        if (d.isONE()) {
+            return P;
+        }
+        if (P.ring.coFac.isField()) { // make monic
+            return P.multiplyLeft(d.inverse()); // avoid the divisions
+            //return P.multiply( d.inverse() ); // avoid the divisions
+        }
+        //GenSolvablePolynomial<C> pp = (GenSolvablePolynomial<C>) P.rightDivideCoeff(d); // rightDivide TODO/done
+        GenSolvablePolynomial<C> pp = (GenSolvablePolynomial<C>) P.leftDivideCoeff(d); // TODO
+        if (debug) {
+            GenSolvablePolynomial<C> p = pp.multiplyLeft(d);
+            if (!p.equals(P)) {
+                throw new ArithmeticException("pp(p)*cont(p) != p: ");
+            }
+        }
+        return pp;
+    }
+
+
+    /**
+     * GenSolvablePolynomial right base coefficient primitive part.
+     * @param P GenSolvablePolynomial.
+     * @return pp(P) with cont(P)*pp(P) = P.
+     */
+    public GenSolvablePolynomial<C> rightBasePrimitivePart(GenSolvablePolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException("P == null");
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        C d = rightBaseContent(P);
+        if (d.isONE()) {
+            return P;
+        }
+        if (P.ring.coFac.isField()) { // make monic
+            return P.multiplyLeft(d.inverse()); // avoid the divisions
+        }
+        GenSolvablePolynomial<C> pp = (GenSolvablePolynomial<C>) P.leftDivideCoeff(d); // leftDivide TODO/done
+        if (debug) {
+            GenSolvablePolynomial<C> p = pp.multiplyLeft(d);
+            if (!p.equals(P)) {
+                throw new ArithmeticException("pp(p)*cont(p) != p: ");
+            }
+        }
+        return pp;
+    }
+
+
+    /**
+     * Univariate GenSolvablePolynomial greatest common divisor. Uses sparse
+     * pseudoRemainder for remainder.
+     * @param P univariate GenSolvablePolynomial.
+     * @param S univariate GenSolvablePolynomial.
+     * @return gcd(P,S) with P = P'*gcd(P,S) and S = S'*gcd(P,S).
+     */
+    public abstract GenSolvablePolynomial<C> leftBaseGcd(GenSolvablePolynomial<C> P,
+                    GenSolvablePolynomial<C> S);
+
+
+    /**
+     * Univariate GenSolvablePolynomial right greatest common divisor. Uses
+     * sparse pseudoRemainder for remainder.
+     * @param P univariate GenSolvablePolynomial.
+     * @param S univariate GenSolvablePolynomial.
+     * @return gcd(P,S) with P = gcd(P,S)*P' and S = gcd(P,S)*S'.
+     */
+    public abstract GenSolvablePolynomial<C> rightBaseGcd(GenSolvablePolynomial<C> P,
+                    GenSolvablePolynomial<C> S);
+
+
+    /**
+     * GenSolvablePolynomial commuting recursive content.
+     * @param P recursive GenSolvablePolynomial with commuting main and
+     *            coefficient variables.
+     * @return cont(P) with cont(P)*pp(P) = pp(P)*cont(P).
+     */
+    public GenSolvablePolynomial<C> recursiveContent(GenSolvablePolynomial<GenPolynomial<C>> P) {
+        if (P == null) {
+            throw new IllegalArgumentException("P == null");
+        }
+        if (P instanceof RecSolvablePolynomial) {
+            RecSolvablePolynomialRing<C> rfac = (RecSolvablePolynomialRing<C>) P.ring;
+            if (!rfac.coeffTable.isEmpty()) {
+                throw new IllegalArgumentException("P is a RecSolvablePolynomial, use recursiveContent()");
+            }
+        }
+        if (P.isZERO()) {
+            return (GenSolvablePolynomial<C>) P.ring.getZEROCoefficient();
+        }
+        if (P.isONE()) {
+            return (GenSolvablePolynomial<C>) P.ring.getONECoefficient();
+        }
+        if (P.leadingBaseCoefficient().isONE()) {
+            return (GenSolvablePolynomial<C>) P.ring.getONECoefficient();
+        }
+        //GenSolvablePolynomial<GenPolynomial<C>> p = P;
+        GenSolvablePolynomial<C> d = null;
+        for (GenPolynomial<C> cp : P.getMap().values()) {
+            GenSolvablePolynomial<C> c = (GenSolvablePolynomial<C>) cp;
+            if (d == null) {
+                d = c;
+            } else {
+                ///d = leftGcd(d, c); // go to recursion
+                d = rightGcd(d, c); // go to recursion
+            }
+            if (d.isONE()) {
+                return d;
+            }
+        }
+        return (GenSolvablePolynomial<C>) d.abs();
+    }
+
+
+    /**
+     * GenSolvablePolynomial right recursive content.
+     * @param P recursive GenSolvablePolynomial.
+     * @return cont(P) with pp(P)*cont(P) = P.
+     */
+    public GenSolvablePolynomial<C> rightRecursiveContent(GenSolvablePolynomial<GenPolynomial<C>> P) {
+        if (P == null) {
+            throw new IllegalArgumentException("P != null");
+        }
+        if (P.isZERO()) {
+            return (GenSolvablePolynomial<C>) P.ring.getZEROCoefficient();
+        }
+        if (P.leadingBaseCoefficient().isONE()) {
+            return (GenSolvablePolynomial<C>) P.ring.getONECoefficient();
+        }
+        GenSolvablePolynomial<C> d = null, cs = null, x;
+        GenSolvablePolynomial<GenPolynomial<C>> Pr = P.rightRecursivePolynomial();
+        logger.info("RI-recCont: P = " + P + ", right(P) = " + Pr);
+        for (GenPolynomial<C> c : Pr.getMap().values()) {
+            cs = (GenSolvablePolynomial<C>) c;
+            if (d == null) {
+                d = cs;
+            } else {
+                x = d;
+                d = leftGcd(d, cs); // go to recursion, P = P'*gcd(P,S)
+                ///d = rightGcd(d, cs); // go to recursion,  P = gcd(P,S)*P'
+                logger.info("RI-recCont: d = " + x + ", cs = " + cs + ", d = " + d);
+            }
+            if (d.isONE()) {
+                return d;
+            }
+        }
+        return (GenSolvablePolynomial<C>) d.abs();
+    }
+
+
+    /**
+     * GenSolvablePolynomial right recursive primitive part.
+     * @param P recursive GenSolvablePolynomial.
+     * @return pp(P) with pp(P)*cont(P) = P.
+     */
+    public GenSolvablePolynomial<GenPolynomial<C>> rightRecursivePrimitivePart(
+                    GenSolvablePolynomial<GenPolynomial<C>> P) {
+        if (P == null) {
+            throw new IllegalArgumentException("P == null");
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        GenSolvablePolynomial<C> d = rightRecursiveContent(P);
+        if (d.isONE()) {
+            return P;
+        }
+        GenSolvablePolynomial<GenPolynomial<C>> pp;
+        pp = FDUtil.<C> recursiveLeftDivide(P, d); //RightEval
+        if (debug) { // not checkable
+            if (!P.equals(pp.multiply(d))) {
+                System.out.println("RI-ppart, P         = " + P);
+                System.out.println("RI-ppart, cont(P)   = " + d);
+                System.out.println("RI-ppart, pp(P)     = " + pp);
+                System.out.println("RI-ppart, pp(P)c(P) = " + pp.multiply(d));
+                throw new RuntimeException("RI-primitivePart: P != pp(P)*cont(P)");
+            }
+        }
+        return pp;
+    }
+
+
+    /**
+     * GenSolvablePolynomial left recursive content.
+     * @param P recursive GenSolvablePolynomial.
+     * @return cont(P) with cont(P)*pp(P) = P.
+     */
+    public GenSolvablePolynomial<C> leftRecursiveContent(GenSolvablePolynomial<GenPolynomial<C>> P) {
+        if (P == null) {
+            throw new IllegalArgumentException("P != null");
+        }
+        if (P.isZERO()) {
+            return (GenSolvablePolynomial<C>) P.ring.getZEROCoefficient();
+        }
+        if (P.leadingBaseCoefficient().isONE()) {
+            return (GenSolvablePolynomial<C>) P.ring.getONECoefficient();
+        }
+        GenSolvablePolynomial<C> d = null, cs = null;
+        GenSolvablePolynomial<GenPolynomial<C>> Pr = P; //FDUtil.<C> rightRecursivePolynomial(P);
+        logger.info("recCont: P = " + P + ", right(P) = " + Pr);
+        for (GenPolynomial<C> c : Pr.getMap().values()) {
+            cs = (GenSolvablePolynomial<C>) c;
+            if (d == null) {
+                d = cs;
+            } else {
+                d = rightGcd(d, cs); // go to recursion
+                ///d = leftGcd(d, cs); // go to recursion
+                logger.info("recCont: cs = " + cs + ", d = " + d);
+            }
+            if (d.isONE()) {
+                return d;
+            }
+        }
+        return (GenSolvablePolynomial<C>) d.abs();
+    }
+
+
+    /**
+     * GenSolvablePolynomial left recursive primitive part.
+     * @param P recursive GenSolvablePolynomial.
+     * @return pp(P) with cont(P)*pp(P) = P.
+     */
+    public GenSolvablePolynomial<GenPolynomial<C>> leftRecursivePrimitivePart(
+                    GenSolvablePolynomial<GenPolynomial<C>> P) {
+        if (P == null) {
+            throw new IllegalArgumentException("P == null");
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        GenSolvablePolynomial<C> d = leftRecursiveContent(P);
+        if (d.isONE()) {
+            return P;
+        }
+        GenSolvablePolynomial<GenPolynomial<C>> pp;
+        pp = FDUtil.<C> recursiveRightDivide(P, d);
+        if (debug) { // not checkable
+            if (!P.equals(pp.multiplyLeft(d))) {
+                System.out.println("ppart, P         = " + P);
+                System.out.println("ppart, cont(P)   = " + d);
+                System.out.println("ppart, pp(P)     = " + pp);
+                System.out.println("ppart, pp(P)c(P) = " + pp.multiplyLeft(d));
+                throw new RuntimeException("primitivePart: P != cont(P)*pp(P)");
+            }
+        }
+        return pp;
+    }
+
+
+    /**
+     * GenSolvablePolynomial base recursive content.
+     * @param P recursive GenSolvablePolynomial.
+     * @return baseCont(P) with pp(P)*cont(P) = P.
+     */
+    public C baseRecursiveContent(GenSolvablePolynomial<GenPolynomial<C>> P) {
+        if (P == null) {
+            throw new IllegalArgumentException("P == null");
+        }
+        if (P.isZERO()) {
+            GenSolvablePolynomialRing<C> cf = (GenSolvablePolynomialRing<C>) P.ring.coFac;
+            return cf.coFac.getZERO();
+        }
+        C d = null;
+        for (GenPolynomial<C> cp : P.getMap().values()) {
+            GenSolvablePolynomial<C> c = (GenSolvablePolynomial<C>) cp;
+            C cc = leftBaseContent(c);
+            if (d == null) {
+                d = cc;
+            } else {
+                d = gcd(d, cc);
+            }
+            if (d.isONE()) {
+                return d;
+            }
+        }
+        return d.abs();
+    }
+
+
+    /**
+     * GenSolvablePolynomial base recursive primitive part.
+     * @param P recursive GenSolvablePolynomial.
+     * @return basePP(P) with pp(P)*cont(P) = P.
+     */
+    public GenSolvablePolynomial<GenPolynomial<C>> baseRecursivePrimitivePart(
+                    GenSolvablePolynomial<GenPolynomial<C>> P) {
+        if (P == null) {
+            throw new IllegalArgumentException("P == null");
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        C d = baseRecursiveContent(P);
+        if (d.isONE()) {
+            return P;
+        }
+        GenSolvablePolynomial<GenPolynomial<C>> pp = (GenSolvablePolynomial<GenPolynomial<C>>) PolyUtil
+                        .<C> baseRecursiveDivide(P, d);
+        return pp;
+    }
+
+
+    /**
+     * GenSolvablePolynomial left recursive greatest common divisor. Uses
+     * pseudoRemainder for remainder.
+     * @param P recursive GenSolvablePolynomial.
+     * @param S recursive GenSolvablePolynomial.
+     * @return gcd(P,S) with P = P'*gcd(P,S)*p and S = S'*gcd(P,S)*s, where
+     *         deg_main(p) = deg_main(s) == 0.
+     */
+    @SuppressWarnings("unchecked")
+    public GenSolvablePolynomial<GenPolynomial<C>> leftRecursiveGcd(GenSolvablePolynomial<GenPolynomial<C>> P,
+                    GenSolvablePolynomial<GenPolynomial<C>> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.ring.nvar == 1) {
+            return leftRecursiveUnivariateGcd(P, S);
+        }
+        // distributed polynomials gcd
+        GenSolvablePolynomialRing<GenPolynomial<C>> rfac = P.ring;
+        GenSolvablePolynomialRing<C> dfac;
+        if (rfac instanceof RecSolvablePolynomialRing) {
+            RecSolvablePolynomialRing<C> rf = (RecSolvablePolynomialRing<C>) rfac;
+            dfac = RecSolvablePolynomialRing.<C> distribute(rf);
+        } else {
+            GenSolvablePolynomialRing<C> df = (GenSolvablePolynomialRing) rfac;
+            dfac = df.distribute();
+        }
+        GenSolvablePolynomial<C> Pd = (GenSolvablePolynomial<C>) PolyUtil.<C> distribute(dfac, P);
+        GenSolvablePolynomial<C> Sd = (GenSolvablePolynomial<C>) PolyUtil.<C> distribute(dfac, S);
+        GenSolvablePolynomial<C> Dd = leftGcd(Pd, Sd);
+        // convert to recursive
+        GenSolvablePolynomial<GenPolynomial<C>> C = (GenSolvablePolynomial<GenPolynomial<C>>) PolyUtil
+                        .<C> recursive(rfac, Dd);
+        return C;
+    }
+
+
+    /**
+     * GenSolvablePolynomial right recursive greatest common divisor. Uses
+     * pseudoRemainder for remainder.
+     * @param P recursive GenSolvablePolynomial.
+     * @param S recursive GenSolvablePolynomial.
+     * @return gcd(P,S) with P = p*gcd(P,S)*P' and S = s*gcd(P,S)*S', where
+     *         deg_main(p) = deg_main(s) == 0.
+     */
+    @SuppressWarnings("unchecked")
+    public GenSolvablePolynomial<GenPolynomial<C>> rightRecursiveGcd(
+                    GenSolvablePolynomial<GenPolynomial<C>> P, GenSolvablePolynomial<GenPolynomial<C>> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.ring.nvar == 1) {
+            return rightRecursiveUnivariateGcd(P, S);
+        }
+        // distributed polynomials gcd
+        GenSolvablePolynomialRing<GenPolynomial<C>> rfac = P.ring;
+        GenSolvablePolynomialRing<C> dfac;
+        if (rfac instanceof RecSolvablePolynomialRing) {
+            RecSolvablePolynomialRing<C> rf = (RecSolvablePolynomialRing<C>) rfac;
+            dfac = RecSolvablePolynomialRing.<C> distribute(rf);
+        } else {
+            GenSolvablePolynomialRing<C> df = (GenSolvablePolynomialRing) rfac;
+            dfac = df.distribute();
+        }
+        GenSolvablePolynomial<C> Pd = (GenSolvablePolynomial<C>) PolyUtil.<C> distribute(dfac, P);
+        GenSolvablePolynomial<C> Sd = (GenSolvablePolynomial<C>) PolyUtil.<C> distribute(dfac, S);
+        GenSolvablePolynomial<C> Dd = rightGcd(Pd, Sd);
+        // convert to recursive
+        GenSolvablePolynomial<GenPolynomial<C>> C = (GenSolvablePolynomial<GenPolynomial<C>>) PolyUtil
+                        .<C> recursive(rfac, Dd);
+        return C;
+    }
+
+
+    /**
+     * Univariate GenSolvablePolynomial recursive greatest common divisor. Uses
+     * pseudoRemainder for remainder.
+     * @param P univariate recursive GenSolvablePolynomial.
+     * @param S univariate recursive GenSolvablePolynomial.
+     * @return gcd(P,S) with P = P'*gcd(P,S)*p and S = S'*gcd(P,S)*s, where
+     *         deg_main(p) = deg_main(s) == 0.
+     */
+    public abstract GenSolvablePolynomial<GenPolynomial<C>> leftRecursiveUnivariateGcd(
+                    GenSolvablePolynomial<GenPolynomial<C>> P, GenSolvablePolynomial<GenPolynomial<C>> S);
+
+
+    /**
+     * Univariate GenSolvablePolynomial right recursive greatest common divisor.
+     * Uses pseudoRemainder for remainder.
+     * @param P univariate recursive GenSolvablePolynomial.
+     * @param S univariate recursive GenSolvablePolynomial.
+     * @return gcd(P,S) with P = p*gcd(P,S)*P' and S = s*gcd(P,S)*S', where
+     *         deg_main(p) = deg_main(s) == 0.
+     */
+    public abstract GenSolvablePolynomial<GenPolynomial<C>> rightRecursiveUnivariateGcd(
+                    GenSolvablePolynomial<GenPolynomial<C>> P, GenSolvablePolynomial<GenPolynomial<C>> S);
+
+
+    /**
+     * GenSolvablePolynomial right content.
+     * @param P GenSolvablePolynomial.
+     * @return cont(P) with pp(P)*cont(P) = P.
+     */
+    public GenSolvablePolynomial<C> rightContent(GenSolvablePolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException("P == null");
+        }
+        GenSolvablePolynomialRing<C> pfac = P.ring;
+        if (pfac.nvar <= 1) {
+            // baseContent not possible by return type
+            throw new IllegalArgumentException("use baseContent() for univariate polynomials");
+        }
+        GenSolvablePolynomialRing<GenPolynomial<C>> rfac // = (RecSolvablePolynomialRing<C>) 
+                        = pfac.recursive(1);
+
+        GenSolvablePolynomial<GenPolynomial<C>> Pr = (RecSolvablePolynomial<C>) PolyUtil.<C> recursive(rfac,
+                        P);
+        GenSolvablePolynomial<C> D = rightRecursiveContent(Pr);
+        return D;
+    }
+
+
+    /**
+     * GenSolvablePolynomial right primitive part.
+     * @param P GenSolvablePolynomial.
+     * @return pp(P) with pp(P)*cont(P) = P.
+     */
+    public GenSolvablePolynomial<C> rightPrimitivePart(GenSolvablePolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException("P == null");
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        GenSolvablePolynomialRing<C> pfac = P.ring;
+        if (pfac.nvar <= 1) {
+            return rightBasePrimitivePart(P);
+        }
+        GenSolvablePolynomialRing<GenPolynomial<C>> rfac = /*(RecSolvablePolynomialRing<C>)*/pfac
+                        .recursive(1);
+
+        GenSolvablePolynomial<GenPolynomial<C>> Pr = (RecSolvablePolynomial<C>) PolyUtil.<C> recursive(rfac,
+                        P);
+        GenSolvablePolynomial<GenPolynomial<C>> PP = rightRecursivePrimitivePart(Pr);
+
+        GenSolvablePolynomial<C> D = (GenSolvablePolynomial<C>) PolyUtil.<C> distribute(pfac, PP);
+        return D;
+    }
+
+
+    /**
+     * GenSolvablePolynomial left content.
+     * @param P GenSolvablePolynomial.
+     * @return cont(P) with cont(P)*pp(P) = P.
+     */
+    public GenSolvablePolynomial<C> leftContent(GenSolvablePolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException("P == null");
+        }
+        GenSolvablePolynomialRing<C> pfac = P.ring;
+        if (pfac.nvar <= 1) {
+            // baseContent not possible by return type
+            throw new IllegalArgumentException("use baseContent() for univariate polynomials");
+        }
+        GenSolvablePolynomialRing<GenPolynomial<C>> rfac // = (RecSolvablePolynomialRing<C>) 
+                        = pfac.recursive(1);
+
+        GenSolvablePolynomial<GenPolynomial<C>> Pr = (RecSolvablePolynomial<C>) PolyUtil.<C> recursive(rfac,
+                        P);
+        GenSolvablePolynomial<C> D = leftRecursiveContent(Pr);
+        return D;
+    }
+
+
+    /**
+     * GenSolvablePolynomial left primitive part.
+     * @param P GenSolvablePolynomial.
+     * @return pp(P) with cont(P)*pp(P) = P.
+     */
+    public GenSolvablePolynomial<C> leftPrimitivePart(GenSolvablePolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException("P == null");
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        GenSolvablePolynomialRing<C> pfac = P.ring;
+        if (pfac.nvar <= 1) {
+            return leftBasePrimitivePart(P);
+        }
+        GenSolvablePolynomialRing<GenPolynomial<C>> rfac = /*(RecSolvablePolynomialRing<C>)*/pfac
+                        .recursive(1);
+
+        GenSolvablePolynomial<GenPolynomial<C>> Pr = (RecSolvablePolynomial<C>) PolyUtil.<C> recursive(rfac,
+                        P);
+        GenSolvablePolynomial<GenPolynomial<C>> PP = leftRecursivePrimitivePart(Pr);
+
+        GenSolvablePolynomial<C> D = (GenSolvablePolynomial<C>) PolyUtil.<C> distribute(pfac, PP);
+        return D;
+    }
+
+
+    /**
+     * GenSolvablePolynomial division. Indirection to GenSolvablePolynomial
+     * method.
+     * @param a GenSolvablePolynomial.
+     * @param b coefficient.
+     * @return a' = a/b with a = a'*b.
+     */
+    public GenSolvablePolynomial<C> divide(GenSolvablePolynomial<C> a, C b) {
+        if (b == null || b.isZERO()) {
+            throw new IllegalArgumentException("division by zero");
+
+        }
+        if (a == null || a.isZERO()) {
+            return a;
+        }
+        return (GenSolvablePolynomial<C>) a.divide(b);
+    }
+
+
+    /*
+     * GenSolvablePolynomial right division. Indirection to GenSolvablePolynomial
+     * method.
+     * @param a GenSolvablePolynomial.
+     * @param b coefficient.
+     * @return a' = a/b with a = b*a'.
+    public GenSolvablePolynomial<C> rightDivide(GenSolvablePolynomial<C> a, C b) {
+        if (b == null || b.isZERO()) {
+            throw new IllegalArgumentException("division by zero");
+    
+        }
+        if (a == null || a.isZERO()) {
+            return a;
+        }
+        return (GenSolvablePolynomial<C>) a.rightDivide(b);
+    }
+     */
+
+
+    /**
+     * Coefficient greatest common divisor. Indirection to coefficient method.
+     * @param a coefficient.
+     * @param b coefficient.
+     * @return gcd(a,b) with a = a'*gcd(a,b) and b = b'*gcd(a,b).
+     */
+    public C gcd(C a, C b) {
+        if (b == null || b.isZERO()) {
+            return a;
+        }
+        if (a == null || a.isZERO()) {
+            return b;
+        }
+        return a.gcd(b);
+    }
+
+
+    /**
+     * GenSolvablePolynomial greatest common divisor.
+     * @param P GenSolvablePolynomial.
+     * @param S GenSolvablePolynomial.
+     * @return gcd(P,S) with P = P'*gcd(P,S)*p and S = S'*gcd(P,S)*s, where
+     *         deg_main(p) = deg_main(s) == 0.
+     */
+    public GenSolvablePolynomial<C> leftGcd(GenSolvablePolynomial<C> P, GenSolvablePolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.isONE()) {
+            return P;
+        }
+        if (S.isONE()) {
+            return S;
+        }
+        GenSolvablePolynomialRing<C> pfac = P.ring;
+        if (pfac.nvar <= 1) {
+            GenSolvablePolynomial<C> T = leftBaseGcd(P, S);
+            return T;
+        }
+        GenSolvablePolynomialRing<GenPolynomial<C>> rfac = pfac.recursive(1); //RecSolvablePolynomialRing<C>
+        GenSolvablePolynomial<GenPolynomial<C>> Pr, Sr, Dr;
+        Pr = (RecSolvablePolynomial<C>) PolyUtil.<C> recursive(rfac, P);
+        Sr = (RecSolvablePolynomial<C>) PolyUtil.<C> recursive(rfac, S);
+        Dr = leftRecursiveUnivariateGcd(Pr, Sr);
+        GenSolvablePolynomial<C> D = (GenSolvablePolynomial<C>) PolyUtil.<C> distribute(pfac, Dr);
+        if (debug) { // not checkable
+            GenSolvablePolynomial<C> ps = FDUtil.<C> rightBaseSparsePseudoRemainder(P, D);
+            GenSolvablePolynomial<C> ss = FDUtil.<C> rightBaseSparsePseudoRemainder(S, D);
+            if (!ps.isZERO() || !ss.isZERO()) {
+                System.out.println("fullGcd, D  = " + D);
+                System.out.println("fullGcd, P  = " + P);
+                System.out.println("fullGcd, S  = " + S);
+                System.out.println("fullGcd, ps = " + ps);
+                System.out.println("fullGcd, ss = " + ss);
+                throw new RuntimeException("fullGcd: not divisible");
+            }
+            logger.info("fullGcd(P,S) okay: D = " + D + ", P = " + P + ", S = " + S);
+        }
+        return D;
+    }
+
+
+    /**
+     * GenSolvablePolynomial left least common multiple.
+     * @param P GenSolvablePolynomial.
+     * @param S GenSolvablePolynomial.
+     * @return lcm(P,S) with lcm(P,S) = P'*P = S'*S.
+     */
+    public GenSolvablePolynomial<C> leftLcm(GenSolvablePolynomial<C> P, GenSolvablePolynomial<C> S) {
+        GenSolvablePolynomial<C>[] oc = leftOreCond(P, S);
+        return oc[0].multiply(P);
+    }
+
+
+    /**
+     * GenSolvablePolynomial right greatest common divisor.
+     * @param P GenSolvablePolynomial.
+     * @param S GenSolvablePolynomial.
+     * @return gcd(P,S) with P = p*gcd(P,S)*P' and S = s*gcd(P,S)*S', where
+     *         deg_main(p) = deg_main(s) == 0.
+     */
+    public GenSolvablePolynomial<C> rightGcd(GenSolvablePolynomial<C> P, GenSolvablePolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.isONE()) {
+            return P;
+        }
+        if (S.isONE()) {
+            return S;
+        }
+        GenSolvablePolynomialRing<C> pfac = P.ring;
+        if (pfac.nvar <= 1) {
+            GenSolvablePolynomial<C> T = rightBaseGcd(P, S);
+            return T;
+        }
+        GenSolvablePolynomialRing<GenPolynomial<C>> rfac = pfac.recursive(1); //RecSolvablePolynomialRing<C>
+        GenSolvablePolynomial<GenPolynomial<C>> Pr, Sr, Dr;
+        Pr = (RecSolvablePolynomial<C>) PolyUtil.<C> recursive(rfac, P);
+        Sr = (RecSolvablePolynomial<C>) PolyUtil.<C> recursive(rfac, S);
+        Dr = rightRecursiveUnivariateGcd(Pr, Sr);
+        GenSolvablePolynomial<C> D = (GenSolvablePolynomial<C>) PolyUtil.<C> distribute(pfac, Dr);
+        if (debug) { // not checkable
+            GenSolvablePolynomial<C> ps = FDUtil.<C> leftBaseSparsePseudoRemainder(P, D);
+            GenSolvablePolynomial<C> ss = FDUtil.<C> leftBaseSparsePseudoRemainder(S, D);
+            if (!ps.isZERO() || !ss.isZERO()) {
+                System.out.println("RI-fullGcd, D  = " + D);
+                System.out.println("RI-fullGcd, P  = " + P);
+                System.out.println("RI-fullGcd, S  = " + S);
+                System.out.println("RI-fullGcd, ps = " + ps);
+                System.out.println("RI-fullGcd, ss = " + ss);
+                throw new RuntimeException("RI-fullGcd: not divisible");
+            }
+            logger.info("RI-fullGcd(P,S) okay: D = " + D);
+        }
+        return D;
+    }
+
+
+    /**
+     * GenSolvablePolynomial right least common multiple.
+     * @param P GenSolvablePolynomial.
+     * @param S GenSolvablePolynomial.
+     * @return lcm(P,S) with lcm(P,S) = P*P' = S*S'.
+     */
+    public GenSolvablePolynomial<C> rightLcm(GenSolvablePolynomial<C> P, GenSolvablePolynomial<C> S) {
+        GenSolvablePolynomial<C>[] oc = rightOreCond(P, S);
+        return P.multiply(oc[0]);
+    }
+
+
+    /**
+     * List of GenSolvablePolynomials left greatest common divisor.
+     * @param A non empty list of GenSolvablePolynomials.
+     * @return gcd(A_i) with A_i = A'_i*gcd(A_i)*a_i, where deg_main(a_i) == 0.
+     */
+    public GenSolvablePolynomial<C> leftGcd(List<GenSolvablePolynomial<C>> A) {
+        if (A == null || A.isEmpty()) {
+            throw new IllegalArgumentException("A may not be empty");
+        }
+        GenSolvablePolynomial<C> g = A.get(0);
+        for (int i = 1; i < A.size(); i++) {
+            GenSolvablePolynomial<C> f = A.get(i);
+            g = leftGcd(g, f);
+        }
+        return g;
+    }
+
+
+    /**
+     * GenSolvablePolynomial co-prime list.
+     * @param A list of GenSolvablePolynomials.
+     * @return B with gcd(b,c) = 1 for all b != c in B and for all non-constant
+     *         a in A there exists b in B with b|a. B does not contain zero or
+     *         constant polynomials.
+     */
+    public List<GenSolvablePolynomial<C>> leftCoPrime(List<GenSolvablePolynomial<C>> A) {
+        if (A == null || A.isEmpty()) {
+            return A;
+        }
+        List<GenSolvablePolynomial<C>> B = new ArrayList<GenSolvablePolynomial<C>>(A.size());
+        // make a coprime to rest of list
+        GenSolvablePolynomial<C> a = A.get(0);
+        //System.out.println("a = " + a);
+        if (!a.isZERO() && !a.isConstant()) {
+            for (int i = 1; i < A.size(); i++) {
+                GenSolvablePolynomial<C> b = A.get(i);
+                GenSolvablePolynomial<C> g = leftGcd(a, b);
+                if (!g.isONE()) {
+                    a = FDUtil.<C> leftBasePseudoQuotient(a, g);
+                    b = FDUtil.<C> leftBasePseudoQuotient(b, g);
+                    GenSolvablePolynomial<C> gp = leftGcd(a, g); //.abs();
+                    while (!gp.isONE()) {
+                        a = FDUtil.<C> leftBasePseudoQuotient(a, gp);
+                        g = FDUtil.<C> leftBasePseudoQuotient(g, gp);
+                        B.add(g); // gcd(a,g) == 1
+                        g = gp;
+                        gp = leftGcd(a, gp);
+                    }
+                    if (!g.isZERO() && !g.isConstant() /*&& !B.contains(g)*/) {
+                        B.add(g); // gcd(a,g) == 1
+                    }
+                }
+                if (!b.isZERO() && !b.isConstant()) {
+                    B.add(b); // gcd(a,b) == 1
+                }
+            }
+        } else {
+            B.addAll(A.subList(1, A.size()));
+        }
+        // make rest coprime
+        B = leftCoPrime(B);
+        //System.out.println("B = " + B);
+        if (!a.isZERO() && !a.isConstant() /*&& !B.contains(a)*/) {
+            a = (GenSolvablePolynomial<C>) a.abs();
+            B.add(a);
+        }
+        return B;
+    }
+
+
+    /**
+     * GenSolvablePolynomial left co-prime list.
+     * @param A list of GenSolvablePolynomials.
+     * @return B with gcd(b,c) = 1 for all b != c in B and for all non-constant
+     *         a in A there exists b in B with b|a. B does not contain zero or
+     *         constant polynomials.
+     */
+    public List<GenSolvablePolynomial<C>> leftCoPrimeRec(List<GenSolvablePolynomial<C>> A) {
+        if (A == null || A.isEmpty()) {
+            return A;
+        }
+        List<GenSolvablePolynomial<C>> B = new ArrayList<GenSolvablePolynomial<C>>();
+        // make a co-prime to rest of list
+        for (GenSolvablePolynomial<C> a : A) {
+            //System.out.println("a = " + a);
+            B = leftCoPrime(a, B);
+            //System.out.println("B = " + B);
+        }
+        return B;
+    }
+
+
+    /**
+     * GenSolvablePolynomial left co-prime list.
+     * @param a GenSolvablePolynomial.
+     * @param P co-prime list of GenSolvablePolynomials.
+     * @return B with gcd(b,c) = 1 for all b != c in B and for non-constant a
+     *         there exists b in P with b|a. B does not contain zero or constant
+     *         polynomials.
+     */
+    public List<GenSolvablePolynomial<C>> leftCoPrime(GenSolvablePolynomial<C> a,
+                    List<GenSolvablePolynomial<C>> P) {
+        if (a == null || a.isZERO() || a.isConstant()) {
+            return P;
+        }
+        List<GenSolvablePolynomial<C>> B = new ArrayList<GenSolvablePolynomial<C>>(P.size() + 1);
+        // make a coprime to elements of the list P
+        for (int i = 0; i < P.size(); i++) {
+            GenSolvablePolynomial<C> b = P.get(i);
+            GenSolvablePolynomial<C> g = leftGcd(a, b);
+            if (!g.isONE()) {
+                a = FDUtil.<C> leftBasePseudoQuotient(a, g);
+                b = FDUtil.<C> leftBasePseudoQuotient(b, g);
+                // make g co-prime to new a, g is co-prime to c != b in P, B
+                GenSolvablePolynomial<C> gp = leftGcd(a, g);
+                while (!gp.isONE()) {
+                    a = FDUtil.<C> leftBasePseudoQuotient(a, gp);
+                    g = FDUtil.<C> leftBasePseudoQuotient(g, gp);
+                    if (!g.isZERO() && !g.isConstant() /*&& !B.contains(g)*/) {
+                        B.add(g); // gcd(a,g) == 1 and gcd(g,c) == 1 for c != b in P, B
+                    }
+                    g = gp;
+                    gp = leftGcd(a, gp);
+                }
+                // make new g co-prime to new b
+                gp = leftGcd(b, g);
+                while (!gp.isONE()) {
+                    b = FDUtil.<C> leftBasePseudoQuotient(b, gp);
+                    g = FDUtil.<C> leftBasePseudoQuotient(g, gp);
+                    if (!g.isZERO() && !g.isConstant() /*&& !B.contains(g)*/) {
+                        B.add(g); // gcd(a,g) == 1 and gcd(g,c) == 1 for c != b in P, B
+                    }
+                    g = gp;
+                    gp = leftGcd(b, gp);
+                }
+                if (!g.isZERO() && !g.isConstant() /*&& !B.contains(g)*/) {
+                    B.add(g); // gcd(a,g) == 1 and gcd(g,c) == 1 for c != b in P, B
+                }
+            }
+            if (!b.isZERO() && !b.isConstant() /*&& !B.contains(b)*/) {
+                B.add(b); // gcd(a,b) == 1 and gcd(b,c) == 1 for c != b in P, B
+            }
+        }
+        if (!a.isZERO() && !a.isConstant() /*&& !B.contains(a)*/) {
+            B.add(a);
+        }
+        return B;
+    }
+
+
+    /**
+     * GenSolvablePolynomial test for co-prime list.
+     * @param A list of GenSolvablePolynomials.
+     * @return true if gcd(b,c) = 1 for all b != c in B, else false.
+     */
+    public boolean isLeftCoPrime(List<GenSolvablePolynomial<C>> A) {
+        if (A == null || A.isEmpty()) {
+            return true;
+        }
+        if (A.size() == 1) {
+            return true;
+        }
+        for (int i = 0; i < A.size(); i++) {
+            GenSolvablePolynomial<C> a = A.get(i);
+            for (int j = i + 1; j < A.size(); j++) {
+                GenSolvablePolynomial<C> b = A.get(j);
+                GenSolvablePolynomial<C> g = leftGcd(a, b);
+                if (!g.isONE()) {
+                    System.out.println("not co-prime, a: " + a);
+                    System.out.println("not co-prime, b: " + b);
+                    System.out.println("not co-prime, g: " + g);
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * GenSolvablePolynomial test for left co-prime list of given list.
+     * @param A list of GenSolvablePolynomials.
+     * @param P list of co-prime GenSolvablePolynomials.
+     * @return true if isCoPrime(P) and for all a in A exists p in P with p | a,
+     *         else false.
+     */
+    public boolean isLeftCoPrime(List<GenSolvablePolynomial<C>> P, List<GenSolvablePolynomial<C>> A) {
+        if (!isLeftCoPrime(P)) {
+            return false;
+        }
+        if (A == null || A.isEmpty()) {
+            return true;
+        }
+        for (GenSolvablePolynomial<C> q : A) {
+            if (q.isZERO() || q.isConstant()) {
+                continue;
+            }
+            boolean divides = false;
+            for (GenSolvablePolynomial<C> p : P) {
+                GenSolvablePolynomial<C> a = FDUtil.<C> leftBaseSparsePseudoRemainder(q, p);
+                if (a.isZERO()) { // p divides q
+                    divides = true;
+                    break;
+                }
+            }
+            if (!divides) {
+                System.out.println("no divisor for: " + q);
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Univariate GenSolvablePolynomial extended greatest common divisor. Uses
+     * sparse pseudoRemainder for remainder.
+     * @param P univariate GenSolvablePolynomial.
+     * @param S univariate GenSolvablePolynomial.
+     * @return [ gcd(P,S), a, b ] with a*P + b*S = gcd(P,S).
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    public GenSolvablePolynomial<C>[] baseExtendedGcd(GenSolvablePolynomial<C> P,
+                    GenSolvablePolynomial<C> S) {
+        //return P.egcd(S);
+        GenSolvablePolynomial<C>[] hegcd = baseHalfExtendedGcd(P, S);
+        GenSolvablePolynomial<C>[] ret = (GenSolvablePolynomial<C>[]) new GenSolvablePolynomial[3];
+        ret[0] = hegcd[0];
+        ret[1] = hegcd[1];
+        GenSolvablePolynomial<C> x = (GenSolvablePolynomial<C>) hegcd[0].subtract(hegcd[1].multiply(P));
+        GenSolvablePolynomial<C>[] qr = FDUtil.<C> leftBasePseudoQuotientRemainder(x, S);
+        // assert qr[1].isZERO() 
+        ret[2] = qr[0];
+        return ret;
+    }
+
+
+    /**
+     * Univariate GenSolvablePolynomial half extended greatest comon divisor.
+     * Uses sparse pseudoRemainder for remainder.
+     * @param S GenSolvablePolynomial.
+     * @return [ gcd(P,S), a ] with a*P + b*S = gcd(P,S).
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    public GenSolvablePolynomial<C>[] baseHalfExtendedGcd(GenSolvablePolynomial<C> P,
+                    GenSolvablePolynomial<C> S) {
+        if (P == null || S == null) {
+            throw new IllegalArgumentException("null P or S not allowed");
+        }
+        GenSolvablePolynomial<C>[] ret = (GenSolvablePolynomial<C>[]) new GenSolvablePolynomial[2];
+        ret[0] = null;
+        ret[1] = null;
+        if (S.isZERO()) {
+            ret[0] = P;
+            ret[1] = P.ring.getONE();
+            return ret;
+        }
+        if (P.isZERO()) {
+            ret[0] = S;
+            ret[1] = S.ring.getZERO();
+            return ret;
+        }
+        if (P.ring.nvar != 1) {
+            throw new IllegalArgumentException("for univariate polynomials only " + P.ring);
+        }
+        GenSolvablePolynomial<C> q = P;
+        GenSolvablePolynomial<C> r = S;
+        GenSolvablePolynomial<C> c1 = P.ring.getONE().copy();
+        GenSolvablePolynomial<C> d1 = P.ring.getZERO().copy();
+        while (!r.isZERO()) {
+            GenSolvablePolynomial<C>[] qr = FDUtil.<C> leftBasePseudoQuotientRemainder(q, r);
+            //q.divideAndRemainder(r);
+            q = qr[0];
+            GenSolvablePolynomial<C> x = (GenSolvablePolynomial<C>) c1.subtract(q.multiply(d1));
+            c1 = d1;
+            d1 = x;
+            q = r;
+            r = qr[1];
+        }
+        // normalize ldcf(q) to 1, i.e. make monic
+        C g = q.leadingBaseCoefficient();
+        if (g.isUnit()) {
+            C h = g.inverse();
+            q = q.multiply(h);
+            c1 = c1.multiply(h);
+        }
+        //assert ( ((c1.multiply(P)).remainder(S).equals(q) )); 
+        ret[0] = q;
+        ret[1] = c1;
+        return ret;
+    }
+
+
+    /**
+     * Univariate GenSolvablePolynomial greatest common divisor diophantine
+     * version.
+     * @param P univariate GenSolvablePolynomial.
+     * @param S univariate GenSolvablePolynomial.
+     * @param c univariate GenSolvablePolynomial.
+     * @return [ a, b ] with a*P + b*S = c and deg(a) &lt; deg(S).
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    public GenSolvablePolynomial<C>[] baseGcdDiophant(GenSolvablePolynomial<C> P, GenSolvablePolynomial<C> S,
+                    GenSolvablePolynomial<C> c) {
+        GenSolvablePolynomial<C>[] egcd = baseExtendedGcd(P, S);
+        GenSolvablePolynomial<C> g = egcd[0];
+        GenSolvablePolynomial<C>[] qr = FDUtil.<C> leftBasePseudoQuotientRemainder(c, g);
+        if (!qr[1].isZERO()) {
+            throw new ArithmeticException("not solvable, r = " + qr[1] + ", c = " + c + ", g = " + g);
+        }
+        GenSolvablePolynomial<C> q = qr[0];
+        GenSolvablePolynomial<C> a = egcd[1].multiply(q);
+        GenSolvablePolynomial<C> b = egcd[2].multiply(q);
+        if (!a.isZERO() && a.degree(0) >= S.degree(0)) {
+            qr = FDUtil.<C> leftBasePseudoQuotientRemainder(a, S);
+            a = qr[1];
+            b = (GenSolvablePolynomial<C>) b.sum(P.multiply(qr[0]));
+        }
+        GenSolvablePolynomial<C>[] ret = (GenSolvablePolynomial<C>[]) new GenSolvablePolynomial[2];
+        ret[0] = a;
+        ret[1] = b;
+        if (debug) {
+            GenSolvablePolynomial<C> y = (GenSolvablePolynomial<C>) ret[0].multiply(P)
+                            .sum(ret[1].multiply(S));
+            if (!y.equals(c)) {
+                System.out.println("P  = " + P);
+                System.out.println("S  = " + S);
+                System.out.println("c  = " + c);
+                System.out.println("a  = " + a);
+                System.out.println("b  = " + b);
+                System.out.println("y  = " + y);
+                throw new ArithmeticException("not diophant, x = " + y.subtract(c));
+            }
+        }
+        return ret;
+    }
+
+
+    /**
+     * Coefficient left Ore condition. Generators for the left Ore condition of
+     * two coefficients.
+     * @param a coefficient.
+     * @param b coefficient.
+     * @return [oa, ob] = leftOreCond(a,b), with oa*a == ob*b.
+     */
+    @SuppressWarnings("unchecked")
+    public C[] leftOreCond(C a, C b) {
+        if (a == null || a.isZERO() || b == null || b.isZERO()) {
+            throw new IllegalArgumentException("a and b must be non zero");
+        }
+        C[] oc = (C[]) new GcdRingElem[2];
+        if (a instanceof GenSolvablePolynomial && b instanceof GenSolvablePolynomial) {
+            GenSolvablePolynomial ap = (GenSolvablePolynomial) a;
+            GenSolvablePolynomial bp = (GenSolvablePolynomial) b;
+            GenSolvablePolynomial[] ocp = leftOreCond(ap, bp);
+            oc[0] = (C) ocp[0];
+            oc[1] = (C) ocp[1];
+            return oc;
+        }
+        RingFactory<C> rf = coFac; // not usable: (RingFactory<C>) a.factory();
+        if (a.equals(b)) { // required because of rationals gcd
+            oc[0] = rf.getONE();
+            oc[1] = rf.getONE();
+            logger.info("Ore multiple: " + Arrays.toString(oc));
+            return oc;
+        }
+        if (a.equals(b.negate())) { // required because of rationals gcd
+            oc[0] = rf.getONE();
+            oc[1] = rf.getONE().negate();
+            logger.info("Ore multiple: " + Arrays.toString(oc));
+            return oc;
+        }
+        if (rf.isCommutative()) {
+            if (debug) {
+                logger.info("left Ore condition on coefficients, commutative case: " + a + ", " + b);
+            }
+            C gcd = a.gcd(b);
+            if (gcd.isONE()) {
+                oc[0] = b;
+                oc[1] = a;
+                if (oc[0].compareTo(rf.getZERO()) < 0 && oc[1].compareTo(rf.getZERO()) < 0) {
+                    oc[0] = oc[0].negate();
+                    oc[1] = oc[1].negate();
+                }
+                logger.info("Ore multiple: " + Arrays.toString(oc));
+                return oc;
+            }
+            C p = a.multiply(b);
+            C lcm = p.divide(gcd).abs();
+            oc[0] = lcm.divide(a);
+            oc[1] = lcm.divide(b);
+            if (oc[0].compareTo(rf.getZERO()) < 0 && oc[1].compareTo(rf.getZERO()) < 0) {
+                oc[0] = oc[0].negate();
+                oc[1] = oc[1].negate();
+            }
+            logger.info("Ore multiple: lcm=" + lcm + ", gcd=" + gcd + ", " + Arrays.toString(oc));
+            return oc;
+        }
+        // now non-commutative
+        if (rf.isField()) {
+            logger.info("left Ore condition on coefficients, skew field " + rf + " case: " + a + ", " + b);
+            //C gcd = a.gcd(b); // always one 
+            //C lcm = rf.getONE();
+            oc[0] = a.inverse(); //lcm.divide(a);
+            oc[1] = b.inverse(); //lcm.divide(b);
+            logger.info("Ore multiple: " + Arrays.toString(oc));
+            return oc;
+        }
+        if (b instanceof StarRingElem) {
+            logger.info("left Ore condition on coefficients, StarRing case: " + a + ", " + b);
+            C bs = (C) ((StarRingElem) b).conjugate();
+            oc[0] = bs.multiply(b); // bar(b) b a = s a 
+            oc[1] = a.multiply(bs); // a bar(b) b = a s
+            logger.info("Ore multiple: " + Arrays.toString(oc));
+            return oc;
+        }
+        throw new UnsupportedOperationException(
+                        "leftOreCond not implemented for " + rf.getClass() + ", rf = " + rf.toScript());
+        //return oc;
+    }
+
+
+    /**
+     * Left Ore condition. Generators for the left Ore condition of two solvable
+     * polynomials.
+     * @param a solvable polynomial
+     * @param b solvable polynomial
+     * @return [p,q] with p*a = q*b
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    public GenSolvablePolynomial<C>[] leftOreCond(GenSolvablePolynomial<C> a, GenSolvablePolynomial<C> b) {
+        if (a == null || a.isZERO() || b == null || b.isZERO()) {
+            throw new IllegalArgumentException("a and b must be non zero");
+        }
+        GenSolvablePolynomialRing<C> pfac = a.ring;
+        GenSolvablePolynomial<C>[] oc = (GenSolvablePolynomial<C>[]) new GenSolvablePolynomial[2];
+        if (a.equals(b)) {
+            oc[0] = pfac.getONE();
+            oc[1] = pfac.getONE();
+            return oc;
+        }
+        if (a.equals(b.negate())) {
+            oc[0] = pfac.getONE();
+            oc[1] = (GenSolvablePolynomial<C>) pfac.getONE().negate();
+            return oc;
+        }
+        if (pfac.isCommutative()) {
+            logger.info("left Ore condition, polynomial commutative case: " + a + ", " + b);
+            edu.jas.ufd.GreatestCommonDivisorAbstract<C> cgcd = GCDFactory.<C> getImplementation(pfac.coFac);
+            GenSolvablePolynomial<C> lcm = (GenSolvablePolynomial<C>) cgcd.lcm(a, b);
+            //oc[0] = FDUtil.<C> basePseudoQuotient(lcm, a);
+            //oc[1] = FDUtil.<C> basePseudoQuotient(lcm, b);
+            oc[0] = (GenSolvablePolynomial<C>) PolyUtil.<C> basePseudoDivide(lcm, a);
+            oc[1] = (GenSolvablePolynomial<C>) PolyUtil.<C> basePseudoDivide(lcm, b);
+            logger.info("Ore multiple: " + lcm + ", " + Arrays.toString(oc));
+            return oc;
+        }
+        oc = syz.leftOreCond(a, b);
+        //logger.info("Ore multiple: " + oc[0].multiply(a) + ", " + Arrays.toString(oc));
+        return oc;
+    }
+
+
+    /**
+     * Coefficient rigth Ore condition. Generators for the right Ore condition
+     * of two coefficients.
+     * @param a coefficient.
+     * @param b coefficient.
+     * @return [oa, ob] = rightOreCond(a,b), with a*oa == b*ob.
+     */
+    @SuppressWarnings("unchecked")
+    public C[] rightOreCond(C a, C b) {
+        if (a == null || a.isZERO() || b == null || b.isZERO()) {
+            throw new IllegalArgumentException("a and b must be non zero");
+        }
+        C[] oc = (C[]) new GcdRingElem[2];
+        if (a instanceof GenSolvablePolynomial && b instanceof GenSolvablePolynomial) {
+            GenSolvablePolynomial ap = (GenSolvablePolynomial) a;
+            GenSolvablePolynomial bp = (GenSolvablePolynomial) b;
+            GenSolvablePolynomial[] ocp = rightOreCond(ap, bp);
+            oc[0] = (C) ocp[0];
+            oc[1] = (C) ocp[1];
+            return oc;
+        }
+        RingFactory<C> rf = coFac; // not usable: (RingFactory<C>) a.factory();
+        if (a.equals(b)) { // required because of rationals gcd
+            oc[0] = rf.getONE();
+            oc[1] = rf.getONE();
+            return oc;
+        }
+        if (a.equals(b.negate())) { // required because of rationals gcd
+            oc[0] = rf.getONE();
+            oc[1] = rf.getONE().negate();
+            return oc;
+        }
+        if (rf.isCommutative()) {
+            logger.info("right Ore condition on coefficients, commutative case: " + a + ", " + b);
+            C gcd = a.gcd(b);
+            if (gcd.isONE()) {
+                oc[0] = b;
+                oc[1] = a;
+                if (oc[0].compareTo(rf.getZERO()) < 0 && oc[1].compareTo(rf.getZERO()) < 0) {
+                    oc[0] = oc[0].negate();
+                    oc[1] = oc[1].negate();
+                }
+                return oc;
+            }
+            C p = a.multiply(b);
+            C lcm = p.divide(gcd).abs();
+            oc[0] = lcm.divide(a);
+            oc[1] = lcm.divide(b);
+            if (oc[0].compareTo(rf.getZERO()) < 0 && oc[1].compareTo(rf.getZERO()) < 0) {
+                oc[0] = oc[0].negate();
+                oc[1] = oc[1].negate();
+            }
+            logger.info("Ore multiple: " + lcm + ", " + Arrays.toString(oc));
+            return oc;
+        }
+        // now non-commutative
+        if (rf.isField()) {
+            logger.info("right Ore condition on coefficients, skew field " + rf + " case: " + a + ", " + b);
+            //C gcd = a.gcd(b); // always one 
+            //C lcm = rf.getONE();
+            oc[0] = a.inverse(); //lcm.divide(a);
+            oc[1] = b.inverse(); //lcm.divide(b);
+            logger.info("Ore multiple: " + Arrays.toString(oc));
+            return oc;
+        }
+        if (b instanceof StarRingElem) {
+            logger.info("right Ore condition on coefficients, StarRing case: " + a + ", " + b);
+            C bs = (C) ((StarRingElem) b).conjugate();
+            oc[0] = b.multiply(bs); // a b bar(b) = a s
+            oc[1] = bs.multiply(a); // b bar(b) a = s a 
+            logger.info("Ore multiple: " + Arrays.toString(oc));
+            return oc;
+        }
+        throw new UnsupportedOperationException(
+                        "rightOreCond not implemented for " + rf.getClass() + ", rf = " + rf.toScript());
+        //return oc;
+    }
+
+
+    /**
+     * Right Ore condition. Generators for the right Ore condition of two
+     * solvable polynomials.
+     * @param a solvable polynomial
+     * @param b solvable polynomial
+     * @return [p,q] with a*p = b*q
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    public GenSolvablePolynomial<C>[] rightOreCond(GenSolvablePolynomial<C> a, GenSolvablePolynomial<C> b) {
+        if (a == null || a.isZERO() || b == null || b.isZERO()) {
+            throw new IllegalArgumentException("a and b must be non zero");
+        }
+        GenSolvablePolynomialRing<C> pfac = a.ring;
+        GenSolvablePolynomial<C>[] oc = (GenSolvablePolynomial<C>[]) new GenSolvablePolynomial[2];
+        if (a.equals(b)) {
+            oc[0] = pfac.getONE();
+            oc[1] = pfac.getONE();
+            return oc;
+        }
+        if (a.equals(b.negate())) {
+            oc[0] = pfac.getONE();
+            oc[1] = (GenSolvablePolynomial<C>) pfac.getONE().negate();
+            return oc;
+        }
+        if (pfac.isCommutative()) {
+            logger.info("right Ore condition, polynomial commutative case: " + a + ", " + b);
+            edu.jas.ufd.GreatestCommonDivisorAbstract<C> cgcd = GCDFactory.<C> getImplementation(pfac.coFac);
+            GenSolvablePolynomial<C> lcm = (GenSolvablePolynomial<C>) cgcd.lcm(a, b);
+            //oc[0] = FDUtil.<C> basePseudoQuotient(lcm, a);
+            //oc[1] = FDUtil.<C> basePseudoQuotient(lcm, b);
+            oc[0] = (GenSolvablePolynomial<C>) PolyUtil.<C> basePseudoDivide(lcm, a);
+            oc[1] = (GenSolvablePolynomial<C>) PolyUtil.<C> basePseudoDivide(lcm, b);
+            logger.info("Ore multiple: " + lcm + ", " + Arrays.toString(oc));
+            return oc;
+        }
+        oc = syz.rightOreCond(a, b);
+        //logger.info("Ore multiple: " + oc[0].multiply(a) + ", " + Arrays.toString(oc));
+        return oc;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/GreatestCommonDivisorFake.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/GreatestCommonDivisorFake.java
@@ -1,0 +1,136 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.fd;
+
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * (Non-unique) factorization domain greatest common divisor common algorithms
+ * with monic polynomial remainder sequence. Fake implementation always returns
+ * 1 for any gcds.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class GreatestCommonDivisorFake<C extends GcdRingElem<C>> extends GreatestCommonDivisorAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GreatestCommonDivisorFake.class);
+
+
+    //private static final boolean debug = true; //logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     * @param cf coefficient ring.
+     */
+    public GreatestCommonDivisorFake(RingFactory<C> cf) {
+        super(cf);
+    }
+
+
+    /**
+     * Univariate GenSolvablePolynomial greatest common divisor. Uses
+     * pseudoRemainder for remainder.
+     * @param P univariate GenSolvablePolynomial.
+     * @param S univariate GenSolvablePolynomial.
+     * @return 1 = gcd(P,S) with P = P'*gcd(P,S) and S = S'*gcd(P,S).
+     */
+    @Override
+    public GenSolvablePolynomial<C> leftBaseGcd(GenSolvablePolynomial<C> P, GenSolvablePolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.ring.nvar > 1) {
+            throw new IllegalArgumentException(this.getClass().getName() + " no univariate polynomial");
+        }
+        logger.warn("fake gcd always returns 1");
+        return P.ring.getONE();
+    }
+
+
+    /**
+     * Univariate GenSolvablePolynomial right greatest common divisor. Uses
+     * pseudoRemainder for remainder.
+     * @param P univariate GenSolvablePolynomial.
+     * @param S univariate GenSolvablePolynomial.
+     * @return 1 = gcd(P,S) with P = gcd(P,S)*P' and S = gcd(P,S)*S'.
+     */
+    @Override
+    public GenSolvablePolynomial<C> rightBaseGcd(GenSolvablePolynomial<C> P, GenSolvablePolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.ring.nvar > 1) {
+            throw new IllegalArgumentException(this.getClass().getName() + " no univariate polynomial");
+        }
+        logger.warn("fake gcd always returns 1");
+        return P.ring.getONE();
+    }
+
+
+    /**
+     * Univariate GenSolvablePolynomial left recursive greatest common divisor.
+     * Uses pseudoRemainder for remainder.
+     * @param P univariate recursive GenSolvablePolynomial.
+     * @param S univariate recursive GenSolvablePolynomial.
+     * @return 1 = gcd(P,S) with P = P'*gcd(P,S)*p and S = S'*gcd(P,S)*s, where
+     *         deg_main(p) = deg_main(s) == 0.
+     */
+    @Override
+    public GenSolvablePolynomial<GenPolynomial<C>> leftRecursiveUnivariateGcd(
+                    GenSolvablePolynomial<GenPolynomial<C>> P, GenSolvablePolynomial<GenPolynomial<C>> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.ring.nvar > 1) {
+            throw new IllegalArgumentException("no univariate polynomial");
+        }
+        return P.ring.getONE();
+    }
+
+
+    /**
+     * Univariate GenSolvablePolynomial right recursive greatest common divisor.
+     * Uses pseudoRemainder for remainder.
+     * @param P univariate recursive GenSolvablePolynomial.
+     * @param S univariate recursive GenSolvablePolynomial.
+     * @return 1 = gcd(P,S) with P = p*gcd(P,S)*P' and S = s*gcd(P,S)*S', where
+     *         deg_main(p) = deg_main(s) == 0.
+     */
+    @Override
+    public GenSolvablePolynomial<GenPolynomial<C>> rightRecursiveUnivariateGcd(
+                    GenSolvablePolynomial<GenPolynomial<C>> P, GenSolvablePolynomial<GenPolynomial<C>> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.ring.nvar > 1) {
+            throw new IllegalArgumentException("no univariate polynomial");
+        }
+        return P.ring.getONE();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/GreatestCommonDivisorLR.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/GreatestCommonDivisorLR.java
@@ -1,0 +1,648 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.fd;
+
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gbufd.SolvableSyzygyAbstract;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.GenSolvablePolynomialRing;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * (Non-unique) factorization domain greatest common divisor common algorithms
+ * with monic polynomial remainder sequence. Fake implementation always returns
+ * 1 for any gcds.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class GreatestCommonDivisorLR<C extends GcdRingElem<C>> extends GreatestCommonDivisorAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GreatestCommonDivisorLR.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     * @param cf coefficient ring.
+     */
+    public GreatestCommonDivisorLR(RingFactory<C> cf) {
+        super(cf);
+    }
+
+
+    /**
+     * Constructor.
+     * @param cf coefficient ring.
+     * @param s algorithm for SolvableSyzygy computation.
+     */
+    public GreatestCommonDivisorLR(RingFactory<C> cf, SolvableSyzygyAbstract<C> s) {
+        super(cf, s);
+    }
+
+
+    /**
+     * Univariate GenSolvablePolynomial greatest common divisor. Uses
+     * pseudoRemainder for remainder.
+     * @param P univariate GenSolvablePolynomial.
+     * @param S univariate GenSolvablePolynomial.
+     * @return [P,S,coP,coS,left,right] with left * coP * right = P and left *
+     *         coS * right = S.
+     */
+    public GCDcoFactors<C> leftRightBaseGcd(GenSolvablePolynomial<C> P, GenSolvablePolynomial<C> S) {
+        if (S == null || P == null) {
+            throw new IllegalArgumentException("null polynomials not allowed");
+        }
+        GenSolvablePolynomialRing<C> ring = P.ring;
+        if (ring.nvar > 1) {
+            throw new IllegalArgumentException("no univariate polynomial");
+        }
+        GCDcoFactors<C> ret;
+        if (P.isZERO() || S.isZERO()) {
+            ret = new GCDcoFactors<C>(this, P, S, P, S, ring.getONE(), ring.getONE());
+            return ret;
+        }
+        // compute on coefficients
+        C contP = leftBaseContent(P);
+        C contS = leftBaseContent(S);
+        C contPS = contP.leftGcd(contS);
+        if (contPS.signum() < 0) {
+            contPS = contPS.negate();
+        }
+        if (debug) {
+            //System.out.println("contP = " + contP + ", contS = " + contS + ", leftGcd(contP,contS) = " + contPS);
+            C r1 = contP.leftDivide(contPS);
+            boolean t = contPS.multiply(r1).equals(contP);
+            if (!t) {
+                System.out.println("r1: " + r1 + " * " + contPS + " != " + contP + ", r1*cP="
+                                + contPS.multiply(r1));
+            }
+            C r2 = contS.leftDivide(contPS);
+            t = contPS.multiply(r2).equals(contS);
+            if (!t) {
+                System.out.println("r2: " + r2 + " * " + contPS + " != " + contS + ", r2*cS="
+                                + contPS.multiply(r2));
+            }
+            //System.out.println("leftGcd(contP,contS) = " + contPS);
+        }
+        GenSolvablePolynomial<C> p = (GenSolvablePolynomial<C>) P.leftDivideCoeff(contP);
+        GenSolvablePolynomial<C> s = (GenSolvablePolynomial<C>) S.leftDivideCoeff(contS);
+        if (debug) {
+            boolean t = p.multiplyLeft(contP).equals(P);
+            if (!t) {
+                System.out.println(
+                                "p: " + p + " * " + contP + " != " + P + ", p*cP=" + p.multiplyLeft(contP));
+            }
+            t = s.multiplyLeft(contS).equals(S);
+            if (!t) {
+                System.out.println(
+                                "s: " + s + " * " + contS + " != " + S + ", s*cS=" + s.multiplyLeft(contS));
+            }
+        }
+        // compute on main variable
+        if (p.isONE()) {
+            ret = new GCDcoFactors<C>(this, P, S, p, s, ring.valueOf(contPS), ring.getONE());
+            return ret;
+        }
+        if (s.isONE()) {
+            ret = new GCDcoFactors<C>(this, P, S, p, s, ring.valueOf(contPS), ring.getONE());
+            return ret;
+        }
+        boolean field = ring.coFac.isField();
+        GenSolvablePolynomial<C> r = p;
+        GenSolvablePolynomial<C> q = s;
+        GenSolvablePolynomial<C> x;
+        //System.out.println("baseGCD: q = " + q + ", r = " + r);
+        while (!r.isZERO()) {
+            x = FDUtil.<C> leftBaseSparsePseudoRemainder(q, r);
+            q = r;
+            if (field) {
+                r = x.monic();
+                //System.out.println("baseGCD: lc(q) = " + q.leadingBaseCoefficient() + ", lc(r) = " + r.leadingBaseCoefficient());
+            } else {
+                r = x;
+            }
+            //System.out.println("baseGCD: q = " + q + ", r = " + r);
+        }
+        q = leftBasePrimitivePart(q);
+        q = (GenSolvablePolynomial<C>) q.abs();
+        // not meaningful:
+        // adjust signum of contPS
+        //C qc = leftBaseContent(q);
+        //q = (GenSolvablePolynomial<C>) q.leftDivideCoeff(qc); 
+        //contPS = qc.multiply(contPS);
+        //System.out.println("leftGcd()*qc = " + contPS);
+        //q = rightBasePrimitivePart(q);
+        //System.out.println("baseGCD: q = " + q + ", r = " + r);
+        p = (GenSolvablePolynomial<C>) P.leftDivideCoeff(contPS); // not contP here
+        s = (GenSolvablePolynomial<C>) S.leftDivideCoeff(contPS); // not contS here
+        GenSolvablePolynomial<C> p1 = FDUtil.<C> leftBasePseudoQuotient(p, q); // TODO
+        GenSolvablePolynomial<C> s1 = FDUtil.<C> leftBasePseudoQuotient(s, q); // TODO 
+        //System.out.println("p1 = " + p1 + ", s1 = " + s1);
+        if (debug) {
+            boolean t = p1.multiply(q).equals(p);
+            if (!t) {
+                GenSolvablePolynomial<C> p1q = (GenSolvablePolynomial<C>) leftBasePrimitivePart(
+                                p1.multiply(q)).abs();
+                GenSolvablePolynomial<C> pp = (GenSolvablePolynomial<C>) leftBasePrimitivePart(p).abs();
+                if (!p1q.equals(pp)) {
+                    System.out.println("p1: " + p1 + " * " + q + " != " + p);
+                    System.out.println("pp(p1*q): " + p1q + " != " + pp);
+                }
+                p1q = p1.multiply(q);
+                pp = p;
+                C c1 = p1q.leadingBaseCoefficient();
+                C c2 = pp.leadingBaseCoefficient();
+                C[] oc = leftOreCond(c1, c2);
+                p1q = p1q.multiplyLeft(oc[0]);
+                pp = pp.multiplyLeft(oc[1]);
+                if (!p1q.equals(pp)) {
+                    System.out.println("p1q: " + p1q + " != " + pp);
+                }
+            }
+            t = s1.multiply(q).equals(s);
+            if (!t) {
+                GenSolvablePolynomial<C> s1q = (GenSolvablePolynomial<C>) leftBasePrimitivePart(
+                                s1.multiply(q)).abs();
+                GenSolvablePolynomial<C> sp = (GenSolvablePolynomial<C>) leftBasePrimitivePart(s).abs();
+                if (!s1q.equals(sp)) {
+                    System.out.println("s1: " + s1 + " * " + q + " != " + s);
+                    System.out.println("pp(s1*q): " + s1q + " != " + sp);
+                }
+                s1q = s1.multiply(q);
+                sp = s;
+                C c1 = s1q.leadingBaseCoefficient();
+                C c2 = sp.leadingBaseCoefficient();
+                C[] oc = leftOreCond(c1, c2);
+                s1q = s1q.multiplyLeft(oc[0]);
+                sp = sp.multiplyLeft(oc[1]);
+                if (!s1q.equals(sp)) {
+                    System.out.println("s1q: " + s1q + " != " + sp);
+                }
+            }
+            t = p.multiplyLeft(contPS).equals(P); // contPS q p1 == P
+            if (!t) {
+                System.out.println("p1P: " + contPS + " * " + p + " != " + P);
+            }
+            t = s.multiplyLeft(contPS).equals(S);
+            if (!t) {
+                System.out.println("s1S: " + contPS + " * " + s + " != " + S);
+            }
+            //System.out.println("isField: " + field);
+        }
+        ret = new GCDcoFactors<C>(this, P, S, p1, s1, ring.valueOf(contPS), q);
+        return ret;
+    }
+
+
+    /**
+     * Univariate GenSolvablePolynomial greatest common divisor. Uses
+     * pseudoRemainder for remainder.
+     * @param P univariate GenSolvablePolynomial.
+     * @param S univariate GenSolvablePolynomial.
+     * @return [P,S,coP,coS,left,right] with left * coP * right = P and left *
+     *         coS * right = S.
+     */
+    public GCDcoFactors<C> rightLeftBaseGcd(GenSolvablePolynomial<C> P, GenSolvablePolynomial<C> S) {
+        if (S == null || P == null) {
+            throw new IllegalArgumentException("null polynomials not allowed");
+        }
+        GenSolvablePolynomialRing<C> ring = P.ring;
+        if (ring.nvar > 1) {
+            throw new IllegalArgumentException("no univariate polynomial");
+        }
+        GCDcoFactors<C> ret;
+        if (P.isZERO() || S.isZERO()) {
+            ret = new GCDcoFactors<C>(this, P, S, P, S, ring.getONE(), ring.getONE());
+            return ret;
+        }
+        // compute on coefficients
+        C contP = rightBaseContent(P);
+        C contS = rightBaseContent(S);
+        C contPS = contP.rightGcd(contS);
+        if (contPS.signum() < 0) {
+            contPS = contPS.negate();
+        }
+        if (debug) {
+            //System.out.println("contP = " + contP + ", contS = " + contS + ", rightGcd(contP,contS) = " + contPS);
+            C r1 = contP.rightDivide(contPS);
+            boolean t = r1.multiply(contPS).equals(contP);
+            if (!t) {
+                System.out.println("r1: " + r1 + " * " + contPS + " != " + contP + ", r1*cP="
+                                + r1.multiply(contPS));
+            }
+            C r2 = contS.rightDivide(contPS);
+            t = r2.multiply(contPS).equals(contS);
+            if (!t) {
+                System.out.println("r2: " + r2 + " * " + contPS + " != " + contS + ", r2*cS="
+                                + r2.multiply(contPS));
+            }
+            //System.out.println("rightGcd(contP,contS) = " + contPS);
+        }
+        GenSolvablePolynomial<C> p = (GenSolvablePolynomial<C>) P.rightDivideCoeff(contP);
+        GenSolvablePolynomial<C> s = (GenSolvablePolynomial<C>) S.rightDivideCoeff(contS);
+        if (debug) {
+            boolean t = p.multiply(contP).equals(P);
+            if (!t) {
+                System.out.println("p: " + p + " * " + contP + " != " + P + ", p*cP=" + p.multiply(contP));
+            }
+            t = s.multiply(contS).equals(S);
+            if (!t) {
+                System.out.println("s: " + s + " * " + contS + " != " + S + ", s*cS=" + s.multiply(contS));
+            }
+        }
+        // compute on main variable
+        if (p.isONE()) {
+            ret = new GCDcoFactors<C>(this, P, S, p, s, ring.getONE(), ring.valueOf(contPS));
+            return ret;
+        }
+        if (s.isONE()) {
+            ret = new GCDcoFactors<C>(this, P, S, p, s, ring.getONE(), ring.valueOf(contPS));
+            return ret;
+        }
+        boolean field = ring.coFac.isField();
+        GenSolvablePolynomial<C> r = p;
+        GenSolvablePolynomial<C> q = s;
+        GenSolvablePolynomial<C> x;
+        //System.out.println("baseGCD: q = " + q + ", r = " + r);
+        while (!r.isZERO()) {
+            x = FDUtil.<C> rightBaseSparsePseudoRemainder(q, r);
+            q = r;
+            if (field) {
+                r = x.monic();
+                //System.out.println("baseGCD: lc(q) = " + q.leadingBaseCoefficient() + ", lc(r) = " + r.leadingBaseCoefficient());
+            } else {
+                r = x;
+            }
+            //System.out.println("baseGCD: r = " + r);
+        }
+        q = rightBasePrimitivePart(q);
+        q = (GenSolvablePolynomial<C>) q.abs();
+        //q = rightBasePrimitivePart(q);
+        //System.out.println("baseGCD: q = " + q + ", r = " + r);
+        p = (GenSolvablePolynomial<C>) P.rightDivideCoeff(contPS); // not contP here
+        s = (GenSolvablePolynomial<C>) S.rightDivideCoeff(contPS); // not contS here
+        GenSolvablePolynomial<C> p1 = FDUtil.<C> rightBasePseudoQuotient(p, q); // TODO
+        GenSolvablePolynomial<C> s1 = FDUtil.<C> rightBasePseudoQuotient(s, q); // TODO 
+        //System.out.println("p1 = " + p1 + ", s1 = " + s1);
+        if (debug) {
+            boolean t = q.multiply(p1).equals(p);
+            if (!t) {
+                GenSolvablePolynomial<C> p1q = p1.multiply(q);
+                GenSolvablePolynomial<C> pp = p;
+                C c1 = p1q.leadingBaseCoefficient();
+                C c2 = pp.leadingBaseCoefficient();
+                C[] oc = rightOreCond(c1, c2);
+                p1q = p1q.multiply(oc[0]);
+                pp = pp.multiply(oc[1]);
+                if (!p1q.equals(pp)) {
+                    System.out.println("p1q: " + p1q + " != " + pp);
+                }
+            }
+            t = q.multiply(s1).equals(s);
+            if (!t) {
+                GenSolvablePolynomial<C> s1q = q.multiply(s1);
+                GenSolvablePolynomial<C> sp = s;
+                C c1 = s1q.leadingBaseCoefficient();
+                C c2 = sp.leadingBaseCoefficient();
+                C[] oc = rightOreCond(c1, c2);
+                s1q = s1q.multiply(oc[0]);
+                sp = sp.multiply(oc[1]);
+                if (!s1q.equals(sp)) {
+                    System.out.println("s1q: " + s1q + " != " + sp);
+                }
+            }
+            t = p.multiply(contPS).equals(P); // contPS q p1 == P
+            if (!t) {
+                System.out.println("p1P: " + contPS + " * " + p + " != " + P);
+            }
+            t = s.multiply(contPS).equals(S);
+            if (!t) {
+                System.out.println("s1S: " + contPS + " * " + s + " != " + S);
+            }
+            //System.out.println("isField: " + field);
+        }
+        ret = new GCDcoFactors<C>(this, P, S, p1, s1, q, ring.valueOf(contPS));
+        return ret;
+    }
+
+
+    /**
+     * Univariate GenSolvablePolynomial greatest common divisor. Uses
+     * pseudoRemainder for remainder.
+     * @param P univariate GenSolvablePolynomial.
+     * @param S univariate GenSolvablePolynomial.
+     * @return l = gcd(P,S) with P = gcd(P,S)*P' and S = gcd(P,S)*S'.
+     */
+    @Override
+    public GenSolvablePolynomial<C> leftBaseGcd(GenSolvablePolynomial<C> P, GenSolvablePolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        GenSolvablePolynomialRing<C> ring = P.ring;
+        if (ring.nvar > 1) {
+            throw new IllegalArgumentException(this.getClass().getName() + " no univariate polynomial");
+        }
+        // compute on coefficients
+        C contP = leftBaseContent(P);
+        C contS = leftBaseContent(S);
+        C contPS = contP.leftGcd(contS);
+        if (contPS.signum() < 0) {
+            contPS = contPS.negate();
+        }
+        if (debug) {
+            //System.out.println("contP = " + contP + ", contS = " + contS + ", leftGcd(contP,contS) = " + contPS);
+            C r1 = contP.leftDivide(contPS);
+            boolean t = contPS.multiply(r1).equals(contP);
+            if (!t) {
+                System.out.println("r1: " + r1 + " * " + contPS + " != " + contP + ", r1*cP="
+                                + contPS.multiply(r1));
+            }
+            C r2 = contS.leftDivide(contPS);
+            t = contPS.multiply(r2).equals(contS);
+            if (!t) {
+                System.out.println("r2: " + r2 + " * " + contPS + " != " + contS + ", r2*cS="
+                                + contPS.multiply(r2));
+            }
+            //System.out.println("contPS = " + contPS);
+        }
+        GenSolvablePolynomial<C> p = (GenSolvablePolynomial<C>) P.leftDivideCoeff(contP);
+        GenSolvablePolynomial<C> s = (GenSolvablePolynomial<C>) S.leftDivideCoeff(contS);
+        if (debug) {
+            boolean t = p.multiplyLeft(contP).equals(P);
+            if (!t) {
+                System.out.println(
+                                "p: " + p + " * " + contP + " != " + P + ", p*cP=" + p.multiplyLeft(contP));
+            }
+            t = s.multiplyLeft(contS).equals(S);
+            if (!t) {
+                System.out.println(
+                                "s: " + s + " * " + contS + " != " + S + ", s*cS=" + s.multiplyLeft(contS));
+            }
+        }
+        // compute on main variable
+        if (p.isONE()) {
+            return ring.valueOf(contPS);
+        }
+        if (s.isONE()) {
+            return ring.valueOf(contPS);
+        }
+        boolean field = ring.coFac.isField();
+        GenSolvablePolynomial<C> r = p;
+        GenSolvablePolynomial<C> q = s;
+        GenSolvablePolynomial<C> x;
+        if (r.degree(0) > q.degree(0)) {
+            x = r;
+            r = q;
+            q = x;
+        }
+        //System.out.println("baseGCD: q = " + q + ", r = " + r);
+        while (!r.isZERO()) {
+            x = FDUtil.<C> rightBaseSparsePseudoRemainder(q, r);
+            q = r;
+            if (field) {
+                r = x.monic();
+            } else {
+                r = x;
+            }
+            //System.out.println("baseGCD: r = " + r);
+        }
+        q = leftBasePrimitivePart(q);
+        //q = rightBasePrimitivePart(q);
+        //q = (GenSolvablePolynomial<C>) q.abs();
+        //System.out.println("baseGCD: q = " + q + ", r = " + r);
+        GenSolvablePolynomial<C> p1 = FDUtil.<C> rightBasePseudoQuotient(p, q); // TODO
+        GenSolvablePolynomial<C> s1 = FDUtil.<C> rightBasePseudoQuotient(s, q); // TODO 
+        //System.out.println("p1 = " + p1 + ", s1 = " + s1);
+        if (debug) {
+            boolean t = q.multiply(p1).equals(p);
+            if (!t) {
+                GenSolvablePolynomial<C> p1q = q.multiply(p1);
+                GenSolvablePolynomial<C> pp = p;
+                C c1 = p1q.leadingBaseCoefficient();
+                C c2 = pp.leadingBaseCoefficient();
+                C[] oc = leftOreCond(c1, c2);
+                p1q = p1q.multiplyLeft(oc[0]);
+                pp = pp.multiplyLeft(oc[1]);
+                if (!p1q.equals(pp)) {
+                    System.out.println("Ore cond, p1q: " + p1q + " != " + pp);
+                }
+            }
+            t = q.multiply(s1).equals(s);
+            if (!t) {
+                GenSolvablePolynomial<C> s1q = q.multiply(s1);
+                GenSolvablePolynomial<C> sp = s;
+                C c1 = s1q.leadingBaseCoefficient();
+                C c2 = sp.leadingBaseCoefficient();
+                C[] oc = leftOreCond(c1, c2);
+                s1q = s1q.multiplyLeft(oc[0]);
+                sp = sp.multiplyLeft(oc[1]);
+                if (!s1q.equals(sp)) {
+                    System.out.println("Ore cond, s1q: " + s1q + " != " + sp);
+                }
+            }
+            t = p.multiplyLeft(contP).equals(P); // contPS q p1 == P
+            if (!t) {
+                System.out.println("p1P: " + contPS + " * " + p + " != " + P);
+            }
+            t = s.multiplyLeft(contS).equals(S); // PS
+            if (!t) {
+                System.out.println("s1S: " + contPS + " * " + s + " != " + S);
+            }
+            //System.out.println("isField: " + field);
+        }
+        return q.multiplyLeft(contPS);
+    }
+
+
+    /**
+     * Univariate GenSolvablePolynomial greatest common divisor. Uses
+     * pseudoRemainder for remainder.
+     * @param P univariate GenSolvablePolynomial.
+     * @param S univariate GenSolvablePolynomial.
+     * @return r = gcd(P,S) with P = P'*gcd(P,S) and S = S'*gcd(P,S).
+     */
+    @Override
+    public GenSolvablePolynomial<C> rightBaseGcd(GenSolvablePolynomial<C> P, GenSolvablePolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        GenSolvablePolynomialRing<C> ring = P.ring;
+        if (ring.nvar > 1) {
+            throw new IllegalArgumentException(this.getClass().getName() + " no univariate polynomial");
+        }
+        // compute on coefficients
+        C contP = rightBaseContent(P);
+        C contS = rightBaseContent(S);
+        C contPS = contP.rightGcd(contS);
+        if (contPS.signum() < 0) {
+            contPS = contPS.negate();
+        }
+        if (debug) {
+            //System.out.println("contP = " + contP + ", contS = " + contS + ", rightGcd(contP,contS) = " + contPS);
+            C r1 = contP.rightDivide(contPS);
+            boolean t = r1.multiply(contPS).equals(contP);
+            if (!t) {
+                System.out.println("r1: " + r1 + " * " + contPS + " != " + contP + ", r1*cP="
+                                + r1.multiply(contPS));
+            }
+            C r2 = contS.rightDivide(contPS);
+            t = r2.multiply(contPS).equals(contS);
+            if (!t) {
+                System.out.println("r2: " + r2 + " * " + contPS + " != " + contS + ", r2*cS="
+                                + r2.multiply(contPS));
+            }
+            //System.out.println("contPS = " + contPS);
+        }
+        GenSolvablePolynomial<C> p = (GenSolvablePolynomial<C>) P.rightDivideCoeff(contP);
+        GenSolvablePolynomial<C> s = (GenSolvablePolynomial<C>) S.rightDivideCoeff(contS);
+        if (debug) {
+            boolean t = p.multiply(contP).equals(P);
+            if (!t) {
+                System.out.println("p: " + p + " * " + contP + " != " + P + ", p*cP=" + p.multiply(contP));
+            }
+            t = s.multiply(contS).equals(S);
+            if (!t) {
+                System.out.println("s: " + s + " * " + contS + " != " + S + ", s*cS=" + s.multiply(contS));
+            }
+        }
+        // compute on main variable
+        if (p.isONE()) {
+            return ring.valueOf(contPS);
+        }
+        if (s.isONE()) {
+            return ring.valueOf(contPS);
+        }
+        boolean field = ring.coFac.isField();
+        GenSolvablePolynomial<C> r = p;
+        GenSolvablePolynomial<C> q = s;
+        GenSolvablePolynomial<C> x;
+        if (r.degree(0) > q.degree(0)) {
+            x = r;
+            r = q;
+            q = x;
+        }
+        //System.out.println("baseGCD: q = " + q + ", r = " + r);
+        while (!r.isZERO()) {
+            x = FDUtil.<C> leftBaseSparsePseudoRemainder(q, r);
+            q = r;
+            if (field) {
+                r = x.monic();
+            } else {
+                r = x;
+            }
+            //System.out.println("baseGCD: r = " + r);
+        }
+        //q = leftBasePrimitivePart(q);
+        q = rightBasePrimitivePart(q);
+        //q = (GenSolvablePolynomial<C>) q.abs();
+        //System.out.println("baseGCD: q = " + q + ", r = " + r);
+        GenSolvablePolynomial<C> p1 = FDUtil.<C> leftBasePseudoQuotient(p, q); // TODO
+        GenSolvablePolynomial<C> s1 = FDUtil.<C> leftBasePseudoQuotient(s, q); // TODO 
+        //System.out.println("p1 = " + p1 + ", s1 = " + s1);
+        if (debug) {
+            boolean t = p1.multiply(q).equals(p);
+            if (!t) {
+                GenSolvablePolynomial<C> p1q = p1.multiply(q);
+                GenSolvablePolynomial<C> pp = p;
+                C c1 = p1q.leadingBaseCoefficient();
+                C c2 = pp.leadingBaseCoefficient();
+                C[] oc = rightOreCond(c1, c2);
+                p1q = p1q.multiply(oc[0]);
+                pp = pp.multiply(oc[1]);
+                if (!p1q.equals(pp)) {
+                    System.out.println("Ore cond, p1q: " + p1q + " != " + pp);
+                }
+            }
+            t = s1.multiply(q).equals(s);
+            if (!t) {
+                GenSolvablePolynomial<C> s1q = s1.multiply(q);
+                GenSolvablePolynomial<C> sp = s;
+                C c1 = s1q.leadingBaseCoefficient();
+                C c2 = sp.leadingBaseCoefficient();
+                C[] oc = rightOreCond(c1, c2);
+                s1q = s1q.multiply(oc[0]);
+                sp = sp.multiply(oc[1]);
+                if (!s1q.equals(sp)) {
+                    System.out.println("Ore cond, s1q: " + s1q + " != " + sp);
+                }
+            }
+            t = p.multiply(contP).equals(P); // contPS q p1 == P
+            if (!t) {
+                System.out.println("p1P: " + contPS + " * " + p + " != " + P);
+            }
+            t = s.multiply(contS).equals(S); // PS
+            if (!t) {
+                System.out.println("s1S: " + contPS + " * " + s + " != " + S);
+            }
+            //System.out.println("isField: " + field);
+        }
+        return q.multiply(contPS);
+    }
+
+
+    /**
+     * Univariate GenSolvablePolynomial left recursive greatest common divisor.
+     * Uses pseudoRemainder for remainder.
+     * @param P univariate recursive GenSolvablePolynomial.
+     * @param S univariate recursive GenSolvablePolynomial.
+     * @return 1 = gcd(P,S) with P = P'*gcd(P,S)*p and S = S'*gcd(P,S)*s, where
+     *         deg_main(p) = deg_main(s) == 0.
+     */
+    @Override
+    public GenSolvablePolynomial<GenPolynomial<C>> leftRecursiveUnivariateGcd(
+                    GenSolvablePolynomial<GenPolynomial<C>> P, GenSolvablePolynomial<GenPolynomial<C>> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.ring.nvar > 1) {
+            throw new IllegalArgumentException("no univariate polynomial");
+        }
+        return P.ring.getONE();
+    }
+
+
+    /**
+     * Univariate GenSolvablePolynomial right recursive greatest common divisor.
+     * Uses pseudoRemainder for remainder.
+     * @param P univariate recursive GenSolvablePolynomial.
+     * @param S univariate recursive GenSolvablePolynomial.
+     * @return 1 = gcd(P,S) with P = p*gcd(P,S)*P' and S = s*gcd(P,S)*S', where
+     *         deg_main(p) = deg_main(s) == 0.
+     */
+    @Override
+    public GenSolvablePolynomial<GenPolynomial<C>> rightRecursiveUnivariateGcd(
+                    GenSolvablePolynomial<GenPolynomial<C>> P, GenSolvablePolynomial<GenPolynomial<C>> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.ring.nvar > 1) {
+            throw new IllegalArgumentException("no univariate polynomial");
+        }
+        return P.ring.getONE();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/GreatestCommonDivisorPrimitive.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/GreatestCommonDivisorPrimitive.java
@@ -1,0 +1,411 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.fd;
+
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * (Non-unique) factorization domain greatest common divisor common algorithms
+ * with primitive polynomial remainder sequence.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class GreatestCommonDivisorPrimitive<C extends GcdRingElem<C>> extends
+                GreatestCommonDivisorAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GreatestCommonDivisorPrimitive.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     * @param cf coefficient ring.
+     */
+    public GreatestCommonDivisorPrimitive(RingFactory<C> cf) {
+        super(cf);
+    }
+
+
+    /**
+     * Univariate GenSolvablePolynomial greatest common divisor. Uses
+     * pseudoRemainder for remainder.
+     * @param P univariate GenSolvablePolynomial.
+     * @param S univariate GenSolvablePolynomial.
+     * @return gcd(P,S) with P = P'*gcd(P,S) and S = S'*gcd(P,S).
+     */
+    @Override
+    public GenSolvablePolynomial<C> leftBaseGcd(GenSolvablePolynomial<C> P, GenSolvablePolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.ring.nvar > 1) {
+            throw new IllegalArgumentException(this.getClass().getName() + " no univariate polynomial");
+        }
+        boolean field = P.ring.coFac.isField();
+        long e = P.degree(0);
+        long f = S.degree(0);
+        GenSolvablePolynomial<C> q;
+        GenSolvablePolynomial<C> r;
+        if (f > e) {
+            r = P;
+            q = S;
+            long g = f;
+            f = e;
+            e = g;
+        } else {
+            q = P;
+            r = S;
+        }
+        if (debug) {
+            logger.debug("degrees: e = " + e + ", f = " + f);
+        }
+        C c;
+        if (field) {
+            r = r.monic();
+            q = q.monic();
+            c = P.ring.getONECoefficient();
+        } else {
+            r = (GenSolvablePolynomial<C>) r.abs();
+            q = (GenSolvablePolynomial<C>) q.abs();
+            C a = rightBaseContent(r);
+            C b = rightBaseContent(q);
+            r = divide(r, a); // indirection
+            q = divide(q, b); // indirection
+            c = gcd(a, b); // indirection
+        }
+        //System.out.println("baseCont: gcd(cont) = " + b);
+        if (r.isONE()) {
+            return r.multiply(c);
+        }
+        if (q.isONE()) {
+            return q.multiply(c);
+        }
+        GenSolvablePolynomial<C> x;
+        //System.out.println("baseGCD: q = " + q);
+        //System.out.println("baseGCD: r = " + r);
+        while (!r.isZERO()) {
+            x = FDUtil.<C> leftBaseSparsePseudoRemainder(q, r);
+            q = r;
+            if (field) {
+                r = x.monic();
+            } else {
+                r = leftBasePrimitivePart(x);
+            }
+            //System.out.println("baseGCD: q = " + q);
+            //System.out.println("baseGCD: r = " + r);
+        }
+        return (GenSolvablePolynomial<C>) (q.multiply(c)).abs();
+    }
+
+
+    /**
+     * Univariate GenSolvablePolynomial right greatest common divisor. Uses
+     * pseudoRemainder for remainder.
+     * @param P univariate GenSolvablePolynomial.
+     * @param S univariate GenSolvablePolynomial.
+     * @return gcd(P,S) with P = gcd(P,S)*P' and S = gcd(P,S)*S'.
+     */
+    @Override
+    public GenSolvablePolynomial<C> rightBaseGcd(GenSolvablePolynomial<C> P, GenSolvablePolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.ring.nvar > 1) {
+            throw new IllegalArgumentException(this.getClass().getName() + " no univariate polynomial");
+        }
+        boolean field = P.ring.coFac.isField();
+        long e = P.degree(0);
+        long f = S.degree(0);
+        GenSolvablePolynomial<C> q;
+        GenSolvablePolynomial<C> r;
+        if (f > e) {
+            r = P;
+            q = S;
+            long g = f;
+            f = e;
+            e = g;
+        } else {
+            q = P;
+            r = S;
+        }
+        if (debug) {
+            logger.debug("degrees: e = " + e + ", f = " + f);
+        }
+        C c;
+        if (field) {
+            r = r.monic();
+            q = q.monic();
+            c = P.ring.getONECoefficient();
+        } else {
+            r = (GenSolvablePolynomial<C>) r.abs();
+            q = (GenSolvablePolynomial<C>) q.abs();
+            C a = leftBaseContent(r);
+            C b = leftBaseContent(q);
+            r = divide(r, a); // indirection
+            q = divide(q, b); // indirection
+            c = gcd(a, b); // indirection
+        }
+        //System.out.println("baseCont: gcd(cont) = " + b);
+        if (r.isONE()) {
+            return r.multiply(c);
+        }
+        if (q.isONE()) {
+            return q.multiply(c);
+        }
+        GenSolvablePolynomial<C> x;
+        //System.out.println("baseGCD: q = " + q);
+        //System.out.println("baseGCD: r = " + r);
+        while (!r.isZERO()) {
+            x = FDUtil.<C> rightBaseSparsePseudoRemainder(q, r);
+            q = r;
+            if (field) {
+                r = x.monic();
+            } else {
+                r = rightBasePrimitivePart(x);
+            }
+            //System.out.println("baseGCD: q = " + q);
+            //System.out.println("baseGCD: r = " + r);
+        }
+        return (GenSolvablePolynomial<C>) (q.multiplyLeft(c)).abs();
+    }
+
+
+    /**
+     * Univariate GenSolvablePolynomial left recursive greatest common divisor.
+     * Uses pseudoRemainder for remainder.
+     * @param P univariate recursive GenSolvablePolynomial.
+     * @param S univariate recursive GenSolvablePolynomial.
+     * @return gcd(P,S) with P = P'*gcd(P,S)*p and S = S'*gcd(P,S)*s, where
+     *         deg_main(p) = deg_main(s) == 0.
+     */
+    @Override
+    public GenSolvablePolynomial<GenPolynomial<C>> leftRecursiveUnivariateGcd(
+                    GenSolvablePolynomial<GenPolynomial<C>> P, GenSolvablePolynomial<GenPolynomial<C>> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.ring.nvar > 1) {
+            throw new IllegalArgumentException("no univariate polynomial");
+        }
+        boolean field = P.leadingBaseCoefficient().ring.coFac.isField();
+        long e = P.degree(0);
+        long f = S.degree(0);
+        GenSolvablePolynomial<GenPolynomial<C>> q, r, x, qs, rs;
+        if (f > e) {
+            r = P;
+            q = S;
+            long g = f;
+            f = e;
+            e = g;
+        } else if (f < e) {
+            q = P;
+            r = S;
+        } else { // f == e
+            if (P.leadingBaseCoefficient().degree() > S.leadingBaseCoefficient().degree()) {
+                q = P;
+                r = S;
+            } else {
+                r = P;
+                q = S;
+            }
+        }
+        if (debug) {
+            logger.debug("degrees: e = " + e + ", f = " + f);
+        }
+        if (field) {
+            r = PolyUtil.<C> monic(r);
+            q = PolyUtil.<C> monic(q);
+        } else {
+            r = (GenSolvablePolynomial<GenPolynomial<C>>) r.abs();
+            q = (GenSolvablePolynomial<GenPolynomial<C>>) q.abs();
+        }
+        GenSolvablePolynomial<C> a = rightRecursiveContent(r);
+        rs = FDUtil.<C> recursiveLeftDivide(r, a);
+        if (debug) {
+            logger.info("recCont a = " + a + ", r = " + r);
+            logger.info("recCont r/a = " + rs + ", r%a = " + r.subtract(rs.multiply(a)));
+            if (!r.equals(rs.multiply(a))) {
+                System.out.println("recGcd, r         = " + r);
+                System.out.println("recGcd, cont(r)   = " + a);
+                System.out.println("recGcd, pp(r)     = " + rs);
+                System.out.println("recGcd, pp(r)c(r) = " + rs.multiply(a));
+                System.out.println("recGcd, c(r)pp(r) = " + rs.multiplyLeft(a));
+                throw new RuntimeException("recGcd, pp: not divisible");
+            }
+        }
+        r = rs;
+        GenSolvablePolynomial<C> b = rightRecursiveContent(q);
+        qs = FDUtil.<C> recursiveLeftDivide(q, b);
+        if (debug) {
+            logger.info("recCont b = " + b + ", q = " + q);
+            logger.info("recCont q/b = " + qs + ", q%b = " + q.subtract(qs.multiply(b)));
+            if (!q.equals(qs.multiply(b))) {
+                System.out.println("recGcd, q         = " + q);
+                System.out.println("recGcd, cont(q)   = " + b);
+                System.out.println("recGcd, pp(q)     = " + qs);
+                System.out.println("recGcd, pp(q)c(q) = " + qs.multiply(b));
+                System.out.println("recGcd, c(q)pp(q) = " + qs.multiplyLeft(b));
+                throw new RuntimeException("recGcd, pp: not divisible");
+            }
+        }
+        q = qs;
+        //no: GenSolvablePolynomial<C> c = leftGcd(a, b); // go to recursion
+        GenSolvablePolynomial<C> c = rightGcd(a, b); // go to recursion
+        logger.info("Gcd(contents) c = " + c + ", a = " + a + ", b = " + b);
+        if (r.isONE()) {
+            return r.multiply(c);
+        }
+        if (q.isONE()) {
+            return q.multiply(c);
+        }
+        if (debug) {
+            logger.info("r.ring = " + r.ring.toScript());
+        }
+        while (!r.isZERO()) {
+            x = FDUtil.<C> recursiveSparsePseudoRemainder(q, r);
+            q = r;
+            r = rightRecursivePrimitivePart(x);
+            if (field) {
+                r = PolyUtil.<C> monic(r);
+            }
+        }
+        if (debug) {
+            logger.info("gcd(pp) = " + q + ", ring = " + P.ring.toScript());
+        }
+        q = (GenSolvablePolynomial<GenPolynomial<C>>) q.multiply(c).abs();
+        return q;
+    }
+
+
+    /**
+     * Univariate GenSolvablePolynomial right recursive greatest common divisor.
+     * Uses pseudoRemainder for remainder.
+     * @param P univariate recursive GenSolvablePolynomial.
+     * @param S univariate recursive GenSolvablePolynomial.
+     * @return gcd(P,S) with P = p*gcd(P,S)*P' and S = s*gcd(P,S)*S', where
+     *         deg_main(p) = deg_main(s) == 0.
+     */
+    @Override
+    public GenSolvablePolynomial<GenPolynomial<C>> rightRecursiveUnivariateGcd(
+                    GenSolvablePolynomial<GenPolynomial<C>> P, GenSolvablePolynomial<GenPolynomial<C>> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.ring.nvar > 1) {
+            throw new IllegalArgumentException("no univariate polynomial");
+        }
+        boolean field = P.leadingBaseCoefficient().ring.coFac.isField();
+        long e = P.degree(0);
+        long f = S.degree(0);
+        GenSolvablePolynomial<GenPolynomial<C>> q, r, x, qs, rs;
+        if (f > e) {
+            r = P;
+            q = S;
+            long g = f;
+            f = e;
+            e = g;
+        } else if (f < e) {
+            q = P;
+            r = S;
+        } else { // f == e
+            if (P.leadingBaseCoefficient().degree() > S.leadingBaseCoefficient().degree()) {
+                q = P;
+                r = S;
+            } else {
+                r = P;
+                q = S;
+            }
+        }
+        if (debug) {
+            logger.debug("RI-degrees: e = " + e + ", f = " + f);
+        }
+        if (field) {
+            r = PolyUtil.<C> monic(r);
+            q = PolyUtil.<C> monic(q);
+        } else {
+            r = (GenSolvablePolynomial<GenPolynomial<C>>) r.abs();
+            q = (GenSolvablePolynomial<GenPolynomial<C>>) q.abs();
+        }
+        GenSolvablePolynomial<C> a = leftRecursiveContent(r);
+        rs = FDUtil.<C> recursiveRightDivide(r, a);
+        if (debug) {
+            logger.info("RI-recCont a = " + a + ", r = " + r);
+            logger.info("RI-recCont r/a = " + r + ", r%a = " + r.subtract(rs.multiplyLeft(a)));
+            if (!r.equals(rs.multiplyLeft(a))) {
+                System.out.println("RI-recGcd, r         = " + r);
+                System.out.println("RI-recGcd, cont(r)   = " + a);
+                System.out.println("RI-recGcd, pp(r)     = " + rs);
+                System.out.println("RI-recGcd, c(r)pp(r) = " + rs.multiplyLeft(a));
+                throw new RuntimeException("RI-recGcd, pp: not divisible");
+            }
+        }
+        r = rs;
+        GenSolvablePolynomial<C> b = leftRecursiveContent(q);
+        qs = FDUtil.<C> recursiveRightDivide(q, b);
+        if (debug) {
+            logger.info("RI-recCont b = " + b + ", q = " + q);
+            logger.info("RI-recCont q/b = " + qs + ", q%b = " + q.subtract(qs.multiplyLeft(b)));
+            if (!q.equals(qs.multiplyLeft(b))) {
+                System.out.println("RI-recGcd, q         = " + q);
+                System.out.println("RI-recGcd, cont(q)   = " + b);
+                System.out.println("RI-recGcd, pp(q)     = " + qs);
+                System.out.println("RI-recGcd, c(q)pp(q) = " + qs.multiplyLeft(b));
+                throw new RuntimeException("RI-recGcd, pp: not divisible");
+            }
+        }
+        q = qs;
+        //no: GenSolvablePolynomial<C> c = rightGcd(a, b); // go to recursion
+        GenSolvablePolynomial<C> c = leftGcd(a, b); // go to recursion
+        logger.info("RI-Gcd(contents) c = " + c + ", a = " + a + ", b = " + b);
+        if (r.isONE()) {
+            return r.multiplyLeft(c);
+        }
+        if (q.isONE()) {
+            return q.multiplyLeft(c);
+        }
+        if (debug) {
+            logger.info("RI-r.ring = " + r.ring.toScript());
+        }
+        while (!r.isZERO()) {
+            x = FDUtil.<C> recursiveRightSparsePseudoRemainder(q, r);
+            q = r;
+            r = leftRecursivePrimitivePart(x);
+            if (field) {
+                r = PolyUtil.<C> monic(r);
+            }
+        }
+        if (debug) {
+            logger.info("RI-gcd(pp) = " + q + ", ring = " + P.ring.toScript());
+        }
+        q = (GenSolvablePolynomial<GenPolynomial<C>>) q.multiplyLeft(c).abs();
+        return q;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/GreatestCommonDivisorSimple.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/GreatestCommonDivisorSimple.java
@@ -1,0 +1,470 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.fd;
+
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * (Non-unique) factorization domain greatest common divisor common algorithms
+ * with monic polynomial remainder sequence. If C is a field, then the monic PRS
+ * (on coefficients) is computed otherwise no simplifications in the reduction
+ * are made.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class GreatestCommonDivisorSimple<C extends GcdRingElem<C>> extends GreatestCommonDivisorAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GreatestCommonDivisorSimple.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     * @param cf coefficient ring.
+     */
+    public GreatestCommonDivisorSimple(RingFactory<C> cf) {
+        super(cf);
+    }
+
+
+    /**
+     * Univariate GenSolvablePolynomial greatest common divisor. Uses
+     * pseudoRemainder for remainder.
+     * @param P univariate GenSolvablePolynomial.
+     * @param S univariate GenSolvablePolynomial.
+     * @return gcd(P,S) with P = P'*gcd(P,S) and S = S'*gcd(P,S).
+     */
+    @Override
+    public GenSolvablePolynomial<C> leftBaseGcd(GenSolvablePolynomial<C> P, GenSolvablePolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.ring.nvar > 1) {
+            throw new IllegalArgumentException(this.getClass().getName() + " no univariate polynomial");
+        }
+        boolean field = P.ring.coFac.isField();
+        long e = P.degree(0);
+        long f = S.degree(0);
+        GenSolvablePolynomial<C> q;
+        GenSolvablePolynomial<C> r;
+        if (f > e) {
+            r = P;
+            q = S;
+            long g = f;
+            f = e;
+            e = g;
+        } else {
+            q = P;
+            r = S;
+        }
+        if (debug) {
+            logger.debug("degrees: e = " + e + ", f = " + f);
+        }
+        C c;
+        if (field) {
+            r = r.monic();
+            q = q.monic();
+            c = P.ring.getONECoefficient();
+        } else {
+            r = (GenSolvablePolynomial<C>) r.abs();
+            q = (GenSolvablePolynomial<C>) q.abs();
+            C a = rightBaseContent(r);
+            C b = rightBaseContent(q);
+            r = divide(r, a); // indirection
+            q = divide(q, b); // indirection
+            c = gcd(a, b); // indirection
+        }
+        //System.out.println("baseCont: gcd(cont) = " + b);
+        if (r.isONE()) {
+            return r.multiply(c);
+        }
+        if (q.isONE()) {
+            return q.multiply(c);
+        }
+        GenSolvablePolynomial<C> x;
+        //System.out.println("baseGCD: q = " + q);
+        //System.out.println("baseGCD: r = " + r);
+        while (!r.isZERO()) {
+            x = FDUtil.<C> leftBaseSparsePseudoRemainder(q, r);
+            q = r;
+            if (field) {
+                r = x.monic();
+            } else {
+                r = x;
+            }
+            //System.out.println("baseGCD: q = " + q);
+            //System.out.println("baseGCD: r = " + r);
+        }
+        ///q = leftBasePrimitivePart(q);
+        q = rightBasePrimitivePart(q);
+        return (GenSolvablePolynomial<C>) (q.multiply(c)).abs();
+    }
+
+
+    /**
+     * Univariate GenSolvablePolynomial right greatest common divisor. Uses
+     * pseudoRemainder for remainder.
+     * @param P univariate GenSolvablePolynomial.
+     * @param S univariate GenSolvablePolynomial.
+     * @return gcd(P,S) with P = gcd(P,S)*P' and S = gcd(P,S)*S'.
+     */
+    @Override
+    public GenSolvablePolynomial<C> rightBaseGcd(GenSolvablePolynomial<C> P, GenSolvablePolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.ring.nvar > 1) {
+            throw new IllegalArgumentException(this.getClass().getName() + " no univariate polynomial");
+        }
+        boolean field = P.ring.coFac.isField();
+        long e = P.degree(0);
+        long f = S.degree(0);
+        GenSolvablePolynomial<C> q;
+        GenSolvablePolynomial<C> r;
+        if (f > e) {
+            r = P;
+            q = S;
+            long g = f;
+            f = e;
+            e = g;
+        } else {
+            q = P;
+            r = S;
+        }
+        if (debug) {
+            logger.debug("degrees: e = " + e + ", f = " + f);
+        }
+        C c;
+        if (field) {
+            r = r.monic();
+            q = q.monic();
+            c = P.ring.getONECoefficient();
+        } else {
+            r = (GenSolvablePolynomial<C>) r.abs();
+            q = (GenSolvablePolynomial<C>) q.abs();
+            C a = leftBaseContent(r);
+            C b = leftBaseContent(q);
+            r = divide(r, a); // indirection
+            q = divide(q, b); // indirection
+            c = gcd(a, b); // indirection
+        }
+        //System.out.println("baseCont: gcd(cont) = " + b);
+        if (r.isONE()) {
+            return r.multiply(c);
+        }
+        if (q.isONE()) {
+            return q.multiply(c);
+        }
+        GenSolvablePolynomial<C> x;
+        //System.out.println("baseGCD: q = " + q);
+        //System.out.println("baseGCD: r = " + r);
+        while (!r.isZERO()) {
+            x = FDUtil.<C> rightBaseSparsePseudoRemainder(q, r);
+            q = r;
+            if (field) {
+                r = x.monic();
+            } else {
+                r = x;
+            }
+            //System.out.println("baseGCD: q = " + q);
+            //System.out.println("baseGCD: r = " + r);
+        }
+        ///q = rightBasePrimitivePart(q);
+        q = leftBasePrimitivePart(q);
+        return (GenSolvablePolynomial<C>) (q.multiplyLeft(c)).abs();
+    }
+
+
+    /**
+     * Univariate GenSolvablePolynomial left recursive greatest common divisor.
+     * Uses pseudoRemainder for remainder.
+     * @param P univariate recursive GenSolvablePolynomial.
+     * @param S univariate recursive GenSolvablePolynomial.
+     * @return gcd(P,S) with P = P'*gcd(P,S)*p and S = S'*gcd(P,S)*s, where
+     *         deg_main(p) = deg_main(s) == 0.
+     */
+    @Override
+    public GenSolvablePolynomial<GenPolynomial<C>> leftRecursiveUnivariateGcd(
+                    GenSolvablePolynomial<GenPolynomial<C>> P, GenSolvablePolynomial<GenPolynomial<C>> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.ring.nvar > 1) {
+            throw new IllegalArgumentException("no univariate polynomial");
+        }
+        boolean field = P.leadingBaseCoefficient().ring.coFac.isField();
+        long e = P.degree(0);
+        long f = S.degree(0);
+        GenSolvablePolynomial<GenPolynomial<C>> q, r, x, qs, rs, qp, rp;
+        if (f > e) {
+            r = P;
+            q = S;
+            long g = f;
+            f = e;
+            e = g;
+        } else if (f < e) {
+            q = P;
+            r = S;
+        } else { // f == e
+            if (P.leadingBaseCoefficient().degree() > S.leadingBaseCoefficient().degree()) {
+                q = P;
+                r = S;
+            } else {
+                r = P;
+                q = S;
+            }
+        }
+        if (debug) {
+            logger.debug("degrees: e = " + e + ", f = " + f);
+        }
+        if (field) {
+            r = PolyUtil.<C> monic(r);
+            q = PolyUtil.<C> monic(q);
+        } else {
+            r = (GenSolvablePolynomial<GenPolynomial<C>>) r.abs();
+            q = (GenSolvablePolynomial<GenPolynomial<C>>) q.abs();
+        }
+        GenSolvablePolynomial<C> a = rightRecursiveContent(r);
+        ///rs = FDUtil.<C> recursiveDivideRightEval(r, a);  
+        rs = FDUtil.<C> recursiveLeftDivide(r, a); 
+        //rs = FDUtil.<C> recursiveRightDivide(r, a);
+        if (debug) {
+            logger.info("recCont a = " + a + ", r = " + r);
+            logger.info("recCont r/a = " + rs + ", r%a = " + r.subtract(rs.multiply(a)));
+            if (!r.equals(rs.multiply(a))) {
+                if (!rs.multiplyLeft(a).equals(r)) {
+                    System.out.println("recGcd, r         = " + r);
+                    System.out.println("recGcd, cont(r)   = " + a);
+                    System.out.println("recGcd, pp(r)     = " + rs);
+                    System.out.println("recGcd, pp(r)c(r) = " + rs.multiply(a));
+                    System.out.println("recGcd, c(r)pp(r) = " + rs.multiplyLeft(a));
+                    throw new RuntimeException("recGcd, pp: not divisible");
+                }
+            }
+        }
+        r = rs;
+        GenSolvablePolynomial<C> b = rightRecursiveContent(q);
+        ///qs = FDUtil.<C> recursiveDivideRightEval(q, b);  
+        qs = FDUtil.<C> recursiveLeftDivide(q, b); 
+        //qs = FDUtil.<C> recursiveRightDivide(q, b);
+        if (debug) {
+            logger.info("recCont b = " + b + ", q = " + q);
+            logger.info("recCont q/b = " + qs + ", q%b = " + q.subtract(qs.multiply(b)));
+            if (!q.equals(qs.multiply(b))) {
+                if (!qs.multiplyLeft(b).equals(q)) {
+                    System.out.println("recGcd, q         = " + q);
+                    System.out.println("recGcd, cont(q)   = " + b);
+                    System.out.println("recGcd, pp(q)     = " + qs);
+                    System.out.println("recGcd, pp(q)c(q) = " + qs.multiply(b));
+                    System.out.println("recGcd, c(q)pp(q) = " + qs.multiplyLeft(b));
+                    throw new RuntimeException("recGcd, pp: not divisible");
+                }
+            }
+        }
+        q = qs;
+        logger.info("Gcd(content).ring = " + a.ring.toScript() + ", a = " + a + ", b = " + b);
+        //no: GenSolvablePolynomial<C> c = leftGcd(a, b); // go to recursion
+        GenSolvablePolynomial<C> c = rightGcd(a, b); // go to recursion
+        logger.info("Gcd(contents) c = " + c + ", a = " + a + ", b = " + b);
+        if (r.isONE()) {
+            return r.multiply(c);
+        }
+        if (q.isONE()) {
+            return q.multiply(c);
+        }
+        if (debug) {
+            logger.info("r.ring = " + r.ring.toScript());
+            logger.info("gcd-loop, start: q = " + q + ", r = " + r);
+        }
+        while (!r.isZERO()) {
+            x = FDUtil.<C> recursiveSparsePseudoRemainder(q, r);
+            q = r;
+            if (field) {
+                r = PolyUtil.<C> monic(x);
+            } else {
+                r = x;
+            }
+            if (debug) {
+                logger.info("gcd-loop, rem: q = " + q + ", r = " + r);
+            }
+        }
+        if (debug) {
+            logger.info("gcd(div) = " + q + ", rs = " + rs + ", qs = " + qs);
+            rp = FDUtil.<C> recursiveSparsePseudoRemainder(rs, q);
+            qp = FDUtil.<C> recursiveSparsePseudoRemainder(qs, q);
+            if (!qp.isZERO() || !rp.isZERO()) {
+                logger.info("gcd(div): rem(r,g) = " + rp + ", rem(q,g) = " + qp);
+                rp = FDUtil.<C> recursivePseudoQuotient(rs, q);
+                qp = FDUtil.<C> recursivePseudoQuotient(qs, q);
+                logger.info("gcd(div): r/g = " + rp + ", q/g = " + qp);
+                throw new RuntimeException("recGcd, div: not divisible");
+            }
+        }
+        qp = q;
+        q = rightRecursivePrimitivePart(q);
+        if (!qp.equals(q)) {
+            logger.info("gcd(pp) = " + q + ", qp = " + qp);
+        }
+        q = (GenSolvablePolynomial<GenPolynomial<C>>) q.multiply(c).abs();
+        return q;
+    }
+
+
+    /**
+     * Univariate GenSolvablePolynomial right recursive greatest common divisor.
+     * Uses pseudoRemainder for remainder.
+     * @param P univariate recursive GenSolvablePolynomial.
+     * @param S univariate recursive GenSolvablePolynomial.
+     * @return gcd(P,S) with P = p*gcd(P,S)*P' and S = s*gcd(P,S)*S', where
+     *         deg_main(p) = deg_main(s) == 0.
+     */
+    @Override
+    public GenSolvablePolynomial<GenPolynomial<C>> rightRecursiveUnivariateGcd(
+                    GenSolvablePolynomial<GenPolynomial<C>> P, GenSolvablePolynomial<GenPolynomial<C>> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.ring.nvar > 1) {
+            throw new IllegalArgumentException("no univariate polynomial");
+        }
+        boolean field = P.leadingBaseCoefficient().ring.coFac.isField();
+        long e = P.degree(0);
+        long f = S.degree(0);
+        GenSolvablePolynomial<GenPolynomial<C>> q, r, x, qs, rs, qp, rp;
+        if (f > e) {
+            r = P;
+            q = S;
+            long g = f;
+            f = e;
+            e = g;
+        } else if (f < e) {
+            q = P;
+            r = S;
+        } else { // f == e
+            if (P.leadingBaseCoefficient().degree() > S.leadingBaseCoefficient().degree()) {
+                q = P;
+                r = S;
+            } else {
+                r = P;
+                q = S;
+            }
+        }
+        if (debug) {
+            logger.debug("RI-degrees: e = " + e + ", f = " + f);
+        }
+        if (field) {
+            r = PolyUtil.<C> monic(r);
+            q = PolyUtil.<C> monic(q);
+        } else {
+            r = (GenSolvablePolynomial<GenPolynomial<C>>) r.abs();
+            q = (GenSolvablePolynomial<GenPolynomial<C>>) q.abs();
+        }
+        GenSolvablePolynomial<C> a = leftRecursiveContent(r);
+        rs = FDUtil.<C> recursiveRightDivide(r, a);
+        //no: rs = FDUtil.<C> recursiveLeftDivide(r, a);
+        //no: rs = FDUtil.<C> recursiveRightPseudoQuotient(r, a);
+        if (debug) {
+            logger.info("RI-recCont a = " + a + ", r = " + r);
+            logger.info("RI-recCont r/a = " + r + ", r%a = " + r.subtract(rs.multiplyLeft(a)));
+            if (!r.equals(rs.multiplyLeft(a))) { // Left
+                System.out.println("RI-recGcd, r         = " + r);
+                System.out.println("RI-recGcd, cont(r)   = " + a);
+                System.out.println("RI-recGcd, pp(r)     = " + rs);
+                System.out.println("RI-recGcd, pp(r)c(r) = " + rs.multiply(a));
+                System.out.println("RI-recGcd, c(r)pp(r) = " + rs.multiplyLeft(a));
+                throw new RuntimeException("RI-recGcd, pp: not divisible");
+            }
+        }
+        r = rs;
+        GenSolvablePolynomial<C> b = leftRecursiveContent(q);
+        qs = FDUtil.<C> recursiveRightDivide(q, b);
+        if (debug) {
+            logger.info("RI-recCont b = " + b + ", q = " + q);
+            logger.info("RI-recCont q/b = " + qs + ", q%b = " + q.subtract(qs.multiplyLeft(b)));
+            if (!q.equals(qs.multiplyLeft(b))) { // Left
+                System.out.println("RI-recGcd, q         = " + q);
+                System.out.println("RI-recGcd, cont(q)   = " + b);
+                System.out.println("RI-recGcd, pp(q)     = " + qs);
+                System.out.println("RI-recGcd, pp(q)c(q) = " + qs.multiply(b));
+                System.out.println("RI-recGcd, c(q)pp(q) = " + qs.multiplyLeft(b));
+                throw new RuntimeException("RI-recGcd, pp: not divisible");
+            }
+        }
+        q = qs;
+        //no: GenSolvablePolynomial<C> c = rightGcd(a, b); // go to recursion
+        GenSolvablePolynomial<C> c = leftGcd(a, b); // go to recursion
+        logger.info("RI-Gcd(contents) c = " + c + ", a = " + a + ", b = " + b);
+        if (r.isONE()) {
+            return r.multiplyLeft(c);
+        }
+        if (q.isONE()) {
+            return q.multiplyLeft(c);
+        }
+        if (debug) {
+            logger.info("RI-r.ring = " + r.ring.toScript());
+            logger.info("RI-gcd-loop, start: q = " + q + ", r = " + r);
+        }
+        while (!r.isZERO()) {
+            x = FDUtil.<C> recursiveRightSparsePseudoRemainder(q, r);
+            q = r;
+            if (field) {
+                r = PolyUtil.<C> monic(x);
+            } else {
+                r = x;
+            }
+            if (debug) {
+                logger.info("RI-gcd-loop, rem: q = " + q + ", r = " + r);
+            }
+        }
+        if (debug) {
+            logger.info("RI-gcd(div) = " + q + ", rs = " + rs + ", qs = " + qs);
+            rp = FDUtil.<C> recursiveRightSparsePseudoRemainder(rs, q);
+            qp = FDUtil.<C> recursiveRightSparsePseudoRemainder(qs, q);
+            if (!qp.isZERO() || !rp.isZERO()) {
+                logger.info("RI-gcd(div): rem(r,g) = " + rp + ", rem(q,g) = " + qp);
+                rp = FDUtil.<C> recursivePseudoQuotient(rs, q);
+                qp = FDUtil.<C> recursivePseudoQuotient(qs, q);
+                logger.info("RI-gcd(div): r/g = " + rp + ", q/g = " + qp);
+                //logger.info("gcd(div): rp*g = " + rp.multiply(q) + ", qp*g = " + qp.multiply(q));
+                throw new RuntimeException("recGcd, div: not divisible");
+            }
+        }
+        qp = q;
+        logger.info("RI-recGcd(P,S) pre pp okay: qp = " + qp);
+        //q = rightRecursivePrimitivePart(q);
+        q = leftRecursivePrimitivePart(q); // sic
+        if (!qp.equals(q)) {
+            logger.info("RI-gcd(pp) = " + q + ", qp = " + qp); // + ", ring = " + P.ring.toScript());
+        }
+        q = (GenSolvablePolynomial<GenPolynomial<C>>) q.multiplyLeft(c).abs();
+        return q;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/GreatestCommonDivisorSyzygy.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/GreatestCommonDivisorSyzygy.java
@@ -1,0 +1,233 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.fd;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.SolvableGroebnerBaseAbstract;
+import edu.jas.gb.SolvableGroebnerBaseSeq;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * (Non-unique) factorization domain greatest common divisor common algorithms
+ * with syzygy computation. The implementation uses solvable syzygy gcd
+ * computation.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class GreatestCommonDivisorSyzygy<C extends GcdRingElem<C>> extends GreatestCommonDivisorAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GreatestCommonDivisorSyzygy.class);
+
+
+    private static final boolean debug = true; //logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     * @param cf coefficient ring.
+     */
+    public GreatestCommonDivisorSyzygy(RingFactory<C> cf) {
+        super(cf);
+    }
+
+
+    /**
+     * Left univariate GenSolvablePolynomial greatest common divisor.
+     * @param P univariate GenSolvablePolynomial.
+     * @param S univariate GenSolvablePolynomial.
+     * @return gcd(P,S) with P = P'*gcd(P,S) and S = S'*gcd(P,S).
+     */
+    @Override
+    public GenSolvablePolynomial<C> leftBaseGcd(GenSolvablePolynomial<C> P, GenSolvablePolynomial<C> S) {
+        return leftGcd(P, S);
+    }
+
+
+    /**
+     * Right univariate GenSolvablePolynomial greatest common divisor.
+     * @param P univariate GenSolvablePolynomial.
+     * @param S univariate GenSolvablePolynomial.
+     * @return gcd(P,S) with P = P'*gcd(P,S) and S = S'*gcd(P,S).
+     */
+    @Override
+    public GenSolvablePolynomial<C> rightBaseGcd(GenSolvablePolynomial<C> P, GenSolvablePolynomial<C> S) {
+        return rightGcd(P, S);
+    }
+
+
+    /**
+     * Left GenSolvablePolynomial greatest common divisor.
+     * @param P GenSolvablePolynomial.
+     * @param S GenSolvablePolynomial.
+     * @return gcd(P,S) with P = P'*gcd(P,S) and S = S'*gcd(P,S).
+     */
+    @Override
+    public GenSolvablePolynomial<C> leftGcd(GenSolvablePolynomial<C> P, GenSolvablePolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.isConstant()) {
+            return P.ring.getONE();
+        }
+        if (S.isConstant()) {
+            return P.ring.getONE();
+        }
+        List<GenSolvablePolynomial<C>> A = new ArrayList<GenSolvablePolynomial<C>>(2);
+        A.add(P);
+        A.add(S);
+        SolvableGroebnerBaseAbstract<C> sbb = new SolvableGroebnerBaseSeq<C>();
+        logger.info("left syzGcd computing GB: " + A);
+        List<GenSolvablePolynomial<C>> G = sbb.rightGB(A); //not: leftGB, not: sbb.twosidedGB(A);
+        if (debug) {
+            logger.info("G = " + G);
+        }
+        if (G.size() == 1) {
+            return G.get(0);
+        }
+        logger.info("gcd not determined, set to 1: " + G); // + ", A = " + A);
+        return P.ring.getONE();
+    }
+
+
+    /**
+     * Right GenSolvablePolynomial right greatest common divisor.
+     * @param P GenSolvablePolynomial.
+     * @param S GenSolvablePolynomial.
+     * @return gcd(P,S) with P = gcd(P,S)*P' and S = gcd(P,S)*S'.
+     */
+    @Override
+    public GenSolvablePolynomial<C> rightGcd(GenSolvablePolynomial<C> P, GenSolvablePolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.isConstant()) {
+            return P.ring.getONE();
+        }
+        if (S.isConstant()) {
+            return P.ring.getONE();
+        }
+        List<GenSolvablePolynomial<C>> A = new ArrayList<GenSolvablePolynomial<C>>(2);
+        A.add(P);
+        A.add(S);
+        SolvableGroebnerBaseAbstract<C> sbb = new SolvableGroebnerBaseSeq<C>();
+        logger.info("left syzGcd computing GB: " + A);
+        List<GenSolvablePolynomial<C>> G = sbb.leftGB(A); //not: sbb.twosidedGB(A);
+        if (debug) {
+            logger.info("G = " + G);
+        }
+        if (G.size() == 1) {
+            return G.get(0);
+        }
+        logger.info("gcd not determined, set to 1: " + G); // + ", A = " + A);
+        return P.ring.getONE();
+    }
+
+
+    /**
+     * Univariate GenSolvablePolynomial left recursive greatest common divisor.
+     * @param P univariate recursive GenSolvablePolynomial.
+     * @param S univariate recursive GenSolvablePolynomial.
+     * @return gcd(P,S) with P = P'*gcd(P,S)*p and S = S'*gcd(P,S)*s, where
+     *         deg_main(p) = deg_main(s) == 0.
+     */
+    @Override
+    public GenSolvablePolynomial<GenPolynomial<C>> leftRecursiveUnivariateGcd(
+                    GenSolvablePolynomial<GenPolynomial<C>> P, GenSolvablePolynomial<GenPolynomial<C>> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.ring.nvar > 1) {
+            throw new IllegalArgumentException("no univariate polynomial");
+        }
+        if (P.isConstant()) {
+            return P.ring.getONE();
+        }
+        if (S.isConstant()) {
+            return P.ring.getONE();
+        }
+        List<GenSolvablePolynomial<GenPolynomial<C>>> A = new ArrayList<GenSolvablePolynomial<GenPolynomial<C>>>(
+                        2);
+        A.add(P);
+        A.add(S);
+        SolvableGroebnerBaseAbstract<GenPolynomial<C>> sbb = new SolvableGroebnerBaseSeq<GenPolynomial<C>>();
+        logger.info("left syzGcd computing GB: " + A);
+        // will not work, not field
+        List<GenSolvablePolynomial<GenPolynomial<C>>> G = sbb.rightGB(A); //not: leftGB, not: sbb.twosidedGB(A);
+        if (debug) {
+            logger.info("G = " + G);
+        }
+        if (G.size() == 1) {
+            return G.get(0);
+        }
+        logger.info("gcd not determined, set to 1: " + G); // + ", A = " + A);
+        return P.ring.getONE();
+    }
+
+
+    /**
+     * Univariate GenSolvablePolynomial right recursive greatest common divisor.
+     * @param P univariate recursive GenSolvablePolynomial.
+     * @param S univariate recursive GenSolvablePolynomial.
+     * @return gcd(P,S) with P = p*gcd(P,S)*P' and S = s*gcd(P,S)*S', where
+     *         deg_main(p) = deg_main(s) == 0.
+     */
+    @Override
+    public GenSolvablePolynomial<GenPolynomial<C>> rightRecursiveUnivariateGcd(
+                    GenSolvablePolynomial<GenPolynomial<C>> P, GenSolvablePolynomial<GenPolynomial<C>> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.ring.nvar > 1) {
+            throw new IllegalArgumentException("no univariate polynomial");
+        }
+        if (P.isConstant()) {
+            return P.ring.getONE();
+        }
+        if (S.isConstant()) {
+            return P.ring.getONE();
+        }
+        List<GenSolvablePolynomial<GenPolynomial<C>>> A = new ArrayList<GenSolvablePolynomial<GenPolynomial<C>>>(
+                        2);
+        A.add(P);
+        A.add(S);
+        SolvableGroebnerBaseAbstract<GenPolynomial<C>> sbb = new SolvableGroebnerBaseSeq<GenPolynomial<C>>();
+        logger.info("right syzGcd computing GB: " + A);
+        // will not work, not field
+        List<GenSolvablePolynomial<GenPolynomial<C>>> G = sbb.leftGB(A); //not: sbb.twosidedGB(A);
+        if (debug) {
+            logger.info("G = " + G);
+        }
+        if (G.size() == 1) {
+            return G.get(0);
+        }
+        logger.info("gcd not determined, set to 1: " + G); // + ", A = " + A);
+        return P.ring.getONE();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/QuotSolvablePolynomial.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/QuotSolvablePolynomial.java
@@ -1,0 +1,613 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.fd;
+
+
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.RecSolvablePolynomial;
+import edu.jas.poly.TableRelation;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * QuotSolvablePolynomial generic recursive solvable polynomials implementing
+ * RingElem. n-variate ordered solvable polynomials over solvable polynomial
+ * coefficients. Objects of this class are intended to be immutable. The
+ * implementation is based on TreeMap respectively SortedMap from exponents to
+ * coefficients by extension of GenPolynomial.
+ * Will be deprecated use QLRSolvablePolynomial.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class QuotSolvablePolynomial<C extends GcdRingElem<C>> extends
+                GenSolvablePolynomial<SolvableQuotient<C>> {
+
+
+    /**
+     * The factory for the recursive solvable polynomial ring. Hides super.ring.
+     */
+    public final QuotSolvablePolynomialRing<C> ring;
+
+
+    private static final Logger logger = LogManager.getLogger(QuotSolvablePolynomial.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor for zero QuotSolvablePolynomial.
+     * @param r solvable polynomial ring factory.
+     */
+    public QuotSolvablePolynomial(QuotSolvablePolynomialRing<C> r) {
+        super(r);
+        ring = r;
+    }
+
+
+    /**
+     * Constructor for QuotSolvablePolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param c coefficient polynomial.
+     * @param e exponent.
+     */
+    public QuotSolvablePolynomial(QuotSolvablePolynomialRing<C> r, SolvableQuotient<C> c, ExpVector e) {
+        this(r);
+        if (c != null && !c.isZERO()) {
+            val.put(e, c);
+        }
+    }
+
+
+    /**
+     * Constructor for QuotSolvablePolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param c coefficient polynomial.
+     */
+    public QuotSolvablePolynomial(QuotSolvablePolynomialRing<C> r, SolvableQuotient<C> c) {
+        this(r, c, r.evzero);
+    }
+
+
+    /**
+     * Constructor for QuotSolvablePolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param S solvable polynomial.
+     */
+    public QuotSolvablePolynomial(QuotSolvablePolynomialRing<C> r,
+                    GenSolvablePolynomial<SolvableQuotient<C>> S) {
+        this(r, S.getMap());
+    }
+
+
+    /**
+     * Constructor for QuotSolvablePolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param v the SortedMap of some other (solvable) polynomial.
+     */
+    protected QuotSolvablePolynomial(QuotSolvablePolynomialRing<C> r,
+                    SortedMap<ExpVector, SolvableQuotient<C>> v) {
+        this(r);
+        val.putAll(v); // assume no zero coefficients
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    @Override
+    public QuotSolvablePolynomialRing<C> factory() {
+        return ring;
+    }
+
+
+    /**
+     * Clone this QuotSolvablePolynomial.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public QuotSolvablePolynomial<C> copy() {
+        return new QuotSolvablePolynomial<C>(ring, this.val);
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object B) {
+        if (!(B instanceof QuotSolvablePolynomial)) {
+            return false;
+        }
+        return super.equals(B);
+    }
+
+
+    /**
+     * Hash code for this polynomial.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+
+    /**
+     * QuotSolvablePolynomial multiplication.
+     * @param Bp QuotSolvablePolynomial.
+     * @return this*Bp, where * denotes solvable multiplication.
+     */
+    // not @Override
+    public QuotSolvablePolynomial<C> multiply(QuotSolvablePolynomial<C> Bp) {
+        if (Bp == null || Bp.isZERO()) {
+            return ring.getZERO();
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        if (Bp.isONE()) {
+            return this;
+        }
+        if (this.isONE()) {
+            return Bp;
+        }
+        assert (ring.nvar == Bp.ring.nvar);
+        if (debug) {
+            logger.debug("ring = " + ring);
+        }
+        //System.out.println("this = " + this + ", Bp = " + Bp);
+        ExpVector Z = ring.evzero;
+        QuotSolvablePolynomial<C> Dp = ring.getZERO().copy();
+        QuotSolvablePolynomial<C> zero = ring.getZERO().copy();
+        SolvableQuotient<C> one = ring.getONECoefficient();
+
+        //QuotSolvablePolynomial<C> C1 = null;
+        //QuotSolvablePolynomial<C> C2 = null;
+        Map<ExpVector, SolvableQuotient<C>> A = val;
+        Map<ExpVector, SolvableQuotient<C>> B = Bp.val;
+        Set<Map.Entry<ExpVector, SolvableQuotient<C>>> Bk = B.entrySet();
+        for (Map.Entry<ExpVector, SolvableQuotient<C>> y : A.entrySet()) {
+            SolvableQuotient<C> a = y.getValue();
+            ExpVector e = y.getKey();
+            if (debug)
+                logger.info("e = " + e + ", a = " + a);
+            // int[] ep = e.dependencyOnVariables();
+            // int el1 = ring.nvar + 1;
+            // if (ep.length > 0) {
+            //     el1 = ep[0];
+            // }
+            // int el1s = ring.nvar + 1 - el1;
+            for (Map.Entry<ExpVector, SolvableQuotient<C>> x : Bk) {
+                SolvableQuotient<C> b = x.getValue();
+                ExpVector f = x.getKey();
+                if (debug)
+                    logger.info("f = " + f + ", b = " + b);
+                int[] fp = f.dependencyOnVariables();
+                int fl1 = 0;
+                if (fp.length > 0) {
+                    fl1 = fp[fp.length - 1];
+                }
+                int fl1s = ring.nvar + 1 - fl1;
+                // polynomial with coefficient multiplication 
+                QuotSolvablePolynomial<C> Cps = ring.getZERO().copy();
+                //QuotSolvablePolynomial<C> Cs;
+                QuotSolvablePolynomial<C> qp;
+                if (ring.polCoeff.coeffTable.isEmpty() || b.isConstant() || e.isZERO()) { // symmetric
+                    Cps = new QuotSolvablePolynomial<C>(ring, b, e);
+                    if (debug)
+                        logger.info("symmetric coeff: b = " + b + ", e = " + e);
+                } else { // unsymmetric
+                    if (debug)
+                        logger.info("unsymmetric coeff: b = " + b + ", e = " + e);
+                    // compute e * b as ( e * 1/b.den ) * b.num
+                    if (b.den.isONE()) { // recursion base
+                        // recursive polynomial coefficient multiplication : e * b.num
+                        RecSolvablePolynomial<C> rsp1 = new RecSolvablePolynomial<C>(ring.polCoeff, e);
+                        RecSolvablePolynomial<C> rsp2 = new RecSolvablePolynomial<C>(ring.polCoeff, b.num);
+                        RecSolvablePolynomial<C> rsp3 = rsp1.multiply(rsp2);
+                        QuotSolvablePolynomial<C> rsp = ring.fromPolyCoefficients(rsp3);
+                        Cps = rsp;
+                    } else { // b.den != 1
+                        if (debug)
+                            logger.info("coeff-num: Cps = " + Cps + ", num = " + b.num + ", den = " + b.den);
+                        Cps = new QuotSolvablePolynomial<C>(ring, b.ring.getONE(), e);
+
+                        // coefficient multiplication with 1/den: 
+                        QuotSolvablePolynomial<C> qv = Cps;
+                        SolvableQuotient<C> qden = new SolvableQuotient<C>(b.ring, b.den); // den/1
+                        //System.out.println("qv = " + qv + ", den = " + den);
+                        // recursion with den==1:
+                        QuotSolvablePolynomial<C> v = qv.multiply(qden);
+                        QuotSolvablePolynomial<C> vl = qv.multiplyLeft(qden);
+                        //System.out.println("v = " + v + ", vl = " + vl + ", qden = " + qden);
+                        QuotSolvablePolynomial<C> vr = (QuotSolvablePolynomial<C>) v.subtract(vl);
+                        SolvableQuotient<C> qdeni = new SolvableQuotient<C>(b.ring, b.ring.ring.getONE(),
+                                        b.den);
+                        //System.out.println("vr = " + vr + ", qdeni = " + qdeni);
+                        // recursion with smaller head term:
+                        QuotSolvablePolynomial<C> rq = vr.multiply(qdeni);
+                        qp = (QuotSolvablePolynomial<C>) qv.subtract(rq);
+                        qp = qp.multiplyLeft(qdeni);
+                        //System.out.println("qp_i = " + qp);
+                        Cps = qp;
+
+                        if (!b.num.isONE()) {
+                            SolvableQuotient<C> qnum = new SolvableQuotient<C>(b.ring, b.num); // num/1
+                            // recursion with den == 1:
+                            Cps = Cps.multiply(qnum);
+                        }
+                    }
+                } // end coeff
+                if (debug)
+                    logger.info("coeff-den: Cps = " + Cps);
+                // polynomial multiplication 
+                QuotSolvablePolynomial<C> Dps = ring.getZERO().copy();
+                QuotSolvablePolynomial<C> Ds = null;
+                QuotSolvablePolynomial<C> D1, D2;
+                if (ring.table.isEmpty() || Cps.isConstant() || f.isZERO()) { // symmetric
+                    if (debug)
+                        logger.info("symmetric poly: b = " + b + ", e = " + e);
+                    ExpVector g = e.sum(f);
+                    if (Cps.isConstant()) {
+                        Ds = new QuotSolvablePolynomial<C>(ring, Cps.leadingBaseCoefficient(), g); // symmetric!
+                    } else {
+                        Ds = Cps.shift(f); // symmetric
+                    }
+                } else { // eventually unsymmetric
+                    if (debug)
+                        logger.info("unsymmetric poly: Cps = " + Cps + ", f = " + f);
+                    for (Map.Entry<ExpVector, SolvableQuotient<C>> z : Cps.val.entrySet()) {
+                        // split g = g1 * g2, f = f1 * f2
+                        SolvableQuotient<C> c = z.getValue();
+                        ExpVector g = z.getKey();
+                        if (debug)
+                            logger.info("g = " + g + ", c = " + c);
+                        int[] gp = g.dependencyOnVariables();
+                        int gl1 = ring.nvar + 1;
+                        if (gp.length > 0) {
+                            gl1 = gp[0];
+                        }
+                        int gl1s = ring.nvar + 1 - gl1;
+                        if (gl1s <= fl1s) { // symmetric
+                            ExpVector h = g.sum(f);
+                            if (debug)
+                                logger.info("disjoint poly: g = " + g + ", f = " + f + ", h = " + h);
+                            Ds = (QuotSolvablePolynomial<C>) zero.sum(one, h); // symmetric!
+                        } else {
+                            ExpVector g1 = g.subst(gl1, 0);
+                            ExpVector g2 = Z.subst(gl1, g.getVal(gl1)); // bug el1, gl1
+                            ExpVector g4;
+                            ExpVector f1 = f.subst(fl1, 0);
+                            ExpVector f2 = Z.subst(fl1, f.getVal(fl1));
+                            if (debug) {
+                                logger.info("poly, g1 = " + g1 + ", f1 = " + f1 + ", Dps = " + Dps);
+                                logger.info("poly, g2 = " + g2 + ", f2 = " + f2);
+                            }
+                            TableRelation<SolvableQuotient<C>> rel = ring.table.lookup(g2, f2);
+                            if (debug)
+                                logger.info("poly, g  = " + g + ", f  = " + f + ", rel = " + rel);
+                            Ds = new QuotSolvablePolynomial<C>(ring, rel.p); //ring.copy(rel.p);
+                            if (rel.f != null) {
+                                D2 = new QuotSolvablePolynomial<C>(ring, one, rel.f);
+                                Ds = Ds.multiply(D2);
+                                if (rel.e == null) {
+                                    g4 = g2;
+                                } else {
+                                    g4 = g2.subtract(rel.e);
+                                }
+                                ring.table.update(g4, f2, Ds);
+                            }
+                            if (rel.e != null) {
+                                D1 = new QuotSolvablePolynomial<C>(ring, one, rel.e);
+                                Ds = D1.multiply(Ds);
+                                ring.table.update(g2, f2, Ds);
+                            }
+                            if (!f1.isZERO()) {
+                                D2 = new QuotSolvablePolynomial<C>(ring, one, f1);
+                                Ds = Ds.multiply(D2);
+                                //ring.table.update(?,f1,Ds)
+                            }
+                            if (!g1.isZERO()) {
+                                D1 = new QuotSolvablePolynomial<C>(ring, one, g1);
+                                Ds = D1.multiply(Ds);
+                                //ring.table.update(e1,?,Ds)
+                            }
+                        }
+                        Ds = Ds.multiplyLeft(c); // c * Ds
+                        Dps = (QuotSolvablePolynomial<C>) Dps.sum(Ds);
+                    } // end Dps loop
+                    Ds = Dps;
+                }
+                Ds = Ds.multiplyLeft(a); // multiply(a,b); // non-symmetric 
+                if (debug)
+                    logger.debug("Ds = " + Ds);
+                Dp = (QuotSolvablePolynomial<C>) Dp.sum(Ds);
+            } // end B loop
+        } // end A loop
+          //System.out.println("this * Bp = " + Dp);
+        return Dp;
+    }
+
+
+    /**
+     * QuotSolvablePolynomial left and right multiplication. Product with two
+     * polynomials.
+     * @param S QuotSolvablePolynomial.
+     * @param T QuotSolvablePolynomial.
+     * @return S*this*T.
+     */
+    // not @Override
+    public QuotSolvablePolynomial<C> multiply(QuotSolvablePolynomial<C> S, QuotSolvablePolynomial<C> T) {
+        if (S.isZERO() || T.isZERO() || this.isZERO()) {
+            return ring.getZERO();
+        }
+        if (S.isONE()) {
+            return multiply(T);
+        }
+        if (T.isONE()) {
+            return S.multiply(this);
+        }
+        return S.multiply(this).multiply(T);
+    }
+
+
+    /**
+     * QuotSolvablePolynomial multiplication. Product with coefficient ring
+     * element.
+     * @param b solvable coefficient.
+     * @return this*b, where * is coefficient multiplication.
+     */
+    @Override
+    public QuotSolvablePolynomial<C> multiply(SolvableQuotient<C> b) {
+        QuotSolvablePolynomial<C> Cp = ring.getZERO().copy();
+        if (b == null || b.isZERO()) {
+            return Cp;
+        }
+        if (b.isONE()) {
+            return this;
+        }
+        Cp = new QuotSolvablePolynomial<C>(ring, b, ring.evzero);
+        return multiply(Cp);
+    }
+
+
+    /**
+     * QuotSolvablePolynomial left and right multiplication. Product with
+     * coefficient ring element.
+     * @param b coefficient polynomial.
+     * @param c coefficient polynomial.
+     * @return b*this*c, where * is coefficient multiplication.
+     */
+    @Override
+    public QuotSolvablePolynomial<C> multiply(SolvableQuotient<C> b, SolvableQuotient<C> c) {
+        QuotSolvablePolynomial<C> Cp = ring.getZERO().copy();
+        if (b == null || b.isZERO()) {
+            return Cp;
+        }
+        if (c == null || c.isZERO()) {
+            return Cp;
+        }
+        if (b.isONE() && c.isONE()) {
+            return this;
+        }
+        Cp = new QuotSolvablePolynomial<C>(ring, b, ring.evzero);
+        QuotSolvablePolynomial<C> Dp = new QuotSolvablePolynomial<C>(ring, c, ring.evzero);
+        return multiply(Cp, Dp);
+    }
+
+
+    /**
+     * QuotSolvablePolynomial multiplication. Product with exponent vector.
+     * @param e exponent.
+     * @return this * x<sup>e</sup>, where * denotes solvable multiplication.
+     */
+    @Override
+    public QuotSolvablePolynomial<C> multiply(ExpVector e) {
+        if (e == null || e.isZERO()) {
+            return this;
+        }
+        SolvableQuotient<C> b = ring.getONECoefficient();
+        return multiply(b, e);
+    }
+
+
+    /**
+     * QuotSolvablePolynomial left and right multiplication. Product with
+     * exponent vector.
+     * @param e exponent.
+     * @param f exponent.
+     * @return x<sup>e</sup> * this * x<sup>f</sup>, where * denotes solvable
+     *         multiplication.
+     */
+    @Override
+    public QuotSolvablePolynomial<C> multiply(ExpVector e, ExpVector f) {
+        if (e == null || e.isZERO()) {
+            return this;
+        }
+        if (f == null || f.isZERO()) {
+            return this;
+        }
+        SolvableQuotient<C> b = ring.getONECoefficient();
+        return multiply(b, e, b, f);
+    }
+
+
+    /**
+     * QuotSolvablePolynomial multiplication. Product with ring element and
+     * exponent vector.
+     * @param b coefficient polynomial.
+     * @param e exponent.
+     * @return this * b x<sup>e</sup>, where * denotes solvable multiplication.
+     */
+    @Override
+    public QuotSolvablePolynomial<C> multiply(SolvableQuotient<C> b, ExpVector e) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        if (b.isONE() && e.isZERO()) {
+            return this;
+        }
+        QuotSolvablePolynomial<C> Cp = new QuotSolvablePolynomial<C>(ring, b, e);
+        return multiply(Cp);
+    }
+
+
+    /**
+     * QuotSolvablePolynomial left and right multiplication. Product with ring
+     * element and exponent vector.
+     * @param b coefficient polynomial.
+     * @param e exponent.
+     * @param c coefficient polynomial.
+     * @param f exponent.
+     * @return b x<sup>e</sup> * this * c x<sup>f</sup>, where * denotes
+     *         solvable multiplication.
+     */
+    @Override
+    public QuotSolvablePolynomial<C> multiply(SolvableQuotient<C> b, ExpVector e, SolvableQuotient<C> c,
+                    ExpVector f) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        if (c == null || c.isZERO()) {
+            return ring.getZERO();
+        }
+        if (b.isONE() && e.isZERO() && c.isONE() && f.isZERO()) {
+            return this;
+        }
+        QuotSolvablePolynomial<C> Cp = new QuotSolvablePolynomial<C>(ring, b, e);
+        QuotSolvablePolynomial<C> Dp = new QuotSolvablePolynomial<C>(ring, c, f);
+        return multiply(Cp, Dp);
+    }
+
+
+    /**
+     * QuotSolvablePolynomial multiplication. Left product with ring element and
+     * exponent vector.
+     * @param b coefficient polynomial.
+     * @param e exponent.
+     * @return b x<sup>e</sup> * this, where * denotes solvable multiplication.
+     */
+    @Override
+    public QuotSolvablePolynomial<C> multiplyLeft(SolvableQuotient<C> b, ExpVector e) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        QuotSolvablePolynomial<C> Cp = new QuotSolvablePolynomial<C>(ring, b, e);
+        return Cp.multiply(this);
+    }
+
+
+    /**
+     * QuotSolvablePolynomial multiplication. Left product with exponent vector.
+     * @param e exponent.
+     * @return x<sup>e</sup> * this, where * denotes solvable multiplication.
+     */
+    @Override
+    public QuotSolvablePolynomial<C> multiplyLeft(ExpVector e) {
+        if (e == null || e.isZERO()) {
+            return this;
+        }
+        SolvableQuotient<C> b = ring.getONECoefficient();
+        QuotSolvablePolynomial<C> Cp = new QuotSolvablePolynomial<C>(ring, b, e);
+        return Cp.multiply(this);
+    }
+
+
+    /**
+     * QuotSolvablePolynomial multiplication. Left product with coefficient ring
+     * element.
+     * @param b coefficient polynomial.
+     * @return b*this, where * is coefficient multiplication.
+     */
+    @Override
+    public QuotSolvablePolynomial<C> multiplyLeft(SolvableQuotient<C> b) {
+        QuotSolvablePolynomial<C> Cp = ring.getZERO().copy();
+        if (b == null || b.isZERO()) {
+            return Cp;
+        }
+        Map<ExpVector, SolvableQuotient<C>> Cm = Cp.val; //getMap();
+        Map<ExpVector, SolvableQuotient<C>> Am = val;
+        SolvableQuotient<C> c;
+        for (Map.Entry<ExpVector, SolvableQuotient<C>> y : Am.entrySet()) {
+            ExpVector e = y.getKey();
+            SolvableQuotient<C> a = y.getValue();
+            c = b.multiply(a);
+            if (!c.isZERO()) {
+                Cm.put(e, c);
+            }
+        }
+        return Cp;
+    }
+
+
+    /**
+     * QuotSolvablePolynomial multiplication. Left product with 'monomial'.
+     * @param m 'monomial'.
+     * @return m * this, where * denotes solvable multiplication.
+     */
+    @Override
+    public QuotSolvablePolynomial<C> multiplyLeft(Map.Entry<ExpVector, SolvableQuotient<C>> m) {
+        if (m == null) {
+            return ring.getZERO();
+        }
+        return multiplyLeft(m.getValue(), m.getKey());
+    }
+
+
+    /**
+     * QuotSolvablePolynomial multiplication. Product with 'monomial'.
+     * @param m 'monomial'.
+     * @return this * m, where * denotes solvable multiplication.
+     */
+    @Override
+    public QuotSolvablePolynomial<C> multiply(Map.Entry<ExpVector, SolvableQuotient<C>> m) {
+        if (m == null) {
+            return ring.getZERO();
+        }
+        return multiply(m.getValue(), m.getKey());
+    }
+
+
+    /**
+     * QuotSolvablePolynomial multiplication. Left product with coefficient ring
+     * element.
+     * @param f exponent vector.
+     * @return B*f, where * is commutative multiplication.
+     */
+    protected QuotSolvablePolynomial<C> shift(ExpVector f) {
+        QuotSolvablePolynomial<C> C = ring.getZERO().copy();
+        if (this.isZERO()) {
+            return C;
+        }
+        if (f == null || f.isZERO()) {
+            return this;
+        }
+        Map<ExpVector, SolvableQuotient<C>> Cm = C.val;
+        Map<ExpVector, SolvableQuotient<C>> Bm = this.val;
+        for (Map.Entry<ExpVector, SolvableQuotient<C>> y : Bm.entrySet()) {
+            ExpVector e = y.getKey();
+            SolvableQuotient<C> a = y.getValue();
+            ExpVector d = e.sum(f);
+            if (!a.isZERO()) {
+                Cm.put(d, a);
+            }
+        }
+        return C;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/QuotSolvablePolynomialRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/QuotSolvablePolynomialRing.java
@@ -1,0 +1,793 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.fd;
+
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.kern.PrettyPrint;
+import edu.jas.kern.Scripting;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.GenPolynomialTokenizer;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.GenSolvablePolynomialRing;
+import edu.jas.poly.RecSolvablePolynomial;
+import edu.jas.poly.RecSolvablePolynomialRing;
+import edu.jas.poly.RelationTable;
+import edu.jas.poly.TermOrder;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * QuotSolvablePolynomialRing generic recursive solvable polynomial factory
+ * implementing RingFactory and extending GenSolvablePolynomialRing factory.
+ * Factory for n-variate ordered solvable polynomials over solvable polynomial
+ * coefficients. The non-commutative multiplication relations are maintained in
+ * a relation table and the non-commutative multiplication relations between the
+ * coefficients and the main variables are maintained in a coefficient relation
+ * table. Almost immutable object, except variable names and relation table
+ * contents. Will be deprecated use <code>QLRSolvablePolynomialRing</code>
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class QuotSolvablePolynomialRing<C extends GcdRingElem<C>>
+                extends GenSolvablePolynomialRing<SolvableQuotient<C>> {
+
+
+    /*
+     * The solvable multiplication relations between variables and coefficients.
+     */
+    //public final RelationTable<GenPolynomial<C>> coeffTable;
+
+
+    /**
+     * Recursive solvable polynomial ring with polynomial coefficients.
+     */
+    public final RecSolvablePolynomialRing<C> polCoeff;
+
+
+    /**
+     * The constant polynomial 0 for this ring. Hides super ZERO.
+     */
+    public final QuotSolvablePolynomial<C> ZERO;
+
+
+    /**
+     * The constant polynomial 1 for this ring. Hides super ONE.
+     */
+    public final QuotSolvablePolynomial<C> ONE;
+
+
+    private static final Logger logger = LogManager.getLogger(QuotSolvablePolynomialRing.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * default term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     */
+    public QuotSolvablePolynomialRing(RingFactory<SolvableQuotient<C>> cf, int n) {
+        this(cf, n, new TermOrder(), null, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * default term order.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param rt solvable multiplication relations.
+     */
+    public QuotSolvablePolynomialRing(RingFactory<SolvableQuotient<C>> cf, int n,
+                    RelationTable<SolvableQuotient<C>> rt) {
+        this(cf, n, new TermOrder(), null, rt);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     */
+    public QuotSolvablePolynomialRing(RingFactory<SolvableQuotient<C>> cf, int n, TermOrder t) {
+        this(cf, n, t, null, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     * @param rt solvable multiplication relations.
+     */
+    public QuotSolvablePolynomialRing(RingFactory<SolvableQuotient<C>> cf, int n, TermOrder t,
+                    RelationTable<SolvableQuotient<C>> rt) {
+        this(cf, n, t, null, rt);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     * @param v names for the variables.
+     */
+    public QuotSolvablePolynomialRing(RingFactory<SolvableQuotient<C>> cf, int n, TermOrder t, String[] v) {
+        this(cf, n, t, v, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param t a term order.
+     * @param v names for the variables.
+     */
+    public QuotSolvablePolynomialRing(RingFactory<SolvableQuotient<C>> cf, TermOrder t, String[] v) {
+        this(cf, v.length, t, v, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * default term order.
+     * @param cf factory for coefficients of type C.
+     * @param v names for the variables.
+     */
+    public QuotSolvablePolynomialRing(RingFactory<SolvableQuotient<C>> cf, String[] v) {
+        this(cf, v.length, new TermOrder(), v, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     * @param v names for the variables.
+     * @param rt solvable multiplication relations.
+     */
+    public QuotSolvablePolynomialRing(RingFactory<SolvableQuotient<C>> cf, int n, TermOrder t, String[] v,
+                    RelationTable<SolvableQuotient<C>> rt) {
+        super(cf, n, t, v, rt);
+        //if (rt == null) { // handled in super }
+        SolvableQuotientRing<C> cfring = (SolvableQuotientRing<C>) cf; // == coFac
+        polCoeff = new RecSolvablePolynomialRing<C>(cfring.ring, n, t, v);
+        if (table.size() > 0) { // TODO
+            ExpVector e = null;
+            ExpVector f = null;
+            GenSolvablePolynomial<GenPolynomial<C>> p = null;
+            polCoeff.table.update(e, f, p); // from rt
+        }
+        //coeffTable = polCoeff.coeffTable; //new RelationTable<GenPolynomial<C>>(polCoeff, true);
+        ZERO = new QuotSolvablePolynomial<C>(this);
+        SolvableQuotient<C> coeff = coFac.getONE();
+        //evzero = ExpVector.create(nvar); // from super
+        ONE = new QuotSolvablePolynomial<C>(this, coeff, evzero);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the the
+     * same term order, number of variables and variable names as the given
+     * polynomial factory, only the coefficient factories differ and the
+     * solvable multiplication relations are <b>empty</b>.
+     * @param cf factory for coefficients of type C.
+     * @param o other solvable polynomial ring.
+     */
+    public QuotSolvablePolynomialRing(RingFactory<SolvableQuotient<C>> cf, GenSolvablePolynomialRing o) {
+        this(cf, o.nvar, o.tord, o.getVars(), null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the the
+     * same term order, number of variables and variable names as the given
+     * polynomial factory, only the coefficient factories differ and the
+     * solvable multiplication relations are <b>empty</b>.
+     * @param cf factory for coefficients of type C.
+     * @param o other solvable polynomial ring.
+     */
+    public QuotSolvablePolynomialRing(RingFactory<SolvableQuotient<C>> cf, QuotSolvablePolynomialRing o) {
+        this(cf, (GenSolvablePolynomialRing) o);
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        String res = super.toString();
+        if (PrettyPrint.isTrue()) {
+            //res += "\n" + table.toString(vars);
+            res += "\n" + polCoeff.coeffTable.toString(vars);
+        } else {
+            res += ", #rel = " + table.size() + " + " + polCoeff.coeffTable.size();
+        }
+        return res;
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        StringBuffer s = new StringBuffer();
+        switch (Scripting.getLang()) {
+        case Ruby:
+            s.append("SolvPolyRing.new(");
+            break;
+        case Python:
+        default:
+            s.append("SolvPolyRing(");
+        }
+        if (coFac instanceof RingElem) {
+            s.append(((RingElem<SolvableQuotient<C>>) coFac).toScriptFactory());
+        } else {
+            s.append(coFac.toScript().trim());
+        }
+        s.append(",\"" + varsToString() + "\",");
+        String to = tord.toScript();
+        s.append(to);
+        if (table.size() > 0) {
+            String rel = table.toScript();
+            s.append(",rel=");
+            s.append(rel);
+        }
+        if (polCoeff.coeffTable.size() > 0) {
+            String rel = polCoeff.coeffTable.toScript();
+            s.append(",coeffrel=");
+            s.append(rel);
+        }
+        s.append(")");
+        return s.toString();
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        }
+        if (!(other instanceof QuotSolvablePolynomialRing)) {
+            return false;
+        }
+        QuotSolvablePolynomialRing<C> oring = (QuotSolvablePolynomialRing<C>) other;
+        // do a super.equals( )
+        if (!super.equals(other)) {
+            return false;
+        }
+        // check same base relations
+        //if ( ! table.equals(oring.table) ) { // done in super
+        //    return false;
+        //}
+        if (!polCoeff.coeffTable.equals(oring.polCoeff.coeffTable)) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Hash code for this polynomial ring.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = super.hashCode();
+        h = 37 * h + table.hashCode(); // may be different after some computations
+        h = 37 * h + polCoeff.coeffTable.hashCode(); // may be different
+        return h;
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as QuotSolvablePolynomial<C>.
+     */
+    @Override
+    public QuotSolvablePolynomial<C> getZERO() {
+        return ZERO;
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as QuotSolvablePolynomial<C>.
+     */
+    @Override
+    public QuotSolvablePolynomial<C> getONE() {
+        return ONE;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true if this ring is commutative, else false.
+     */
+    @Override
+    public boolean isCommutative() {
+        if (polCoeff.coeffTable.size() == 0) {
+            return super.isCommutative();
+        }
+        // todo: check structure of relations
+        return false;
+    }
+
+
+    /**
+     * Query if this ring is associative. Test if the relations between the mian
+     * variables and the coefficient generators define an associative solvable
+     * ring.
+     * @return true, if this ring is associative, else false.
+     */
+    @Override
+    public boolean isAssociative() {
+        if (!coFac.isAssociative()) {
+            return false;
+        }
+        QuotSolvablePolynomial<C> Xi, Xj, Xk, p, q;
+        List<GenPolynomial<SolvableQuotient<C>>> gens = generators();
+        int ngen = gens.size();
+        for (int i = 0; i < ngen; i++) {
+            Xi = (QuotSolvablePolynomial<C>) gens.get(i);
+            for (int j = i + 1; j < ngen; j++) {
+                Xj = (QuotSolvablePolynomial<C>) gens.get(j);
+                for (int k = j + 1; k < ngen; k++) {
+                    Xk = (QuotSolvablePolynomial<C>) gens.get(k);
+                    p = Xk.multiply(Xj).multiply(Xi);
+                    q = Xk.multiply(Xj.multiply(Xi));
+                    if (!p.equals(q)) {
+                        if (logger.isInfoEnabled()) {
+                            logger.info("Xk = " + Xk + ", Xj = " + Xj + ", Xi = " + Xi);
+                            logger.info("p = ( Xk * Xj ) * Xi = " + p);
+                            logger.info("q = Xk * ( Xj * Xi ) = " + q);
+                            logger.info("q-p = " + p.subtract(q));
+                        }
+                        return false;
+                    }
+                }
+            }
+        }
+        return true; //coFac.isAssociative();
+    }
+
+
+    /**
+     * Get a (constant) QuotSolvablePolynomial&lt;C&gt; element from a long
+     * value.
+     * @param a long.
+     * @return a QuotSolvablePolynomial&lt;C&gt;.
+     */
+    @Override
+    public QuotSolvablePolynomial<C> fromInteger(long a) {
+        return new QuotSolvablePolynomial<C>(this, coFac.fromInteger(a), evzero);
+    }
+
+
+    /**
+     * Get a (constant) QuotSolvablePolynomial&lt;C&gt; element from a
+     * BigInteger value.
+     * @param a BigInteger.
+     * @return a QuotSolvablePolynomial&lt;C&gt;.
+     */
+    @Override
+    public QuotSolvablePolynomial<C> fromInteger(BigInteger a) {
+        return new QuotSolvablePolynomial<C>(this, coFac.fromInteger(a), evzero);
+    }
+
+
+    /**
+     * Random solvable polynomial. Generates a random solvable polynomial with k
+     * = 5, l = n, d = (nvar == 1) ? n : 3, q = (nvar == 1) ? 0.7 : 0.3.
+     * @param n number of terms.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    public QuotSolvablePolynomial<C> random(int n) {
+        return random(n, random);
+    }
+
+
+    /**
+     * Random solvable polynomial. Generates a random solvable polynomial with k
+     * = 5, l = n, d = (nvar == 1) ? n : 3, q = (nvar == 1) ? 0.7 : 0.3.
+     * @param n number of terms.
+     * @param rnd is a source for random bits.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    public QuotSolvablePolynomial<C> random(int n, Random rnd) {
+        if (nvar == 1) {
+            return random(5, n, n, 0.7f, rnd);
+        }
+        return random(5, n, 3, 0.3f, rnd);
+    }
+
+
+    /**
+     * Generate a random solvable polynomial.
+     * @param k bitsize of random coefficients.
+     * @param l number of terms.
+     * @param d maximal degree in each variable.
+     * @param q density of nozero exponents.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    public QuotSolvablePolynomial<C> random(int k, int l, int d, float q) {
+        return random(k, l, d, q, random);
+    }
+
+
+    /**
+     * Random solvable polynomial.
+     * @param k size of random coefficients.
+     * @param l number of terms.
+     * @param d maximal degree in each variable.
+     * @param q density of nozero exponents.
+     * @param rnd is a source for random bits.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    public QuotSolvablePolynomial<C> random(int k, int l, int d, float q, Random rnd) {
+        QuotSolvablePolynomial<C> r = getZERO(); // copy( ZERO ); 
+        ExpVector e;
+        SolvableQuotient<C> a;
+        // add random coeffs and exponents
+        for (int i = 0; i < l; i++) {
+            e = ExpVector.random(nvar, d, q, rnd);
+            a = coFac.random(k, rnd);
+            r = (QuotSolvablePolynomial<C>) r.sum(a, e);
+            // somewhat inefficient but clean
+        }
+        return r;
+    }
+
+
+    /**
+     * Copy polynomial c.
+     * @param c
+     * @return a copy of c.
+     */
+    public QuotSolvablePolynomial<C> copy(QuotSolvablePolynomial<C> c) {
+        return new QuotSolvablePolynomial<C>(this, c.getMap());
+    }
+
+
+    /**
+     * Parse a solvable polynomial with the use of GenPolynomialTokenizer
+     * @param s String.
+     * @return QuotSolvablePolynomial from s.
+     */
+    @Override
+    public QuotSolvablePolynomial<C> parse(String s) {
+        return parse(new StringReader(s));
+    }
+
+
+    /**
+     * Parse a solvable polynomial with the use of GenPolynomialTokenizer
+     * @param r Reader.
+     * @return next QuotSolvablePolynomial from r.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public QuotSolvablePolynomial<C> parse(Reader r) {
+        GenPolynomialTokenizer pt = new GenPolynomialTokenizer(this, r);
+        QuotSolvablePolynomial<C> p = null;
+        try {
+            GenSolvablePolynomial<SolvableQuotient<C>> s = pt.nextSolvablePolynomial();
+            p = new QuotSolvablePolynomial<C>(this, s);
+        } catch (IOException e) {
+            logger.error(e.toString() + " parse " + this);
+            p = ZERO;
+        }
+        return p;
+    }
+
+
+    /**
+     * Generate univariate solvable polynomial in a given variable.
+     * @param i the index of the variable.
+     * @return X_i as solvable univariate polynomial.
+     */
+    @Override
+    public QuotSolvablePolynomial<C> univariate(int i) {
+        return (QuotSolvablePolynomial<C>) super.univariate(i);
+    }
+
+
+    /**
+     * Generate univariate solvable polynomial in a given variable with given
+     * exponent.
+     * @param i the index of the variable.
+     * @param e the exponent of the variable.
+     * @return X_i^e as solvable univariate polynomial.
+     */
+    @Override
+    public QuotSolvablePolynomial<C> univariate(int i, long e) {
+        return (QuotSolvablePolynomial<C>) super.univariate(i, e);
+    }
+
+
+    /**
+     * Generate univariate solvable polynomial in a given variable with given
+     * exponent.
+     * @param modv number of module variables.
+     * @param i the index of the variable.
+     * @param e the exponent of the variable.
+     * @return X_i^e as solvable univariate polynomial.
+     */
+    @Override
+    public QuotSolvablePolynomial<C> univariate(int modv, int i, long e) {
+        return (QuotSolvablePolynomial<C>) super.univariate(modv, i, e);
+    }
+
+
+    /**
+     * Generate list of univariate polynomials in all variables.
+     * @return List(X_1,...,X_n) a list of univariate polynomials.
+     */
+    @Override
+    public List<QuotSolvablePolynomial<C>> univariateList() {
+        return univariateList(0, 1L);
+    }
+
+
+    /**
+     * Generate list of univariate polynomials in all variables.
+     * @param modv number of module variables.
+     * @return List(X_1,...,X_n) a list of univariate polynomials.
+     */
+    @Override
+    public List<QuotSolvablePolynomial<C>> univariateList(int modv) {
+        return univariateList(modv, 1L);
+    }
+
+
+    /**
+     * Generate list of univariate polynomials in all variables with given
+     * exponent.
+     * @param modv number of module variables.
+     * @param e the exponent of the variables.
+     * @return List(X_1^e,...,X_n^e) a list of univariate polynomials.
+     */
+    @Override
+    public List<QuotSolvablePolynomial<C>> univariateList(int modv, long e) {
+        List<QuotSolvablePolynomial<C>> pols = new ArrayList<QuotSolvablePolynomial<C>>(nvar);
+        int nm = nvar - modv;
+        for (int i = 0; i < nm; i++) {
+            QuotSolvablePolynomial<C> p = univariate(modv, nm - 1 - i, e);
+            pols.add(p);
+        }
+        return pols;
+    }
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by i.
+     * @param i number of variables to extend.
+     * @return extended solvable polynomial ring factory.
+     */
+    @Override
+    public QuotSolvablePolynomialRing<C> extend(int i) {
+        return extend(i, false);
+    }
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by i.
+     * @param i number of variables to extend.
+     * @param top true for TOP term order, false for POT term order.
+     * @return extended solvable polynomial ring factory.
+     */
+    @Override
+    public QuotSolvablePolynomialRing<C> extend(int i, boolean top) {
+        GenPolynomialRing<SolvableQuotient<C>> pfac = super.extend(i, top);
+        QuotSolvablePolynomialRing<C> spfac = new QuotSolvablePolynomialRing<C>(pfac.coFac, pfac.nvar,
+                        pfac.tord, pfac.getVars());
+        spfac.table.extend(this.table);
+        spfac.polCoeff.coeffTable.extend(this.polCoeff.coeffTable);
+        return spfac;
+    }
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by i.
+     * @param vn names for extended variables.
+     * @return extended solvable polynomial ring factory.
+     */
+    @Override
+    public QuotSolvablePolynomialRing<C> extend(String[] vn) {
+        return extend(vn, false);
+    }
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by i.
+     * @param vn names for extended variables.
+     * @param top true for TOP term order, false for POT term order.
+     * @return extended solvable polynomial ring factory.
+     */
+    @Override
+    public QuotSolvablePolynomialRing<C> extend(String[] vn, boolean top) {
+        GenPolynomialRing<SolvableQuotient<C>> pfac = super.extend(vn, top);
+        QuotSolvablePolynomialRing<C> spfac = new QuotSolvablePolynomialRing<C>(pfac.coFac, pfac.nvar,
+                        pfac.tord, pfac.getVars());
+        spfac.table.extend(this.table);
+        spfac.polCoeff.coeffTable.extend(this.polCoeff.coeffTable);
+        return spfac;
+    }
+
+
+    /**
+     * Contract variables. Used e.g. in module embedding. Contract number of
+     * variables by i.
+     * @param i number of variables to remove.
+     * @return contracted solvable polynomial ring factory.
+     */
+    @Override
+    public QuotSolvablePolynomialRing<C> contract(int i) {
+        GenPolynomialRing<SolvableQuotient<C>> pfac = super.contract(i);
+        QuotSolvablePolynomialRing<C> spfac = new QuotSolvablePolynomialRing<C>(pfac.coFac, pfac.nvar,
+                        pfac.tord, pfac.getVars());
+        spfac.table.contract(this.table);
+        spfac.polCoeff.coeffTable.contract(this.polCoeff.coeffTable);
+        return spfac;
+    }
+
+
+    /**
+     * Reverse variables. Used e.g. in opposite rings.
+     * @return solvable polynomial ring factory with reversed variables.
+     */
+    @Override
+    public QuotSolvablePolynomialRing<C> reverse() {
+        return reverse(false);
+    }
+
+
+    /**
+     * Reverse variables. Used e.g. in opposite rings.
+     * @param partial true for partialy reversed term orders.
+     * @return solvable polynomial ring factory with reversed variables.
+     */
+    @Override
+    public QuotSolvablePolynomialRing<C> reverse(boolean partial) {
+        GenPolynomialRing<SolvableQuotient<C>> pfac = super.reverse(partial);
+        QuotSolvablePolynomialRing<C> spfac = new QuotSolvablePolynomialRing<C>(pfac.coFac, pfac.nvar,
+                        pfac.tord, pfac.getVars());
+        spfac.partial = partial;
+        spfac.table.reverse(this.table);
+        spfac.polCoeff.coeffTable.reverse(this.polCoeff.coeffTable);
+        return spfac;
+    }
+
+
+    /**
+     * Rational function from integral polynomial coefficients. Represent as
+     * polynomial with type SolvableQuotient<C> coefficients.
+     * @param A polynomial with integral polynomial coefficients to be
+     *            converted.
+     * @return polynomial with type SolvableQuotient<C> coefficients.
+     */
+    public QuotSolvablePolynomial<C> fromPolyCoefficients(GenSolvablePolynomial<GenPolynomial<C>> A) {
+        QuotSolvablePolynomial<C> B = getZERO().copy();
+        if (A == null || A.isZERO()) {
+            return B;
+        }
+        RingFactory<SolvableQuotient<C>> cfac = coFac;
+        SolvableQuotientRing<C> qfac = (SolvableQuotientRing<C>) cfac;
+        for (Map.Entry<ExpVector, GenPolynomial<C>> y : A.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            GenSolvablePolynomial<C> a = (GenSolvablePolynomial<C>) y.getValue();
+            SolvableQuotient<C> p = new SolvableQuotient<C>(qfac, a); // can not be zero
+            if (!p.isZERO()) {
+                //B = B.sum( p, e ); // inefficient
+                B.doPutToMap(e, p);
+            }
+        }
+        return B;
+    }
+
+
+    /**
+     * Integral function from rational polynomial coefficients. Represent as
+     * polynomial with type GenSolvablePolynomial<C> coefficients.
+     * @param A polynomial with rational polynomial coefficients to be
+     *            converted.
+     * @return polynomial with type GenSolvablePolynomial<C> coefficients.
+     */
+    public RecSolvablePolynomial<C> toPolyCoefficients(QuotSolvablePolynomial<C> A) {
+        RecSolvablePolynomial<C> B = polCoeff.getZERO().copy();
+        if (A == null || A.isZERO()) {
+            return B;
+        }
+        for (Map.Entry<ExpVector, SolvableQuotient<C>> y : A.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            SolvableQuotient<C> a = y.getValue();
+            if (!a.den.isONE()) {
+                throw new IllegalArgumentException("den != 1 not supported: " + a);
+            }
+            GenPolynomial<C> p = a.num; // can not be zero
+            if (!p.isZERO()) {
+                //B = B.sum( p, e ); // inefficient
+                B.doPutToMap(e, p);
+            }
+        }
+        return B;
+    }
+
+
+    /**
+     * Integral function from rational polynomial coefficients. Represent as
+     * polynomial with type GenSolvablePolynomial<C> coefficients.
+     * @param A polynomial with rational polynomial coefficients to be
+     *            converted.
+     * @return polynomial with type GenSolvablePolynomial<C> coefficients.
+     */
+    public RecSolvablePolynomial<C> toPolyCoefficients(GenPolynomial<SolvableQuotient<C>> A) {
+        RecSolvablePolynomial<C> B = polCoeff.getZERO().copy();
+        if (A == null || A.isZERO()) {
+            return B;
+        }
+        for (Map.Entry<ExpVector, SolvableQuotient<C>> y : A.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            SolvableQuotient<C> a = y.getValue();
+            if (!a.den.isONE()) {
+                throw new IllegalArgumentException("den != 1 not supported: " + a);
+            }
+            GenPolynomial<C> p = a.num; // can not be zero
+            if (!p.isZERO()) {
+                //B = B.sum( p, e ); // inefficient
+                B.doPutToMap(e, p);
+            }
+        }
+        return B;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/SGCDFactory.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/SGCDFactory.java
@@ -1,0 +1,287 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.fd;
+
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.arith.BigInteger;
+import edu.jas.arith.BigRational;
+import edu.jas.arith.ModInteger;
+import edu.jas.arith.ModIntegerRing;
+import edu.jas.arith.ModLong;
+import edu.jas.arith.ModLongRing;
+import edu.jas.kern.ComputerThreads;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Solvable greatest common divisor algorithms factory. Select appropriate SGCD
+ * engine based on the coefficient types.
+ * <p>
+ * <b>Usage:</b> To create objects that implement the
+ * <code>GreatestCommonDivisor</code> interface use the
+ * <code>SGCDFactory</code>. It will select an appropriate implementation based
+ * on the types of polynomial coefficients C. There are two methods to obtain an
+ * implementation: <code>getProxy()</code> and <code>getImplementation()</code>.
+ * <code>getImplementation()</code> returns an object of a class which
+ * implements the <code>GreatestCommonDivisor</code> interface.
+ * <code>getProxy()</code> returns a proxy object of a class which implements
+ * the <code>GreatestCommonDivisor</code> interface. The proxy will run two
+ * implementations in parallel, return the first computed result and cancel the
+ * second running task. On systems with one CPU the computing time will be two
+ * times the time of the fastest algorithm implementation. On systems with more
+ * than two CPUs the computing time will be the time of the fastest algorithm
+ * implementation.
+ * 
+ * <pre>
+ * GreatestCommonDivisor&lt;CT&gt; engine;
+ * engine = SGCDFactory.&lt;CT&gt; getImplementation(cofac);
+ * or engine = SGCDFactory.&lt;CT&gt; getProxy(cofac);
+ * c = engine.leftGcd(a, b);
+ * </pre>
+ * <p>
+ * For example, if the coefficient type is <code>BigInteger</code>, the usage
+ * looks like
+ * 
+ * <pre>
+ * BigInteger cofac = new BigInteger();
+ * GreatestCommonDivisor&lt;BigInteger&gt; engine;
+ * engine = SGCDFactory.getImplementation(cofac);
+ * or engine = SGCDFactory.getProxy(cofac);
+ * c = engine.leftGcd(a, b);
+ * </pre>
+ * 
+ * @author Heinz Kredel
+ *
+ * @see edu.jas.fd.GreatestCommonDivisor#leftGcd(edu.jas.poly.GenSolvablePolynomial
+ *      P, edu.jas.poly.GenSolvablePolynomial S)
+ */
+
+public class SGCDFactory {
+
+
+    private static final Logger logger = LogManager.getLogger(SGCDFactory.class);
+
+
+    /**
+     * Protected factory constructor.
+     */
+    protected SGCDFactory() {
+    }
+
+
+    /**
+     * Determine suitable implementation of gcd algorithms, case ModLong.
+     * @param fac ModLongRing.
+     * @return gcd algorithm implementation.
+     */
+    public static GreatestCommonDivisorAbstract<ModLong> getImplementation(ModLongRing fac) {
+        GreatestCommonDivisorAbstract<ModLong> ufd;
+        if (fac.isField()) {
+            ufd = new GreatestCommonDivisorSimple<ModLong>(fac);
+            return ufd;
+        }
+        ufd = new GreatestCommonDivisorPrimitive<ModLong>(fac);
+        return ufd;
+    }
+
+
+    /**
+     * Determine suitable proxy for gcd algorithms, case ModLong.
+     * @param fac ModLongRing.
+     * @return gcd algorithm implementation.
+     */
+    public static GreatestCommonDivisorAbstract<ModLong> getProxy(ModLongRing fac) {
+        GreatestCommonDivisorAbstract<ModLong> ufd1, ufd2;
+        ufd1 = new GreatestCommonDivisorPrimitive<ModLong>(fac);
+        if (fac.isField()) {
+            ufd2 = new GreatestCommonDivisorSimple<ModLong>(fac);
+        } else {
+            ufd2 = new GreatestCommonDivisorSyzygy<ModLong>(fac);
+        }
+        return new SGCDParallelProxy<ModLong>(fac, ufd1, ufd2);
+    }
+
+
+    /**
+     * Determine suitable implementation of gcd algorithms, case ModInteger.
+     * @param fac ModIntegerRing.
+     * @return gcd algorithm implementation.
+     */
+    public static GreatestCommonDivisorAbstract<ModInteger> getImplementation(ModIntegerRing fac) {
+        GreatestCommonDivisorAbstract<ModInteger> ufd;
+        if (fac.isField()) {
+            ufd = new GreatestCommonDivisorSimple<ModInteger>(fac);
+            return ufd;
+        }
+        ufd = new GreatestCommonDivisorPrimitive<ModInteger>(fac);
+        return ufd;
+    }
+
+
+    /**
+     * Determine suitable proxy for gcd algorithms, case ModInteger.
+     * @param fac ModIntegerRing.
+     * @return gcd algorithm implementation.
+     */
+    public static GreatestCommonDivisorAbstract<ModInteger> getProxy(ModIntegerRing fac) {
+        GreatestCommonDivisorAbstract<ModInteger> ufd1, ufd2;
+        ufd1 = new GreatestCommonDivisorPrimitive<ModInteger>(fac);
+        if (fac.isField()) {
+            ufd2 = new GreatestCommonDivisorSimple<ModInteger>(fac);
+        } else {
+            ufd2 = new GreatestCommonDivisorSyzygy<ModInteger>(fac);
+        }
+        return new SGCDParallelProxy<ModInteger>(fac, ufd1, ufd2);
+    }
+
+
+    /**
+     * Determine suitable implementation of gcd algorithms, case BigInteger.
+     * @param fac BigInteger.
+     * @return gcd algorithm implementation.
+     */
+    @SuppressWarnings("unused")
+    public static GreatestCommonDivisorAbstract<BigInteger> getImplementation(BigInteger fac) {
+        GreatestCommonDivisorAbstract<BigInteger> ufd;
+        if (true) {
+            ufd = new GreatestCommonDivisorPrimitive<BigInteger>(fac);
+        } else {
+            ufd = new GreatestCommonDivisorSimple<BigInteger>(fac);
+        }
+        return ufd;
+    }
+
+
+    /**
+     * Determine suitable proxy for gcd algorithms, case BigInteger.
+     * @param fac BigInteger.
+     * @return gcd algorithm implementation.
+     */
+    public static GreatestCommonDivisorAbstract<BigInteger> getProxy(BigInteger fac) {
+        if (fac == null) {
+            throw new IllegalArgumentException("fac == null not supported");
+        }
+        GreatestCommonDivisorAbstract<BigInteger> ufd1, ufd2;
+        ufd1 = new GreatestCommonDivisorPrimitive<BigInteger>(fac);
+        ufd2 = new GreatestCommonDivisorSyzygy<BigInteger>(fac);
+        return new SGCDParallelProxy<BigInteger>(fac, ufd1, ufd2);
+    }
+
+
+    /**
+     * Determine suitable implementation of gcd algorithms, case BigRational.
+     * @param fac BigRational.
+     * @return gcd algorithm implementation.
+     */
+    public static GreatestCommonDivisorAbstract<BigRational> getImplementation(BigRational fac) {
+        if (fac == null) {
+            throw new IllegalArgumentException("fac == null not supported");
+        }
+        GreatestCommonDivisorAbstract<BigRational> ufd;
+        ufd = new GreatestCommonDivisorPrimitive<BigRational>(fac);
+        return ufd;
+    }
+
+
+    /**
+     * Determine suitable proxy for gcd algorithms, case BigRational.
+     * @param fac BigRational.
+     * @return gcd algorithm implementation.
+     */
+    public static GreatestCommonDivisorAbstract<BigRational> getProxy(BigRational fac) {
+        if (fac == null) {
+            throw new IllegalArgumentException("fac == null not supported");
+        }
+        GreatestCommonDivisorAbstract<BigRational> ufd1, ufd2;
+        ufd1 = new GreatestCommonDivisorPrimitive<BigRational>(fac);
+        ufd2 = new GreatestCommonDivisorSimple<BigRational>(fac);
+        return new SGCDParallelProxy<BigRational>(fac, ufd1, ufd2);
+    }
+
+
+    /**
+     * Determine suitable implementation of gcd algorithms, other cases.
+     * @param fac RingFactory&lt;C&gt;.
+     * @return gcd algorithm implementation.
+     */
+    @SuppressWarnings("unchecked")
+    public static <C extends GcdRingElem<C>> GreatestCommonDivisorAbstract<C> getImplementation(
+                    RingFactory<C> fac) {
+        GreatestCommonDivisorAbstract/*raw type<C>*/ ufd;
+        logger.debug("fac = " + fac.getClass().getName());
+        Object ofac = fac;
+        if (ofac instanceof BigInteger) {
+            ufd = new GreatestCommonDivisorPrimitive<C>(fac);
+        } else if (ofac instanceof ModIntegerRing) {
+            if (fac.isField()) {
+                ufd = new GreatestCommonDivisorSimple<C>(fac);
+            } else {
+                ufd = new GreatestCommonDivisorPrimitive<C>(fac);
+            }
+        } else if (ofac instanceof ModLongRing) {
+            if (fac.isField()) {
+                ufd = new GreatestCommonDivisorSimple<C>(fac);
+            } else {
+                ufd = new GreatestCommonDivisorPrimitive<C>(fac);
+            }
+        } else if (ofac instanceof BigRational) {
+            ufd = new GreatestCommonDivisorSimple<C>(fac);
+        } else {
+            if (fac.isField()) {
+                ufd = new GreatestCommonDivisorSimple<C>(fac);
+            } else {
+                ufd = new GreatestCommonDivisorPrimitive<C>(fac);
+            }
+        }
+        logger.debug("implementation = " + ufd);
+        return ufd;
+    }
+
+
+    /**
+     * Determine suitable proxy for gcd algorithms, other cases.
+     * @param fac RingFactory&lt;C&gt;.
+     * @return gcd algorithm implementation. <b>Note:</b> This method contains a
+     *         hack for Google app engine to not use threads.
+     * @see edu.jas.kern.ComputerThreads#NO_THREADS
+     */
+    @SuppressWarnings("unchecked")
+    public static <C extends GcdRingElem<C>> GreatestCommonDivisorAbstract<C> getProxy(RingFactory<C> fac) {
+        if (ComputerThreads.NO_THREADS) { // hack for Google app engine
+            return SGCDFactory.<C> getImplementation(fac);
+        }
+        GreatestCommonDivisorAbstract/*raw type<C>*/ ufd;
+        logger.debug("fac = " + fac.getClass().getName());
+        Object ofac = fac;
+        if (ofac instanceof BigInteger) {
+            ufd = new SGCDParallelProxy<C>(fac, new GreatestCommonDivisorSimple<C>(fac),
+                            new GreatestCommonDivisorPrimitive<C>(fac));
+        } else if (ofac instanceof ModIntegerRing) {
+            ufd = new SGCDParallelProxy<C>(fac, new GreatestCommonDivisorSimple<C>(fac),
+                            new GreatestCommonDivisorPrimitive<C>(fac));
+        } else if (ofac instanceof ModLongRing) {
+            ufd = new SGCDParallelProxy<C>(fac, new GreatestCommonDivisorSimple<C>(fac),
+                            new GreatestCommonDivisorPrimitive<C>(fac));
+        } else if (ofac instanceof BigRational) {
+            ufd = new SGCDParallelProxy<C>(fac, new GreatestCommonDivisorPrimitive<C>(fac),
+                            new GreatestCommonDivisorSimple<C>(fac));
+        } else {
+            if (fac.isField()) {
+                ufd = new SGCDParallelProxy<C>(fac, new GreatestCommonDivisorSimple<C>(fac),
+                                new GreatestCommonDivisorPrimitive<C>(fac));
+            } else {
+                ufd = new SGCDParallelProxy<C>(fac, new GreatestCommonDivisorSyzygy<C>(fac),
+                                new GreatestCommonDivisorPrimitive<C>(fac));
+            }
+        }
+        logger.debug("ufd = " + ufd);
+        return ufd;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/SGCDParallelProxy.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/SGCDParallelProxy.java
@@ -1,0 +1,649 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.fd;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeoutException;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.kern.ComputerThreads;
+import edu.jas.kern.PreemptingException;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Solvable greatest common divisor parallel proxy. Executes methods from two
+ * implementations in parallel and returns the result from the fastest run. Uses
+ * timeout on <code>invokeAny()</code> and return fake common divisor <it>1</it>
+ * in case of timeout.
+ * @author Heinz Kredel
+ */
+
+public class SGCDParallelProxy<C extends GcdRingElem<C>> extends GreatestCommonDivisorAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(SGCDParallelProxy.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled(); //logger.isInfoEnabled();
+
+
+    /**
+     * GCD engines.
+     */
+    public final GreatestCommonDivisorAbstract<C> e0;
+
+
+    public final GreatestCommonDivisorAbstract<C> e1;
+
+
+    public final GreatestCommonDivisorAbstract<C> e2;
+
+
+    /**
+     * Thread pool.
+     */
+    protected transient ExecutorService pool;
+
+
+    /**
+     * ParallelProxy constructor.
+     * @param cf coefficient ring.
+     */
+    public SGCDParallelProxy(RingFactory<C> cf, GreatestCommonDivisorAbstract<C> e1,
+                    GreatestCommonDivisorAbstract<C> e2) {
+        super(cf);
+        this.e0 = new GreatestCommonDivisorFake<C>(cf);
+        this.e1 = e1;
+        this.e2 = e2;
+        pool = ComputerThreads.getPool();
+        //System.out.println("pool 2 = "+pool);
+    }
+
+
+    /**
+     * Get the String representation with gcd engines.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "SGCDParallelProxy[ " + e1.getClass().getName() + ", " + e2.getClass().getName() + " ]";
+    }
+
+
+    /**
+     * Left univariate GenSolvablePolynomial greatest common divisor.
+     * @param P univariate GenSolvablePolynomial.
+     * @param S univariate GenSolvablePolynomial.
+     * @return gcd(P,S).
+     */
+    @Override
+    public GenSolvablePolynomial<C> leftBaseGcd(final GenSolvablePolynomial<C> P,
+                    final GenSolvablePolynomial<C> S) {
+        if (debug) {
+            if (ComputerThreads.NO_THREADS) {
+                throw new RuntimeException("this should not happen");
+            }
+        }
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        // parallel case
+        GenSolvablePolynomial<C> g = P.ring.getONE();
+        //Callable<GenSolvablePolynomial<C>> c0;
+        //Callable<GenSolvablePolynomial<C>> c1;
+        List<Callable<GenSolvablePolynomial<C>>> cs = new ArrayList<Callable<GenSolvablePolynomial<C>>>(2);
+        cs.add(new Callable<GenSolvablePolynomial<C>>() {
+
+
+            public GenSolvablePolynomial<C> call() {
+                try {
+                    //System.out.println("starting e1 " + e1.getClass().getName());
+                    GenSolvablePolynomial<C> g = e1.leftBaseGcd(P, S);
+                    if (debug) {
+                        logger.info("SGCDParallelProxy done e1 " + e1.getClass().getName());
+                    }
+                    return g;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("SGCDParallelProxy e1 pre " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("SGCDParallelProxy e1 " + e);
+                    logger.info("SGCDParallelProxy P = " + P);
+                    logger.info("SGCDParallelProxy S = " + S);
+                    throw new RuntimeException("SGCDParallelProxy e1 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        cs.add(new Callable<GenSolvablePolynomial<C>>() {
+
+
+            public GenSolvablePolynomial<C> call() {
+                try {
+                    //System.out.println("starting e2 " + e2.getClass().getName());
+                    GenSolvablePolynomial<C> g = e2.leftBaseGcd(P, S);
+                    if (debug) {
+                        logger.info("SGCDParallelProxy done e2 " + e2.getClass().getName());
+                    }
+                    return g;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("SGCDParallelProxy e2 pre " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("SGCDParallelProxy e2 " + e);
+                    logger.info("SGCDParallelProxy P = " + P);
+                    logger.info("SGCDParallelProxy S = " + S);
+                    throw new RuntimeException("SGCDParallelProxy e2 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        try {
+            if (ComputerThreads.getTimeout() < 0) {
+                g = pool.invokeAny(cs);
+            } else {
+                g = pool.invokeAny(cs, ComputerThreads.getTimeout(), ComputerThreads.getTimeUnit());
+            }
+        } catch (InterruptedException ignored) {
+            logger.info("InterruptedException " + ignored);
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
+            logger.info("ExecutionException " + e);
+            Thread.currentThread().interrupt();
+        } catch (TimeoutException e) {
+            logger.info("TimeoutException after " + ComputerThreads.getTimeout() + " "
+                            + ComputerThreads.getTimeUnit());
+            g = e0.leftBaseGcd(P, S); // fake returns 1
+        }
+        return g;
+    }
+
+
+    /**
+     * left univariate GenSolvablePolynomial recursive greatest common divisor.
+     * @param P univariate recursive GenSolvablePolynomial.
+     * @param S univariate recursive GenSolvablePolynomial.
+     * @return gcd(P,S).
+     */
+    @Override
+    public GenSolvablePolynomial<GenPolynomial<C>> leftRecursiveUnivariateGcd(
+                    final GenSolvablePolynomial<GenPolynomial<C>> P,
+                    final GenSolvablePolynomial<GenPolynomial<C>> S) {
+        if (debug) {
+            if (ComputerThreads.NO_THREADS) {
+                throw new RuntimeException("this should not happen");
+            }
+        }
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        // parallel case
+        GenSolvablePolynomial<GenPolynomial<C>> g = P.ring.getONE();
+        //Callable<GenSolvablePolynomial<GenPolynomial<C>>> c0;
+        //Callable<GenSolvablePolynomial<GenPolynomial<C>>> c1;
+        List<Callable<GenSolvablePolynomial<GenPolynomial<C>>>> cs = new ArrayList<Callable<GenSolvablePolynomial<GenPolynomial<C>>>>(
+                        2);
+        cs.add(new Callable<GenSolvablePolynomial<GenPolynomial<C>>>() {
+
+
+            public GenSolvablePolynomial<GenPolynomial<C>> call() {
+                try {
+                    GenSolvablePolynomial<GenPolynomial<C>> g = e1.leftRecursiveUnivariateGcd(P, S);
+                    if (debug) {
+                        logger.info("SGCDParallelProxy done e1 " + e1.getClass().getName());
+                    }
+                    return g;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("SGCDParallelProxy e1 pre " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("SGCDParallelProxy e1 " + e);
+                    logger.info("SGCDParallelProxy P = " + P);
+                    logger.info("SGCDParallelProxy S = " + S);
+                    throw new RuntimeException("SGCDParallelProxy e1 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        cs.add(new Callable<GenSolvablePolynomial<GenPolynomial<C>>>() {
+
+
+            public GenSolvablePolynomial<GenPolynomial<C>> call() {
+                try {
+                    GenSolvablePolynomial<GenPolynomial<C>> g = e2.leftRecursiveUnivariateGcd(P, S);
+                    if (debug) {
+                        logger.info("SGCDParallelProxy done e2 " + e2.getClass().getName());
+                    }
+                    return g;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("SGCDParallelProxy e2 pre " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("SGCDParallelProxy e2 " + e);
+                    logger.info("SGCDParallelProxy P = " + P);
+                    logger.info("SGCDParallelProxy S = " + S);
+                    throw new RuntimeException("SGCDParallelProxy e2 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        try {
+            if (ComputerThreads.getTimeout() < 0) {
+                g = pool.invokeAny(cs);
+            } else {
+                g = pool.invokeAny(cs, ComputerThreads.getTimeout(), ComputerThreads.getTimeUnit());
+            }
+        } catch (InterruptedException ignored) {
+            logger.info("InterruptedException " + ignored);
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
+            logger.info("ExecutionException " + e);
+            Thread.currentThread().interrupt();
+        } catch (TimeoutException e) {
+            logger.info("TimeoutException after " + ComputerThreads.getTimeout() + " "
+                            + ComputerThreads.getTimeUnit());
+            g = e0.leftRecursiveUnivariateGcd(P, S); // fake returns 1
+        }
+        return g;
+    }
+
+
+    /**
+     * Left GenSolvablePolynomial greatest common divisor.
+     * @param P GenSolvablePolynomial.
+     * @param S GenSolvablePolynomial.
+     * @return leftGcd(P,S).
+     */
+    @Override
+    public GenSolvablePolynomial<C> leftGcd(final GenSolvablePolynomial<C> P,
+                    final GenSolvablePolynomial<C> S) {
+        if (debug) {
+            if (ComputerThreads.NO_THREADS) {
+                throw new RuntimeException("this should not happen");
+            }
+        }
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        // parallel case
+        GenSolvablePolynomial<C> g = P.ring.getONE();
+        //Callable<GenSolvablePolynomial<C>> c0;
+        //Callable<GenSolvablePolynomial<C>> c1;
+        List<Callable<GenSolvablePolynomial<C>>> cs = new ArrayList<Callable<GenSolvablePolynomial<C>>>(2);
+        cs.add(new Callable<GenSolvablePolynomial<C>>() {
+
+
+            public GenSolvablePolynomial<C> call() {
+                try {
+                    //System.out.println("starting e1 " + e1.getClass().getName());
+                    GenSolvablePolynomial<C> g = e1.leftGcd(P, S);
+                    if (debug) {
+                        logger.info("SGCDParallelProxy done e1 " + e1.getClass().getName());
+                    }
+                    return g;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("SGCDParallelProxy e1 pre " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("SGCDParallelProxy e1 " + e);
+                    logger.info("SGCDParallelProxy P = " + P);
+                    logger.info("SGCDParallelProxy S = " + S);
+                    throw new RuntimeException("SGCDParallelProxy e1 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        cs.add(new Callable<GenSolvablePolynomial<C>>() {
+
+
+            public GenSolvablePolynomial<C> call() {
+                try {
+                    //System.out.println("starting e2 " + e2.getClass().getName());
+                    GenSolvablePolynomial<C> g = e2.leftGcd(P, S);
+                    if (debug) {
+                        logger.info("SGCDParallelProxy done e2 " + e2.getClass().getName());
+                    }
+                    return g;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("SGCDParallelProxy e2 pre " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("SGCDParallelProxy e2 " + e);
+                    logger.info("SGCDParallelProxy P = " + P);
+                    logger.info("SGCDParallelProxy S = " + S);
+                    throw new RuntimeException("SGCDParallelProxy e2 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        try {
+            if (ComputerThreads.getTimeout() < 0) {
+                g = pool.invokeAny(cs);
+            } else {
+                g = pool.invokeAny(cs, ComputerThreads.getTimeout(), ComputerThreads.getTimeUnit());
+            }
+        } catch (InterruptedException ignored) {
+            logger.info("InterruptedException " + ignored);
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
+            logger.info("ExecutionException " + e);
+            Thread.currentThread().interrupt();
+        } catch (TimeoutException e) {
+            logger.info("TimeoutException after " + ComputerThreads.getTimeout() + " "
+                            + ComputerThreads.getTimeUnit());
+            g = e0.leftGcd(P, S); // fake returns 1
+        }
+        return g;
+    }
+
+
+    /**
+     * Right univariate GenSolvablePolynomial greatest common divisor.
+     * @param P univariate GenSolvablePolynomial.
+     * @param S univariate GenSolvablePolynomial.
+     * @return gcd(P,S).
+     */
+    @Override
+    public GenSolvablePolynomial<C> rightBaseGcd(final GenSolvablePolynomial<C> P,
+                    final GenSolvablePolynomial<C> S) {
+        if (debug) {
+            if (ComputerThreads.NO_THREADS) {
+                throw new RuntimeException("this should not happen");
+            }
+        }
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        // parallel case
+        GenSolvablePolynomial<C> g = P.ring.getONE();
+        //Callable<GenSolvablePolynomial<C>> c0;
+        //Callable<GenSolvablePolynomial<C>> c1;
+        List<Callable<GenSolvablePolynomial<C>>> cs = new ArrayList<Callable<GenSolvablePolynomial<C>>>(2);
+        cs.add(new Callable<GenSolvablePolynomial<C>>() {
+
+
+            public GenSolvablePolynomial<C> call() {
+                try {
+                    //System.out.println("starting e1 " + e1.getClass().getName());
+                    GenSolvablePolynomial<C> g = e1.rightBaseGcd(P, S);
+                    if (debug) {
+                        logger.info("SGCDParallelProxy done e1 " + e1.getClass().getName());
+                    }
+                    return g;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("SGCDParallelProxy e1 pre " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("SGCDParallelProxy e1 " + e);
+                    logger.info("SGCDParallelProxy P = " + P);
+                    logger.info("SGCDParallelProxy S = " + S);
+                    throw new RuntimeException("SGCDParallelProxy e1 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        cs.add(new Callable<GenSolvablePolynomial<C>>() {
+
+
+            public GenSolvablePolynomial<C> call() {
+                try {
+                    //System.out.println("starting e2 " + e2.getClass().getName());
+                    GenSolvablePolynomial<C> g = e2.rightBaseGcd(P, S);
+                    if (debug) {
+                        logger.info("SGCDParallelProxy done e2 " + e2.getClass().getName());
+                    }
+                    return g;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("SGCDParallelProxy e2 pre " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("SGCDParallelProxy e2 " + e);
+                    logger.info("SGCDParallelProxy P = " + P);
+                    logger.info("SGCDParallelProxy S = " + S);
+                    throw new RuntimeException("SGCDParallelProxy e2 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        try {
+            if (ComputerThreads.getTimeout() < 0) {
+                g = pool.invokeAny(cs);
+            } else {
+                g = pool.invokeAny(cs, ComputerThreads.getTimeout(), ComputerThreads.getTimeUnit());
+            }
+        } catch (InterruptedException ignored) {
+            logger.info("InterruptedException " + ignored);
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
+            logger.info("ExecutionException " + e);
+            Thread.currentThread().interrupt();
+        } catch (TimeoutException e) {
+            logger.info("TimeoutException after " + ComputerThreads.getTimeout() + " "
+                            + ComputerThreads.getTimeUnit());
+            g = e0.rightBaseGcd(P, S); // fake returns 1
+        }
+        return g;
+    }
+
+
+    /**
+     * right univariate GenSolvablePolynomial recursive greatest common divisor.
+     * @param P univariate recursive GenSolvablePolynomial.
+     * @param S univariate recursive GenSolvablePolynomial.
+     * @return gcd(P,S).
+     */
+    @Override
+    public GenSolvablePolynomial<GenPolynomial<C>> rightRecursiveUnivariateGcd(
+                    final GenSolvablePolynomial<GenPolynomial<C>> P,
+                    final GenSolvablePolynomial<GenPolynomial<C>> S) {
+        if (debug) {
+            if (ComputerThreads.NO_THREADS) {
+                throw new RuntimeException("this should not happen");
+            }
+        }
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        // parallel case
+        GenSolvablePolynomial<GenPolynomial<C>> g = P.ring.getONE();
+        //Callable<GenSolvablePolynomial<GenPolynomial<C>>> c0;
+        //Callable<GenSolvablePolynomial<GenPolynomial<C>>> c1;
+        List<Callable<GenSolvablePolynomial<GenPolynomial<C>>>> cs = new ArrayList<Callable<GenSolvablePolynomial<GenPolynomial<C>>>>(
+                        2);
+        cs.add(new Callable<GenSolvablePolynomial<GenPolynomial<C>>>() {
+
+
+            public GenSolvablePolynomial<GenPolynomial<C>> call() {
+                try {
+                    GenSolvablePolynomial<GenPolynomial<C>> g = e1.rightRecursiveUnivariateGcd(P, S);
+                    if (debug) {
+                        logger.info("SGCDParallelProxy done e1 " + e1.getClass().getName());
+                    }
+                    return g;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("SGCDParallelProxy e1 pre " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("SGCDParallelProxy e1 " + e);
+                    logger.info("SGCDParallelProxy P = " + P);
+                    logger.info("SGCDParallelProxy S = " + S);
+                    throw new RuntimeException("SGCDParallelProxy e1 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        cs.add(new Callable<GenSolvablePolynomial<GenPolynomial<C>>>() {
+
+
+            public GenSolvablePolynomial<GenPolynomial<C>> call() {
+                try {
+                    GenSolvablePolynomial<GenPolynomial<C>> g = e2.rightRecursiveUnivariateGcd(P, S);
+                    if (debug) {
+                        logger.info("SGCDParallelProxy done e2 " + e2.getClass().getName());
+                    }
+                    return g;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("SGCDParallelProxy e2 pre " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("SGCDParallelProxy e2 " + e);
+                    logger.info("SGCDParallelProxy P = " + P);
+                    logger.info("SGCDParallelProxy S = " + S);
+                    throw new RuntimeException("SGCDParallelProxy e2 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        try {
+            if (ComputerThreads.getTimeout() < 0) {
+                g = pool.invokeAny(cs);
+            } else {
+                g = pool.invokeAny(cs, ComputerThreads.getTimeout(), ComputerThreads.getTimeUnit());
+            }
+        } catch (InterruptedException ignored) {
+            logger.info("InterruptedException " + ignored);
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
+            logger.info("ExecutionException " + e);
+            Thread.currentThread().interrupt();
+        } catch (TimeoutException e) {
+            logger.info("TimeoutException after " + ComputerThreads.getTimeout() + " "
+                            + ComputerThreads.getTimeUnit());
+            g = e0.rightRecursiveUnivariateGcd(P, S); // fake returns 1
+        }
+        return g;
+    }
+
+
+    /**
+     * Right GenSolvablePolynomial greatest common divisor.
+     * @param P GenSolvablePolynomial.
+     * @param S GenSolvablePolynomial.
+     * @return rightGcd(P,S).
+     */
+    @Override
+    public GenSolvablePolynomial<C> rightGcd(final GenSolvablePolynomial<C> P,
+                    final GenSolvablePolynomial<C> S) {
+        if (debug) {
+            if (ComputerThreads.NO_THREADS) {
+                throw new RuntimeException("this should not happen");
+            }
+        }
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        // parallel case
+        GenSolvablePolynomial<C> g = P.ring.getONE();
+        //Callable<GenSolvablePolynomial<C>> c0;
+        //Callable<GenSolvablePolynomial<C>> c1;
+        List<Callable<GenSolvablePolynomial<C>>> cs = new ArrayList<Callable<GenSolvablePolynomial<C>>>(2);
+        cs.add(new Callable<GenSolvablePolynomial<C>>() {
+
+
+            public GenSolvablePolynomial<C> call() {
+                try {
+                    //System.out.println("starting e1 " + e1.getClass().getName());
+                    GenSolvablePolynomial<C> g = e1.rightGcd(P, S);
+                    if (debug) {
+                        logger.info("SGCDParallelProxy done e1 " + e1.getClass().getName());
+                    }
+                    return g;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("SGCDParallelProxy e1 pre " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("SGCDParallelProxy e1 " + e);
+                    logger.info("SGCDParallelProxy P = " + P);
+                    logger.info("SGCDParallelProxy S = " + S);
+                    throw new RuntimeException("SGCDParallelProxy e1 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        cs.add(new Callable<GenSolvablePolynomial<C>>() {
+
+
+            public GenSolvablePolynomial<C> call() {
+                try {
+                    //System.out.println("starting e2 " + e2.getClass().getName());
+                    GenSolvablePolynomial<C> g = e2.rightGcd(P, S);
+                    if (debug) {
+                        logger.info("SGCDParallelProxy done e2 " + e2.getClass().getName());
+                    }
+                    return g;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("SGCDParallelProxy e2 pre " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("SGCDParallelProxy e2 " + e);
+                    logger.info("SGCDParallelProxy P = " + P);
+                    logger.info("SGCDParallelProxy S = " + S);
+                    throw new RuntimeException("SGCDParallelProxy e2 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        try {
+            if (ComputerThreads.getTimeout() < 0) {
+                g = pool.invokeAny(cs);
+            } else {
+                g = pool.invokeAny(cs, ComputerThreads.getTimeout(), ComputerThreads.getTimeUnit());
+            }
+        } catch (InterruptedException ignored) {
+            logger.info("InterruptedException " + ignored);
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
+            logger.info("ExecutionException " + e);
+            Thread.currentThread().interrupt();
+        } catch (TimeoutException e) {
+            logger.info("TimeoutException after " + ComputerThreads.getTimeout() + " "
+                            + ComputerThreads.getTimeUnit());
+            g = e0.rightGcd(P, S); // fake returns 1
+        }
+        return g;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/SolvableQuotient.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/SolvableQuotient.java
@@ -1,0 +1,718 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.fd;
+
+
+import java.util.Arrays;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.kern.PrettyPrint;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.QuotPair;
+
+
+/**
+ * SolvableQuotient, that is a (left) rational function, based on
+ * GenSolvablePolynomial with RingElem interface. Objects of this class are
+ * immutable.
+ * @author Heinz Kredel
+ */
+public class SolvableQuotient<C extends GcdRingElem<C>>
+                implements GcdRingElem<SolvableQuotient<C>>, QuotPair<GenPolynomial<C>> {
+    // should be QuotPair<GenSolvablePolynomial<C>
+
+
+    private static final Logger logger = LogManager.getLogger(SolvableQuotient.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * SolvableQuotient class factory data structure.
+     */
+    public final SolvableQuotientRing<C> ring;
+
+
+    /**
+     * Numerator part of the element data structure.
+     */
+    public final GenSolvablePolynomial<C> num;
+
+
+    /**
+     * Denominator part of the element data structure.
+     */
+    public final GenSolvablePolynomial<C> den;
+
+
+    /**
+     * The constructor creates a SolvableQuotient object from a ring factory.
+     * @param r ring factory.
+     */
+    public SolvableQuotient(SolvableQuotientRing<C> r) {
+        this(r, r.ring.getZERO());
+    }
+
+
+    /**
+     * The constructor creates a SolvableQuotient object from a ring factory and
+     * a numerator polynomial. The denominator is assumed to be 1.
+     * @param r ring factory.
+     * @param n numerator solvable polynomial.
+     */
+    public SolvableQuotient(SolvableQuotientRing<C> r, GenSolvablePolynomial<C> n) {
+        this(r, n, r.ring.getONE(), true);
+    }
+
+
+    /**
+     * The constructor creates a SolvableQuotient object from a ring factory and
+     * a numerator and denominator solvable polynomial.
+     * @param r ring factory.
+     * @param n numerator polynomial.
+     * @param d denominator polynomial.
+     */
+    public SolvableQuotient(SolvableQuotientRing<C> r, GenSolvablePolynomial<C> n,
+                    GenSolvablePolynomial<C> d) {
+        this(r, n, d, false);
+    }
+
+
+    /**
+     * The constructor creates a SolvableQuotient object from a ring factory and
+     * a numerator and denominator polynomial.
+     * @param r ring factory.
+     * @param n numerator polynomial.
+     * @param d denominator polynomial.
+     * @param isred <em>unused at the moment</em>.
+     */
+    protected SolvableQuotient(SolvableQuotientRing<C> r, GenSolvablePolynomial<C> n,
+                    GenSolvablePolynomial<C> d, boolean isred) {
+        if (d == null || d.isZERO()) {
+            throw new IllegalArgumentException("denominator may not be zero");
+        }
+        ring = r;
+        if (d.signum() < 0) {
+            n = (GenSolvablePolynomial<C>) n.negate();
+            d = (GenSolvablePolynomial<C>) d.negate();
+        }
+        if (isred) {
+            num = n;
+            den = d;
+            return;
+        }
+        C lc = d.leadingBaseCoefficient();
+        if (!lc.isONE() && lc.isUnit()) {
+            lc = lc.inverse();
+            n = n.multiply(lc);
+            d = d.multiply(lc);
+        }
+        if (n.compareTo(d) == 0) {
+            num = ring.ring.getONE();
+            den = ring.ring.getONE();
+            return;
+        }
+        if (n.negate().compareTo(d) == 0) {
+            num = (GenSolvablePolynomial<C>) ring.ring.getONE().negate();
+            den = ring.ring.getONE();
+            return;
+        }
+        if (n.isZERO()) {
+            num = n;
+            den = ring.ring.getONE();
+            return;
+        }
+        //if (n.isONE() || d.isONE()) {
+        if (n.isConstant() || d.isConstant()) {
+            num = n;
+            den = d;
+            return;
+        }
+        // must reduce to lowest terms
+        // not perfect, TODO 
+        //GenSolvablePolynomial<C>[] gcd = PolyModUtil.<C> syzGcdCofactors(r.ring, n, d);
+        GenSolvablePolynomial<C>[] gcd = FDUtil.<C> leftGcdCofactors(r.ring, n, d);
+        if (!gcd[0].isONE()) {
+            logger.info("constructor: gcd = " + Arrays.toString(gcd)); // + ", " + n + ", " +d);
+            n = gcd[1];
+            d = gcd[2];
+        }
+        gcd = FDUtil.<C> rightGcdCofactors(r.ring, n, d);
+        if (!gcd[0].isONE()) {
+            logger.info("constructor: gcd = " + Arrays.toString(gcd)); // + ", " + n + ", " +d);
+            n = gcd[1];
+            d = gcd[2];
+        }
+        // not perfect, TODO 
+        GenSolvablePolynomial<C>[] simp = ring.engine.leftSimplifier(n, d);
+        logger.info("simp: " + Arrays.toString(simp) + ", " + n + ", " + d);
+        num = simp[0];
+        den = simp[1];
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public SolvableQuotientRing<C> factory() {
+        return ring;
+    }
+
+
+    /**
+     * Numerator.
+     * @see edu.jas.structure.QuotPair#numerator()
+     */
+    public GenSolvablePolynomial<C> numerator() {
+        return num;
+    }
+
+
+    /**
+     * Denominator.
+     * @see edu.jas.structure.QuotPair#denominator()
+     */
+    public GenSolvablePolynomial<C> denominator() {
+        return den;
+    }
+
+
+    /**
+     * Clone this.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public SolvableQuotient<C> copy() {
+        return new SolvableQuotient<C>(ring, num, den, true);
+    }
+
+
+    /**
+     * Is SolvableQuotient zero.
+     * @return If this is 0 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isZERO()
+     */
+    public boolean isZERO() {
+        return num.isZERO();
+    }
+
+
+    /**
+     * Is SolvableQuotient one.
+     * @return If this is 1 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isONE()
+     */
+    public boolean isONE() {
+        return num.compareTo(den) == 0;
+    }
+
+
+    /**
+     * Is SolvableQuotient a unit.
+     * @return If this is a unit then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isUnit()
+     */
+    public boolean isUnit() {
+        if (num.isZERO()) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Is Qoutient a constant.
+     * @return true, if this has constant numerator and denominator, else false.
+     */
+    public boolean isConstant() {
+        return num.isConstant() && den.isConstant();
+    }
+
+
+    /**
+     * Get the String representation as RingElem.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        if (PrettyPrint.isTrue()) {
+            String s = "{ " + num.toString(ring.ring.getVars());
+            if (!den.isONE()) {
+                s += " | " + den.toString(ring.ring.getVars());
+            }
+            return s + " }";
+        }
+        return "SolvableQuotient[ " + num.toString() + " | " + den.toString() + " ]";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // any scripting case
+        if (den.isONE()) {
+            return num.toScript();
+        }
+        return num.toScript() + " / " + den.toScript();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        return factory().toScript();
+    }
+
+
+    /**
+     * SolvableQuotient comparison.
+     * @param b SolvableQuotient.
+     * @return sign(this-b).
+     */
+    @Override
+    public int compareTo(SolvableQuotient<C> b) {
+        if (b == null || b.isZERO()) {
+            return this.signum();
+        }
+        if (this.isZERO()) {
+            return -b.signum();
+        }
+        // assume sign(den,b.den) > 0
+        int s1 = num.signum();
+        int s2 = b.num.signum();
+        int t = (s1 - s2) / 2;
+        if (t != 0) {
+            return t;
+        }
+        if (den.compareTo(b.den) == 0) {
+            return num.compareTo(b.num);
+        }
+        GenSolvablePolynomial<C> r, s;
+        // if (den.isONE()) {
+        //     r = b.den.multiply(num);
+        //     s = b.num;
+        //     return r.compareTo(s);
+        // }
+        // if (b.den.isONE()) {
+        //     r = num;
+        //     s = den.multiply(b.num);
+        //     return r.compareTo(s);
+        // }
+        GenSolvablePolynomial<C>[] oc = ring.engine.leftOreCond(den, b.den);
+        if (debug) {
+            System.out.println("oc[0] den =<>= oc[1] b.den: (" + oc[0] + ") (" + den + ") = (" + oc[1] + ") ("
+                            + b.den + ")");
+        }
+        r = oc[0].multiply(num);
+        s = oc[1].multiply(b.num);
+        //System.out.println("r = " + r);
+        //System.out.println("s = " + s);
+        return r.compareTo(s);
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean equals(Object b) {
+        if (b == null) {
+            return false;
+        }
+        if (!(b instanceof SolvableQuotient)) {
+            return false;
+        }
+        SolvableQuotient<C> a = (SolvableQuotient<C>) b;
+        if (num.equals(a.num) && den.equals(a.den)) { // short cut
+            return true;
+        }
+        return compareTo(a) == 0;
+    }
+
+
+    /**
+     * Hash code for this element.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = ring.hashCode();
+        h = 37 * h + num.hashCode();
+        h = 37 * h + den.hashCode();
+        return h;
+    }
+
+
+    /**
+     * SolvableQuotient right fraction. <b>Note:</b> It is not possible to
+     * distinguish right from left fractions in the current implementation. So
+     * it is not possible to compute with right fractions.
+     * @return SolvableQuotient(a,b), where den<sup>-1</sup> num = a b
+     *         <sup>-1</sup>
+     */
+    public SolvableQuotient<C> rightFraction() {
+        if (isZERO() || isONE()) {
+            return this;
+        }
+        GenSolvablePolynomial<C>[] oc = ring.engine.rightOreCond(num, den);
+        return new SolvableQuotient<C>(ring, oc[1], oc[0], true); // reversed, true is wrong but okay
+    }
+
+
+    /**
+     * Test if SolvableQuotient right fraction. <b>Note:</b> It is not possible
+     * to distinguish right from left fractions in the current implementation.
+     * So it is not possible to compute with right fractions.
+     * @param s = SolvableQuotient(a,b)
+     * @return true if s is a right fraction of this, i.e. den<sup>-1</sup> num
+     *         = a b<sup>-1</sup>
+     */
+    public boolean isRightFraction(SolvableQuotient<C> s) {
+        if (isZERO()) {
+            return s.isZERO();
+        }
+        if (isONE()) {
+            return s.isONE();
+        }
+        GenSolvablePolynomial<C> x = den.multiply(s.num);
+        GenSolvablePolynomial<C> y = num.multiply(s.den);
+        return x.compareTo(y) == 0;
+    }
+
+
+    /**
+     * SolvableQuotient absolute value.
+     * @return the absolute value of this.
+     * @see edu.jas.structure.RingElem#abs()
+     */
+    public SolvableQuotient<C> abs() {
+        return new SolvableQuotient<C>(ring, (GenSolvablePolynomial<C>) num.abs(), den, true);
+    }
+
+
+    /**
+     * SolvableQuotient summation.
+     * @param S SolvableQuotient.
+     * @return this+S.
+     */
+    public SolvableQuotient<C> sum(SolvableQuotient<C> S) {
+        if (S == null || S.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return S;
+        }
+        GenSolvablePolynomial<C> n, d, n1, n2;
+        if (den.isONE() && S.den.isONE()) {
+            n = (GenSolvablePolynomial<C>) num.sum(S.num);
+            return new SolvableQuotient<C>(ring, n, den, true);
+        }
+        /* wrong:
+        if (den.isONE()) {
+            n = S.den.multiply(num);
+            n = (GenSolvablePolynomial<C>) n.sum(S.num);
+            return new SolvableQuotient<C>(ring, n, S.den, false);
+        }
+        if (S.den.isONE()) {
+            n = den.multiply(S.num);
+            n = (GenSolvablePolynomial<C>) n.sum(num);
+            return new SolvableQuotient<C>(ring, n, den, false);
+        }
+        */
+        if (den.compareTo(S.den) == 0) { // correct ?
+            //d = den.multiply(den);
+            //n1 = den.multiply(S.num);
+            //n2 = S.den.multiply(num);
+            n = (GenSolvablePolynomial<C>) num.sum(S.num);
+            return new SolvableQuotient<C>(ring, n, den, false);
+        }
+        // general case
+        GenSolvablePolynomial<C>[] oc = ring.engine.leftOreCond(den, S.den);
+        if (debug) {
+            System.out.println("oc[0] den =sum= oc[1] S.den: (" + oc[0] + ") (" + den + ") = (" + oc[1]
+                            + ") (" + S.den + ")");
+        }
+        d = oc[0].multiply(den);
+        n1 = oc[0].multiply(num);
+        n2 = oc[1].multiply(S.num);
+        n = (GenSolvablePolynomial<C>) n1.sum(n2);
+        //System.out.println("n = " + n);
+        //System.out.println("d = " + d);
+        return new SolvableQuotient<C>(ring, n, d, false);
+    }
+
+
+    /**
+     * SolvableQuotient negate.
+     * @return -this.
+     * @see edu.jas.structure.RingElem#negate()
+     */
+    public SolvableQuotient<C> negate() {
+        return new SolvableQuotient<C>(ring, (GenSolvablePolynomial<C>) num.negate(), den, true);
+    }
+
+
+    /**
+     * SolvableQuotient signum.
+     * @see edu.jas.structure.RingElem#signum()
+     * @return signum(this).
+     */
+    public int signum() {
+        // assume sign(den) > 0
+        return num.signum();
+    }
+
+
+    /**
+     * SolvableQuotient subtraction.
+     * @param S SolvableQuotient.
+     * @return this-S.
+     */
+    public SolvableQuotient<C> subtract(SolvableQuotient<C> S) {
+        return sum(S.negate());
+    }
+
+
+    /**
+     * SolvableQuotient division.
+     * @param S SolvableQuotient.
+     * @return this/S.
+     */
+    public SolvableQuotient<C> divide(SolvableQuotient<C> S) {
+        return multiply(S.inverse());
+    }
+
+
+    /**
+     * SolvableQuotient inverse.
+     * @see edu.jas.structure.RingElem#inverse()
+     * @return S with S = 1/this.
+     */
+    public SolvableQuotient<C> inverse() {
+        if (num.isZERO()) {
+            throw new ArithmeticException("element not invertible " + this);
+        }
+        return new SolvableQuotient<C>(ring, den, num, true);
+    }
+
+
+    /**
+     * SolvableQuotient remainder.
+     * @param S SolvableQuotient.
+     * @return this - (this/S)*S.
+     */
+    public SolvableQuotient<C> remainder(SolvableQuotient<C> S) {
+        if (S.isZERO()) {
+            throw new ArithmeticException("element not invertible " + S);
+        }
+        return ring.getZERO();
+    }
+
+
+    /**
+     * Quotient and remainder by division of this by S.
+     * @param S a SolvableQuotient
+     * @return [this/S, this - (this/S)*S].
+     */
+    @SuppressWarnings("unchecked")
+    public SolvableQuotient<C>[] quotientRemainder(SolvableQuotient<C> S) {
+        return new SolvableQuotient[] { divide(S), remainder(S) };
+    }
+
+
+    /**
+     * SolvableQuotient multiplication.
+     * @param S SolvableQuotient.
+     * @return this*S.
+     */
+    public SolvableQuotient<C> multiply(SolvableQuotient<C> S) {
+        if (S == null || S.isZERO()) {
+            return S;
+        }
+        if (num.isZERO()) {
+            return this;
+        }
+        if (S.isONE()) {
+            return this;
+        }
+        if (this.isONE()) {
+            return S;
+        }
+        GenSolvablePolynomial<C> n, d;
+        if (den.isONE() && S.den.isONE()) {
+            n = num.multiply(S.num);
+            return new SolvableQuotient<C>(ring, n, den, true);
+        }
+        /* wrong:
+        if (den.isONE()) { 
+            d = S.den;
+            n = num.multiply(S.num);
+            return new SolvableQuotient<C>(ring, n, d, false);
+        }
+        if (S.den.isONE()) { 
+            d = den;
+            n = num.multiply(S.num);
+            return new SolvableQuotient<C>(ring, n, d, false);
+        }
+        */
+        // if ( den.compareTo(S.den) == 0 ) { // not correct ?
+        //     d = den.multiply(den);
+        //     n = num.multiply(S.num);
+        //     return new SolvableQuotient<C>(ring, n, d, false);
+        // }
+        GenSolvablePolynomial<C>[] oc = ring.engine.leftOreCond(num, S.den);
+        n = oc[1].multiply(S.num);
+        d = oc[0].multiply(den);
+        if (debug) {
+            System.out.println("oc[0] num =mult= oc[1] S.den: (" + oc[0] + ") (" + num + ") = (" + oc[1]
+                            + ") (" + S.den + ")");
+        }
+        return new SolvableQuotient<C>(ring, n, d, false);
+    }
+
+
+    /**
+     * SolvableQuotient multiplication by GenSolvablePolynomial.
+     * @param b GenSolvablePolynomial<C>.
+     * @return this*b.
+     */
+    public SolvableQuotient<C> multiply(GenSolvablePolynomial<C> b) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        if (num.isZERO()) {
+            return this;
+        }
+        if (b.isONE()) {
+            return this;
+        }
+        GenSolvablePolynomial<C> n = num.multiply(b);
+        return new SolvableQuotient<C>(ring, n, den, false);
+    }
+
+
+    /**
+     * SolvableQuotient multiplication by coefficient.
+     * @param b coefficient.
+     * @return this*b.
+     */
+    public SolvableQuotient<C> multiply(C b) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        if (num.isZERO()) {
+            return this;
+        }
+        if (b.isONE()) {
+            return this;
+        }
+        GenSolvablePolynomial<C> n = num.multiply(b);
+        return new SolvableQuotient<C>(ring, n, den, false);
+    }
+
+
+    /**
+     * SolvableQuotient multiplication by exponent.
+     * @param e exponent vector.
+     * @return this*b.
+     */
+    public SolvableQuotient<C> multiply(ExpVector e) {
+        if (e == null || e.isZERO()) {
+            return this;
+        }
+        if (num.isZERO()) {
+            return this;
+        }
+        GenSolvablePolynomial<C> n = num.multiply(e);
+        return new SolvableQuotient<C>(ring, n, den, false);
+    }
+
+
+    /**
+     * SolvableQuotient monic.
+     * @return this with monic value part.
+     */
+    public SolvableQuotient<C> monic() {
+        if (num.isZERO()) {
+            return this;
+        }
+        C lbc = num.leadingBaseCoefficient();
+        if (!lbc.isUnit()) {
+            return this;
+        }
+        lbc = lbc.inverse();
+        //lbc = lbc.abs();
+        GenSolvablePolynomial<C> n = num.multiply(lbc);
+        //GenSolvablePolynomial<C> d = (GenSolvablePolynomial<C>) den.multiply(lbc);
+        return new SolvableQuotient<C>(ring, n, den, true);
+    }
+
+
+    /**
+     * Greatest common divisor.
+     * @param b other element.
+     * @return gcd(this,b).
+     */
+    public SolvableQuotient<C> gcd(SolvableQuotient<C> b) {
+        if (b == null || b.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return b;
+        }
+        if (this.equals(b)) {
+            return this;
+        }
+        return ring.getONE();
+    }
+
+
+    /**
+     * Extended greatest common divisor.
+     * @param b other element.
+     * @return [ gcd(this,b), c1, c2 ] with c1*this + c2*b = gcd(this,b).
+     */
+    @SuppressWarnings("unchecked")
+    public SolvableQuotient<C>[] egcd(SolvableQuotient<C> b) {
+        @SuppressWarnings("cast")
+        SolvableQuotient<C>[] ret = (SolvableQuotient<C>[]) new SolvableQuotient[3];
+        ret[0] = null;
+        ret[1] = null;
+        ret[2] = null;
+        if (b == null || b.isZERO()) {
+            ret[0] = this;
+            return ret;
+        }
+        if (this.isZERO()) {
+            ret[0] = b;
+            return ret;
+        }
+        GenSolvablePolynomial<C> two = ring.ring.fromInteger(2);
+        ret[0] = ring.getONE();
+        ret[1] = (this.multiply(two)).inverse();
+        ret[2] = (b.multiply(two)).inverse();
+        return ret;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/SolvableQuotientRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/SolvableQuotientRing.java
@@ -1,0 +1,373 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.fd;
+
+
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gbufd.SolvableSyzygyAbstract;
+import edu.jas.gbufd.SolvableSyzygySeq;
+import edu.jas.kern.StringUtil;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.GenSolvablePolynomialRing;
+import edu.jas.poly.PolynomialList;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.QuotPairFactory;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * SolvableQuotient ring factory based on GenPolynomial with RingElem interface.
+ * Objects of this class are immutable.
+ * @author Heinz Kredel
+ */
+public class SolvableQuotientRing<C extends GcdRingElem<C>> implements RingFactory<SolvableQuotient<C>>,
+                QuotPairFactory<GenPolynomial<C>, SolvableQuotient<C>> {
+    // should be QuotPairFactory<GenSolvablePolynomial<C>
+
+
+    private static final Logger logger = LogManager.getLogger(SolvableQuotientRing.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Solvable polynomial ring of the factory.
+     */
+    public final GenSolvablePolynomialRing<C> ring;
+
+
+    /**
+     * Syzygy engine of the factory.
+     */
+    public final SolvableSyzygyAbstract<C> engine;
+
+
+    /**
+     * The constructor creates a SolvableQuotientRing object from a
+     * GenSolvablePolynomialRing.
+     * @param r solvable polynomial ring.
+     */
+    public SolvableQuotientRing(GenSolvablePolynomialRing<C> r) {
+        ring = r;
+        engine = new SolvableSyzygySeq<C>(ring.coFac);
+        logger.debug("quotient ring constructed");
+    }
+
+
+    /**
+     * Factory for base elements.
+     */
+    public GenSolvablePolynomialRing<C> pairFactory() {
+        return ring;
+    }
+
+
+    /**
+     * Create from numerator.
+     */
+    @SuppressWarnings("unchecked")
+    public SolvableQuotient<C> create(GenPolynomial<C> n) {
+        return new SolvableQuotient<C>(this, (GenSolvablePolynomial<C>) n);
+    }
+
+
+    /**
+     * Create from numerator, denominator pair.
+     */
+    @SuppressWarnings("unchecked")
+    public SolvableQuotient<C> create(GenPolynomial<C> n, GenPolynomial<C> d) {
+        return new SolvableQuotient<C>(this, (GenSolvablePolynomial<C>) n, (GenSolvablePolynomial<C>) d);
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     */
+    public boolean isFinite() {
+        return ring.isFinite();
+    }
+
+
+    /**
+     * Copy SolvableQuotient element c.
+     * @param c
+     * @return a copy of c.
+     */
+    public SolvableQuotient<C> copy(SolvableQuotient<C> c) {
+        return new SolvableQuotient<C>(c.ring, c.num, c.den, true);
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as SolvableQuotient.
+     */
+    public SolvableQuotient<C> getZERO() {
+        return new SolvableQuotient<C>(this, ring.getZERO());
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as SolvableQuotient.
+     */
+    public SolvableQuotient<C> getONE() {
+        return new SolvableQuotient<C>(this, ring.getONE());
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     */
+    public List<SolvableQuotient<C>> generators() {
+        List<GenSolvablePolynomial<C>> pgens = PolynomialList.<C> castToSolvableList(ring.generators());
+        List<SolvableQuotient<C>> gens = new ArrayList<SolvableQuotient<C>>(pgens.size() * 2 - 1);
+        GenSolvablePolynomial<C> one = ring.getONE();
+        for (GenSolvablePolynomial<C> p : pgens) {
+            SolvableQuotient<C> q = new SolvableQuotient<C>(this, p);
+            gens.add(q);
+            if (!p.isONE()) {
+                q = new SolvableQuotient<C>(this, one, p);
+                gens.add(q);
+            }
+        }
+        return gens;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true if this ring is commutative, else false.
+     */
+    public boolean isCommutative() {
+        return ring.isCommutative();
+    }
+
+
+    /**
+     * Query if this ring is associative.
+     * @return true if this ring is associative, else false.
+     */
+    public boolean isAssociative() {
+        if (!ring.isAssociative()) {
+            return false;
+        }
+        SolvableQuotient<C> Xi, Xj, Xk, p, q;
+        List<SolvableQuotient<C>> gens = generators();
+        int ngen = gens.size();
+        for (int i = 0; i < ngen; i++) {
+            Xi = gens.get(i);
+            for (int j = i + 1; j < ngen; j++) {
+                Xj = gens.get(j);
+                for (int k = j + 1; k < ngen; k++) {
+                    Xk = gens.get(k);
+                    p = Xk.multiply(Xj).multiply(Xi);
+                    q = Xk.multiply(Xj.multiply(Xi));
+                    if (!p.equals(q)) {
+                        if (logger.isInfoEnabled()) {
+                            logger.info("Xk = " + Xk + ", Xj = " + Xj + ", Xi = " + Xi);
+                            logger.info("p = ( Xk * Xj ) * Xi = " + p);
+                            logger.info("q = Xk * ( Xj * Xi ) = " + q);
+                        }
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Query if this ring is a field.
+     * @return true.
+     */
+    public boolean isField() {
+        return true;
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic() {
+        return ring.characteristic();
+    }
+
+
+    /**
+     * Get a SolvableQuotient element from a BigInteger value.
+     * @param a BigInteger.
+     * @return a SolvableQuotient.
+     */
+    public SolvableQuotient<C> fromInteger(java.math.BigInteger a) {
+        return new SolvableQuotient<C>(this, ring.fromInteger(a));
+    }
+
+
+    /**
+     * Get a SolvableQuotient element from a long value.
+     * @param a long.
+     * @return a SolvableQuotient.
+     */
+    public SolvableQuotient<C> fromInteger(long a) {
+        return new SolvableQuotient<C>(this, ring.fromInteger(a));
+    }
+
+
+    /**
+     * Get the String representation as RingFactory.
+     */
+    @Override
+    public String toString() {
+        String s = null;
+        if (ring.coFac.characteristic().signum() == 0) {
+            s = "RatFunc";
+        } else {
+            s = "ModFunc";
+        }
+        return s + "( " + ring.toString() + " )";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this ElemFactory.
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        return "SRF(" + ring.toScript() + ")";
+    }
+
+
+    /**
+     * Comparison with any other object.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (b == null) {
+            return false;
+        }
+        if (!(b instanceof SolvableQuotientRing)) {
+            return false;
+        }
+        SolvableQuotientRing<C> a = (SolvableQuotientRing<C>) b;
+        return ring.equals(a.ring);
+    }
+
+
+    /**
+     * Hash code for this quotient ring.
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = ring.hashCode();
+        return h;
+    }
+
+
+    /**
+     * SolvableQuotient random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @return a random quotient element.
+     */
+    public SolvableQuotient<C> random(int n) {
+        GenSolvablePolynomial<C> r = ring.random(n).monic();
+        GenSolvablePolynomial<C> s;
+        do {
+            s = ring.random(n).monic();
+        } while (s.isZERO());
+        return new SolvableQuotient<C>(this, r, s, false);
+    }
+
+
+    /**
+     * Generate a random quotient.
+     * @param k bitsize of random coefficients.
+     * @param l number of terms.
+     * @param d maximal degree in each variable.
+     * @param q density of nozero exponents.
+     * @return a random quotient.
+     */
+    public SolvableQuotient<C> random(int k, int l, int d, float q) {
+        GenSolvablePolynomial<C> r = ring.random(k, l, d, q).monic();
+        GenSolvablePolynomial<C> s = ring.random(k, l, d, q).monic();
+        do {
+            s = ring.random(k, l, d, q).monic();
+        } while (s.isZERO());
+        return new SolvableQuotient<C>(this, r, s, false);
+    }
+
+
+    /**
+     * SolvableQuotient random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @param rnd is a source for random bits.
+     * @return a random quotient element.
+     */
+    public SolvableQuotient<C> random(int n, Random rnd) {
+        GenSolvablePolynomial<C> r = ring.random(n, rnd).monic();
+        GenSolvablePolynomial<C> s = ring.random(n, rnd).monic();
+        do {
+            s = ring.random(n, rnd).monic();
+        } while (s.isZERO());
+        return new SolvableQuotient<C>(this, r, s, false);
+    }
+
+
+    /**
+     * Parse SolvableQuotient from String. Syntax: "{ polynomial | polynomial }"
+     * or "{ polynomial }" or " polynomial | polynomial " or " polynomial "
+     * @param s String.
+     * @return SolvableQuotient from s.
+     */
+    public SolvableQuotient<C> parse(String s) {
+        int i = s.indexOf("{");
+        if (i >= 0) {
+            s = s.substring(i + 1);
+        }
+        i = s.lastIndexOf("}");
+        if (i >= 0) {
+            s = s.substring(0, i);
+        }
+        i = s.indexOf("|");
+        if (i < 0) {
+            GenSolvablePolynomial<C> n = ring.parse(s);
+            return new SolvableQuotient<C>(this, n);
+        }
+        String s1 = s.substring(0, i);
+        String s2 = s.substring(i + 1);
+        GenSolvablePolynomial<C> n = ring.parse(s1);
+        GenSolvablePolynomial<C> d = ring.parse(s2);
+        return new SolvableQuotient<C>(this, n, d);
+    }
+
+
+    /**
+     * Parse SolvableQuotient from Reader.
+     * @param r Reader.
+     * @return next SolvableQuotient from r.
+     */
+    public SolvableQuotient<C> parse(Reader r) {
+        String s = StringUtil.nextPairedString(r, '{', '}');
+        return parse(s);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/package.html
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/fd/package.html
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "../DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>Factorization Domain package for solvable polynomial rings</title>
+  </head>
+
+  <body>
+    <h1>Factorization domain package for solvable polynomial rings.</h1>
+
+<p>
+  This package contains classes for solvable polynomials rings as
+  (non-unique) factorization domains.  Methods provided with interface
+  <code>GreatestCommonDivisor</code> are e.g. left / right greatest
+  common divisors <code>leftGcd()</code>, <code>rightGcd()</code>,
+  left / right primitive part <code>leftPrimitivePart()</code> or
+  <code>leftCoPrime()</code>.
+</p>
+<p>
+  To choose the correct implementation it is best use the factory classes
+  <code>SGCDFactory</code> with methods
+  <code>getImplementation()</code> or <code>getProxy()</code>.  These
+  methods will take care of all possible (implemented) coefficient
+  rings properties.  The polynomial coefficients must implement the
+  <code>GcdRingElem</code> interface and so must allow greatest common
+  divisor computations.  Greatest common divisor computation is
+  completely generic and works for any implemented integral domain.
+  If special, optimized implementations exist they will be used.
+</p>
+<!--p>
+  The implementation was new in 2013/14.
+</p-->
+ 
+    <hr />
+    <address><a href="mailto:kredel at rz.uni-mannheim.de">Heinz Kredel</a></address>
+<p>
+<!-- Created: Thu Dec 26 18:11:18 CET 2013 -->
+<!-- hhmts start -->
+Last modified: Fri May 13 19:57:34 CEST 2016
+<!-- hhmts end -->
+</p>
+<p>$Id$ 
+</p>
+  </body>
+</html>
+

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/AbstractPair.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/AbstractPair.java
@@ -1,0 +1,114 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+import java.io.Serializable;
+
+import edu.jas.structure.RingElem;
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+
+
+/**
+ * Serializable abstract subclass to hold pairs of polynomials.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+public abstract class AbstractPair<C extends RingElem<C> > 
+                      implements Serializable {
+
+    public final ExpVector e;
+    public final GenPolynomial<C> pi;
+    public final GenPolynomial<C> pj;
+    public final int i;
+    public final int j;
+    protected int s;
+
+
+    /**
+     * AbstractPair constructor.
+     * @param a polynomial i.
+     * @param b polynomial j.
+     * @param i first index.
+     * @param j second index.
+     */
+    public AbstractPair(GenPolynomial<C> a, GenPolynomial<C> b, 
+                        int i, int j) {
+        this(a.leadingExpVector().lcm(b.leadingExpVector()),a,b,i,j); 
+    }
+
+
+    /**
+     * AbstractPair constructor.
+     * @param a polynomial i.
+     * @param b polynomial j.
+     * @param i first index.
+     * @param j second index.
+     * @param s maximal index.
+     */
+    public AbstractPair(GenPolynomial<C> a, GenPolynomial<C> b, 
+                        int i, int j, int s) {
+        this(a.leadingExpVector().lcm(b.leadingExpVector()),a,b,i,j,s); 
+    }
+
+
+    /**
+     * AbstractPair constructor.
+     * @param lcm least common multiple of lt(a) and lt(b).
+     * @param a polynomial i.
+     * @param b polynomial j.
+     * @param i first index.
+     * @param j second index.
+     */
+    public AbstractPair(ExpVector lcm, GenPolynomial<C> a, GenPolynomial<C> b, 
+                        int i, int j) {
+        this(lcm,a,b,i,j,0); 
+    }
+
+
+    /**
+     * AbstractPair constructor.
+     * @param lcm least common multiple of lt(a) and lt(b).
+     * @param a polynomial i.
+     * @param b polynomial j.
+     * @param i first index.
+     * @param j second index.
+     * @param s maximal index.
+     */
+    public AbstractPair(ExpVector lcm, GenPolynomial<C> a, GenPolynomial<C> b, 
+                        int i, int j, int s) {
+        e = lcm;
+        pi = a; 
+        pj = b; 
+        this.i = i; 
+        this.j = j;
+        s = Math.max(i,s);
+        s = Math.max(j,s);
+        this.s = s;
+    }
+
+
+    /**
+     * Set maximal index.
+     * @param s maximal index for pair polynomials.
+     */
+    public void maxIndex(int s) {
+        s = Math.max(this.i,s);
+        s = Math.max(this.j,s);
+        this.s = s;
+    }
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString() {
+        return "pair(" + i + "," + j + "," + s + ",{" + pi.length() + "," + pj.length() + "},"
+                       + e + ")";
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/CriticalPair.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/CriticalPair.java
@@ -1,0 +1,131 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+import java.io.Serializable;
+
+import edu.jas.structure.RingElem;
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+
+
+/**
+ * Serializable subclass to hold critical pairs of polynomials.
+ * Used also to manage reduction status of the pair.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+public class CriticalPair<C extends RingElem<C> > extends AbstractPair<C> {
+
+    protected volatile boolean inReduction;
+    protected volatile GenPolynomial<C> reductum;
+    //public final ExpVector sugar;
+
+
+    /**
+     * CriticalPair constructor.
+     * @param e lcm(lt(pi),lt(pj).
+     * @param pi polynomial i.
+     * @param pj polynomial j.
+     * @param i index of pi.
+     * @param j index pf pj.
+     */
+    public CriticalPair(ExpVector e,
+                        GenPolynomial<C> pi, GenPolynomial<C> pj, 
+                        int i, int j) {
+        super(e,pi,pj,i,j);
+        inReduction = false; 
+        reductum = null;
+    }
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString() {
+        StringBuffer s = new StringBuffer(super.toString() + "[ ");
+        if ( inReduction ) {
+           s.append("," + inReduction);
+        } 
+        if ( reductum != null ) {
+           s.append("," + reductum.leadingExpVector());
+        } 
+        s.append(" ]");
+        return s.toString();
+    }
+
+
+    /**
+     * Set in reduction status.
+     * inReduction is set to true.
+     */
+    public void setInReduction() {
+        if ( inReduction ) {
+           throw new IllegalStateException("already in reduction " + this);
+        }
+        inReduction = true;
+    }
+
+
+    /**
+     * Get in reduction status.
+     * @return true if the polynomial is currently in reduction, else false.
+     */
+    public boolean getInReduction() {
+        return inReduction;
+    }
+
+
+    /**
+     * Get reduced polynomial.
+     * @return the reduced polynomial or null if not done.
+     */
+    public GenPolynomial<C> getReductum() {
+        return reductum;
+    }
+
+
+    /**
+     * Set reduced polynomial.
+     * @param r the reduced polynomial.
+     */
+    public void setReductum(GenPolynomial<C> r) {
+        if ( r == null ) {
+           throw new IllegalArgumentException("reduction null not allowed " + this);
+        }
+        inReduction = false;
+        reductum = r;
+    }
+
+
+    /**
+     * Is reduced to zero.
+     * @return true if the S-polynomial of this CriticalPair 
+     *         was reduced to ZERO, else false.
+     */
+    public boolean isZERO() {
+        if ( reductum == null ) { // not jet done
+            return false;
+        }
+        return reductum.isZERO();
+    }
+
+
+    /**
+     * Is reduced to one.
+     * @return true if the S-polynomial of this CriticalPair was 
+     *         reduced to ONE, else false.
+     */
+    public boolean isONE() {
+        if ( reductum == null ) { // not jet done
+            return false;
+        }
+        return reductum.isONE();
+    }
+
+}
+

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/CriticalPairComparator.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/CriticalPairComparator.java
@@ -1,0 +1,88 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.io.Serializable;
+import java.util.Comparator;
+
+import edu.jas.poly.TermOrder;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Comparator for critical pairs of polynomials. Immutable objects.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+public class CriticalPairComparator<C extends RingElem<C>>
+                implements Serializable, Comparator<AbstractPair<C>> {
+
+
+    public final TermOrder tord;
+
+
+    protected final TermOrder.EVComparator ec;
+
+
+    /**
+     * Constructor.
+     * @param t TermOrder.
+     */
+    public CriticalPairComparator(TermOrder t) {
+        tord = t;
+        ec = tord.getAscendComparator();
+    }
+
+
+    /**
+     * Compare. Compares exponents and if equal, compares polynomial indices.
+     * @param p1 first critical pair.
+     * @param p2 second critical pair.
+     * @return 0 if ( p1 == p2 ), -1 if ( p1 &lt; p2 ) and +1 if ( p1 &gt; p2 ).
+     */
+    public int compare(AbstractPair<C> p1, AbstractPair<C> p2) {
+        int s = ec.compare(p1.e, p2.e);
+        if (s == 0) {
+            /* not ok  
+            if ( p1.j < p2.j ) {
+              s = -1;
+            } else if ( p1.j > p2.j ) {
+               s = 1;
+            } else if ( p1.i < p2.i ) {
+               s = -1;
+            } else if ( p1.i > p2.i ) {
+               s = 1;
+            } else {
+               s = 0;
+            }
+            */
+            /* ok */
+            if (p1.j > p2.j) {
+                s = -1;
+            } else if (p1.j < p2.j) {
+                s = 1;
+            } else if (p1.i > p2.i) {
+                s = -1;
+            } else if (p1.i < p2.i) {
+                s = 1;
+            } else {
+                s = 0;
+            }
+            /* */
+        }
+        return s;
+    }
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString() {
+        return "CriticalPairComparator(" + tord + ")";
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/CriticalPairList.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/CriticalPairList.java
@@ -1,0 +1,347 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.GenSolvablePolynomialRing;
+import edu.jas.structure.RingElem;
+
+/**
+ * Critical pair list management.
+ * Makes some effort to produce the same sequence of critical pairs 
+ * as in the sequential case, when used in parallel.
+ * However already reduced pairs are not re-reduced if new
+ * polynomials appear.
+ * Implemented using GenPolynomial, SortedSet / TreeSet and BitSet.
+ * @author Heinz Kredel
+ */
+
+public class CriticalPairList<C extends RingElem<C>> extends OrderedPairlist<C> {
+
+    protected final SortedSet< CriticalPair<C> > pairlist; // hide super
+
+    protected int recordCount;
+
+    private static final Logger logger = LogManager.getLogger(CriticalPairList.class);
+
+
+    /**
+     * Constructor for CriticalPairList.
+     */
+    public CriticalPairList() {
+        super();
+        pairlist = null;
+    }
+
+
+    /**
+     * Constructor for CriticalPairList.
+     * @param r polynomial factory.
+     */
+    public CriticalPairList(GenPolynomialRing<C> r) {
+        this(0,r);
+    }
+
+
+    /**
+     * Constructor for CriticalPairList.
+     * @param m number of module variables.
+     * @param r polynomial factory.
+     */
+    public CriticalPairList(int m, GenPolynomialRing<C> r) {
+        super(m,r);
+        Comparator< AbstractPair<C> > cpc; 
+        cpc = new CriticalPairComparator<C>( ring.tord ); 
+        pairlist = new TreeSet< CriticalPair<C> >( cpc );
+        recordCount = 0;
+    }
+
+
+    /**
+     * Create a new PairList.
+     * @param r polynomial ring.
+     */
+    public PairList<C> create(GenPolynomialRing<C> r) {
+        return new CriticalPairList<C>(r);
+    }
+
+
+    /**
+     * Create a new PairList.
+     * @param m number of module variables.
+     * @param r polynomial ring.
+     */
+    public PairList<C> create(int m, GenPolynomialRing<C> r) {
+        return new CriticalPairList<C>(m,r);
+    }
+
+
+    /**
+     * Put a polynomial to the pairlist and reduction matrix.
+     * @param p polynomial.
+     * @return the index of the added polynomial.
+     */
+    public synchronized int put(GenPolynomial<C> p) { 
+        putCount++;
+        if ( oneInGB ) { 
+           return P.size()-1;
+        }
+        ExpVector e = p.leadingExpVector(); 
+        int len = P.size();
+        for ( int j = 0; j < len; j++ ) {
+            GenPolynomial<C> pj = P.get(j);
+            ExpVector f = pj.leadingExpVector(); 
+            if ( moduleVars > 0 ) { // test moduleCriterion
+               if ( !reduction.moduleCriterion( moduleVars, e, f) ) {
+                  continue; // skip pair
+               }
+            }
+            ExpVector g =  e.lcm( f );
+            CriticalPair<C> pair = new CriticalPair<C>( g, pj, p, j, len );
+            //System.out.println("put pair = " + pair );
+            pairlist.add( pair );
+        }
+        P.add( p );
+        BitSet redi = new BitSet();
+        redi.set( 0, len ); // >= jdk 1.4
+        red.add( redi );
+        if ( recordCount < len ) {
+            recordCount = len;
+        }
+        return len;
+    }
+
+
+    /**
+     * Test if there is possibly a pair in the list.
+     * @return true if a next pair could exist, otherwise false.
+     */
+    public synchronized boolean hasNext() { 
+          return pairlist.size() > 0;
+    }
+
+
+    /**
+     * Get and remove the next required pair from the pairlist.
+     * Appy the criterions 3 and 4 to see if the S-polynomial is required.
+     * The pair is not removed from the pair list.
+     * @return the next pair if one exists, otherwise null.
+     */
+    public synchronized Pair<C> removeNext() { 
+        CriticalPair<C> cp = getNext();
+        if ( cp == null ) {
+            return null;
+        }
+        return new Pair<C>(cp.pi,cp.pj,cp.i,cp.j);
+    }
+
+
+    /**
+     * Get the next required pair from the pairlist.
+     * Appy the criterions 3 and 4 to see if the S-polynomial is required.
+     * The pair is not removed from the pair list.
+     * @return the next pair if one exists, otherwise null.
+     */
+    public synchronized CriticalPair<C> getNext() { 
+        if ( oneInGB ) {
+           return null;
+        }
+        CriticalPair<C> pair = null;
+        Iterator< CriticalPair<C> > ip = pairlist.iterator();
+        boolean c = false;
+        while ( !c && ip.hasNext() )  { // findbugs
+           pair = ip.next();
+           if ( pair.getInReduction() ) {
+               continue;
+           }
+           if ( pair.getReductum() != null ) {
+               continue;
+           }
+           if ( logger.isInfoEnabled() ) {
+              logger.info("" + pair);
+           }
+           if ( useCriterion4 ) {
+              c = reduction.criterion4( pair.pi, pair.pj, pair.e ); 
+              // System.out.println("c4  = " + c); 
+           } else {
+              c = true;
+           }
+           if ( c ) {
+              c = criterion3( pair.i, pair.j, pair.e );
+              // System.out.println("c3  = " + c); 
+           }
+           red.get( pair.j ).clear( pair.i ); // set(i,false) jdk1.4
+           if ( ! c ) { // set done
+               pair.setReductum( ring.getZERO() );
+           }
+        }
+        if ( ! c ) {
+           pair = null;
+        } else {
+           remCount++; // count only real pairs
+           pair.setInReduction(); // set to work
+        }
+        return pair; 
+    }
+
+
+    /**
+     * Record reduced polynomial.
+     * @param pair the corresponding critical pair.
+     * @param p polynomial.
+     * @return index of recorded polynomial, or -1 if not added.
+     */
+    public int record(CriticalPair<C> pair, GenPolynomial<C> p) { 
+        if ( p == null ) {
+            p = ring.getZERO();
+        }
+        pair.setReductum(p);
+        // trigger thread
+        if ( ! p.isZERO() && ! p.isONE() ) {
+           recordCount++;
+           return recordCount;
+        }
+        return -1;
+    }
+
+
+    /**
+     * Record reduced polynomial and update critical pair list. 
+     * Note: it is better to use record and uptate separately.
+     * @param pair the corresponding critical pair.
+     * @param p polynomial.
+     * @return index of recorded polynomial
+     */
+    public int update(CriticalPair<C> pair, GenPolynomial<C> p) { 
+        if ( p == null ) {
+            p = ring.getZERO();
+        }
+        pair.setReductum(p);
+        if ( ! p.isZERO() && ! p.isONE() ) {
+           recordCount++;
+        }
+        int c = update();
+        if (c < 0) { // use for findbugs 
+            System.out.println("c < 0");
+        }
+        if ( ! p.isZERO() && ! p.isONE() ) {
+           return recordCount;
+        } 
+        return -1;
+    }
+
+
+    /**
+     * Update pairlist.
+     * Preserve the sequential pair sequence.
+     * Remove pairs with completed reductions.
+     * @return the number of added polynomials.
+     */
+    public synchronized int update() { 
+        int num = 0;
+        if ( oneInGB ) {
+           return num;
+        }
+        while ( pairlist.size() > 0 ) {
+            CriticalPair<C> pair = pairlist.first();
+            GenPolynomial<C> p = pair.getReductum();
+            if ( p != null ) {
+               pairlist.remove( pair );
+               num++;
+               if ( ! p.isZERO() ) {
+                  if ( p.isONE() ) {
+                     putOne(); // sets size = 1
+                  } else {
+                     put( p ); // changes pair list
+                  }
+               }
+            } else {
+               break;
+            }
+        }
+        return num;
+    }
+
+
+    /**
+     * In work pairs. List pairs which are currently reduced.
+     * @return list of critical pairs which are in reduction.
+     */
+    public synchronized List<CriticalPair<C>> inWork() { 
+        List<CriticalPair<C>> iw;
+        iw = new ArrayList<CriticalPair<C>>();
+        if ( oneInGB ) {
+            return iw;
+        }
+        for ( CriticalPair<C> pair : pairlist ) {
+            if ( pair.getInReduction() ) {
+               iw.add( pair );
+            }
+        }
+        return iw;
+    }
+
+
+    /**
+     * Update pairlist, several pairs at once. 
+     * This version does not preserve the sequential pair sequence.
+     * Remove pairs with completed reductions.
+     * @return the number of added polynomials.
+     */
+    public synchronized int updateMany() { 
+        int num = 0;
+        if ( oneInGB ) {
+           return num;
+        }
+        List<CriticalPair<C>> rem = new ArrayList<CriticalPair<C>>();
+        for ( CriticalPair<C> pair : pairlist ) {
+            if ( pair.getReductum() != null ) {
+               rem.add( pair );
+               num++;
+            } else {
+               break;
+            }
+        }
+        // must work on a copy to avoid concurrent modification
+        for ( CriticalPair<C> pair : rem ) {
+            // System.out.println("update = " + pair); 
+            pairlist.remove( pair );
+            GenPolynomial<C> p = pair.getReductum();
+            if ( ! p.isZERO() ) {
+               if ( p.isONE() ) {
+                  putOne();
+               } else {
+                  put( p );
+               }
+            }
+        }
+        return num;
+    }
+
+
+    /**
+     * Put the ONE-Polynomial to the pairlist.
+     * @return the index of the last polynomial.
+     */
+    public synchronized int putOne() { 
+        super.putOne();
+        pairlist.clear();
+        return 0;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/Cyclic.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/Cyclic.java
@@ -1,0 +1,153 @@
+/*
+ * $Id$
+  */
+
+package edu.jas.gb;
+
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.jas.arith.BigInteger;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+
+
+/**
+ * Class to produce a system of equations defined as Cyclic.
+ * 
+ * @author Heinz Kredel
+ */
+public class Cyclic {
+
+   /**
+    * main.
+    */
+    public static void main(String[] args) {
+        if ( args.length == 0 ) {
+           System.out.println("usage: Cyclic N <order> <var>");
+           return;
+        }
+        int n = Integer.parseInt(args[0]);
+        Cyclic k = null;
+        if ( args.length == 1 ) {               
+           k = new Cyclic(n);
+        }
+        if ( args.length == 2 ) {               
+           k = new Cyclic("x",n, args[1]);
+        }
+        if ( args.length == 3 ) {               
+           k = new Cyclic(args[2],n, args[1]);
+        }
+        System.out.println("#Cyclic equations for N = " + n + ":");
+        System.out.println("" + k);
+    }
+
+    final int N;
+    final String var;
+    final String order;
+    public final GenPolynomialRing<BigInteger> ring;
+
+    /**
+     * Cyclic constructor.
+     * @param n problem size.
+     */
+    public Cyclic(int n) {
+           this("x", n);
+    }
+
+
+    /**
+     * Cyclic constructor.
+     * @param v name of variables.
+     * @param n problem size.
+     */
+    public Cyclic(String v, int n) {
+           this(v, n, "G");
+    }
+
+
+    /**
+     * Cyclic constructor.
+     * @param var name of variables.
+     * @param n problem size.
+     * @param order term order letter for output.
+     */
+    public Cyclic(String var, int n, String order) {
+           this.var = var;
+           this.N = n;
+           this.order = order;
+           BigInteger fac = new BigInteger();
+           ring = new GenPolynomialRing<BigInteger>(fac, N); //,var);
+           //System.out.println("ring = " + ring);
+    }
+
+
+
+    /**
+     * toString.
+     * @return Cyclic problem as string.
+     */
+    @Override
+    public String toString() {
+           StringBuffer s = new StringBuffer();
+           s.append(ring.toString().replace("BigInteger","Z"));
+           s.append(System.getProperty("line.separator"));
+           s.append( cyclicPolys(ring).toString() );
+           return s.toString();
+    }
+
+
+    /**
+     * Compute list of polynomials.
+     * @return Cyclic problem as string of list of polynomials.
+     */
+    public String polyList() {
+        return cyclicPolys(ring).toString().replace("[","(").replace("]",")");
+    }
+
+
+    /**
+     * Compute list of polynomials.
+     * @return Cyclic problem as list of polynomials.
+     */
+    public List<GenPolynomial<BigInteger>> cyclicPolys() {
+        return cyclicPolys(ring);
+    }
+
+
+    /**
+     * Compute list of polynomials.
+     * @param ring polynomial ring.
+     * @return Cyclic problem as list of polynomials.
+     */
+   List<GenPolynomial<BigInteger>> cyclicPolys(GenPolynomialRing<BigInteger> ring) {
+        int n = ring.nvar;
+        List<GenPolynomial<BigInteger>> cp = new ArrayList<GenPolynomial<BigInteger>>(n);
+        for (int i = 1; i <= n; i++) {
+            GenPolynomial<BigInteger> p = cyclicPoly(ring, n, i);
+            cp.add(p);
+            //System.out.println("p[" + i + "] = " + p);
+        }
+        return cp;
+    }
+
+
+    GenPolynomial<BigInteger> cyclicPoly(GenPolynomialRing<BigInteger> ring, int n, int i) {
+        List<? extends GenPolynomial<BigInteger>> X = ring.univariateList();
+        GenPolynomial<BigInteger> p = ring.getZERO();
+        for (int j = 1; j <= n; j++) {
+            GenPolynomial<BigInteger> pi = ring.getONE();
+            for (int k = j; k < j + i; k++) {
+                pi = pi.multiply(X.get(k % n));
+            }
+            p = p.sum(pi);
+            if (i == n) {
+                p = p.subtract(ring.getONE());
+                break;
+            }
+        }
+        return p;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/DGroebnerBaseSeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/DGroebnerBaseSeq.java
@@ -1,0 +1,224 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ListIterator;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * D-Groebner Base sequential algorithm. Implements D-Groebner bases and GB
+ * test. <b>Note:</b> Minimal reduced GBs are not unique. see BWK, section 10.1.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class DGroebnerBaseSeq<C extends RingElem<C>> extends GroebnerBaseAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(DGroebnerBaseSeq.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Reduction engine.
+     */
+    protected DReduction<C> dred; // shadow super.red ??
+
+
+    /**
+     * Constructor.
+     */
+    public DGroebnerBaseSeq() {
+        this(new DReductionSeq<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param dred D-Reduction engine
+     */
+    public DGroebnerBaseSeq(DReduction<C> dred) {
+        super(dred);
+        this.dred = dred;
+        assert this.dred == super.red;
+    }
+
+
+    /**
+     * D-Groebner base test.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return true, if F is a D-Groebner base, else false.
+     */
+    @Override
+    public boolean isGB(int modv, List<GenPolynomial<C>> F) {
+        GenPolynomial<C> pi, pj, s, d;
+        for (int i = 0; i < F.size(); i++) {
+            pi = F.get(i);
+            for (int j = i + 1; j < F.size(); j++) {
+                pj = F.get(j);
+                if (!red.moduleCriterion(modv, pi, pj)) {
+                    continue;
+                }
+                d = dred.GPolynomial(pi, pj);
+                if (!d.isZERO()) {
+                    // better check for top reduction only
+                    d = red.normalform(F, d);
+                }
+                if (!d.isZERO()) {
+                    System.out.println("d-pol(" + i + "," + j + ") != 0: " + d);
+                    return false;
+                }
+                // works ok
+                if (!red.criterion4(pi, pj)) {
+                    continue;
+                }
+                s = red.SPolynomial(pi, pj);
+                if (!s.isZERO()) {
+                    s = red.normalform(F, s);
+                }
+                if (!s.isZERO()) {
+                    System.out.println("s-pol(" + i + "," + j + ") != 0: " + s);
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * D-Groebner base using pairlist class.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return GB(F) a D-Groebner base of F.
+     */
+    public List<GenPolynomial<C>> GB(int modv, List<GenPolynomial<C>> F) {
+        List<GenPolynomial<C>> G = normalizeZerosOnes(F);
+        if ( G.size() <= 1 ) {
+            return G;
+        }
+        GenPolynomialRing<C> ring = G.get(0).ring;
+        OrderedDPairlist<C> pairlist = new OrderedDPairlist<C>(modv, ring);
+        pairlist.put(G);
+        /*
+          int l = G.size();
+          GenPolynomial<C> p;
+          //new ArrayList<GenPolynomial<C>>();
+          ListIterator<GenPolynomial<C>> it = F.listIterator();
+          while (it.hasNext()) {
+          p = it.next();
+          if (!p.isZERO()) {
+          p = p.abs(); // not monic
+          if (p.isONE()) {
+          G.clear();
+          G.add(p);
+          return G; // since no threads are activated
+          }
+          G.add(p); //G.add( 0, p ); //reverse list
+          if (pairlist == null) {
+          pairlist = new OrderedDPairlist<C>(modv, p.ring);
+          }
+          // putOne not required
+          pairlist.put(p);
+          } else {
+          l--;
+          }
+          }
+          if (l <= 1) {
+          return G; // since no threads are activated
+          }
+        */
+
+        Pair<C> pair;
+        GenPolynomial<C> pi, pj, S, D, H;
+        while (pairlist.hasNext()) {
+            pair = pairlist.removeNext();
+            //System.out.println("pair = " + pair);
+            if (pair == null)
+                continue;
+
+            pi = pair.pi;
+            pj = pair.pj;
+            if (debug) {
+                logger.debug("pi    = " + pi);
+                logger.debug("pj    = " + pj);
+            }
+
+            // D-polynomial case ----------------------
+            D = dred.GPolynomial(pi, pj);
+            //System.out.println("D_d = " + D);
+            if (!D.isZERO() && !red.isTopReducible(G, D)) {
+                H = red.normalform(G, D);
+                if (H.isONE()) {
+                    G.clear();
+                    G.add(H);
+                    return G; // since no threads are activated
+                }
+                if (!H.isZERO()) {
+                    logger.info("Dred = " + H);
+                    //l++;
+                    G.add(H);
+                    pairlist.put(H);
+                }
+            }
+
+            // S-polynomial case -----------------------
+            if (pair.getUseCriterion3() && pair.getUseCriterion4()) {
+                S = red.SPolynomial(pi, pj);
+                //System.out.println("S_d = " + S);
+                if (S.isZERO()) {
+                    pair.setZero();
+                    continue;
+                }
+                if (logger.isDebugEnabled()) {
+                    logger.debug("ht(S) = " + S.leadingExpVector());
+                }
+
+                H = red.normalform(G, S);
+                if (H.isZERO()) {
+                    pair.setZero();
+                    continue;
+                }
+                if (logger.isDebugEnabled()) {
+                    logger.debug("ht(H) = " + H.leadingExpVector());
+                }
+
+                if (H.isONE()) {
+                    G.clear();
+                    G.add(H);
+                    return G; // since no threads are activated
+                }
+                if (logger.isDebugEnabled()) {
+                    logger.debug("H = " + H);
+                }
+                if (!H.isZERO()) {
+                    logger.info("Sred = " + H);
+                    //len = G.size();
+                    //l++;
+                    G.add(H);
+                    pairlist.put(H);
+                }
+            }
+        }
+        logger.debug("#sequential list = " + G.size());
+        G = minimalGB(G);
+        logger.info("" + pairlist);
+        return G;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/DReduction.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/DReduction.java
@@ -1,0 +1,51 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+import java.util.List;
+
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Polynomial D Reduction interface.
+ * Defines additionally D-Polynomial.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public interface DReduction<C extends RingElem<C>> 
+                 extends Reduction<C> {
+
+
+    /**
+     * G-Polynomial.
+     * @param Ap polynomial.
+     * @param Bp polynomial.
+     * @return gpol(Ap,Bp) the g-polynomial of Ap and Bp.
+     */
+    public GenPolynomial<C> GPolynomial(GenPolynomial<C> Ap, 
+                                        GenPolynomial<C> Bp);
+
+
+    /**
+     * D-Polynomial with recording.
+     * @param S recording matrix, is modified.
+     * @param i index of Ap in basis list.
+     * @param Ap a polynomial.
+     * @param j index of Bp in basis list.
+     * @param Bp a polynomial.
+     * @return gpol(Ap, Bp), the g-Polynomial for Ap and Bp.
+     */
+    public GenPolynomial<C> 
+           GPolynomial(List<GenPolynomial<C>> S,
+                       int i,
+                       GenPolynomial<C> Ap, 
+                       int j,
+                       GenPolynomial<C> Bp);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/DReductionSeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/DReductionSeq.java
@@ -1,0 +1,528 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Polynomial D-Reduction sequential use algorithm. Implements normalform.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class DReductionSeq<C extends RingElem<C>> extends ReductionAbstract<C> implements DReduction<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(DReductionSeq.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     */
+    public DReductionSeq() {
+    }
+
+
+    /**
+     * Is top reducible.
+     * @param A polynomial.
+     * @param P polynomial list.
+     * @return true if A is top reducible with respect to P.
+     */
+    //SuppressWarnings("unchecked") // not jet working
+    @Override
+    public boolean isTopReducible(List<GenPolynomial<C>> P, GenPolynomial<C> A) {
+        if (P == null || P.isEmpty()) {
+            return false;
+        }
+        if (A == null || A.isZERO()) {
+            return false;
+        }
+        boolean mt = false;
+        ExpVector e = A.leadingExpVector();
+        C a = A.leadingBaseCoefficient();
+        for (GenPolynomial<C> p : P) {
+            mt = e.multipleOf(p.leadingExpVector());
+            if (mt) {
+                C b = p.leadingBaseCoefficient();
+                C r = a.remainder(b);
+                mt = r.isZERO();
+                if (mt) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+
+    /**
+     * Is in Normalform.
+     * @param Ap polynomial.
+     * @param Pp polynomial list.
+     * @return true if Ap is in normalform with respect to Pp.
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean isNormalform(List<GenPolynomial<C>> Pp, GenPolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return true;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return true;
+        }
+        int l;
+        GenPolynomial<C>[] P;
+        synchronized (Pp) {
+            l = Pp.size();
+            P = new GenPolynomial[l];
+            //P = Pp.toArray();
+            for (int i = 0; i < Pp.size(); i++) {
+                P[i] = Pp.get(i);
+            }
+        }
+        ExpVector[] htl = new ExpVector[l];
+        C[] lbc = (C[]) new RingElem[l]; // want <C>
+        GenPolynomial<C>[] p = new GenPolynomial[l];
+        Map.Entry<ExpVector, C> m;
+        int i;
+        int j = 0;
+        for (i = 0; i < l; i++) {
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        boolean mt = false;
+        Map<ExpVector, C> Am = Ap.getMap();
+        for (Map.Entry<ExpVector, C> me : Am.entrySet()) {
+            ExpVector e = me.getKey();
+            C a = me.getValue(); //Am.get(e);
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt) {
+                    C r = a.remainder(lbc[i]);
+                    mt = r.isZERO();
+                    if (mt) {
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Normalform using d-reduction.
+     * @param Ap polynomial.
+     * @param Pp polynomial list.
+     * @return d-nf(Ap) with respect to Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public GenPolynomial<C> normalform(List<GenPolynomial<C>> Pp, GenPolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        int l;
+        GenPolynomial<C>[] P;
+        synchronized (Pp) {
+            l = Pp.size();
+            P = (GenPolynomial<C>[]) new GenPolynomial[l];
+            //P = Pp.toArray();
+            for (int i = 0; i < Pp.size(); i++) {
+                P[i] = Pp.get(i).abs();
+            }
+        }
+        //System.out.println("l = " + l);
+        Map.Entry<ExpVector, C> m;
+        ExpVector[] htl = new ExpVector[l];
+        C[] lbc = (C[]) new RingElem[l]; // want <C>
+        GenPolynomial<C>[] p = (GenPolynomial<C>[]) new GenPolynomial[l];
+        int i;
+        int j = 0;
+        for (i = 0; i < l; i++) {
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        ExpVector e;
+        C a;
+        C r = null;
+        boolean mt = false;
+        GenPolynomial<C> R = Ap.ring.getZERO();
+        GenPolynomial<C> Q = null;
+        GenPolynomial<C> S = Ap;
+        while (S.length() > 0) {
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt) {
+                    r = a.remainder(lbc[i]);
+                    mt = r.isZERO(); // && mt
+                }
+                if (mt)
+                    break;
+            }
+            if (!mt) {
+                //logger.debug("irred");
+                R = R.sum(a, e);
+                //S = S.subtract( a, e ); 
+                S = S.reductum();
+                //System.out.println(" S = " + S);
+            } else {
+                //logger.info("red div = " + e);
+                ExpVector f = e.subtract(htl[i]);
+                C b = a.divide(lbc[i]);
+                R = R.sum(r, e);
+                Q = p[i].multiply(b, f);
+                S = S.reductum().subtract(Q.reductum()); // ok also with reductum
+            }
+        }
+        return R.abs();
+    }
+
+
+    /**
+     * S-Polynomial.
+     * @param Ap polynomial.
+     * @param Bp polynomial.
+     * @return spol(Ap,Bp) the S-polynomial of Ap and Bp.
+     */
+    @Override
+    public GenPolynomial<C> SPolynomial(GenPolynomial<C> Ap, GenPolynomial<C> Bp) {
+        if (logger.isInfoEnabled()) {
+            if (Bp == null || Bp.isZERO()) {
+                return Ap.ring.getZERO();
+            }
+            if (Ap == null || Ap.isZERO()) {
+                return Bp.ring.getZERO();
+            }
+            if (!Ap.ring.equals(Bp.ring)) {
+                logger.error("rings not equal");
+            }
+        }
+        Map.Entry<ExpVector, C> ma = Ap.leadingMonomial();
+        Map.Entry<ExpVector, C> mb = Bp.leadingMonomial();
+
+        ExpVector e = ma.getKey();
+        ExpVector f = mb.getKey();
+
+        ExpVector g = e.lcm(f);
+        ExpVector e1 = g.subtract(e);
+        ExpVector f1 = g.subtract(f);
+
+        C a = ma.getValue();
+        C b = mb.getValue();
+        C c = a.gcd(b);
+        C m = a.multiply(b);
+        C l = m.divide(c); // = lcm(a,b)
+
+        C a1 = l.divide(a);
+        C b1 = l.divide(b);
+
+        GenPolynomial<C> App = Ap.multiply(a1, e1);
+        GenPolynomial<C> Bpp = Bp.multiply(b1, f1);
+        GenPolynomial<C> Cp = App.subtract(Bpp);
+        return Cp;
+    }
+
+
+    /**
+     * G-Polynomial.
+     * @param Ap polynomial.
+     * @param Bp polynomial.
+     * @return gpol(Ap,Bp) the g-polynomial of Ap and Bp.
+     */
+    public GenPolynomial<C> GPolynomial(GenPolynomial<C> Ap, GenPolynomial<C> Bp) {
+        if (logger.isInfoEnabled()) {
+            if (Bp == null || Bp.isZERO()) {
+                return Ap.ring.getZERO();
+            }
+            if (Ap == null || Ap.isZERO()) {
+                return Bp.ring.getZERO();
+            }
+            if (!Ap.ring.equals(Bp.ring)) {
+                logger.error("rings not equal");
+            }
+        }
+        Map.Entry<ExpVector, C> ma = Ap.leadingMonomial();
+        Map.Entry<ExpVector, C> mb = Bp.leadingMonomial();
+
+        ExpVector e = ma.getKey();
+        ExpVector f = mb.getKey();
+
+        ExpVector g = e.lcm(f);
+        ExpVector e1 = g.subtract(e);
+        ExpVector f1 = g.subtract(f);
+
+        C a = ma.getValue();
+        C b = mb.getValue();
+        C[] c = a.egcd(b);
+
+        //System.out.println("egcd[0] " + c[0]);
+
+        GenPolynomial<C> App = Ap.multiply(c[1], e1);
+        GenPolynomial<C> Bpp = Bp.multiply(c[2], f1);
+        GenPolynomial<C> Cp = App.sum(Bpp);
+        return Cp;
+    }
+
+
+    /**
+     * D-Polynomial with recording.
+     * @param S recording matrix, is modified.
+     * @param i index of Ap in basis list.
+     * @param Ap a polynomial.
+     * @param j index of Bp in basis list.
+     * @param Bp a polynomial.
+     * @return gpol(Ap, Bp), the g-Polynomial for Ap and Bp.
+     */
+    public GenPolynomial<C> GPolynomial(List<GenPolynomial<C>> S, int i, GenPolynomial<C> Ap, int j,
+                    GenPolynomial<C> Bp) {
+        throw new UnsupportedOperationException("not yet implemented");
+    }
+
+
+    /**
+     * GB criterium 4. Use only for commutative polynomial rings. This version
+     * works also for d-Groebner bases.
+     * @param A polynomial.
+     * @param B polynomial.
+     * @param e = lcm(ht(A),ht(B))
+     * @return true if the S-polynomial(i,j) is required, else false.
+     */
+    @Override
+    public boolean criterion4(GenPolynomial<C> A, GenPolynomial<C> B, ExpVector e) {
+        if (logger.isInfoEnabled()) {
+            if (!A.ring.equals(B.ring)) {
+                logger.error("rings equal");
+            }
+            if (A instanceof GenSolvablePolynomial || B instanceof GenSolvablePolynomial) {
+                logger.error("GBCriterion4 not applicabable to SolvablePolynomials");
+                return true;
+            }
+        }
+        ExpVector ei = A.leadingExpVector();
+        ExpVector ej = B.leadingExpVector();
+        ExpVector g = ei.sum(ej);
+        // boolean t =  g == e ;
+        ExpVector h = g.subtract(e);
+        int s = h.signum();
+        if (s == 0) { // disjoint ht
+            C a = A.leadingBaseCoefficient();
+            C b = B.leadingBaseCoefficient();
+            C d = a.gcd(b);
+            if (d.isONE()) { // disjoint hc
+                //System.out.println("d1 = " + d + ", a = " + a + ", b = " + b);
+                return false; // can skip pair
+            }
+        }
+        return true; //! ( s == 0 );
+    }
+
+
+    /**
+     * GB criterium 4. Use only for commutative polynomial rings. This version
+     * works also for d-Groebner bases.
+     * @param A polynomial.
+     * @param B polynomial.
+     * @return true if the S-polynomial(i,j) is required, else false.
+     */
+    @Override
+    public boolean criterion4(GenPolynomial<C> A, GenPolynomial<C> B) {
+        if (logger.isInfoEnabled()) {
+            if (A instanceof GenSolvablePolynomial || B instanceof GenSolvablePolynomial) {
+                logger.error("GBCriterion4 not applicabable to SolvablePolynomials");
+                return true;
+            }
+        }
+        ExpVector ei = A.leadingExpVector();
+        ExpVector ej = B.leadingExpVector();
+        ExpVector g = ei.sum(ej);
+        ExpVector e = ei.lcm(ej);
+        //        boolean t =  g == e ;
+        ExpVector h = g.subtract(e);
+        int s = h.signum();
+        if (s == 0) { // disjoint ht
+            C a = A.leadingBaseCoefficient();
+            C b = B.leadingBaseCoefficient();
+            C d = a.gcd(b);
+            if (d.isONE()) { // disjoint hc
+                return false; // can skip pair
+            }
+        }
+        return true; //! ( s == 0 );
+    }
+
+
+    /**
+     * Normalform with recording.
+     * @param row recording matrix, is modified.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @return nf(Pp,Ap), the normal form of Ap wrt. Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public GenPolynomial<C> normalform(List<GenPolynomial<C>> row, List<GenPolynomial<C>> Pp,
+                    GenPolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        throw new UnsupportedOperationException("not yet implemented");
+        /*
+        int l = Pp.size();
+        GenPolynomial<C>[] P = new GenPolynomial[l];
+        synchronized (Pp) {
+            //P = Pp.toArray();
+            for ( int i = 0; i < Pp.size(); i++ ) {
+                P[i] = Pp.get(i);
+            }
+        }
+        ExpVector[] htl = new ExpVector[ l ];
+        Object[] lbc = new Object[ l ]; // want <C>
+        GenPolynomial<C>[] p = new GenPolynomial[ l ];
+        Map.Entry<ExpVector,C> m;
+        int j = 0;
+        int i;
+        for ( i = 0; i < l; i++ ) { 
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if ( m != null ) { 
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        ExpVector e;
+        C a;
+        boolean mt = false;
+        GenPolynomial<C> zero = Ap.ring.getZERO();
+        GenPolynomial<C> R = Ap.ring.getZERO();
+
+        GenPolynomial<C> fac = null;
+        // GenPolynomial<C> T = null;
+        GenPolynomial<C> Q = null;
+        GenPolynomial<C> S = Ap;
+        while ( S.length() > 0 ) { 
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            for ( i = 0; i < l; i++ ) {
+                mt =  e.multipleOf( htl[i] );
+                if ( mt ) break; 
+            }
+            if ( ! mt ) { 
+                //logger.debug("irred");
+                R = R.sum( a, e );
+                S = S.subtract( a, e ); 
+                // System.out.println(" S = " + S);
+            } else { 
+                e =  e.subtract( htl[i] );
+                //logger.info("red div = " + e);
+                C c = (C)lbc[i];
+                a = a.divide( c );
+                Q = p[i].multiply( a, e );
+                S = S.subtract( Q );
+                fac = row.get(i);
+                if ( fac == null ) {
+                    fac = zero.sum( a, e );
+                } else {
+                    fac = fac.sum( a, e );
+                }
+                row.set(i,fac);
+            }
+        }
+        return R;
+        */
+    }
+
+
+    /**
+     * Irreducible set.
+     * @param Pp polynomial list.
+     * @return a list P of polynomials which are in normalform wrt. P.
+     */
+    @Override
+    public List<GenPolynomial<C>> irreducibleSet(List<GenPolynomial<C>> Pp) {
+        ArrayList<GenPolynomial<C>> P = new ArrayList<GenPolynomial<C>>();
+        if (Pp == null) {
+            return null;
+        }
+        for (GenPolynomial<C> a : Pp) {
+            if (!a.isZERO()) {
+                P.add(a);
+            }
+        }
+        int l = P.size();
+        if (l <= 1)
+            return P;
+
+        int irr = 0;
+        ExpVector e;
+        ExpVector f;
+        GenPolynomial<C> a;
+        logger.debug("irr = ");
+        while (irr != l) {
+            a = P.remove(0);
+            e = a.leadingExpVector();
+            a = normalform(P, a);
+            logger.debug(String.valueOf(irr));
+            if (a.isZERO()) {
+                l--;
+                if (l <= 1) {
+                    return P;
+                }
+            } else {
+                f = a.leadingExpVector();
+                if (e.equals(f)) {
+                    irr++;
+                } else {
+                    irr = 0;
+                }
+                P.add(a);
+            }
+        }
+        //System.out.println();
+        return P;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/EGroebnerBaseSeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/EGroebnerBaseSeq.java
@@ -1,0 +1,51 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import edu.jas.structure.RingElem;
+
+
+/**
+ * E-Groebner Base sequential algorithm. Nearly empty class, only the
+ * e-reduction is used instead of d-reduction. <b>Note:</b> Minimal reduced GBs
+ * are again unique. see BWK, section 10.1.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class EGroebnerBaseSeq<C extends RingElem<C>> extends DGroebnerBaseSeq<C> {
+
+
+    //private static final Logger logger = LogManager.getLogger(EGroebnerBaseSeq.class);
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Reduction engine.
+     */
+    protected EReduction<C> ered; // shadow super.red ??
+
+
+    /**
+     * Constructor.
+     */
+    public EGroebnerBaseSeq() {
+        this(new EReductionSeq<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param ered E-Reduction engine
+     */
+    public EGroebnerBaseSeq(EReductionSeq<C> ered) {
+        super(ered);
+        this.ered = ered;
+        assert this.ered == super.red;
+    }
+
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/EReduction.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/EReduction.java
@@ -1,0 +1,23 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Polynomial E-Reduction interface.
+ * Empty marker interface since all required methods are already 
+ * defined in the DReduction interface.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public interface EReduction<C extends RingElem<C>> 
+                 extends DReduction<C> {
+
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/EReductionSeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/EReductionSeq.java
@@ -1,0 +1,378 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Polynomial E-Reduction sequential use algorithm. Implements normalform.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class EReductionSeq<C extends RingElem<C>> extends DReductionSeq<C> implements EReduction<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(DReductionSeq.class);
+
+
+    /**
+     * Constructor.
+     */
+    public EReductionSeq() {
+    }
+
+
+    /**
+     * Is top reducible.
+     * @param A polynomial.
+     * @param P polynomial list.
+     * @return true if A is top reducible with respect to P.
+     */
+    //SuppressWarnings("unchecked") // not jet working
+    @Override
+    public boolean isTopReducible(List<GenPolynomial<C>> P, GenPolynomial<C> A) {
+        if (P == null || P.isEmpty()) {
+            return false;
+        }
+        if (A == null || A.isZERO()) {
+            return false;
+        }
+        boolean mt = false;
+        ExpVector e = A.leadingExpVector();
+        C a = A.leadingBaseCoefficient();
+        for (GenPolynomial<C> p : P) {
+            mt = e.multipleOf(p.leadingExpVector());
+            if (mt) {
+                C b = p.leadingBaseCoefficient();
+                C r = a.remainder(b);
+                mt = !r.equals(a);
+                if (mt) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+
+    /**
+     * Is in Normalform.
+     * @param Ap polynomial.
+     * @param Pp polynomial list.
+     * @return true if Ap is in normalform with respect to Pp.
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean isNormalform(List<GenPolynomial<C>> Pp, GenPolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return true;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return true;
+        }
+        int l;
+        GenPolynomial<C>[] P;
+        synchronized (Pp) {
+            l = Pp.size();
+            P = new GenPolynomial[l];
+            //P = Pp.toArray();
+            for (int i = 0; i < Pp.size(); i++) {
+                P[i] = Pp.get(i);
+            }
+        }
+        ExpVector[] htl = new ExpVector[l];
+        C[] lbc = (C[]) new RingElem[l]; // want <C>
+        GenPolynomial<C>[] p = new GenPolynomial[l];
+        Map.Entry<ExpVector, C> m;
+        int i;
+        int j = 0;
+        for (i = 0; i < l; i++) {
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        boolean mt = false;
+        Map<ExpVector, C> Am = Ap.getMap();
+        for (Map.Entry<ExpVector, C> me : Am.entrySet()) {
+            ExpVector e = me.getKey();
+            C a = me.getValue(); //Am.get(e);
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt) {
+                    C r = a.remainder(lbc[i]);
+                    mt = !r.equals(a);
+                    if (mt) {
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Normalform using e-reduction.
+     * @param Ap polynomial.
+     * @param Pp polynomial list.
+     * @return e-nf(Ap) with respect to Pp.
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public GenPolynomial<C> normalform(List<GenPolynomial<C>> Pp, GenPolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        int l;
+        GenPolynomial<C>[] P;
+        synchronized (Pp) {
+            l = Pp.size();
+            P = (GenPolynomial<C>[]) new GenPolynomial[l];
+            //P = Pp.toArray();
+            for (int i = 0; i < Pp.size(); i++) {
+                P[i] = Pp.get(i).abs();
+            }
+        }
+        Map.Entry<ExpVector, C> m;
+        ExpVector[] htl = new ExpVector[l];
+        C[] lbc = (C[]) new RingElem[l]; // want <C>
+        GenPolynomial<C>[] p = (GenPolynomial<C>[]) new GenPolynomial[l];
+        int i;
+        int j = 0;
+        for (i = 0; i < l; i++) {
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        ExpVector e = null;
+        ExpVector f = null;
+        C a = null;
+        C b = null;
+        C r = null;
+        GenPolynomial<C> R = Ap.ring.getZERO();
+        //GenPolynomial<C> T = Ap.ring.getZERO();
+        GenPolynomial<C> Q = null;
+        GenPolynomial<C> S = Ap;
+        //try { // required to avoid a compiler error in the while loop
+        while (S.length() > 0) {
+            boolean mt = false;
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt) {
+                    f = e.subtract(htl[i]);
+                    //logger.info("red div = " + f);
+                    r = a.remainder(lbc[i]);
+                    b = a.divide(lbc[i]);
+                    if (f == null) { // compiler produced this case
+                        System.out.println("f = null: " + e + ", " + htl[i]);
+                        Q = p[i].multiply(b);
+                    } else {
+                        Q = p[i].multiply(b, f);
+                    }
+                    S = S.subtract(Q); // ok also with reductum
+                    //System.out.println(" r = " + r);
+                    a = r;
+                    if (r.isZERO()) {
+                        break;
+                    }
+                }
+            }
+            if (!a.isZERO()) { //! mt ) { 
+                //logger.debug("irred");
+                R = R.sum(a, e);
+                //S = S.subtract( a, e ); 
+                S = S.reductum();
+            }
+            //System.out.println(" R = " + R);
+            //System.out.println(" S = " + S);
+        }
+        //} catch (Exception ex) {
+        //    System.out.println("R = " + R);
+        //    System.out.println("S = " + S);
+        //    System.out.println("f = " + f + ", " + e + ", " + htl[i]);
+        //    System.out.println("a = " + a + ", " + b + ", " + r + ", " + lbc[i]);
+        //    //throw ex;
+        //    return T;
+        //}
+        return R.abs();
+    }
+
+
+    /**
+     * Normalform with recording.
+     * @param row recording matrix, is modified.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @return nf(Pp,Ap), the normal form of Ap wrt. Pp.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    // not jet working
+    public GenPolynomial<C> normalform(List<GenPolynomial<C>> row, List<GenPolynomial<C>> Pp,
+                    GenPolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        throw new UnsupportedOperationException("not jet implemented");
+        /*
+        int l = Pp.size();
+        GenPolynomial<C>[] P = new GenPolynomial[l];
+        synchronized (Pp) {
+            //P = Pp.toArray();
+            for ( int i = 0; i < Pp.size(); i++ ) {
+                P[i] = Pp.get(i);
+            }
+        }
+        ExpVector[] htl = new ExpVector[ l ];
+        Object[] lbc = new Object[ l ]; // want <C>
+        GenPolynomial<C>[] p = new GenPolynomial[ l ];
+        Map.Entry<ExpVector,C> m;
+        int j = 0;
+        int i;
+        for ( i = 0; i < l; i++ ) { 
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if ( m != null ) { 
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        ExpVector e;
+        C a;
+        boolean mt = false;
+        GenPolynomial<C> zero = Ap.ring.getZERO();
+        GenPolynomial<C> R = Ap.ring.getZERO();
+
+        GenPolynomial<C> fac = null;
+        // GenPolynomial<C> T = null;
+        GenPolynomial<C> Q = null;
+        GenPolynomial<C> S = Ap;
+        while ( S.length() > 0 ) { 
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            for ( i = 0; i < l; i++ ) {
+                mt =  e.multipleOf( htl[i] );
+                if ( mt ) break; 
+            }
+            if ( ! mt ) { 
+                //logger.debug("irred");
+                R = R.sum( a, e );
+                S = S.subtract( a, e ); 
+                // System.out.println(" S = " + S);
+            } else { 
+                e =  e.subtract( htl[i] );
+                //logger.info("red div = " + e);
+                C c = (C)lbc[i];
+                a = a.divide( c );
+                Q = p[i].multiply( a, e );
+                S = S.subtract( Q );
+                fac = row.get(i);
+                if ( fac == null ) {
+                    fac = zero.sum( a, e );
+                } else {
+                    fac = fac.sum( a, e );
+                }
+                row.set(i,fac);
+            }
+        }
+        return R;
+        */
+    }
+
+
+    /**
+     * Irreducible set.
+     * @param Pp polynomial list.
+     * @return a list P of polynomials which are in normalform wrt. P.
+     */
+    @Override
+    public List<GenPolynomial<C>> irreducibleSet(List<GenPolynomial<C>> Pp) {
+        ArrayList<GenPolynomial<C>> P = new ArrayList<GenPolynomial<C>>();
+        if (Pp == null) {
+            return null;
+        }
+        for (GenPolynomial<C> a : Pp) {
+            if (!a.isZERO()) {
+                P.add(a);
+            }
+        }
+        int l = P.size();
+        if (l <= 1)
+            return P;
+
+        int irr = 0;
+        ExpVector e;
+        ExpVector f;
+        C c;
+        C d;
+        GenPolynomial<C> a;
+        //Iterator<GenPolynomial<C>> it;
+        logger.debug("irr = ");
+        while (irr != l) {
+            //it = P.listIterator(); 
+            //a = P.get(0); //it.next();
+            a = P.remove(0);
+            e = a.leadingExpVector();
+            c = a.leadingBaseCoefficient();
+            a = normalform(P, a);
+            logger.debug(String.valueOf(irr));
+            if (a.isZERO()) {
+                l--;
+                if (l <= 1) {
+                    return P;
+                }
+            } else {
+                f = a.leadingExpVector();
+                d = a.leadingBaseCoefficient();
+                if (e.equals(f) && c.equals(d)) {
+                    irr++;
+                } else {
+                    irr = 0;
+                }
+                P.add(a);
+            }
+        }
+        //System.out.println();
+        return P;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/ExtendedGB.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/ExtendedGB.java
@@ -1,0 +1,79 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+import java.util.List;
+
+import edu.jas.structure.RingElem;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.ModuleList;
+import edu.jas.poly.PolynomialList;
+
+
+
+/**
+  * Container for a GB and transformation matrices.
+  * A container for F, G, calG and calF.
+  * Immutable objects.
+  * @param <C> coefficient type
+  * @param F an ideal base.
+  * @param G a Groebner base of F.
+  * @param F2G a transformation matrix from F to G.
+  * @param G2F a transformation matrix from G to F.
+  */
+public class ExtendedGB<C extends RingElem<C>> {
+
+       public final List<GenPolynomial<C>> F;
+       public final List<GenPolynomial<C>> G;
+       public final List<List<GenPolynomial<C>>> F2G;
+       public final List<List<GenPolynomial<C>>> G2F;
+       public final GenPolynomialRing<C> ring;
+
+
+       public ExtendedGB( List<GenPolynomial<C>> F,
+                          List<GenPolynomial<C>> G,
+                          List<List<GenPolynomial<C>>> F2G,
+                          List<List<GenPolynomial<C>>> G2F) {
+            this.F = F;
+            this.G = G;
+            this.F2G = F2G;
+            this.G2F = G2F;
+            GenPolynomialRing<C> r = null;
+         if ( G != null ) {
+               for ( GenPolynomial<C> p : G ) {
+                   if ( p != null ) {
+                      r = p.ring;
+                      break;
+                   }
+               }
+               if ( r != null && r.getVars() == null ) {
+                  r.setVars( r.newVars("y") );
+               }
+         }
+            this.ring = r;
+        }
+
+
+        /** Get the String representation.
+         * @see java.lang.Object#toString()
+         */
+        @Override
+          public String toString() {
+            PolynomialList<C> P;
+            ModuleList<C> M;
+            StringBuffer s = new StringBuffer("ExtendedGB: \n\n");
+            P = new PolynomialList<C>( ring, F );
+            s.append("F = " + P + "\n\n");
+            P = new PolynomialList<C>( ring, G );
+            s.append("G = " + P + "\n\n");
+            M = new ModuleList<C>( ring, F2G );
+            s.append("F2G = " + M + "\n\n");
+            M = new ModuleList<C>( ring, G2F );
+            s.append("G2F = " + M + "\n");
+            return s.toString();
+        }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GBDistSP.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GBDistSP.java
@@ -1,0 +1,145 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.io.IOException;
+import java.util.List;
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.RingElem;
+import edu.jas.util.DistThreadPool;
+import edu.jas.util.RemoteExecutable;
+
+
+/**
+ * Setup to run a distributed GB example.
+ * @author Heinz Kredel
+ * @see edu.jas.application.RunGB
+ * @see edu.jas.application.RunSGB
+ * @deprecated use RunGB or RunSGB for standalone execution
+ */
+@Deprecated
+public class GBDistSP<C extends RingElem<C>> {
+
+
+    /**
+     * machine file to use.
+     */
+    private final String mfile;
+
+
+    /**
+     * Number of threads to use.
+     */
+    protected final int threads;
+
+
+    /**
+     * Server port to use.
+     */
+    protected final int port;
+
+
+    /**
+     * GB algorithm to use.
+     */
+    private final GroebnerBaseSeqPairDistributed<C> bbd;
+
+
+    /**
+     * Distributed thread pool to use.
+     */
+    private final DistThreadPool dtp;
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads respectivly processes.
+     * @param mfile name of the machine file.
+     * @param port for GB server.
+     */
+    public GBDistSP(int threads, String mfile, int port) {
+        this.threads = threads;
+        if (mfile == null || mfile.length() == 0) {
+            this.mfile = "../util/machines";
+        } else {
+            this.mfile = mfile;
+        }
+        this.port = port;
+        bbd = new GroebnerBaseSeqPairDistributed<C>(threads, this.port);
+        dtp = new DistThreadPool(threads, this.mfile);
+    }
+
+
+    /**
+     * Execute a distributed GB example. Distribute clients and start master.
+     * @param F list of polynomials
+     * @return GB(F) a Groebner base for F.
+     */
+    public List<GenPolynomial<C>> execute(List<GenPolynomial<C>> F) {
+        String master = dtp.getEC().getMasterHost();
+        int port = dtp.getEC().getMasterPort();
+        GBClientSP<C> gbc = new GBClientSP<C>(master, port);
+        for (int i = 0; i < threads; i++) {
+            // schedule remote clients
+            dtp.addJob(gbc);
+        }
+        // run master
+        List<GenPolynomial<C>> G = bbd.GB(F);
+        return G;
+    }
+
+
+    /**
+     * Terminates the distributed thread pools.
+     * @param shutDown true, if shut-down of the remote executable servers is
+     *            requested, false, if remote executable servers stay alive.
+     */
+    public void terminate(boolean shutDown) {
+        bbd.terminate();
+        dtp.terminate(shutDown);
+    }
+
+}
+
+
+/**
+ * Objects of this class are to be send to a ExecutableServer.
+ */
+class GBClientSP<C extends RingElem<C>> implements RemoteExecutable {
+
+
+    String host;
+
+
+    int port;
+
+
+    /**
+     * GBClient.
+     * @param host
+     * @param port
+     */
+    public GBClientSP(String host, int port) {
+        this.host = host;
+        this.port = port;
+    }
+
+
+    /**
+     * run.
+     */
+    public void run() {
+        GroebnerBaseSeqPairDistributed<C> bbd;
+        bbd = new GroebnerBaseSeqPairDistributed<C>(1, null, port);
+        try {
+            bbd.clientPart(host);
+        } catch (IOException ignored) {
+        }
+        bbd.terminate();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GBOptimized.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GBOptimized.java
@@ -1,0 +1,136 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.OptimizedPolynomialList;
+import edu.jas.poly.TermOrderOptimization;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Groebner bases via optimized variable and term order.
+ * @author Heinz Kredel
+ */
+
+public class GBOptimized<C extends GcdRingElem<C>> extends GroebnerBaseAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GBOptimized.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled(); //logger.isInfoEnabled();
+
+
+    /**
+     * GB engine.
+     */
+    public final GroebnerBaseAbstract<C> e1;
+
+
+    /**
+     * Indicator for return of permuted polynomials.
+     */
+    public final boolean retPermuted;
+
+
+    /**
+     * GBOptimized constructor.
+     * @param e1 Groebner base engine.
+     */
+    public GBOptimized(GroebnerBaseAbstract<C> e1) {
+        this(e1, false); // true ??
+    }
+
+
+    /**
+     * GBOptimized constructor.
+     * @param e1 Groebner base engine.
+     * @param rP true for return of permuted polynomials, false for inverse
+     *            permuted polynomials and new GB computation.
+     */
+    public GBOptimized(GroebnerBaseAbstract<C> e1, boolean rP) {
+        this.e1 = e1;
+        this.retPermuted = rP;
+    }
+
+
+    /**
+     * Get the String representation with GB engine.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "GBOptimized[ " + e1.toString() + " ]";
+    }
+
+
+    /**
+     * Cleanup and terminate ThreadPool.
+     */
+    @Override
+    public void terminate() {
+        e1.terminate();
+    }
+
+
+    /**
+     * Cancel ThreadPool.
+     */
+    @Override
+    public int cancel() {
+        int s = e1.cancel();
+        return s;
+    }
+
+
+    /**
+     * Groebner base.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return GB(F) a Groebner base of F.
+     */
+    @Override
+    public List<GenPolynomial<C>> GB(int modv, List<GenPolynomial<C>> F) {
+        if (F == null || F.isEmpty()) {
+            return F;
+        }
+        if (modv != 0) {
+            throw new UnsupportedOperationException("implemented only for modv = 0, not " + modv);
+        }
+        GenPolynomialRing<C> pfac = F.get(0).ring;
+        OptimizedPolynomialList<C> opt = TermOrderOptimization.<C> optimizeTermOrder(pfac, F);
+        List<GenPolynomial<C>> P = opt.list;
+        if (debug) {
+            logger.info("optimized polynomials: " + P);
+        }
+        List<Integer> iperm = TermOrderOptimization.inversePermutation(opt.perm);
+        logger.info("optimize perm: " + opt.perm + ", de-optimize perm: " + iperm);
+
+        // compute GB with backing engine
+        List<GenPolynomial<C>> G = e1.GB(modv, P);
+        if (retPermuted || G.isEmpty()) {
+            return G;
+        }
+        List<GenPolynomial<C>> iopt = TermOrderOptimization.<C> permutation(iperm, pfac, G);
+        if (debug) {
+            logger.info("de-optimized polynomials: " + iopt);
+        }
+        if (iopt.size() == 1) {
+            return iopt;
+        }
+        logger.warn("recomputing GB");
+        G = e1.GB(modv, iopt);
+        return G;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GBProxy.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GBProxy.java
@@ -1,0 +1,168 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.kern.ComputerThreads;
+import edu.jas.kern.PreemptingException;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Groebner bases parallel proxy.
+ * @author Heinz Kredel
+ */
+
+public class GBProxy<C extends GcdRingElem<C>> extends GroebnerBaseAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GBProxy.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled(); //logger.isInfoEnabled();
+
+
+    /**
+     * GB engines.
+     */
+    public final GroebnerBaseAbstract<C> e1;
+
+
+    public final GroebnerBaseAbstract<C> e2;
+
+
+    /**
+     * Thread pool.
+     */
+    protected transient ExecutorService pool;
+
+
+    /**
+     * Proxy constructor.
+     * @param e1 Groebner base engine.
+     * @param e2 Groebner base engine.
+     */
+    public GBProxy(GroebnerBaseAbstract<C> e1, GroebnerBaseAbstract<C> e2) {
+        this.e1 = e1;
+        this.e2 = e2;
+        pool = ComputerThreads.getPool();
+        //System.out.println("pool 2 = "+pool);
+    }
+
+
+    /**
+     * Get the String representation with GB engines.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "GBProxy[ " + e1.toString() + ", " + e2.toString() + " ]";
+    }
+
+
+    /**
+     * Cleanup and terminate ThreadPool.
+     */
+    @Override
+    public void terminate() {
+        e1.terminate();
+        e2.terminate();
+    }
+
+
+    /**
+     * Cancel ThreadPool.
+     */
+    @Override
+    public int cancel() {
+        int s = e1.cancel();
+        s += e2.cancel();
+        return s;
+    }
+
+
+    /**
+     * Groebner base.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return GB(F) a Groebner base of F.
+     */
+    @Override
+    public List<GenPolynomial<C>> GB(final int modv, final List<GenPolynomial<C>> F) {
+        if (F == null || F.isEmpty()) {
+            return F;
+        }
+        // parallel case
+        List<GenPolynomial<C>> G = null;
+        List<Callable<List<GenPolynomial<C>>>> cs = new ArrayList<Callable<List<GenPolynomial<C>>>>(2);
+        cs.add(new Callable<List<GenPolynomial<C>>>() {
+
+
+            public List<GenPolynomial<C>> call() {
+                try {
+                    //System.out.println("starting e1 " + e1.getClass().getName());
+                    List<GenPolynomial<C>> G = e1.GB(modv, F);
+                    if (debug) {
+                        logger.info("GBProxy done e1 " + e1.getClass().getName());
+                    }
+                    return G;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("GBProxy e1 preempted " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("GBProxy e1 " + e);
+                    logger.info("Exception GBProxy F = " + F);
+                    throw new RuntimeException("GBProxy e1 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        cs.add(new Callable<List<GenPolynomial<C>>>() {
+
+
+            public List<GenPolynomial<C>> call() {
+                try {
+                    //System.out.println("starting e2 " + e2.getClass().getName());
+                    List<GenPolynomial<C>> G = e2.GB(modv, F);
+                    if (debug) {
+                        logger.info("GBProxy done e2 " + e2.getClass().getName());
+                    }
+                    return G;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("GBProxy e2 preempted " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("GBProxy e2 " + e);
+                    logger.info("Exception GBProxy F = " + F);
+                    throw new RuntimeException("GBProxy e2 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        try {
+            G = pool.invokeAny(cs);
+        } catch (InterruptedException ignored) {
+            logger.info("InterruptedException " + ignored);
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
+            logger.info("ExecutionException " + e);
+            Thread.currentThread().interrupt();
+        }
+        return G;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GBTransportMess.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GBTransportMess.java
@@ -1,0 +1,182 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.io.Serializable;
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Distributed GB transport message. This class and its subclasses are used for
+ * transport of polynomials and pairs and as markers in distributed GB
+ * algorithms.
+ * @author Heinz Kredel
+ */
+
+public class GBTransportMess implements Serializable {
+
+
+    public GBTransportMess() {
+    }
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString() {
+        return this.getClass().getName();
+    }
+}
+
+
+/**
+ * Distributed GB transport message for requests.
+ */
+
+final class GBTransportMessReq extends GBTransportMess {
+
+
+    public GBTransportMessReq() {
+    }
+}
+
+
+/**
+ * Distributed GB transport message for termination.
+ */
+
+final class GBTransportMessEnd extends GBTransportMess {
+
+
+    public GBTransportMessEnd() {
+    }
+}
+
+
+/**
+ * Distributed GB transport message for polynomial.
+ */
+
+final class GBTransportMessPoly<C extends RingElem<C>> extends GBTransportMess {
+
+
+    /**
+     * The polynomial to transport.
+     */
+    public final GenPolynomial<C> pol;
+
+
+    /**
+     * GBTransportMessPoly.
+     * @param p polynomial to transfered.
+     */
+    public GBTransportMessPoly(GenPolynomial<C> p) {
+        this.pol = p;
+    }
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString() {
+        return super.toString() + "( " + pol + " )";
+    }
+}
+
+
+/**
+ * Distributed GB transport message for pairs.
+ */
+
+final class GBTransportMessPair<C extends RingElem<C>> extends GBTransportMess {
+
+
+    public final Pair<C> pair;
+
+
+    /**
+     * GBTransportMessPair.
+     * @param p pair for transfer.
+     */
+    public GBTransportMessPair(Pair<C> p) {
+        this.pair = p;
+    }
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString() {
+        return super.toString() + "( " + pair + " )";
+    }
+}
+
+
+/**
+ * Distributed GB transport message for index pairs.
+ */
+
+final class GBTransportMessPairIndex extends GBTransportMess {
+
+
+    public final int i;
+
+
+    public final int j;
+
+
+    public final int s;
+
+
+    /**
+     * GBTransportMessPairIndex.
+     * @param p pair for transport.
+     */
+    public GBTransportMessPairIndex(Pair p) {
+        this(p.i, p.j, p.s);
+    }
+
+
+    /**
+     * GBTransportMessPairIndex.
+     * @param i first index.
+     * @param j second index.
+     * @param s maximal index.
+     */
+    public GBTransportMessPairIndex(int i, int j, int s) {
+        this.i = i;
+        this.j = j;
+        s = Math.max(this.i, s);
+        s = Math.max(this.j, s);
+        this.s = s;
+    }
+
+
+    /**
+     * GBTransportMessPairIndex.
+     * @param i first index.
+     * @param j second index.
+     * @param s maximal index.
+     */
+    public GBTransportMessPairIndex(Integer i, Integer j, Integer s) {
+        this(i.intValue(), j.intValue(), s.intValue());
+    }
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString() {
+        return super.toString() + "(" + i + "," + j + "," + s + ")";
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GroebnerBase.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GroebnerBase.java
@@ -1,0 +1,136 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+import java.util.List;
+
+import java.io.Serializable;
+
+import edu.jas.structure.RingElem;
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.ModuleList;
+
+
+/**
+ * Groebner Bases interface.
+ * Defines methods for Groebner bases and GB test.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ *
+ * @see edu.jas.application.GBAlgorithmBuilder
+ * @see edu.jas.gbufd.GBFactory
+ */
+
+public interface GroebnerBase<C extends RingElem<C>> 
+                 extends Serializable {
+
+
+    /**
+     * Groebner base test.
+     * @param F polynomial list.
+     * @return true, if F is a Groebner base, else false.
+     */
+    public boolean isGB(List<GenPolynomial<C>> F);
+
+
+    /**
+     * Groebner base test.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return true, if F is a Groebner base, else false.
+     */
+    public boolean isGB(int modv, List<GenPolynomial<C>> F);
+
+
+    /**
+     * Groebner base using pairlist class.
+     * @param F polynomial list.
+     * @return GB(F) a Groebner base of F.
+     */
+    public List<GenPolynomial<C>> 
+           GB( List<GenPolynomial<C>> F );
+
+
+    /**
+     * Groebner base using pairlist class.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return GB(F) a Groebner base of F.
+     */
+    public List<GenPolynomial<C>> 
+           GB( int modv, 
+               List<GenPolynomial<C>> F );
+
+
+    /**
+     * isGB.
+     * @param M a module basis.
+     * @return true, if M is a Groebner base, else false.
+     */
+    public boolean isGB(ModuleList<C> M);
+
+
+    /**
+     * GB.
+     * @param M a module basis.
+     * @return GB(M), a Groebner base of M.
+     */
+    public ModuleList<C> GB(ModuleList<C> M);
+
+
+    /** 
+     * Extended Groebner base using critical pair class.
+     * @param F polynomial list.
+     * @return a container for a Groebner base G of F together with back-and-forth transformations.
+     */
+    public ExtendedGB<C>  
+           extGB( List<GenPolynomial<C>> F );
+
+
+    /**
+     * Extended Groebner base using critical pair class.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return a container for a Groebner base G of F together with back-and-forth transformations.
+     */
+    public ExtendedGB<C> 
+           extGB( int modv, 
+                  List<GenPolynomial<C>> F );
+
+
+    /**
+     * Minimal ordered groebner basis.
+     * @param Gp a Groebner base.
+     * @return a reduced Groebner base of Gp.
+     */
+    public List<GenPolynomial<C>> 
+               minimalGB(List<GenPolynomial<C>> Gp);
+
+
+    /**
+     * Test if reduction matrix.
+     * @param exgb an ExtendedGB container.
+     * @return true, if exgb contains a reduction matrix, else false.
+     */
+    public boolean
+           isReductionMatrix(ExtendedGB<C> exgb); 
+
+
+    /**
+     * Test if reduction matrix.
+     * @param F a polynomial list.
+     * @param G a Groebner base.
+     * @param Mf a possible reduction matrix.
+     * @param Mg a possible reduction matrix.
+     * @return true, if Mg and Mf are reduction matrices, else false.
+     */
+    public boolean
+           isReductionMatrix(List<GenPolynomial<C>> F, 
+                             List<GenPolynomial<C>> G,
+                             List<List<GenPolynomial<C>>> Mf,  
+                             List<List<GenPolynomial<C>>> Mg);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GroebnerBaseAbstract.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GroebnerBaseAbstract.java
@@ -1,0 +1,957 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.ModuleList;
+import edu.jas.poly.OrderedPolynomialList;
+import edu.jas.poly.PolyUtil;
+import edu.jas.poly.PolynomialList;
+import edu.jas.poly.TermOrder;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.vector.BasicLinAlg;
+
+
+/**
+ * Groebner Bases abstract class. Implements common Groebner bases and GB test
+ * methods.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ * 
+ * @see edu.jas.application.GBAlgorithmBuilder
+ * @see edu.jas.gbufd.GBFactory
+ */
+
+public abstract class GroebnerBaseAbstract<C extends RingElem<C>> implements GroebnerBase<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GroebnerBaseAbstract.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Reduction engine.
+     */
+    public final Reduction<C> red;
+
+
+    /**
+     * Strategy for pair selection.
+     */
+    public final PairList<C> strategy;
+
+
+    /**
+     * linear algebra engine.
+     */
+    public final BasicLinAlg<GenPolynomial<C>> blas;
+
+
+    /**
+     * Constructor.
+     */
+    public GroebnerBaseAbstract() {
+        this(new ReductionSeq<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param red Reduction engine
+     */
+    public GroebnerBaseAbstract(Reduction<C> red) {
+        this(red, new OrderedPairlist<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param pl pair selection strategy
+     */
+    public GroebnerBaseAbstract(PairList<C> pl) {
+        this(new ReductionSeq<C>(), pl);
+    }
+
+
+    /**
+     * Constructor.
+     * @param red Reduction engine
+     * @param pl pair selection strategy
+     */
+    public GroebnerBaseAbstract(Reduction<C> red, PairList<C> pl) {
+        if (red == null) {
+            red = new ReductionSeq<C>();
+        }
+        this.red = red;
+        if (pl == null) {
+            pl = new OrderedPairlist<C>();
+        }
+        this.strategy = pl;
+        blas = new BasicLinAlg<GenPolynomial<C>>();
+    }
+
+
+    /**
+     * Get the String representation with GB engines.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName();
+    }
+
+
+    /**
+     * Normalize polynomial list.
+     * @param A list of polynomials.
+     * @return list of polynomials with zeros removed and ones/units reduced.
+     */
+    public List<GenPolynomial<C>> normalizeZerosOnes(List<GenPolynomial<C>> A) {
+        if (A == null) {
+            return A;
+        }
+        List<GenPolynomial<C>> N = new ArrayList<GenPolynomial<C>>(A.size());
+        if (A.isEmpty()) {
+            return N;
+        }
+        for (GenPolynomial<C> p : A) {
+            if (p == null || p.isZERO()) {
+                continue;
+            }
+            if (p.isUnit()) {
+                N.clear();
+                N.add(p.ring.getONE());
+                return N;
+            }
+            N.add(p.abs());
+        }
+        //N.trimToSize();
+        return N;
+    }
+
+
+    /**
+     * Groebner base test.
+     * @param F polynomial list.
+     * @return true, if F is a Groebner base, else false.
+     */
+    public boolean isGB(List<GenPolynomial<C>> F) {
+        return isGB(0, F);
+    }
+
+
+    /**
+     * Groebner base test.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return true, if F is a Groebner base, else false.
+     */
+    public boolean isGB(int modv, List<GenPolynomial<C>> F) {
+        return isGB(modv, F, true);
+    }
+
+
+    /**
+     * Groebner base test.
+     * @param F polynomial list.
+     * @param b true for simple test, false for GB test.
+     * @return true, if F is a Groebner base, else false.
+     */
+    public boolean isGB(List<GenPolynomial<C>> F, boolean b) {
+        return isGB(0, F, b);
+    }
+
+
+    /**
+     * Groebner base test.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @param b true for simple test, false for GB test.
+     * @return true, if F is a Groebner base, else false.
+     */
+    public boolean isGB(int modv, List<GenPolynomial<C>> F, boolean b) {
+        if (b) {
+            return isGBsimple(modv, F);
+        }
+        return isGBidem(modv, F);
+    }
+
+
+    /**
+     * Groebner base simple test.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return true, if F is a Groebner base, else false.
+     */
+    public boolean isGBsimple(int modv, List<GenPolynomial<C>> F) {
+        if (F == null || F.isEmpty()) {
+            return true;
+        }
+        GenPolynomial<C> pi, pj, s, h;
+        ExpVector ei, ej, eij;
+        for (int i = 0; i < F.size(); i++) {
+            pi = F.get(i);
+            ei = pi.leadingExpVector();
+            for (int j = i + 1; j < F.size(); j++) {
+                pj = F.get(j);
+                ej = pj.leadingExpVector();
+                if (!red.moduleCriterion(modv, ei, ej)) {
+                    continue;
+                }
+                eij = ei.lcm(ej);
+                if (!red.criterion4(ei, ej, eij)) {
+                    continue;
+                }
+                if (!criterion3(i, j, eij, F)) {
+                    continue;
+                }
+                s = red.SPolynomial(pi, pj);
+                if (s.isZERO()) {
+                    continue;
+                }
+                //System.out.println("i, j = " + i + ", " + j); 
+                h = red.normalform(F, s);
+                if (!h.isZERO()) {
+                    logger.info("no GB: pi = " + pi + ", pj = " + pj);
+                    logger.info("s  = " + s + ", h = " + h);
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * GB criterium 3.
+     * @return true if the S-polynomial(i,j) is required.
+     */
+    boolean criterion3(int i, int j, ExpVector eij, List<GenPolynomial<C>> P) {
+        assert i < j;
+        //for ( int k = 0; k < P.size(); k++ ) {
+        // not of much use
+        for (int k = 0; k < i; k++) {
+            GenPolynomial<C> A = P.get(k);
+            ExpVector ek = A.leadingExpVector();
+            if (eij.multipleOf(ek)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Groebner base idempotence test.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return true, if F is equal to GB(F), else false.
+     */
+    public boolean isGBidem(int modv, List<GenPolynomial<C>> F) {
+        if (F == null || F.isEmpty()) {
+            return true;
+        }
+        GenPolynomialRing<C> pring = F.get(0).ring;
+        List<GenPolynomial<C>> G = GB(modv, F);
+        PolynomialList<C> Fp = new PolynomialList<C>(pring, F);
+        PolynomialList<C> Gp = new PolynomialList<C>(pring, G);
+        return Fp.compareTo(Gp) == 0;
+    }
+
+
+    /**
+     * Common zero test.
+     * @param F polynomial list.
+     * @return -1, 0 or 1 if dimension(ideal(F)) &eq; -1, 0 or &ge; 1.
+     */
+    public int commonZeroTest(List<GenPolynomial<C>> F) {
+        if (F == null || F.isEmpty()) {
+            return 1;
+        }
+        GenPolynomialRing<C> pfac = F.get(0).ring;
+        if (pfac.nvar <= 0) {
+            return -1;
+        }
+        //int uht = 0;
+        Set<Integer> v = new HashSet<Integer>(); // for non reduced GBs
+        for (GenPolynomial<C> p : F) {
+            if (p.isZERO()) {
+                continue;
+            }
+            if (p.isConstant()) { // for non-monic lists
+                return -1;
+            }
+            ExpVector e = p.leadingExpVector();
+            if (e == null) {
+                continue;
+            }
+            int[] u = e.dependencyOnVariables();
+            if (u == null) {
+                continue;
+            }
+            if (u.length == 1) {
+                //uht++;
+                v.add(u[0]);
+            }
+        }
+        if (pfac.nvar == v.size()) {
+            return 0;
+        }
+        return 1;
+    }
+
+
+    /**
+     * Groebner base using pairlist class.
+     * @param F polynomial list.
+     * @return GB(F) a Groebner base of F.
+     */
+    public List<GenPolynomial<C>> GB(List<GenPolynomial<C>> F) {
+        return GB(0, F);
+    }
+
+
+    /**
+     * isGB.
+     * @param M a module basis.
+     * @return true, if M is a Groebner base, else false.
+     */
+    public boolean isGB(ModuleList<C> M) {
+        return isGB(M,false);
+    }
+
+    
+    /**
+     * isGB.
+     * @param M a module basis.
+     * @param top true for TOP term order, false for POT term order.
+     * @return true, if M is a Groebner base, else false.
+     */
+    public boolean isGB(ModuleList<C> M, boolean top) {
+        if (M == null || M.list == null) {
+            return true;
+        }
+        if (M.rows == 0 || M.cols == 0) {
+            return true;
+        }
+        PolynomialList<C> F = M.getPolynomialList(top);
+        int modv = M.cols; // > 0  
+        return isGB(modv, F.list);
+    }
+
+
+    /**
+     * GB.
+     * @param M a module basis.
+     * @return GB(M), a Groebner base of M.
+     */
+    public ModuleList<C> GB(ModuleList<C> M) {
+        return GB(M,false);
+    }
+
+    
+    /**
+     * GB.
+     * @param M a module basis.
+     * @param top true for TOP term order, false for POT term order.
+     * @return GB(M), a Groebner base of M wrt. TOP or POT.
+     */
+    public ModuleList<C> GB(ModuleList<C> M, boolean top) {
+        ModuleList<C> N = M;
+        if (M == null || M.list == null) {
+            return N;
+        }
+        if (M.rows == 0 || M.cols == 0) {
+            return N;
+        }
+        PolynomialList<C> F = M.getPolynomialList(top);
+        int modv = M.cols;
+        List<GenPolynomial<C>> G = GB(modv, F.list);
+        F = new PolynomialList<C>(F.ring, G);
+        N = F.getModuleList(modv);
+        return N;
+    }
+
+
+    /**
+     * Extended Groebner base using critical pair class.
+     * @param F polynomial list.
+     * @return a container for a Groebner base G of F together with
+     *         back-and-forth transformations.
+     */
+    public ExtendedGB<C> extGB(List<GenPolynomial<C>> F) {
+        return extGB(0, F);
+    }
+
+
+    /**
+     * Extended Groebner base using critical pair class.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return a container for a Groebner base G of F together with
+     *         back-and-forth transformations.
+     */
+    public ExtendedGB<C> extGB(int modv, List<GenPolynomial<C>> F) {
+        throw new UnsupportedOperationException("extGB not implemented in " + this.getClass().getSimpleName());
+    }
+
+
+    /**
+     * Minimal ordered Groebner basis.
+     * @param Gp a Groebner base.
+     * @return a reduced Groebner base of Gp.
+     */
+    public List<GenPolynomial<C>> minimalGB(List<GenPolynomial<C>> Gp) {
+        if (Gp == null || Gp.size() <= 1) {
+            return Gp;
+        }
+        // remove zero polynomials
+        List<GenPolynomial<C>> G = new ArrayList<GenPolynomial<C>>(Gp.size());
+        for (GenPolynomial<C> a : Gp) {
+            if (a != null && !a.isZERO()) { // always true in GB()
+                // already positive a = a.abs();
+                G.add(a);
+            }
+        }
+        if (G.size() <= 1) {
+            return G;
+        }
+        // remove top reducible polynomials
+        GenPolynomial<C> a;
+        List<GenPolynomial<C>> F;
+        F = new ArrayList<GenPolynomial<C>>(G.size());
+        while (G.size() > 0) {
+            a = G.remove(0);
+            if (red.isTopReducible(G, a) || red.isTopReducible(F, a)) {
+                // drop polynomial 
+                if (debug) {
+                    System.out.println("dropped " + a);
+                    List<GenPolynomial<C>> ff;
+                    ff = new ArrayList<GenPolynomial<C>>(G);
+                    ff.addAll(F);
+                    a = red.normalform(ff, a);
+                    if (!a.isZERO()) {
+                        System.out.println("error, nf(a) " + a);
+                    }
+                }
+            } else {
+                F.add(a);
+            }
+        }
+        G = F;
+        if (G.size() <= 1) {
+            return G;
+        }
+        // reduce remaining polynomials
+        Collections.reverse(G); // important for lex GB
+        int len = G.size();
+        if (debug) {
+            System.out.println("#G " + len);
+            for (GenPolynomial<C> aa : G) {
+                System.out.println("aa = " + aa.length() + ", lt = " + aa.getMap().keySet());
+            }
+        }
+        int i = 0;
+        while (i < len) {
+            a = G.remove(0);
+            if (debug) {
+                System.out.println("doing " + a.length() + ", lt = " + a.leadingExpVector());
+            }
+            a = red.normalform(G, a);
+            G.add(a); // adds as last
+            i++;
+        }
+        Collections.reverse(G); // undo reverse
+        return G;
+    }
+
+
+    /**
+     * Test for minimal ordered Groebner basis.
+     * @param Gp an ideal base.
+     * @return true, if Gp is a reduced minimal Groebner base.
+     */
+    public boolean isMinimalGB(List<GenPolynomial<C>> Gp) {
+        if (Gp == null || Gp.size() == 0) {
+            return true;
+        }
+        // test for zero polynomials
+        for (GenPolynomial<C> a : Gp) {
+            if (a == null || a.isZERO()) {
+                if (debug) {
+                    logger.debug("zero polynomial " + a);
+                }
+                return false;
+            }
+        }
+        // test for top reducible polynomials
+        List<GenPolynomial<C>> G = new ArrayList<GenPolynomial<C>>(Gp);
+        List<GenPolynomial<C>> F = new ArrayList<GenPolynomial<C>>(G.size());
+        while (G.size() > 0) {
+            GenPolynomial<C> a = G.remove(0);
+            if (red.isTopReducible(G, a) || red.isTopReducible(F, a)) {
+                if (debug) {
+                    logger.debug("top reducible polynomial " + a);
+                }
+                return false;
+            }
+            F.add(a);
+        }
+        G = F;
+        if (G.size() <= 1) {
+            return true;
+        }
+        // test reducibility of polynomials
+        int len = G.size();
+        int i = 0;
+        while (i < len) {
+            GenPolynomial<C> a = G.remove(0);
+            if (!red.isNormalform(G, a)) {
+                if (debug) {
+                    logger.debug("reducible polynomial " + a);
+                }
+                return false;
+            }
+            G.add(a); // re-adds as last
+            i++;
+        }
+        return true;
+    }
+
+
+    /**
+     * Test if reduction matrix.
+     * @param exgb an ExtendedGB container.
+     * @return true, if exgb contains a reduction matrix, else false.
+     */
+    public boolean isReductionMatrix(ExtendedGB<C> exgb) {
+        if (exgb == null) {
+            return true;
+        }
+        return isReductionMatrix(exgb.F, exgb.G, exgb.F2G, exgb.G2F);
+    }
+
+
+    /**
+     * Test if reduction matrix.
+     * @param F a polynomial list.
+     * @param G a Groebner base.
+     * @param Mf a possible reduction matrix.
+     * @param Mg a possible reduction matrix.
+     * @return true, if Mg and Mf are reduction matrices, else false.
+     */
+    public boolean isReductionMatrix(List<GenPolynomial<C>> F, List<GenPolynomial<C>> G,
+                    List<List<GenPolynomial<C>>> Mf, List<List<GenPolynomial<C>>> Mg) {
+        // no more check G and Mg: G * Mg[i] == 0
+        // check F and Mg: F * Mg[i] == G[i]
+        int k = 0;
+        for (List<GenPolynomial<C>> row : Mg) {
+            boolean t = red.isReductionNF(row, F, G.get(k), null);
+            if (!t) {
+                logger.error("F isReductionMatrix s, k = " + F.size() + ", " + k);
+                return false;
+            }
+            k++;
+        }
+        // check G and Mf: G * Mf[i] == F[i]
+        k = 0;
+        for (List<GenPolynomial<C>> row : Mf) {
+            boolean t = red.isReductionNF(row, G, F.get(k), null);
+            if (!t) {
+                logger.error("G isReductionMatrix s, k = " + G.size() + ", " + k);
+                return false;
+            }
+            k++;
+        }
+        return true;
+    }
+
+
+    /**
+     * Normalize M. Make all rows the same size and make certain column elements
+     * zero.
+     * @param M a reduction matrix.
+     * @return normalized M.
+     */
+    public List<List<GenPolynomial<C>>> normalizeMatrix(int flen, List<List<GenPolynomial<C>>> M) {
+        if (M == null) {
+            return M;
+        }
+        if (M.size() == 0) {
+            return M;
+        }
+        List<List<GenPolynomial<C>>> N = new ArrayList<List<GenPolynomial<C>>>();
+        List<List<GenPolynomial<C>>> K = new ArrayList<List<GenPolynomial<C>>>();
+        int len = M.get(M.size() - 1).size(); // longest row
+        // pad / extend rows
+        for (List<GenPolynomial<C>> row : M) {
+            List<GenPolynomial<C>> nrow = new ArrayList<GenPolynomial<C>>(row);
+            for (int i = row.size(); i < len; i++) {
+                nrow.add(null);
+            }
+            N.add(nrow);
+        }
+        // System.out.println("norm N fill = " + N);
+        // make zero columns
+        int k = flen;
+        for (int i = 0; i < N.size(); i++) { // 0
+            List<GenPolynomial<C>> row = N.get(i);
+            if (debug) {
+                logger.info("row = " + row);
+            }
+            K.add(row);
+            if (i < flen) { // skip identity part
+                continue;
+            }
+            List<GenPolynomial<C>> xrow;
+            GenPolynomial<C> a;
+            //System.out.println("norm i = " + i);
+            for (int j = i + 1; j < N.size(); j++) {
+                List<GenPolynomial<C>> nrow = N.get(j);
+                //System.out.println("nrow j = " +j + ", " + nrow);
+                if (k < nrow.size()) { // always true
+                    a = nrow.get(k);
+                    //System.out.println("k, a = " + k + ", " + a);
+                    if (a != null && !a.isZERO()) {
+                        xrow = blas.scalarProduct(a, row);
+                        xrow = blas.vectorAdd(xrow, nrow);
+                        //System.out.println("xrow = " + xrow);
+                        N.set(j, xrow);
+                    }
+                }
+            }
+            k++;
+        }
+        //System.out.println("norm K reduc = " + K);
+        // truncate 
+        N.clear();
+        for (List<GenPolynomial<C>> row : K) {
+            List<GenPolynomial<C>> tr = new ArrayList<GenPolynomial<C>>();
+            for (int i = 0; i < flen; i++) {
+                tr.add(row.get(i));
+            }
+            N.add(tr);
+        }
+        K = N;
+        //System.out.println("norm K trunc = " + K);
+        return K;
+    }
+
+
+    /**
+     * Minimal extended groebner basis.
+     * @param Gp a Groebner base.
+     * @param M a reduction matrix, is modified.
+     * @return a (partially) reduced Groebner base of Gp in a container.
+     */
+    public ExtendedGB<C> minimalExtendedGB(int flen, List<GenPolynomial<C>> Gp, List<List<GenPolynomial<C>>> M) {
+        if (Gp == null) {
+            return null; //new ExtendedGB<C>(null,Gp,null,M);
+        }
+        if (Gp.size() <= 1) {
+            return new ExtendedGB<C>(null, Gp, null, M);
+        }
+        List<GenPolynomial<C>> G;
+        List<GenPolynomial<C>> F;
+        G = new ArrayList<GenPolynomial<C>>(Gp);
+        F = new ArrayList<GenPolynomial<C>>(Gp.size());
+
+        List<List<GenPolynomial<C>>> Mg;
+        List<List<GenPolynomial<C>>> Mf;
+        Mg = new ArrayList<List<GenPolynomial<C>>>(M.size());
+        Mf = new ArrayList<List<GenPolynomial<C>>>(M.size());
+        List<GenPolynomial<C>> row;
+        for (List<GenPolynomial<C>> r : M) {
+            // must be copied also
+            row = new ArrayList<GenPolynomial<C>>(r);
+            Mg.add(row);
+        }
+        row = null;
+
+        GenPolynomial<C> a;
+        ExpVector e;
+        ExpVector f;
+        GenPolynomial<C> p;
+        boolean mt;
+        ListIterator<GenPolynomial<C>> it;
+        ArrayList<Integer> ix = new ArrayList<Integer>();
+        ArrayList<Integer> jx = new ArrayList<Integer>();
+        int k = 0;
+        //System.out.println("flen, Gp, M = " + flen + ", " + Gp.size() + ", " + M.size() );
+        while (G.size() > 0) {
+            a = G.remove(0);
+            e = a.leadingExpVector();
+
+            it = G.listIterator();
+            mt = false;
+            while (it.hasNext() && !mt) {
+                p = it.next();
+                f = p.leadingExpVector();
+                mt = e.multipleOf(f);
+            }
+            it = F.listIterator();
+            while (it.hasNext() && !mt) {
+                p = it.next();
+                f = p.leadingExpVector();
+                mt = e.multipleOf(f);
+            }
+            //System.out.println("k, mt = " + k + ", " + mt);
+            if (!mt) {
+                F.add(a);
+                ix.add(k);
+            } else { // drop polynomial and corresponding row and column
+                // F.add( a.ring.getZERO() );
+                jx.add(k);
+            }
+            k++;
+        }
+        if (debug) {
+            logger.debug("ix, #M, jx = " + ix + ", " + Mg.size() + ", " + jx);
+        }
+        int fix = -1; // copied polys
+        // copy Mg to Mf as indicated by ix
+        for (int i = 0; i < ix.size(); i++) {
+            int u = ix.get(i);
+            if (u >= flen && fix == -1) {
+                fix = Mf.size();
+            }
+            //System.out.println("copy u, fix = " + u + ", " + fix);
+            if (u >= 0) {
+                row = Mg.get(u);
+                Mf.add(row);
+            }
+        }
+        if (F.size() <= 1 || fix == -1) {
+            return new ExtendedGB<C>(null, F, null, Mf);
+        }
+        // must return, since extended normalform has not correct order of polys
+        /*
+        G = F;
+        F = new ArrayList<GenPolynomial<C>>( G.size() );
+        List<GenPolynomial<C>> temp;
+        k = 0;
+        final int len = G.size();
+        while ( G.size() > 0 ) {
+            a = G.remove(0);
+            if ( k >= fix ) { // dont touch copied polys
+               row = Mf.get( k );
+               //System.out.println("doing k = " + k + ", " + a);
+               // must keep order, but removed polys missing
+               temp = new ArrayList<GenPolynomial<C>>( len );
+               temp.addAll( F );
+               temp.add( a.ring.getZERO() ); // ??
+               temp.addAll( G );
+               //System.out.println("row before = " + row);
+               a = red.normalform( row, temp, a );
+               //System.out.println("row after  = " + row);
+            }
+            F.add( a );
+            k++;
+        }
+        // does Mf need renormalization?
+        */
+        return new ExtendedGB<C>(null, F, null, Mf);
+    }
+
+
+    /**
+     * Univariate head term degrees.
+     * @param A list of polynomials.
+     * @return a list of the degrees of univariate head terms.
+     */
+    public List<Long> univariateDegrees(List<GenPolynomial<C>> A) {
+        List<Long> ud = new ArrayList<Long>();
+        if (A == null || A.size() == 0) {
+            return ud;
+        }
+        GenPolynomialRing<C> pfac = A.get(0).ring;
+        if (pfac.nvar <= 0) {
+            return ud;
+        }
+        //int uht = 0;
+        Map<Integer, Long> v = new TreeMap<Integer, Long>(); // for non reduced GBs
+        for (GenPolynomial<C> p : A) {
+            ExpVector e = p.leadingExpVector();
+            if (e == null) {
+                continue;
+            }
+            int[] u = e.dependencyOnVariables();
+            if (u == null) {
+                continue;
+            }
+            if (u.length == 1) {
+                //uht++;
+                Long d = v.get(u[0]);
+                if (d == null) {
+                    v.put(u[0], e.getVal(u[0]));
+                }
+            }
+        }
+        for (int i = 0; i < pfac.nvar; i++) {
+            Long d = v.get(i);
+            ud.add(d);
+        }
+        //Collections.reverse(ud);
+        return ud;
+    }
+
+
+    /**
+     * Construct univariate polynomial of minimal degree in variable i of a zero
+     * dimensional ideal(G).
+     * @param i variable index.
+     * @param G list of polynomials, a monic reduced Gr&ouml;bner base of a zero
+     *            dimensional ideal.
+     * @return univariate polynomial of minimal degree in variable i in ideal(G)
+     */
+    public GenPolynomial<C> constructUnivariate(int i, List<GenPolynomial<C>> G) {
+        if (G == null || G.size() == 0) {
+            throw new IllegalArgumentException("G may not be null or empty");
+        }
+        //logger.info("G in  = " + G);
+        //Collections.reverse(G); // test
+        G = OrderedPolynomialList.<C> sort(G); // better performance
+        List<Long> ud = univariateDegrees(G);
+        if (ud.size() <= i) {
+            //logger.info("univ pol, ud = " + ud);
+            throw new IllegalArgumentException("ideal(G) not zero dimensional " + ud);
+        }
+        int ll = 0;
+        Long di = ud.get(i);
+        if (di != null) {
+            ll = (int) (long) di;
+        } else {
+            throw new IllegalArgumentException("ideal(G) not zero dimensional");
+        }
+        long vsdim = 1;
+        for (Long d : ud) {
+            if (d != null) {
+                vsdim *= d;
+            }
+        }
+        logger.info("univariate construction, deg = " + ll + ", vsdim = " + vsdim);
+        GenPolynomialRing<C> pfac = G.get(0).ring;
+        RingFactory<C> cfac = pfac.coFac;
+        String var = pfac.getVars()[pfac.nvar - 1 - i];
+        GenPolynomialRing<C> ufac = new GenPolynomialRing<C>(cfac, 1, new TermOrder(TermOrder.INVLEX),
+                        new String[] { var });
+
+        GenPolynomialRing<C> cpfac = new GenPolynomialRing<C>(cfac, ll, new TermOrder(TermOrder.INVLEX));
+        GenPolynomialRing<GenPolynomial<C>> rfac = new GenPolynomialRing<GenPolynomial<C>>(cpfac, pfac);
+        GenPolynomial<GenPolynomial<C>> P = rfac.getZERO();
+        for (int k = 0; k < ll; k++) {
+            GenPolynomial<GenPolynomial<C>> Pp = rfac.univariate(i, k);
+            GenPolynomial<C> cp = cpfac.univariate(cpfac.nvar - 1 - k);
+            Pp = Pp.multiply(cp);
+            P = P.sum(Pp);
+        }
+        if (debug) {
+            logger.info("univariate construction, P = " + P);
+            logger.info("univariate construction, deg_*(G) = " + ud);
+            //throw new RuntimeException("check");
+        }
+        GenPolynomial<C> X;
+        GenPolynomial<C> XP;
+        // solve system of linear equations for the coefficients of the univariate polynomial
+        List<GenPolynomial<C>> ls;
+        int z = -1;
+        do {
+            //System.out.println("ll  = " + ll);
+            GenPolynomial<GenPolynomial<C>> Pp = rfac.univariate(i, ll);
+            GenPolynomial<C> cp = cpfac.univariate(cpfac.nvar - 1 - ll);
+            Pp = Pp.multiply(cp);
+            P = P.sum(Pp);
+            X = pfac.univariate(i, ll);
+            XP = red.normalform(G, X);
+            if (debug) {
+                logger.info("XP = " + XP);
+            }
+            GenPolynomial<GenPolynomial<C>> XPp = PolyUtil.<C> toRecursive(rfac, XP);
+            GenPolynomial<GenPolynomial<C>> XPs = XPp.sum(P);
+            ls = new ArrayList<GenPolynomial<C>>(XPs.getMap().values());
+            //System.out.println("ls,1 = " + ls);
+            ls = red.irreducibleSet(ls);
+            z = commonZeroTest(ls);
+            if (z != 0) {
+                ll++;
+                if (ll > vsdim) {
+                    logger.info("univariate construction, P = " + P);
+                    logger.info("univariate construction, nf(P) = " + XP);
+                    logger.info("G = " + G);
+                    throw new ArithmeticException(
+                                    "univariate polynomial degree greater than vector space dimansion");
+                }
+                cpfac = cpfac.extend(1);
+                rfac = new GenPolynomialRing<GenPolynomial<C>>(cpfac, pfac);
+                P = PolyUtil.<C> extendCoefficients(rfac, P, 0, 0L);
+                XPp = PolyUtil.<C> extendCoefficients(rfac, XPp, 0, 1L);
+                P = P.sum(XPp);
+            }
+        } while (z != 0); // && ll <= 5 && !XP.isZERO()
+        // construct result polynomial
+        GenPolynomial<C> pol = ufac.univariate(0, ll);
+        for (GenPolynomial<C> pc : ls) {
+            ExpVector e = pc.leadingExpVector();
+            if (e == null) {
+                continue;
+            }
+            int[] v = e.dependencyOnVariables();
+            if (v == null || v.length == 0) {
+                continue;
+            }
+            int vi = v[0];
+            C lc = pc.leadingBaseCoefficient();
+            C tc = pc.trailingBaseCoefficient();
+            tc = tc.negate();
+            if (!lc.isONE()) {
+                tc = tc.divide(lc);
+            }
+            GenPolynomial<C> pi = ufac.univariate(0, ll - 1 - vi);
+            pi = pi.multiply(tc);
+            pol = pol.sum(pi);
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("univariate construction, pol = " + pol);
+        }
+        return pol;
+    }
+
+
+    /**
+     * Cleanup and terminate ThreadPool.
+     */
+    public void terminate() {
+        logger.info("terminate not implemented");
+        //throw new RuntimeException("get a stack trace");
+    }
+
+
+    /**
+     * Cancel ThreadPool.
+     */
+    public int cancel() {
+        logger.info("cancel not implemented");
+        return 0;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GroebnerBaseArriSigSeqIter.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GroebnerBaseArriSigSeqIter.java
@@ -1,0 +1,242 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Groebner Base Arri signature based sequential iterative algorithm. Implements
+ * Groebner bases.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ * 
+ * @see edu.jas.application.GBAlgorithmBuilder
+ * @see edu.jas.gbufd.GBFactory
+ */
+
+public class GroebnerBaseArriSigSeqIter<C extends RingElem<C>> extends GroebnerBaseSigSeqIter<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GroebnerBaseArriSigSeqIter.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     */
+    public GroebnerBaseArriSigSeqIter() {
+        this(new SigReductionSeq<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param red Reduction engine
+     */
+    public GroebnerBaseArriSigSeqIter(SigReductionSeq<C> red) {
+        super(red);
+    }
+
+
+    /**
+     * S-Polynomial.
+     * @param P pair.
+     * @return spol(A,B) the S-polynomial of the pair (A,B).
+     */
+    @Override
+    GenPolynomial<C> SPolynomial(SigPair<C> P) {
+        return P.pi.poly;
+    }
+
+
+    /**
+     * Pair with signature.
+     * @param A polynomial with signature.
+     * @param B polynomial with signature.
+     * @param G polynomial ith signature list.
+     * @return signature pair according to algorithm.
+     */
+    @Override
+    SigPair<C> newPair(SigPoly<C> A, SigPoly<C> B, List<SigPoly<C>> G) {
+        ExpVector e = A.poly.leadingExpVector().lcm(B.poly.leadingExpVector())
+                        .subtract(A.poly.leadingExpVector());
+        GenPolynomial<C> sp = SPolynomial(A, B);
+        GenPolynomial<C> sig = sp.ring.valueOf(e);
+        return new SigPair<C>(sig, new SigPoly<C>(sig, sp), B, G);
+    }
+
+
+    /**
+     * Pair with signature.
+     * @param s signature for pair.
+     * @param A polynomial with signature.
+     * @param B polynomial with signature.
+     * @param G polynomial ith signature list.
+     * @return signature pair according to algorithm.
+     */
+    @Override
+    SigPair<C> newPair(GenPolynomial<C> s, SigPoly<C> A, SigPoly<C> B, List<SigPoly<C>> G) {
+        GenPolynomial<C> sp = SPolynomial(A, B);
+        return new SigPair<C>(s, new SigPoly<C>(s, sp), B, G);
+    }
+
+
+    /**
+     * Top normalform.
+     * @param A polynomial.
+     * @param F polynomial list.
+     * @param G polynomial list.
+     * @return nf(A) with respect to F and G.
+     */
+    @Override
+    SigPoly<C> sigNormalform(List<GenPolynomial<C>> F, List<SigPoly<C>> G, SigPoly<C> A) {
+        return sred.sigSemiNormalform(F, G, A);
+    }
+
+
+    /**
+     * Prune total pair list P.
+     * @param P pair list.
+     * @param syz list of exponent vectors representing syzygies.
+     * @return updated pair list.
+     */
+    @Override
+    List<SigPair<C>> pruneP(List<SigPair<C>> P, List<ExpVector> syz) {
+        List<SigPair<C>> res = new ArrayList<SigPair<C>>(P.size());
+        for (SigPair<C> p : P) {
+            ExpVector f = p.sigma.leadingExpVector();
+            if (f == null) {
+                continue;
+            }
+            boolean div = false;
+            for (ExpVector e : syz) {
+                if (f.multipleOf(e)) {
+                    div = true;
+                    break;
+                }
+            }
+            if (div) {
+                continue;
+            }
+            res.add(p);
+        }
+        return res;
+    }
+
+
+    /**
+     * Prune pair list of degree d.
+     * @param S pair list.
+     * @param syz list of exponent vectors representing syzygies.
+     * @param done list of treated polynomials.
+     * @param G polynomial with signature list.
+     * @return updated pair list.
+     */
+    @Override
+    List<SigPair<C>> pruneS(List<SigPair<C>> S, List<ExpVector> syz, List<SigPoly<C>> done,
+                    List<SigPoly<C>> G) {
+        List<SigPair<C>> res = new ArrayList<SigPair<C>>(S.size());
+        for (SigPair<C> p : S) {
+            ExpVector f = p.sigma.leadingExpVector();
+            if (f == null) {
+                continue;
+            }
+            boolean div = false;
+            for (ExpVector e : syz) {
+                if (f.multipleOf(e)) {
+                    div = true;
+                    break;
+                }
+            }
+            if (div) {
+                continue;
+            }
+            div = false;
+            for (SigPair<C> q : S) {
+                if (p.sigma.equals(q.sigma)) {
+                    if (p.pi.poly.compareTo(q.pi.poly) > 0) {
+                        div = true;
+                        break;
+                    }
+                }
+            }
+            if (div) {
+                continue;
+            }
+            div = false;
+            for (SigPoly<C> q : done) {
+                ExpVector e = q.sigma.leadingExpVector();
+                if (e == null) {
+                    continue;
+                }
+                if (f.multipleOf(e)) {
+                    ExpVector g = f.subtract(e);
+                    ExpVector f1 = g.sum(q.poly.leadingExpVector());
+                    ExpVector e1 = p.pi.poly.leadingExpVector();
+                    if (e1 == null) {
+                        continue;
+                    }
+                    if (f1.compareTo(e1) < 0) {
+                        div = true;
+                        break;
+                    }
+                }
+            }
+            if (div) {
+                continue;
+            }
+            res.add(p);
+            logger.debug("added p = " + p.sigma);
+        }
+        return res;
+    }
+
+
+    /**
+     * Initializes syzygy list.
+     * @param F polynomial list.
+     * @param G polynomial with signature list.
+     * @return list of exponent vectors representing syzygies.
+     */
+    @Override
+    List<ExpVector> initializeSyz(List<GenPolynomial<C>> F, List<SigPoly<C>> G) {
+        List<ExpVector> P = new ArrayList<ExpVector>();
+        for (GenPolynomial<C> p : F) {
+            if (p.isZERO()) {
+                continue;
+            }
+            P.add(p.leadingExpVector());
+        }
+        return P;
+    }
+
+
+    /**
+     * Update syzygy list.
+     * @param syz list of exponent vectors representing syzygies.
+     * @param r polynomial. <b>Note:</b> szy is modified to represent updated
+     *            list of exponent vectors.
+     */
+    @Override
+    void updateSyz(List<ExpVector> syz, SigPoly<C> r) {
+        if (r.poly.isZERO() && !r.sigma.isZERO()) {
+            syz.add(r.sigma.leadingExpVector());
+        }
+        return;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GroebnerBaseDistributedEC.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GroebnerBaseDistributedEC.java
@@ -1,0 +1,1007 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.RingElem;
+import edu.jas.util.ChannelFactory;
+import edu.jas.util.DistHashTable;
+import edu.jas.util.DistHashTableServer;
+import edu.jas.util.DistThreadPool;
+import edu.jas.util.RemoteExecutable;
+import edu.jas.util.SocketChannel;
+import edu.jas.util.Terminator;
+
+
+/**
+ * Groebner Base distributed algorithm. Implements a distributed memory parallel
+ * version of Groebner bases with executable channels. Using pairlist class,
+ * distributed tasks do reduction, one communication channel per task.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class GroebnerBaseDistributedEC<C extends RingElem<C>> extends GroebnerBaseAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GroebnerBaseDistributedEC.class);
+
+
+    /**
+     * Number of threads to use.
+     */
+    protected final int threads;
+
+
+    /**
+     * Default number of threads.
+     */
+    protected static final int DEFAULT_THREADS = 2;
+
+
+    /**
+     * Pool of threads to use. <b>Note:</b> No ComputerThreads for one node
+     * tests
+     */
+    protected transient final ExecutorService pool;
+
+
+    /**
+     * Default server port.
+     */
+    protected static final int DEFAULT_PORT = 55711;
+
+
+    /**
+     * Default distributed hash table server port.
+     */
+    protected final int DHT_PORT;
+
+
+    /**
+     * Server port to use.
+     */
+    protected final int port;
+
+
+    /**
+     * machine file to use.
+     */
+    protected final String mfile;
+
+
+    /**
+     * Distributed thread pool to use.
+     */
+    private final transient DistThreadPool dtp;
+
+
+    /**
+     * Distributed hash table server to use.
+     */
+    private final transient DistHashTableServer<Integer> dhts;
+
+
+    /**
+     * Constructor.
+     * @param mfile name of the machine file.
+     */
+    public GroebnerBaseDistributedEC(String mfile) {
+        this(mfile, DEFAULT_THREADS, DEFAULT_PORT);
+    }
+
+
+    /**
+     * Constructor.
+     * @param mfile name of the machine file.
+     * @param threads number of threads to use.
+     */
+    public GroebnerBaseDistributedEC(String mfile, int threads) {
+        this(mfile, threads, Executors.newFixedThreadPool(threads), DEFAULT_PORT);
+    }
+
+
+    /**
+     * Constructor.
+     * @param mfile name of the machine file.
+     * @param threads number of threads to use.
+     * @param port server port to use.
+     */
+    public GroebnerBaseDistributedEC(String mfile, int threads, int port) {
+        this(mfile, threads, Executors.newFixedThreadPool(threads), port);
+    }
+
+
+    /**
+     * Constructor.
+     * @param mfile name of the machine file.
+     * @param threads number of threads to use.
+     * @param pool ExecutorService to use.
+     * @param port server port to use.
+     */
+    public GroebnerBaseDistributedEC(String mfile, int threads, ExecutorService pool, int port) {
+        this(mfile, threads, pool, new OrderedPairlist<C>(), port);
+    }
+
+
+    /**
+     * Constructor.
+     * @param mfile name of the machine file.
+     * @param threads number of threads to use.
+     * @param pl pair selection strategy
+     * @param port server port to use.
+     */
+    public GroebnerBaseDistributedEC(String mfile, int threads, PairList<C> pl, int port) {
+        this(mfile, threads, Executors.newFixedThreadPool(threads), pl, port);
+    }
+
+
+    /**
+     * Constructor.
+     * @param mfile name of the machine file.
+     * @param threads number of threads to use.
+     * @param pool ExecutorService to use.
+     * @param pl pair selection strategy
+     * @param port server port to use.
+     */
+    public GroebnerBaseDistributedEC(String mfile, int threads, ExecutorService pool, PairList<C> pl, int port) {
+        super(new ReductionPar<C>(), pl);
+        this.threads = threads;
+        if (mfile == null || mfile.length() == 0) {
+            this.mfile = "../util/machines"; // contains localhost
+        } else {
+            this.mfile = mfile;
+        }
+        if (threads < 1) {
+            threads = 1;
+        }
+        if (pool == null) {
+            pool = Executors.newFixedThreadPool(threads);
+        }
+        this.pool = pool;
+        this.port = port;
+        logger.info("machine file " + mfile + ", port = " + port);
+        this.dtp = new DistThreadPool(this.threads, this.mfile);
+        logger.info("running " + dtp);
+        this.DHT_PORT = this.dtp.getEC().getMasterPort() + 100;
+        this.dhts = new DistHashTableServer<Integer>(this.DHT_PORT);
+        this.dhts.init();
+        logger.info("running " + dhts);
+    }
+
+
+    /**
+     * Cleanup and terminate ExecutorService.
+     */
+    @Override
+    public void terminate() {
+        terminate(true);
+    }
+
+
+    /**
+     * Terminates the distributed thread pools.
+     * @param shutDown true, if shut-down of the remote executable servers is
+     *            requested, false, if remote executable servers stay alive.
+     */
+    public void terminate(boolean shutDown) {
+        pool.shutdown();
+        try {
+            while (!pool.isTerminated()) {
+                //logger.info("await");
+                boolean rest = pool.awaitTermination(1000L, TimeUnit.MILLISECONDS);
+            }
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        logger.info(pool.toString());
+        dtp.terminate(shutDown);
+        logger.info("dhts.terminate()");
+        dhts.terminate();
+    }
+
+
+    /**
+     * Distributed Groebner base.
+     * @param modv number of module variables.
+     * @param F polynomial list.
+     * @return GB(F) a Groebner base of F or null, if a IOException occurs.
+     */
+    public List<GenPolynomial<C>> GB(int modv, List<GenPolynomial<C>> F) {
+        List<GenPolynomial<C>> Fp = normalizeZerosOnes(F);
+        Fp = PolyUtil.<C> monic(Fp);
+        if (Fp.size() <= 1) {
+            return Fp;
+        }
+        if (!Fp.get(0).ring.coFac.isField()) {
+            throw new IllegalArgumentException("coefficients not from a field");
+        }
+
+        String master = dtp.getEC().getMasterHost();
+        //int port = dtp.getEC().getMasterPort(); // wrong port
+        GBExerClient<C> gbc = new GBExerClient<C>(master, port, DHT_PORT);
+        for (int i = 0; i < threads; i++) {
+            // schedule remote clients
+            dtp.addJob(gbc);
+        }
+        // run master
+        List<GenPolynomial<C>> G = GBMaster(modv, Fp);
+        return G;
+    }
+
+
+    /**
+     * Distributed Groebner base.
+     * @param modv number of module variables.
+     * @param F non empty monic polynomial list.
+     * @return GB(F) a Groebner base of F or null, if a IOException occurs.
+     */
+    List<GenPolynomial<C>> GBMaster(int modv, List<GenPolynomial<C>> F) {
+        ChannelFactory cf = new ChannelFactory(port);
+        cf.init();
+        logger.info("GBMaster on " + cf);
+
+        List<GenPolynomial<C>> G = F;
+        if (G.isEmpty()) {
+            throw new IllegalArgumentException("empty polynomial list not allowed");
+        }
+        GenPolynomialRing<C> ring = G.get(0).ring;
+        if (!ring.coFac.isField()) {
+            throw new IllegalArgumentException("coefficients not from a field");
+        }
+        PairList<C> pairlist = strategy.create(modv, ring);
+        pairlist.put(G);
+
+        /*
+        GenPolynomial<C> p;
+        List<GenPolynomial<C>> G = new ArrayList<GenPolynomial<C>>();
+        PairList<C> pairlist = null;
+        boolean oneInGB = false;
+        int l = F.size();
+        int unused;
+        ListIterator<GenPolynomial<C>> it = F.listIterator();
+        while (it.hasNext()) {
+            p = it.next();
+            if (p.length() > 0) {
+                p = p.monic();
+                if (p.isONE()) {
+                    oneInGB = true;
+                    G.clear();
+                    G.add(p);
+                    //return G; must signal termination to others
+                }
+                if (!oneInGB) {
+                    G.add(p);
+                }
+                if (pairlist == null) {
+                    //pairlist = new OrderedPairlist<C>(modv, p.ring);
+                    pairlist = strategy.create(modv, p.ring);
+                    if (!p.ring.coFac.isField()) {
+                        throw new IllegalArgumentException("coefficients not from a field");
+                    }
+                }
+                // theList not updated here
+                if (p.isONE()) {
+                    unused = pairlist.putOne();
+                } else {
+                    unused = pairlist.put(p);
+                }
+            } else {
+                l--;
+            }
+        }
+        logger.info("start " + pairlist); 
+        //if (l <= 1) {
+        //return G; must signal termination to others
+        //}
+        */
+        logger.debug("looking for clients");
+        DistHashTable<Integer, GenPolynomial<C>> theList = new DistHashTable<Integer, GenPolynomial<C>>(
+                        "localhost", DHT_PORT);
+        theList.init();
+        List<GenPolynomial<C>> al = pairlist.getList();
+        for (int i = 0; i < al.size(); i++) {
+            GenPolynomial<C> nn = theList.put(Integer.valueOf(i), al.get(i));
+            if (nn != null) {
+                logger.info("double polynomials " + i + ", nn = " + nn + ", al(i) = " + al.get(i));
+            }
+        }
+        // wait for arrival
+        while (theList.size() < al.size()) {
+            logger.info("#distributed list = " + theList.size() + " #pairlist list = " + al.size());
+            @SuppressWarnings("unused")
+            GenPolynomial<C> nn = theList.getWait(al.size() - 1);
+        }
+
+        Terminator fin = new Terminator(threads);
+        ReducerServerEC<C> R;
+        for (int i = 0; i < threads; i++) {
+            R = new ReducerServerEC<C>(fin, cf, theList, pairlist);
+            pool.execute(R);
+        }
+        logger.debug("main loop waiting");
+        fin.waitDone();
+        int ps = theList.size();
+        logger.debug("#distributed list = " + ps);
+        // make sure all polynomials arrived: not needed in master
+        G = pairlist.getList();
+        if (ps != G.size()) {
+            logger.warn("#distributed list = " + theList.size() + " #pairlist list = " + G.size());
+        }
+        long time = System.currentTimeMillis();
+        List<GenPolynomial<C>> Gp;
+        Gp = minimalGB(G); // not jet distributed but threaded
+        time = System.currentTimeMillis() - time;
+        logger.debug("parallel gbmi = " + time);
+        /*
+          time = System.currentTimeMillis();
+          G = GroebnerBase.<C>GBmi(G); // sequential
+          time = System.currentTimeMillis() - time;
+          logger.info("sequential gbmi = " + time);
+        */
+        G = Gp;
+        logger.debug("cf.terminate()");
+        cf.terminate();
+        logger.debug("theList.terminate()");
+        theList.clear();
+        theList.terminate();
+        logger.info("" + pairlist);
+        return G;
+    }
+
+
+    /**
+     * GB distributed client part.
+     * @param host the server runs on.
+     * @param port the server runs.
+     * @param dhtport of the DHT server.
+     * @throws IOException
+     */
+    public static <C extends RingElem<C>> void clientPart(String host, int port, int dhtport)
+                    throws IOException {
+        ChannelFactory cf = new ChannelFactory(port + 10); // != port for localhost
+        cf.init();
+        logger.info("clientPart connecting to " + host + ", port = " + port + ", dhtport = " + dhtport);
+        SocketChannel pairChannel = cf.getChannel(host, port);
+
+        DistHashTable<Integer, GenPolynomial<C>> theList = new DistHashTable<Integer, GenPolynomial<C>>(host,
+                        dhtport);
+        theList.init();
+        ReducerClientEC<C> R = new ReducerClientEC<C>(pairChannel, theList);
+
+        logger.info("clientPart running on " + host + ", pairChannel = " + pairChannel);
+        R.run();
+
+        pairChannel.close();
+        //master only: theList.clear();
+        theList.terminate();
+        cf.terminate();
+        return;
+    }
+
+
+    /**
+     * Minimal ordered groebner basis.
+     * @param Fp a Groebner base.
+     * @return a reduced Groebner base of Fp.
+     */
+    @Override
+    public List<GenPolynomial<C>> minimalGB(List<GenPolynomial<C>> Fp) {
+        GenPolynomial<C> a;
+        ArrayList<GenPolynomial<C>> G;
+        G = new ArrayList<GenPolynomial<C>>(Fp.size());
+        ListIterator<GenPolynomial<C>> it = Fp.listIterator();
+        while (it.hasNext()) {
+            a = it.next();
+            if (a.length() != 0) { // always true
+                // already monic  a = a.monic();
+                G.add(a);
+            }
+        }
+        if (G.size() <= 1) {
+            return G;
+        }
+
+        ExpVector e;
+        ExpVector f;
+        GenPolynomial<C> p;
+        ArrayList<GenPolynomial<C>> F;
+        F = new ArrayList<GenPolynomial<C>>(G.size());
+        boolean mt;
+
+        while (G.size() > 0) {
+            a = G.remove(0);
+            e = a.leadingExpVector();
+
+            it = G.listIterator();
+            mt = false;
+            while (it.hasNext() && !mt) {
+                p = it.next();
+                f = p.leadingExpVector();
+                mt = e.multipleOf(f);
+            }
+            it = F.listIterator();
+            while (it.hasNext() && !mt) {
+                p = it.next();
+                f = p.leadingExpVector();
+                mt = e.multipleOf(f);
+            }
+            if (!mt) {
+                F.add(a);
+            } else {
+                // System.out.println("dropped " + a.length());
+            }
+        }
+        G = F;
+        if (G.size() <= 1) {
+            return G;
+        }
+        Collections.reverse(G); // important for lex GB
+
+        @SuppressWarnings("unchecked")
+        MiReducerServerEC<C>[] mirs = (MiReducerServerEC<C>[]) new MiReducerServerEC[G.size()];
+        int i = 0;
+        F = new ArrayList<GenPolynomial<C>>(G.size());
+        while (G.size() > 0) {
+            a = G.remove(0);
+            // System.out.println("doing " + a.length());
+            List<GenPolynomial<C>> R = new ArrayList<GenPolynomial<C>>(G.size() + F.size());
+            R.addAll(G);
+            R.addAll(F);
+            mirs[i] = new MiReducerServerEC<C>(R, a);
+            pool.execute(mirs[i]);
+            i++;
+            F.add(a);
+        }
+        G = F;
+        F = new ArrayList<GenPolynomial<C>>(G.size());
+        for (i = 0; i < mirs.length; i++) {
+            a = mirs[i].getNF();
+            F.add(a);
+        }
+        return F;
+    }
+
+}
+
+
+/**
+ * Distributed server reducing worker threads.
+ * @param <C> coefficient type
+ */
+
+class ReducerServerEC<C extends RingElem<C>> implements Runnable {
+
+
+    private final Terminator pool;
+
+
+    private final ChannelFactory cf;
+
+
+    private SocketChannel pairChannel;
+
+
+    private final DistHashTable<Integer, GenPolynomial<C>> theList;
+
+
+    //private List<GenPolynomial<C>> G;
+    private final PairList<C> pairlist;
+
+
+    private static final Logger logger = LogManager.getLogger(ReducerServerEC.class);
+
+
+    ReducerServerEC(Terminator fin, ChannelFactory cf, DistHashTable<Integer, GenPolynomial<C>> dl,
+                    PairList<C> L) {
+        pool = fin;
+        this.cf = cf;
+        theList = dl;
+        //this.G = G;
+        pairlist = L;
+    }
+
+
+    @SuppressWarnings("unchecked")
+    public void run() {
+        logger.info("reducer server running with " + cf);
+        try {
+            pairChannel = cf.getChannel();
+        } catch (InterruptedException e) {
+            logger.debug("get pair channel interrupted");
+            e.printStackTrace();
+            return;
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug("pairChannel = " + pairChannel);
+        }
+        Pair<C> pair;
+        //GenPolynomial<C> pi;
+        //GenPolynomial<C> pj;
+        //GenPolynomial<C> S;
+        GenPolynomial<C> H = null;
+        boolean set = false;
+        boolean goon = true;
+        int polIndex = -1;
+        int red = 0;
+        int sleeps = 0;
+
+        // while more requests
+        while (goon) {
+            // receive request
+            logger.info("receive request");
+            Object req = null;
+            try {
+                req = pairChannel.receive();
+            } catch (IOException e) {
+                goon = false;
+                e.printStackTrace();
+            } catch (ClassNotFoundException e) {
+                goon = false;
+                e.printStackTrace();
+            }
+            //logger.debug("received request, req = " + req);
+            if (req == null) {
+                goon = false;
+                break;
+            }
+            if (!(req instanceof GBTransportMessReq)) {
+                goon = false;
+                break;
+            }
+
+            // find pair
+            logger.debug("find pair");
+            while (!pairlist.hasNext()) { // wait
+                if (!set) {
+                    pool.beIdle();
+                    set = true;
+                }
+                if (!pool.hasJobs() && !pairlist.hasNext()) {
+                    goon = false;
+                    break;
+                }
+                try {
+                    sleeps++;
+                    if (sleeps % 10 == 0) {
+                        logger.info("reducer is sleeping, pool = " + pool);
+                    }
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    goon = false;
+                    break;
+                }
+            }
+            if (Thread.currentThread().isInterrupted()) {
+                goon = false;
+                break;
+            }
+            if (!pairlist.hasNext() && !pool.hasJobs()) {
+                goon = false;
+                break; //continue; //break?
+            }
+            if (set) {
+                set = false;
+                pool.notIdle();
+            }
+
+            pair = pairlist.removeNext();
+            /*
+             * send pair to client, receive H
+             */
+            logger.debug("send pair = " + pair);
+            GBTransportMess msg = null;
+            if (pair != null) {
+                msg = new GBTransportMessPairIndex(pair); // ,pairlist.size()-1); // size-1
+            } else {
+                msg = new GBTransportMess(); // not End(); at this time
+                // goon ?= false;
+            }
+            try {
+                pairChannel.send(msg);
+            } catch (IOException e) {
+                e.printStackTrace();
+                goon = false;
+                break;
+            }
+            logger.debug("#distributed list = " + theList.size());
+            Object rh = null;
+            try {
+                rh = pairChannel.receive();
+            } catch (IOException e) {
+                e.printStackTrace();
+                goon = false;
+                break;
+            } catch (ClassNotFoundException e) {
+                e.printStackTrace();
+                goon = false;
+                break;
+            }
+            //logger.debug("received H polynomial");
+            if (rh == null) {
+                if (pair != null) {
+                    pair.setZero();
+                }
+            } else if (rh instanceof GBTransportMessPoly) {
+                // update pair list
+                red++;
+                H = ((GBTransportMessPoly<C>) rh).pol;
+                if (logger.isDebugEnabled()) {
+                    logger.debug("H = " + H);
+                }
+                if (H == null) {
+                    if (pair != null) {
+                        pair.setZero();
+                    }
+                } else {
+                    if (H.isZERO()) {
+                        pair.setZero();
+                    } else {
+                        if (H.isONE()) {
+                            // pool.allIdle();
+                            polIndex = pairlist.putOne();
+                            theList.putWait(Integer.valueOf(polIndex), H);
+                            goon = false;
+                            break;
+                        }
+                        polIndex = pairlist.put(H);
+                        // use putWait ? but still not all distributed
+                        theList.putWait(Integer.valueOf(polIndex), H);
+                    }
+                }
+            }
+        }
+        logger.info("terminated, done " + red + " reductions");
+
+        /*
+         * send end mark to client
+         */
+        logger.debug("send end");
+        try {
+            pairChannel.send(new GBTransportMessEnd());
+        } catch (IOException e) {
+            if (logger.isDebugEnabled()) {
+                e.printStackTrace();
+            }
+        }
+        pool.beIdle();
+        pairChannel.close();
+    }
+
+}
+
+
+/**
+ * Distributed clients reducing worker threads.
+ */
+
+class ReducerClientEC<C extends RingElem<C>> implements Runnable {
+
+
+    private final SocketChannel pairChannel;
+
+
+    private final DistHashTable<Integer, GenPolynomial<C>> theList;
+
+
+    private final ReductionPar<C> red;
+
+
+    private static final Logger logger = LogManager.getLogger(ReducerClientEC.class);
+
+
+    ReducerClientEC(SocketChannel pc, DistHashTable<Integer, GenPolynomial<C>> dl) {
+        pairChannel = pc;
+        theList = dl;
+        red = new ReductionPar<C>();
+    }
+
+
+    public void run() {
+        logger.debug("pairChannel = " + pairChannel + " reducer client running");
+        Pair<C> pair = null;
+        GenPolynomial<C> pi, pj, ps;
+        GenPolynomial<C> S;
+        GenPolynomial<C> H = null;
+        //boolean set = false;
+        boolean goon = true;
+        int reduction = 0;
+        //int sleeps = 0;
+        Integer pix, pjx, psx;
+
+        while (goon) {
+            /* protocol:
+             * request pair, process pair, send result
+             */
+            // pair = (Pair) pairlist.removeNext();
+            Object req = new GBTransportMessReq();
+            logger.debug("send request = " + req);
+            H = null;
+            try {
+                pairChannel.send(req);
+            } catch (IOException e) {
+                goon = false;
+                e.printStackTrace();
+                break;
+            }
+            logger.debug("receive pair, goon = " + goon);
+            Object pp = null;
+            try {
+                pp = pairChannel.receive();
+            } catch (IOException e) {
+                goon = false;
+                if (logger.isDebugEnabled()) {
+                    e.printStackTrace();
+                }
+                break;
+            } catch (ClassNotFoundException e) {
+                goon = false;
+                e.printStackTrace();
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("received pair = " + pp);
+            }
+            if (pp == null) { // should not happen
+                continue;
+            }
+            if (pp instanceof GBTransportMessEnd) {
+                goon = false;
+                continue;
+            }
+            if (pp instanceof GBTransportMessPair || pp instanceof GBTransportMessPairIndex) {
+                pi = pj = ps = null;
+                if (pp instanceof GBTransportMessPair) { // obsolete, for tests
+                    @SuppressWarnings("unchecked")
+                    GBTransportMessPair<C> tmp = (GBTransportMessPair<C>) pp;
+                    pair = tmp.pair;
+                    if (pair != null) {
+                        pi = pair.pi;
+                        pj = pair.pj;
+                        //logger.debug("pair: pix = " + pair.i 
+                        //               + ", pjx = " + pair.j);
+                    }
+                }
+                if (pp instanceof GBTransportMessPairIndex) {
+                    GBTransportMessPairIndex tmpi = (GBTransportMessPairIndex) pp;
+                    pix = tmpi.i;
+                    pjx = tmpi.j;
+                    psx = tmpi.s;
+                    pi = theList.getWait(pix);
+                    pj = theList.getWait(pjx);
+                    ps = theList.getWait(psx);
+                    //logger.info("pix = " + pix + ", pjx = " + pjx + ", psx = " + psx);
+                }
+
+                if (pi != null && pj != null) {
+                    S = red.SPolynomial(pi, pj);
+                    //System.out.println("S   = " + S);
+                    if (S.isZERO()) {
+                        // pair.setZero(); does not work in dist
+                    } else {
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("ht(S) = " + S.leadingExpVector());
+                        }
+                        H = red.normalform(theList, S);
+                        reduction++;
+                        if (H.isZERO()) {
+                            // pair.setZero(); does not work in dist
+                        } else {
+                            H = H.monic();
+                            if (logger.isInfoEnabled()) {
+                                logger.info("ht(H) = " + H.leadingExpVector());
+                            }
+                        }
+                    }
+                } else {
+                    logger.info("pi = " + pi + ", pj = " + pj + ", ps = " + ps);
+                }
+            }
+
+            // send H or must send null
+            if (logger.isDebugEnabled()) {
+                logger.debug("#distributed list = " + theList.size());
+                logger.debug("send H polynomial = " + H);
+            }
+            try {
+                pairChannel.send(new GBTransportMessPoly<C>(H));
+            } catch (IOException e) {
+                goon = false;
+                e.printStackTrace();
+            }
+        }
+        logger.info("terminated, " + reduction + " reductions, " + theList.size() + " polynomials");
+        pairChannel.close();
+    }
+}
+
+
+/**
+ * Distributed server reducing worker threads for minimal GB Not jet distributed
+ * but threaded.
+ */
+
+class MiReducerServerEC<C extends RingElem<C>> implements Runnable {
+
+
+    private final List<GenPolynomial<C>> G;
+
+
+    private GenPolynomial<C> H;
+
+
+    private final Semaphore done = new Semaphore(0);
+
+
+    private final Reduction<C> red;
+
+
+    private static final Logger logger = LogManager.getLogger(MiReducerServerEC.class);
+
+
+    MiReducerServerEC(List<GenPolynomial<C>> G, GenPolynomial<C> p) {
+        this.G = G;
+        H = p;
+        red = new ReductionPar<C>();
+    }
+
+
+    /**
+     * getNF. Blocks until the normal form is computed.
+     * @return the computed normal form.
+     */
+    public GenPolynomial<C> getNF() {
+        try {
+            done.acquire(); //done.P();
+        } catch (InterruptedException e) {
+        }
+        return H;
+    }
+
+
+    public void run() {
+        if (logger.isDebugEnabled()) {
+            logger.debug("ht(H) = " + H.leadingExpVector());
+        }
+        H = red.normalform(G, H); //mod
+        done.release(); //done.V();
+        if (logger.isDebugEnabled()) {
+            logger.debug("ht(H) = " + H.leadingExpVector());
+        }
+        // H = H.monic();
+    }
+}
+
+
+/**
+ * Distributed clients reducing worker threads for minimal GB. Not jet used.
+ */
+
+class MiReducerClientEC<C extends RingElem<C>> implements Runnable {
+
+
+    private final List<GenPolynomial<C>> G;
+
+
+    private GenPolynomial<C> H;
+
+
+    private final Reduction<C> red;
+
+
+    private final Semaphore done = new Semaphore(0);
+
+
+    private static final Logger logger = LogManager.getLogger(MiReducerClientEC.class);
+
+
+    MiReducerClientEC(List<GenPolynomial<C>> G, GenPolynomial<C> p) {
+        this.G = G;
+        H = p;
+        red = new ReductionPar<C>();
+    }
+
+
+    /**
+     * getNF. Blocks until the normal form is computed.
+     * @return the computed normal form.
+     */
+    public GenPolynomial<C> getNF() {
+        try {
+            done.acquire(); //done.P();
+        } catch (InterruptedException u) {
+            Thread.currentThread().interrupt();
+        }
+        return H;
+    }
+
+
+    public void run() {
+        if (logger.isDebugEnabled()) {
+            logger.debug("ht(S) = " + H.leadingExpVector());
+        }
+        H = red.normalform(G, H); //mod
+        done.release(); //done.V();
+        if (logger.isDebugEnabled()) {
+            logger.debug("ht(H) = " + H.leadingExpVector());
+        }
+        // H = H.monic();
+    }
+}
+
+
+/**
+ * Objects of this class are to be send to a ExecutableServer.
+ */
+
+class GBExerClient<C extends RingElem<C>> implements RemoteExecutable {
+
+
+    String host;
+
+
+    int port;
+
+
+    int dhtport;
+
+
+    /**
+     * GBExerClient.
+     * @param host
+     * @param port
+     * @param dhtport
+     */
+    public GBExerClient(String host, int port, int dhtport) {
+        this.host = host;
+        this.port = port;
+        this.dhtport = dhtport;
+    }
+
+
+    /**
+     * run.
+     */
+    public void run() {
+        //System.out.println("running " + this);
+        try {
+            GroebnerBaseDistributedEC.<C> clientPart(host, port, dhtport);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+
+    /**
+     * String representation.
+     */
+    @Override
+    public String toString() {
+        StringBuffer s = new StringBuffer("GBExerClient(");
+        s.append("host=" + host);
+        s.append(", port=" + port);
+        s.append(", dhtport=" + dhtport);
+        s.append(")");
+        return s.toString();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GroebnerBaseDistributedHybridEC.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GroebnerBaseDistributedHybridEC.java
@@ -1,0 +1,1240 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.RingElem;
+import edu.jas.util.ChannelFactory;
+import edu.jas.util.DistHashTable;
+import edu.jas.util.DistHashTableServer;
+import edu.jas.util.DistThreadPool;
+import edu.jas.util.RemoteExecutable;
+import edu.jas.util.SocketChannel;
+import edu.jas.util.TaggedSocketChannel;
+import edu.jas.util.Terminator;
+
+
+/**
+ * Groebner Base distributed hybrid algorithm. Implements a distributed memory
+ * with multi-core CPUs parallel version of Groebner bases with executable
+ * channels. Using pairlist class, distributed multi-threaded tasks do
+ * reduction, one communication channel per remote node.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class GroebnerBaseDistributedHybridEC<C extends RingElem<C>> extends GroebnerBaseAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GroebnerBaseDistributedHybridEC.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Number of threads to use.
+     */
+    protected final int threads;
+
+
+    /**
+     * Default number of threads.
+     */
+    protected static final int DEFAULT_THREADS = 2;
+
+
+    /**
+     * Number of threads per node to use.
+     */
+    protected final int threadsPerNode;
+
+
+    /**
+     * Default number of threads per compute node.
+     */
+    protected static final int DEFAULT_THREADS_PER_NODE = 1;
+
+
+    /**
+     * Pool of threads to use.
+     */
+    //protected final ExecutorService pool; // not for single node tests
+    protected transient final ExecutorService pool;
+
+
+    /**
+     * Default server port.
+     */
+    protected static final int DEFAULT_PORT = 55711;
+
+
+    /**
+     * Default distributed hash table server port.
+     */
+    protected final int DHT_PORT;
+
+
+    /**
+     * machine file to use.
+     */
+    protected final String mfile;
+
+
+    /**
+     * Server port to use.
+     */
+    protected final int port;
+
+
+    /**
+     * Distributed thread pool to use.
+     */
+    private final transient DistThreadPool dtp;
+
+
+    /**
+     * Distributed hash table server to use.
+     */
+    private final transient DistHashTableServer<Integer> dhts;
+
+
+    /**
+     * Message tag for pairs.
+     */
+    public static final Integer pairTag = Integer.valueOf(1);
+
+
+    /**
+     * Message tag for results.
+     */
+    public static final Integer resultTag = Integer.valueOf(2);
+
+
+    /**
+     * Message tag for acknowledgments.
+     */
+    public static final Integer ackTag = Integer.valueOf(3);
+
+
+    /**
+     * Constructor.
+     * @param mfile name of the machine file.
+     */
+    public GroebnerBaseDistributedHybridEC(String mfile) {
+        this(mfile, DEFAULT_THREADS, DEFAULT_PORT);
+    }
+
+
+    /**
+     * Constructor.
+     * @param mfile name of the machine file.
+     * @param threads number of threads to use.
+     */
+    public GroebnerBaseDistributedHybridEC(String mfile, int threads) {
+        this(mfile, threads, Executors.newFixedThreadPool(threads), DEFAULT_PORT);
+    }
+
+
+    /**
+     * Constructor.
+     * @param mfile name of the machine file.
+     * @param threads number of threads to use.
+     * @param port server port to use.
+     */
+    public GroebnerBaseDistributedHybridEC(String mfile, int threads, int port) {
+        this(mfile, threads, Executors.newFixedThreadPool(threads), port);
+    }
+
+
+    /**
+     * Constructor.
+     * @param mfile name of the machine file.
+     * @param threads number of threads to use.
+     * @param threadsPerNode threads per node to use.
+     * @param port server port to use.
+     */
+    public GroebnerBaseDistributedHybridEC(String mfile, int threads, int threadsPerNode, int port) {
+        this(mfile, threads, threadsPerNode, Executors.newFixedThreadPool(threads), port);
+    }
+
+
+    /**
+     * Constructor.
+     * @param mfile name of the machine file.
+     * @param threads number of threads to use.
+     * @param pool ExecutorService to use.
+     * @param port server port to use.
+     */
+    public GroebnerBaseDistributedHybridEC(String mfile, int threads, ExecutorService pool, int port) {
+        this(mfile, threads, DEFAULT_THREADS_PER_NODE, pool, port);
+    }
+
+
+    /**
+     * Constructor.
+     * @param mfile name of the machine file.
+     * @param threads number of threads to use.
+     * @param threadsPerNode threads per node to use.
+     * @param pl pair selection strategy
+     * @param port server port to use.
+     */
+    public GroebnerBaseDistributedHybridEC(String mfile, int threads, int threadsPerNode, PairList<C> pl,
+                    int port) {
+        this(mfile, threads, threadsPerNode, Executors.newFixedThreadPool(threads), pl, port);
+    }
+
+
+    /**
+     * Constructor.
+     * @param mfile name of the machine file.
+     * @param threads number of threads to use.
+     * @param threadsPerNode threads per node to use.
+     * @param port server port to use.
+     */
+    public GroebnerBaseDistributedHybridEC(String mfile, int threads, int threadsPerNode, ExecutorService pool,
+                    int port) {
+        this(mfile, threads, threadsPerNode, pool, new OrderedPairlist<C>(), port);
+    }
+
+
+    /**
+     * Constructor.
+     * @param mfile name of the machine file.
+     * @param threads number of threads to use.
+     * @param threadsPerNode threads per node to use.
+     * @param pool ExecutorService to use.
+     * @param pl pair selection strategy
+     * @param port server port to use.
+     */
+    public GroebnerBaseDistributedHybridEC(String mfile, int threads, int threadsPerNode, ExecutorService pool,
+                    PairList<C> pl, int port) {
+        super(new ReductionPar<C>(), pl);
+        this.threads = threads;
+        if (mfile == null || mfile.length() == 0) {
+            this.mfile = "../util/machines"; // contains localhost
+        } else {
+            this.mfile = mfile;
+        }
+        if (threads < 1) {
+            threads = 1;
+        }
+        this.threadsPerNode = threadsPerNode;
+        if (pool == null) {
+            pool = Executors.newFixedThreadPool(threads);
+            logger.error("pool must not be null: " + pool);
+            //throw new IllegalArgumentException("pool must not be null");
+        }
+        this.pool = pool;
+        this.port = port;
+        logger.info("machine file " + mfile + ", port = " + port + ", pool = " + pool);
+        this.dtp = new DistThreadPool(this.threads, this.mfile);
+        logger.info("running " + dtp);
+        this.DHT_PORT = this.dtp.getEC().getMasterPort() + 100;
+        this.dhts = new DistHashTableServer<Integer>(this.DHT_PORT);
+        this.dhts.init();
+        logger.info("running " + dhts);
+    }
+
+
+    /**
+     * Cleanup and terminate ExecutorService.
+     */
+    @Override
+    public void terminate() {
+        terminate(true);
+    }
+
+
+    /**
+     * Terminates the distributed thread pools.
+     * @param shutDown true, if shut-down of the remote executable servers is
+     *            requested, false, if remote executable servers stay alive.
+     */
+    public void terminate(boolean shutDown) {
+        pool.shutdown();
+        try {
+            while (!pool.isTerminated()) {
+                //logger.info("await");
+                boolean rest = pool.awaitTermination(1000L, TimeUnit.MILLISECONDS);
+            }
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        logger.info(pool.toString());
+        dtp.terminate(shutDown);
+        logger.info("dhts.terminate()");
+        dhts.terminate();
+    }
+
+
+    /**
+     * Distributed Groebner base.
+     * @param modv number of module variables.
+     * @param F polynomial list.
+     * @return GB(F) a Groebner base of F or null, if a IOException occurs.
+     */
+    public List<GenPolynomial<C>> GB(int modv, List<GenPolynomial<C>> F) {
+        List<GenPolynomial<C>> Fp = normalizeZerosOnes(F);
+        Fp = PolyUtil.<C> monic(Fp);
+        if (Fp.size() <= 1) {
+            return Fp;
+        }
+        if (!Fp.get(0).ring.coFac.isField()) {
+            throw new IllegalArgumentException("coefficients not from a field");
+        }
+
+        String master = dtp.getEC().getMasterHost();
+        //int port = dtp.getEC().getMasterPort(); // wrong port
+        GBHybridExerClient<C> gbc = new GBHybridExerClient<C>(master, threadsPerNode, port, DHT_PORT);
+        for (int i = 0; i < threads; i++) {
+            // schedule remote clients
+            dtp.addJob(gbc);
+        }
+        try {
+            Thread.currentThread().sleep(1000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        // run master
+        List<GenPolynomial<C>> G = GBMaster(modv, Fp);
+        return G;
+    }
+
+
+    /**
+     * Distributed hybrid Groebner base.
+     * @param modv number of module variables.
+     * @param F non empty monic polynomial list without zeros.
+     * @return GB(F) a Groebner base of F or null, if a IOException occurs.
+     */
+    List<GenPolynomial<C>> GBMaster(int modv, List<GenPolynomial<C>> F) {
+        long t = System.currentTimeMillis();
+        ChannelFactory cf = new ChannelFactory(port);
+        cf.init();
+
+        List<GenPolynomial<C>> G = F;
+        if (G.isEmpty()) {
+            throw new IllegalArgumentException("empty polynomial list not allowed");
+        }
+        GenPolynomialRing<C> ring = G.get(0).ring;
+        PairList<C> pairlist = strategy.create(modv, ring);
+        pairlist.put(G);
+        logger.info("start " + pairlist);
+        DistHashTable<Integer, GenPolynomial<C>> theList = new DistHashTable<Integer, GenPolynomial<C>>(
+                        "localhost", DHT_PORT);
+        theList.init();
+        List<GenPolynomial<C>> al = pairlist.getList();
+        for (int i = 0; i < al.size(); i++) {
+            // no wait required
+            GenPolynomial<C> nn = null;
+            theList.putWait(Integer.valueOf(i), al.get(i));
+            if (nn != null) {
+                logger.info("double polynomials " + i + ", nn = " + nn + ", al(i) = " + al.get(i));
+            }
+        }
+
+        Terminator finner = new Terminator(threads * threadsPerNode);
+        HybridReducerServerEC<C> R;
+        logger.info("using pool = " + pool);
+        for (int i = 0; i < threads; i++) {
+            R = new HybridReducerServerEC<C>(threadsPerNode, finner, cf, theList, pairlist);
+            pool.execute(R);
+            //logger.info("server submitted " + R);
+        }
+        try {
+            Thread.currentThread().sleep(1000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        logger.info("main loop waiting " + finner);
+        finner.waitDone();
+        int ps = theList.size();
+        logger.info("#distributed list = " + ps);
+        // make sure all polynomials arrived: not needed in master
+        // G = (ArrayList)theList.values();
+        G = pairlist.getList();
+        if (ps != G.size()) {
+            logger.info("#distributed list = " + theList.size() + " #pairlist list = " + G.size());
+        }
+        for (GenPolynomial<C> q : theList.getValueList()) {
+            if (debug && q != null && !q.isZERO()) {
+                logger.debug("final q = " + q.leadingExpVector());
+            }
+        }
+        logger.debug("distributed list end");
+        long time = System.currentTimeMillis();
+        List<GenPolynomial<C>> Gp;
+        Gp = minimalGB(G); // not jet distributed but threaded
+        time = System.currentTimeMillis() - time;
+        logger.debug("parallel gbmi time = " + time);
+        G = Gp;
+        logger.debug("server cf.terminate()");
+        cf.terminate();
+        logger.debug("server theList.terminate() " + theList.size());
+        theList.clear();
+        theList.terminate();
+        t = System.currentTimeMillis() - t;
+        logger.info("server GB end, time = " + t + ", " + pairlist.toString());
+        return G;
+    }
+
+
+    /**
+     * GB distributed client part.
+     * @param host the server runs on.
+     * @param port the server runs.
+     * @param dhtport of the DHT server.
+     * @throws IOException
+     */
+    public static <C extends RingElem<C>> void clientPart(String host, int threadsPerNode, int port,
+                    int dhtport) throws IOException {
+        ChannelFactory cf = new ChannelFactory(port + 10); // != port for localhost
+        cf.init();
+        logger.info("clientPart connecting to " + host + ", port = " + port + ", dhtport = " + dhtport);
+        SocketChannel channel = cf.getChannel(host, port);
+        TaggedSocketChannel pairChannel = new TaggedSocketChannel(channel);
+        pairChannel.init();
+
+        DistHashTable<Integer, GenPolynomial<C>> theList = new DistHashTable<Integer, GenPolynomial<C>>(host,
+                        dhtport);
+        theList.init();
+
+        ExecutorService pool = Executors.newFixedThreadPool(threadsPerNode);
+        //ThreadPool pool = new ThreadPool(threadsPerNode);
+        logger.info("client using pool = " + pool);
+        for (int i = 0; i < threadsPerNode; i++) {
+            HybridReducerClientEC<C> Rr = new HybridReducerClientEC<C>(/*threadsPerNode,*/pairChannel, /*i,*/
+            theList);
+            pool.execute(Rr);
+        }
+        logger.info("clients submitted");
+
+        pool.shutdown();
+        try {
+            while (!pool.isTerminated()) {
+                //logger.info("await");
+                boolean rest = pool.awaitTermination(1000L, TimeUnit.MILLISECONDS);
+            }
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        //pool.terminate();
+        logger.info("client pool.terminate()");
+
+        pairChannel.close();
+        logger.debug("client pairChannel.close()");
+
+        //master only: theList.clear();
+        theList.terminate();
+        cf.terminate();
+        logger.info("client cf.terminate()");
+
+        channel.close();
+        logger.info("client channel.close()");
+        return;
+    }
+
+
+    /**
+     * Minimal ordered groebner basis.
+     * @param Fp a Groebner base.
+     * @return a reduced Groebner base of Fp.
+     */
+    @Override
+    public List<GenPolynomial<C>> minimalGB(List<GenPolynomial<C>> Fp) {
+        GenPolynomial<C> a;
+        ArrayList<GenPolynomial<C>> G;
+        G = new ArrayList<GenPolynomial<C>>(Fp.size());
+        ListIterator<GenPolynomial<C>> it = Fp.listIterator();
+        while (it.hasNext()) {
+            a = it.next();
+            if (a.length() != 0) { // always true
+                // already monic  a = a.monic();
+                G.add(a);
+            }
+        }
+        if (G.size() <= 1) {
+            return G;
+        }
+
+        ExpVector e;
+        ExpVector f;
+        GenPolynomial<C> p;
+        ArrayList<GenPolynomial<C>> F;
+        F = new ArrayList<GenPolynomial<C>>(G.size());
+        boolean mt;
+
+        while (G.size() > 0) {
+            a = G.remove(0);
+            e = a.leadingExpVector();
+
+            it = G.listIterator();
+            mt = false;
+            while (it.hasNext() && !mt) {
+                p = it.next();
+                f = p.leadingExpVector();
+                mt = e.multipleOf(f);
+            }
+            it = F.listIterator();
+            while (it.hasNext() && !mt) {
+                p = it.next();
+                f = p.leadingExpVector();
+                mt = e.multipleOf(f);
+            }
+            if (!mt) {
+                F.add(a);
+            } else {
+                // System.out.println("dropped " + a.length());
+            }
+        }
+        G = F;
+        if (G.size() <= 1) {
+            return G;
+        }
+        Collections.reverse(G); // important for lex GB
+
+        @SuppressWarnings("unchecked")
+        MiReducerServer<C>[] mirs = (MiReducerServer<C>[]) new MiReducerServer[G.size()];
+        int i = 0;
+        F = new ArrayList<GenPolynomial<C>>(G.size());
+        while (G.size() > 0) {
+            a = G.remove(0);
+            // System.out.println("doing " + a.length());
+            List<GenPolynomial<C>> R = new ArrayList<GenPolynomial<C>>(G.size() + F.size());
+            R.addAll(G);
+            R.addAll(F);
+            mirs[i] = new MiReducerServer<C>(R, a);
+            pool.execute(mirs[i]);
+            i++;
+            F.add(a);
+        }
+        G = F;
+        F = new ArrayList<GenPolynomial<C>>(G.size());
+        for (i = 0; i < mirs.length; i++) {
+            a = mirs[i].getNF();
+            F.add(a);
+        }
+        return F;
+    }
+
+}
+
+
+/**
+ * Distributed server reducing worker proxy threads.
+ * @param <C> coefficient type
+ */
+class HybridReducerServerEC<C extends RingElem<C>> implements Runnable {
+
+
+    private static final Logger logger = LogManager.getLogger(HybridReducerServerEC.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    private final Terminator finner;
+
+
+    private final ChannelFactory cf;
+
+
+    private TaggedSocketChannel pairChannel;
+
+
+    private final DistHashTable<Integer, GenPolynomial<C>> theList;
+
+
+    private final PairList<C> pairlist;
+
+
+    private final int threadsPerNode;
+
+
+    /**
+     * Message tag for pairs.
+     */
+    public final Integer pairTag = GroebnerBaseDistributedHybridEC.pairTag;
+
+
+    /**
+     * Message tag for results.
+     */
+    public final Integer resultTag = GroebnerBaseDistributedHybridEC.resultTag;
+
+
+    /**
+     * Message tag for acknowledgments.
+     */
+    public final Integer ackTag = GroebnerBaseDistributedHybridEC.ackTag;
+
+
+    /**
+     * Constructor.
+     * @param tpn number of threads per node
+     * @param fin terminator
+     * @param cf channel factory
+     * @param dl distributed hash table
+     * @param L ordered pair list
+     */
+    HybridReducerServerEC(int tpn, Terminator fin, ChannelFactory cf,
+                    DistHashTable<Integer, GenPolynomial<C>> dl, PairList<C> L) {
+        threadsPerNode = tpn;
+        finner = fin;
+        this.cf = cf;
+        theList = dl;
+        pairlist = L;
+        //logger.info("reducer server created " + this);
+    }
+
+
+    /**
+     * Work loop.
+     * @see java.lang.Runnable#run()
+     */
+    @Override
+    public void run() {
+        logger.debug("reducer server running with " + cf);
+        SocketChannel channel = null;
+        try {
+            channel = cf.getChannel();
+            pairChannel = new TaggedSocketChannel(channel);
+            pairChannel.init();
+        } catch (InterruptedException e) {
+            logger.debug("get pair channel interrupted");
+            e.printStackTrace();
+            return;
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("pairChannel   = " + pairChannel);
+        }
+        // record idle remote workers (minus one?)
+        //finner.beIdle(threadsPerNode-1);
+        finner.initIdle(threadsPerNode);
+        AtomicInteger active = new AtomicInteger(0);
+
+        // start receiver
+        HybridReducerReceiverEC<C> receiver = new HybridReducerReceiverEC<C>(/*threadsPerNode,*/finner,
+                        active, pairChannel, theList, pairlist);
+        receiver.start();
+
+        Pair<C> pair;
+        //boolean set = false;
+        boolean goon = true;
+        //int polIndex = -1;
+        int red = 0;
+        int sleeps = 0;
+
+        // while more requests
+        while (goon) {
+            // receive request if thread is reported incactive
+            logger.info("receive request");
+            Object req = null;
+            try {
+                req = pairChannel.receive(pairTag);
+            } catch (InterruptedException e) {
+                goon = false;
+                //e.printStackTrace();
+            } catch (IOException e) {
+                goon = false;
+                //e.printStackTrace();
+            } catch (ClassNotFoundException e) {
+                goon = false;
+                e.printStackTrace();
+            }
+            logger.info("received request, req = " + req);
+            if (req == null) {
+                goon = false;
+                break;
+            }
+            if (!(req instanceof GBTransportMessReq)) {
+                goon = false;
+                break;
+            }
+
+            // find pair and manage termination status
+            logger.debug("find pair");
+            while (!pairlist.hasNext()) { // wait
+                if (!finner.hasJobs() && !pairlist.hasNext()) {
+                    goon = false;
+                    break;
+                }
+                try {
+                    sleeps++;
+                    if (sleeps % 3 == 0) {
+                        logger.info("waiting for reducers, remaining = " + finner);
+                    }
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    goon = false;
+                    break;
+                }
+            }
+            if (Thread.currentThread().isInterrupted()) {
+                goon = false;
+                break;
+            }
+            if (!pairlist.hasNext() && !finner.hasJobs()) {
+                logger.info("termination detection: no pairs and no jobs left");
+                goon = false;
+                break; //continue; //break?
+            }
+            finner.notIdle(); // before pairlist get!!
+            pair = pairlist.removeNext();
+            // send pair to client, even if null
+            if (logger.isInfoEnabled()) {
+                logger.info("active count = " + active.get());
+                logger.info("send pair = " + pair);
+            }
+            GBTransportMess msg = null;
+            if (pair != null) {
+                msg = new GBTransportMessPairIndex(pair); //,pairlist.size()-1); // size-1
+            } else {
+                msg = new GBTransportMess(); // not End(); at this time
+                // goon ?= false;
+            }
+            try {
+                red++;
+                pairChannel.send(pairTag, msg);
+                @SuppressWarnings("unused")
+                int a = active.getAndIncrement();
+            } catch (IOException e) {
+                e.printStackTrace();
+                goon = false;
+                break;
+            }
+            //logger.debug("#distributed list = " + theList.size());
+        }
+        logger.info("terminated, send " + red + " reduction pairs");
+
+        /*
+         * send end mark to clients
+         */
+        logger.debug("send end");
+        try {
+            for (int i = 0; i < threadsPerNode; i++) { // -1
+                //do not wait: Object rq = pairChannel.receive(pairTag);
+                pairChannel.send(pairTag, new GBTransportMessEnd());
+            }
+            // send also end to receiver
+            pairChannel.send(resultTag, new GBTransportMessEnd());
+            //beware of race condition 
+        } catch (IOException e) {
+            if (logger.isDebugEnabled()) {
+                e.printStackTrace();
+            }
+        }
+        receiver.terminate();
+
+        int d = active.get();
+        if (d > 0) {
+            logger.info("remaining active tasks = " + d);
+        }
+        //logger.info("terminated, send " + red + " reduction pairs");
+        pairChannel.close();
+        logger.debug("redServ pairChannel.close()");
+        finner.release();
+
+        channel.close();
+        logger.info("redServ channel.close()");
+    }
+}
+
+
+/**
+ * Distributed server receiving worker thread.
+ * @param <C> coefficient type
+ */
+class HybridReducerReceiverEC<C extends RingElem<C>> extends Thread {
+
+
+    private static final Logger logger = LogManager.getLogger(HybridReducerReceiverEC.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    private final DistHashTable<Integer, GenPolynomial<C>> theList;
+
+
+    private final PairList<C> pairlist;
+
+
+    private final TaggedSocketChannel pairChannel;
+
+
+    private final Terminator finner;
+
+
+    //private final int threadsPerNode;
+
+
+    private final AtomicInteger active;
+
+
+    private volatile boolean goon;
+
+
+    /**
+     * Message tag for pairs.
+     */
+    public final Integer pairTag = GroebnerBaseDistributedHybridEC.pairTag;
+
+
+    /**
+     * Message tag for results.
+     */
+    public final Integer resultTag = GroebnerBaseDistributedHybridEC.resultTag;
+
+
+    /**
+     * Message tag for acknowledgments.
+     */
+    public final Integer ackTag = GroebnerBaseDistributedHybridEC.ackTag;
+
+
+    /**
+     * Constructor.
+     * @param fin terminator
+     * @param a active remote tasks count
+     * @param pc tagged socket channel
+     * @param dl distributed hash table
+     * @param L ordered pair list
+     */
+    //param tpn number of threads per node
+    HybridReducerReceiverEC(/*int tpn,*/Terminator fin, AtomicInteger a, TaggedSocketChannel pc,
+                    DistHashTable<Integer, GenPolynomial<C>> dl, PairList<C> L) {
+        active = a;
+        //threadsPerNode = tpn;
+        finner = fin;
+        pairChannel = pc;
+        theList = dl;
+        pairlist = L;
+        goon = true;
+        //logger.info("reducer server created " + this);
+    }
+
+
+    /**
+     * Work loop.
+     * @see java.lang.Thread#run()
+     */
+    @Override
+    public void run() {
+        //Pair<C> pair = null;
+        GenPolynomial<C> H = null;
+        int red = 0;
+        int polIndex = -1;
+        //Integer senderId; // obsolete
+
+        // while more requests
+        while (goon) {
+            // receive request
+            logger.info("receive result");
+            //senderId = null;
+            Object rh = null;
+            try {
+                rh = pairChannel.receive(resultTag);
+                @SuppressWarnings("unused")
+                int i = active.getAndDecrement();
+            } catch (InterruptedException e) {
+                goon = false;
+                //e.printStackTrace();
+                //?? finner.initIdle(1);
+                break;
+            } catch (IOException e) {
+                //e.printStackTrace();
+                goon = false;
+                //finner.initIdle(1);
+                break;
+            } catch (ClassNotFoundException e) {
+                e.printStackTrace();
+                goon = false;
+                finner.initIdle(1);
+                break;
+            }
+            logger.info("received H polynomial " + rh);
+            if (rh == null) {
+                if (this.isInterrupted()) {
+                    goon = false;
+                    finner.initIdle(1);
+                    break;
+                }
+                //finner.initIdle(1);
+            } else if (rh instanceof GBTransportMessEnd) { // should only happen from server
+                logger.info("received GBTransportMessEnd");
+                goon = false;
+                //?? finner.initIdle(1);
+                break;
+            } else if (rh instanceof GBTransportMessPoly) {
+                // update pair list
+                red++;
+                @SuppressWarnings("unchecked")
+                GBTransportMessPoly<C> mpi = (GBTransportMessPoly<C>) rh;
+                H = mpi.pol;
+                //senderId = mpi.threadId;
+                if (H != null) {
+                    if (logger.isInfoEnabled()) {
+                        logger.info("H = " + H.leadingExpVector());
+                    }
+                    if (!H.isZERO()) {
+                        if (H.isONE()) {
+                            // finner.allIdle();
+                            polIndex = pairlist.putOne();
+                            theList.putWait(Integer.valueOf(polIndex), H);
+                            //goon = false; must wait for other clients
+                            //finner.initIdle(1);
+                            //break;
+                        } else {
+                            polIndex = pairlist.put(H);
+                            // use putWait ? but still not all distributed
+                            //GenPolynomial<C> nn = 
+                            theList.putWait(Integer.valueOf(polIndex), H);
+                        }
+                    }
+                }
+            }
+            // only after recording in pairlist !
+            finner.initIdle(1);
+            try {
+                pairChannel.send(ackTag, new GBTransportMess());
+                logger.debug("send acknowledgement");
+            } catch (IOException e) {
+                e.printStackTrace();
+                goon = false;
+                break;
+            }
+        } // end while
+        goon = false;
+        logger.info("terminated, received " + red + " reductions");
+    }
+
+
+    /**
+     * Terminate.
+     */
+    public void terminate() {
+        goon = false;
+        //this.interrupt();
+        try {
+            this.join();
+        } catch (InterruptedException e) {
+            // unfug Thread.currentThread().interrupt();
+        }
+        logger.debug("HybridReducerReceiver terminated");
+    }
+
+}
+
+
+/**
+ * Distributed clients reducing worker threads.
+ */
+class HybridReducerClientEC<C extends RingElem<C>> implements Runnable {
+
+
+    private static final Logger logger = LogManager.getLogger(HybridReducerClientEC.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    private final TaggedSocketChannel pairChannel;
+
+
+    private final DistHashTable<Integer, GenPolynomial<C>> theList;
+
+
+    private final ReductionPar<C> red;
+
+
+    //private final int threadsPerNode;
+
+
+    /*
+     * Identification number for this thread.
+     */
+    //public final Integer threadId; // obsolete
+
+
+    /**
+     * Message tag for pairs.
+     */
+    public final Integer pairTag = GroebnerBaseDistributedHybridEC.pairTag;
+
+
+    /**
+     * Message tag for results.
+     */
+    public final Integer resultTag = GroebnerBaseDistributedHybridEC.resultTag;
+
+
+    /**
+     * Message tag for acknowledgments.
+     */
+    public final Integer ackTag = GroebnerBaseDistributedHybridEC.ackTag;
+
+
+    /**
+     * Constructor.
+     * @param tc tagged socket channel
+     * @param dl distributed hash table
+     */
+    //param tpn number of threads per node
+    //param tid thread identification
+    HybridReducerClientEC(/*int tpn,*/TaggedSocketChannel tc, /*Integer tid,*/
+                    DistHashTable<Integer, GenPolynomial<C>> dl) {
+        //threadsPerNode = tpn;
+        pairChannel = tc;
+        //threadId = 100 + tid; // keep distinct from other tags
+        theList = dl;
+        red = new ReductionPar<C>();
+    }
+
+
+    /**
+     * Work loop.
+     * @see java.lang.Runnable#run()
+     */
+    @Override
+    public void run() {
+        if (logger.isInfoEnabled()) {
+            logger.info("pairChannel   = " + pairChannel + " reducer client running");
+        }
+        Pair<C> pair = null;
+        GenPolynomial<C> pi, pj, ps;
+        GenPolynomial<C> S;
+        GenPolynomial<C> H = null;
+        //boolean set = false;
+        boolean goon = true;
+        boolean doEnd = true;
+        int reduction = 0;
+        //int sleeps = 0;
+        Integer pix, pjx, psx;
+
+        while (goon) {
+            /* protocol:
+             * request pair, process pair, send result, receive acknowledgment
+             */
+            // pair = (Pair) pairlist.removeNext();
+            Object req = new GBTransportMessReq();
+            logger.info("send request");
+            try {
+                pairChannel.send(pairTag, req);
+            } catch (IOException e) {
+                goon = false;
+                if (logger.isDebugEnabled()) {
+                    e.printStackTrace();
+                }
+                logger.info("receive pair, IOexception ");
+                break;
+            }
+            logger.info("receive on pairTag, goon = " + goon);
+            doEnd = true;
+            Object pp = null;
+            try {
+                pp = pairChannel.receive(pairTag);
+            } catch (InterruptedException e) {
+                goon = false;
+                e.printStackTrace();
+            } catch (IOException e) {
+                goon = false;
+                if (logger.isDebugEnabled()) {
+                    e.printStackTrace();
+                }
+                break;
+            } catch (ClassNotFoundException e) {
+                goon = false;
+                e.printStackTrace();
+            }
+            if (logger.isInfoEnabled()) {
+                logger.info("received pair = " + pp);
+            }
+            H = null;
+            if (pp == null) { // should not happen
+                continue;
+            }
+            if (pp instanceof GBTransportMessEnd) {
+                goon = false;
+                //doEnd = false;
+                continue;
+            }
+            if (pp instanceof GBTransportMessPair || pp instanceof GBTransportMessPairIndex) {
+                pi = pj = ps = null;
+                if (pp instanceof GBTransportMessPair) { // obsolet, for tests
+                    @SuppressWarnings("unchecked")
+                    GBTransportMessPair<C> tmp = (GBTransportMessPair<C>) pp;
+                    pair = tmp.pair;
+                    if (pair != null) {
+                        pi = pair.pi;
+                        pj = pair.pj;
+                        //logger.debug("pair: pix = " + pair.i 
+                        //               + ", pjx = " + pair.j);
+                    }
+                }
+                if (pp instanceof GBTransportMessPairIndex) {
+                    GBTransportMessPairIndex tmpi = (GBTransportMessPairIndex) pp;
+                    pix = tmpi.i;
+                    pjx = tmpi.j;
+                    psx = tmpi.s;
+                    pi = theList.getWait(pix);
+                    pj = theList.getWait(pjx);
+                    ps = theList.getWait(psx);
+                    //logger.info("pix = " + pix + ", pjx = " + pjx + ", psx = " + psx);
+                }
+                if (pi != null && pj != null) {
+                    S = red.SPolynomial(pi, pj);
+                    //logger.info("ht(S) = " + S.leadingExpVector());
+                    if (S.isZERO()) {
+                        // pair.setZero(); does not work in dist
+                    } else {
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("ht(S) = " + S.leadingExpVector());
+                        }
+                        H = red.normalform(theList, S);
+                        //logger.info("ht(H) = " + H.leadingExpVector());
+                        reduction++;
+                        if (H.isZERO()) {
+                            // pair.setZero(); does not work in dist
+                        } else {
+                            H = H.monic();
+                            if (logger.isInfoEnabled()) {
+                                logger.info("ht(H) = " + H.leadingExpVector());
+                            }
+                        }
+                    }
+                } else {
+                    logger.info("pi = " + pi + ", pj = " + pj + ", ps = " + ps);
+                }
+            }
+            if (pp instanceof GBTransportMess) {
+                logger.debug("null pair results in null H poly");
+            }
+
+            // send H or must send null, if not at end
+            if (logger.isDebugEnabled()) {
+                logger.debug("#distributed list = " + theList.size());
+                logger.debug("send H polynomial = " + H);
+            }
+            try {
+                pairChannel.send(resultTag, new GBTransportMessPoly<C>(H)); //,threadId));
+                doEnd = false;
+            } catch (IOException e) {
+                goon = false;
+                e.printStackTrace();
+            }
+            //logger.info("done send poly message of " + pp);
+            try {
+                //pp = pairChannel.receive(threadId);
+                pp = pairChannel.receive(ackTag);
+            } catch (InterruptedException e) {
+                goon = false;
+                e.printStackTrace();
+            } catch (IOException e) {
+                goon = false;
+                if (logger.isDebugEnabled()) {
+                    e.printStackTrace();
+                }
+                break;
+            } catch (ClassNotFoundException e) {
+                goon = false;
+                e.printStackTrace();
+            }
+            if (!(pp instanceof GBTransportMess)) {
+                logger.error("invalid acknowledgement " + pp);
+            }
+            logger.info("received acknowledgment ");
+        }
+        logger.info("terminated, " + reduction + " reductions, " + theList.size() + " polynomials");
+        if (doEnd) {
+            try {
+                pairChannel.send(resultTag, new GBTransportMessEnd());
+            } catch (IOException e) {
+                //e.printStackTrace();
+            }
+            logger.debug("terminated, send done");
+        }
+    }
+}
+
+
+/**
+ * Objects of this class are to be send to a ExecutableServer.
+ */
+class GBHybridExerClient<C extends RingElem<C>> implements RemoteExecutable {
+
+
+    String host;
+
+
+    int port;
+
+
+    int dhtport;
+
+
+    int threadsPerNode;
+
+
+    /**
+     * GBHybridExerClient.
+     * @param host
+     * @param port
+     * @param dhtport
+     */
+    public GBHybridExerClient(String host, int threadsPerNode, int port, int dhtport) {
+        this.host = host;
+        this.threadsPerNode = threadsPerNode;
+        this.port = port;
+        this.dhtport = dhtport;
+    }
+
+
+    /**
+     * run.
+     */
+    public void run() {
+        try {
+            GroebnerBaseDistributedHybridEC.<C> clientPart(host, threadsPerNode, port, dhtport);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+
+    /**
+     * String representation.
+     */
+    @Override
+    public String toString() {
+        StringBuffer s = new StringBuffer("GBHybridExerClient(");
+        s.append("host=" + host);
+        s.append(", threadsPerNode=" + threadsPerNode);
+        s.append(", port=" + port);
+        s.append(", dhtport=" + dhtport);
+        s.append(")");
+        return s.toString();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GroebnerBaseF5zSigSeqIter.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GroebnerBaseF5zSigSeqIter.java
@@ -1,0 +1,193 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Groebner Base F5z signature based sequential iterative algorithm. Implements
+ * Groebner bases.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ * 
+ * @see edu.jas.application.GBAlgorithmBuilder
+ * @see edu.jas.gbufd.GBFactory
+ */
+
+public class GroebnerBaseF5zSigSeqIter<C extends RingElem<C>> extends GroebnerBaseSigSeqIter<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GroebnerBaseF5zSigSeqIter.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     */
+    public GroebnerBaseF5zSigSeqIter() {
+        this(new SigReductionSeq<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param red Reduction engine
+     */
+    public GroebnerBaseF5zSigSeqIter(SigReductionSeq<C> red) {
+        super(red);
+    }
+
+
+    /**
+     * Top normalform.
+     * @param A polynomial.
+     * @param F polynomial list.
+     * @param G polynomial list.
+     * @return nf(A) with respect to F and G.
+     */
+    @Override
+    SigPoly<C> sigNormalform(List<GenPolynomial<C>> F, List<SigPoly<C>> G, SigPoly<C> A) {
+        return sred.sigSemiNormalform(F, G, A);
+    }
+
+
+    /**
+     * Prune total pair list P.
+     * @param P pair list.
+     * @param syz list of exponent vectors representing syzygies.
+     * @return updated pair list. <b>Note:<b> stores polynomials not only
+     *         indices.
+     */
+    @Override
+    List<SigPair<C>> pruneP(List<SigPair<C>> P, List<ExpVector> syz) {
+        List<SigPair<C>> res = new ArrayList<SigPair<C>>(P.size());
+        for (SigPair<C> p : P) {
+            ExpVector f = p.sigma.leadingExpVector();
+            if (f == null) {
+                continue;
+            }
+            boolean div = false;
+            for (ExpVector e : syz) {
+                if (f.multipleOf(e)) {
+                    div = true;
+                    break;
+                }
+            }
+            if (div) {
+                continue;
+            }
+            res.add(p);
+        }
+        return res;
+    }
+
+
+    /**
+     * Prune pair list of degree d.
+     * @param S pair list.
+     * @param syz list of exponent vectors representing syzygies.
+     * @param done list of treated polynomials.
+     * @param G polynomial with signature list.
+     * @return updated pair list.
+     */
+    @Override
+    List<SigPair<C>> pruneS(List<SigPair<C>> S, List<ExpVector> syz, List<SigPoly<C>> done,
+                    List<SigPoly<C>> G) {
+        List<SigPair<C>> res = new ArrayList<SigPair<C>>(S.size());
+        for (SigPair<C> p : S) {
+            if (p.sigma.isZERO()) {
+                continue;
+            }
+            ExpVector f = p.sigma.leadingExpVector();
+            boolean div = false;
+            for (ExpVector e : syz) {
+                if (f.multipleOf(e)) {
+                    div = true;
+                    break;
+                }
+            }
+            if (div) {
+                continue;
+            }
+            if (p.pi.sigma.isZERO()) {
+                logger.info("pruneS, p.pi.sigma = 0");
+                res.add(p);
+                continue;
+            }
+            ExpVector fi = p.pi.poly.leadingExpVector();
+            ExpVector fj = p.pj.poly.leadingExpVector();
+            ExpVector fu = fi.lcm(fj).subtract(fi);
+            f = p.pi.sigma.leadingExpVector();
+            fu = fu.sum(f);
+            div = false;
+            for (SigPoly<C> q : done) {
+                ExpVector e = q.sigma.leadingExpVector();
+                if (e == null) {
+                    continue;
+                }
+                if (fu.multipleOf(e)) {
+                    if (q.sigma.compareTo(p.pi.sigma) > 0) {
+                        div = true;
+                        break;
+                    }
+                }
+            }
+            if (div) {
+                continue;
+            }
+            res.add(p);
+            logger.debug("added p = " + p.sigma);
+        }
+        return res;
+    }
+
+
+    /**
+     * Initializes syzygy list.
+     * @param F polynomial list.
+     * @param G polynomial with signature list.
+     * @return list of exponent vectors representing syzygies.
+     */
+    @Override
+    List<ExpVector> initializeSyz(List<GenPolynomial<C>> F, List<SigPoly<C>> G) {
+        List<ExpVector> P = new ArrayList<ExpVector>();
+        for (GenPolynomial<C> p : F) {
+            if (p.isZERO()) {
+                continue;
+            }
+            P.add(p.leadingExpVector());
+        }
+        return P;
+    }
+
+
+    /**
+     * Update syzygy list.
+     * @param syz list of exponent vectors representing syzygies.
+     * @param r polynomial. <b>Note:</b> szy is modified to represent updated
+     *            list of exponent vectors.
+     */
+    @Override
+    void updateSyz(List<ExpVector> syz, SigPoly<C> r) {
+        if (r.poly.isZERO() && !r.sigma.isZERO()) {
+            //logger.info("update_syz, sigma = " + r.sigma);
+            syz.add(r.sigma.leadingExpVector());
+        }
+        return;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GroebnerBaseGGVSigSeqIter.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GroebnerBaseGGVSigSeqIter.java
@@ -1,0 +1,186 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Groebner Base GGV signature based sequential iterative algorithm. Implements
+ * Groebner bases.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ * 
+ * @see edu.jas.application.GBAlgorithmBuilder
+ * @see edu.jas.gbufd.GBFactory
+ */
+
+public class GroebnerBaseGGVSigSeqIter<C extends RingElem<C>> extends GroebnerBaseSigSeqIter<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GroebnerBaseGGVSigSeqIter.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     */
+    public GroebnerBaseGGVSigSeqIter() {
+        this(new SigReductionSeq<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param red Reduction engine
+     */
+    public GroebnerBaseGGVSigSeqIter(SigReductionSeq<C> red) {
+        super(red);
+    }
+
+
+    /**
+     * S-Polynomial.
+     * @param A polynomial.
+     * @param B polynomial.
+     * @return spol(A,B) the S-polynomial of A and B.
+     */
+    @Override
+    GenPolynomial<C> SPolynomial(SigPoly<C> A, SigPoly<C> B) {
+        return sred.SPolynomialHalf(A, B);
+    }
+
+
+    /**
+     * Prune total pair list P.
+     * @param P pair list.
+     * @param syz list of exponent vectors representing syzygies.
+     * @return updated pair list.
+     */
+    @Override
+    List<SigPair<C>> pruneP(List<SigPair<C>> P, List<ExpVector> syz) {
+        List<SigPair<C>> res = new ArrayList<SigPair<C>>(P.size());
+        for (SigPair<C> p : P) {
+            ExpVector f = p.sigma.leadingExpVector();
+            if (f == null) {
+                continue;
+            }
+            boolean div = false;
+            for (ExpVector e : syz) {
+                if (f.multipleOf(e)) {
+                    div = true;
+                    break;
+                }
+            }
+            if (div) {
+                continue;
+            }
+            res.add(p);
+        }
+        return res;
+    }
+
+
+    /**
+     * Prune pair list of degree d.
+     * @param S pair list.
+     * @param syz list of exponent vectors representing syzygies.
+     * @param done list of treated polynomials.
+     * @param G polynomial with signature list.
+     * @return updated pair list.
+     */
+    @Override
+    List<SigPair<C>> pruneS(List<SigPair<C>> S, List<ExpVector> syz, List<SigPoly<C>> done,
+                    List<SigPoly<C>> G) {
+        List<SigPair<C>> res = new ArrayList<SigPair<C>>(S.size());
+        for (SigPair<C> p : S) {
+            ExpVector f = p.sigma.leadingExpVector();
+            if (f == null) {
+                continue;
+            }
+            boolean div = false;
+            for (ExpVector e : syz) {
+                if (f.multipleOf(e)) {
+                    div = true;
+                    break;
+                }
+            }
+            if (div) {
+                continue;
+            }
+            div = false;
+            for (SigPair<C> q : S) {
+                if (f.equals(q.sigma.leadingExpVector())) {
+                    if (p.pi.poly.compareTo(q.pi.poly) < 0) {
+                        div = true;
+                        break;
+                    }
+                }
+            }
+            if (div) {
+                continue;
+            }
+            div = false;
+            for (SigPair<C> q : res) {
+                if (f.equals(q.sigma.leadingExpVector())) {
+                    div = true;
+                    break;
+                }
+            }
+            if (div) {
+                continue;
+            }
+            res.add(p);
+            logger.debug("added p = " + p.sigma);
+        }
+        return res;
+    }
+
+
+    /**
+     * Initializes syzygy list.
+     * @param F polynomial list.
+     * @param G polynomial with signature list.
+     * @return list of exponent vectors representing syzygies.
+     */
+    @Override
+    List<ExpVector> initializeSyz(List<GenPolynomial<C>> F, List<SigPoly<C>> G) {
+        List<ExpVector> P = new ArrayList<ExpVector>();
+        for (GenPolynomial<C> p : F) {
+            if (p.isZERO()) {
+                continue;
+            }
+            P.add(p.leadingExpVector());
+        }
+        return P;
+    }
+
+
+    /**
+     * Update syzygy list.
+     * @param syz list of exponent vectors representing syzygies.
+     * @param r polynomial. <b>Note:</b> szy is modified to represent updated
+     *            list of exponent vectors.
+     */
+    @Override
+    void updateSyz(List<ExpVector> syz, SigPoly<C> r) {
+        if (r.poly.isZERO() && !r.sigma.isZERO()) {
+            syz.add(r.sigma.leadingExpVector());
+        }
+        return;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GroebnerBaseParIter.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GroebnerBaseParIter.java
@@ -1,0 +1,565 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.OrderedPolynomialList;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.RingElem;
+import edu.jas.util.Terminator;
+
+
+/**
+ * Groebner Base parallel iterative algortihm. Implements a shared memory
+ * parallel version of Groebner bases.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ * 
+ * @see edu.jas.application.GBAlgorithmBuilder
+ * @see edu.jas.gbufd.GBFactory
+ */
+
+public class GroebnerBaseParIter<C extends RingElem<C>> extends GroebnerBaseAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GroebnerBaseParIter.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Number of threads to use.
+     */
+    protected final int threads;
+
+
+    /**
+     * Pool of threads to use.
+     */
+    protected transient final ExecutorService pool;
+
+
+    /**
+     * Constructor.
+     */
+    public GroebnerBaseParIter() {
+        this(2);
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     */
+    public GroebnerBaseParIter(int threads) {
+        this(threads, Executors.newFixedThreadPool(threads));
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param red parallelism aware reduction engine
+     */
+    public GroebnerBaseParIter(int threads, Reduction<C> red) {
+        this(threads, Executors.newFixedThreadPool(threads), red);
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param pl pair selection strategy
+     */
+    public GroebnerBaseParIter(int threads, PairList<C> pl) {
+        this(threads, Executors.newFixedThreadPool(threads), new ReductionPar<C>(), pl);
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param pool ExecutorService to use.
+     */
+    public GroebnerBaseParIter(int threads, ExecutorService pool) {
+        this(threads, pool, new ReductionPar<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param pool ExecutorService to use.
+     * @param red Reduction engine
+     */
+    public GroebnerBaseParIter(int threads, ExecutorService pool, Reduction<C> red) {
+        this(threads, pool, red, new OrderedPairlist<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param red Reduction engine
+     * @param pl pair selection strategy
+     */
+    public GroebnerBaseParIter(int threads, Reduction<C> red, PairList<C> pl) {
+        this(threads, Executors.newFixedThreadPool(threads), red, pl);
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param pool ExecutorService to use.
+     * @param red parallelism aware reduction engine
+     * @param pl pair selection strategy
+     */
+    public GroebnerBaseParIter(int threads, ExecutorService pool, Reduction<C> red, PairList<C> pl) {
+        super(red, pl);
+        if (!(red instanceof ReductionPar)) {
+            logger.warn("parallel GB should use parallel aware reduction");
+        }
+        if (threads < 1) {
+            threads = 1;
+        }
+        this.threads = threads;
+        this.pool = pool;
+    }
+
+
+    /**
+     * Cleanup and terminate ExecutorService.
+     */
+    @Override
+    public void terminate() {
+        if (pool == null) {
+            return;
+        }
+        pool.shutdown();
+        try {
+            while (!pool.isTerminated()) {
+                //logger.info("await");
+                boolean rest = pool.awaitTermination(1000L, TimeUnit.MILLISECONDS);
+            }
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        logger.info(pool.toString());
+    }
+
+
+    /**
+     * Cancel ExecutorService.
+     */
+    @Override
+    public int cancel() {
+        if (pool == null) {
+            return 0;
+        }
+        int s = pool.shutdownNow().size();
+        logger.info(pool.toString());
+        return s;
+    }
+
+
+    /**
+     * Parallel iterative Groebner base using pairlist class.
+     * @param modv number of module variables.
+     * @param F polynomial list.
+     * @return GB(F) a Groebner base of F.
+     */
+    public List<GenPolynomial<C>> GB(int modv, List<GenPolynomial<C>> F) {
+        List<GenPolynomial<C>> G = normalizeZerosOnes(F);
+        G = PolyUtil.<C> monic(G);
+        if (G.size() <= 1) {
+            return G;
+        }
+        // sort, no reverse
+        G = OrderedPolynomialList.<C> sort(G);
+        //no: Collections.reverse(G);
+        logger.info("G-sort = " + G);
+
+        List<GenPolynomial<C>> Gp = new ArrayList<GenPolynomial<C>>();
+        for (GenPolynomial<C> p : G) {
+            if (debug) {
+                logger.info("p = " + p);
+            }
+            Gp = GB(modv, Gp, p);
+            //System.out.println("GB(Gp+p) = " + Gp);
+            if (Gp.size() > 0) {
+                if (Gp.get(0).isONE()) {
+                    return Gp;
+                }
+            }
+        }
+        return Gp;
+    }
+
+
+    /**
+     * Groebner base using pairlist class.
+     * @param modv module variable number.
+     * @param G polynomial list of a Groebner base.
+     * @param f polynomial.
+     * @return GB(G,f) a Groebner base of G+(f).
+     */
+    public List<GenPolynomial<C>> GB(int modv, List<GenPolynomial<C>> G, GenPolynomial<C> f) {
+        List<GenPolynomial<C>> F = new ArrayList<GenPolynomial<C>>(G);
+        GenPolynomial<C> g = f.monic();
+        if (F.isEmpty()) {
+            F.add(g);
+            return F;
+        }
+        if (g.isZERO()) {
+            return F;
+        }
+        if (g.isONE()) {
+            F.clear();
+            F.add(g);
+            return F;
+        }
+        GenPolynomialRing<C> ring = G.get(0).ring;
+        if (!ring.coFac.isField()) {
+            throw new IllegalArgumentException("coefficients not from a field");
+        }
+        PairList<C> pairlist = strategy.create(modv, ring);
+        pairlist.setList(G);
+        G.add(g);
+        pairlist.put(g);
+        logger.info("start " + pairlist);
+
+        Terminator fin = new Terminator(threads);
+        for (int i = 0; i < threads; i++) {
+            ReducerIter<C> R = new ReducerIter<C>(fin, G, pairlist);
+            pool.execute(R);
+        }
+        fin.waitDone();
+        if (Thread.currentThread().isInterrupted()) {
+            throw new RuntimeException("interrupt before minimalGB");
+        }
+        logger.debug("#parallel list = " + G.size());
+        G = minimalGB(G);
+        // not in this context // pool.terminate();
+        logger.info("end   " + pairlist);
+        return G;
+    }
+
+
+    /**
+     * Minimal ordered groebner basis, parallel.
+     * @param Fp a Groebner base.
+     * @return minimalGB(F) a minimal Groebner base of Fp.
+     */
+    @Override
+    public List<GenPolynomial<C>> minimalGB(List<GenPolynomial<C>> Fp) {
+        GenPolynomial<C> a;
+        ArrayList<GenPolynomial<C>> G;
+        G = new ArrayList<GenPolynomial<C>>(Fp.size());
+        ListIterator<GenPolynomial<C>> it = Fp.listIterator();
+        while (it.hasNext()) {
+            a = it.next();
+            if (a.length() != 0) { // always true
+                // already monic  a = a.monic();
+                G.add(a);
+            }
+        }
+        if (G.size() <= 1) {
+            return G;
+        }
+
+        ExpVector e;
+        ExpVector f;
+        GenPolynomial<C> p;
+        ArrayList<GenPolynomial<C>> F;
+        F = new ArrayList<GenPolynomial<C>>(G.size());
+        boolean mt;
+        while (G.size() > 0) {
+            a = G.remove(0);
+            e = a.leadingExpVector();
+
+            it = G.listIterator();
+            mt = false;
+            while (it.hasNext() && !mt) {
+                p = it.next();
+                f = p.leadingExpVector();
+                mt = e.multipleOf(f);
+            }
+            it = F.listIterator();
+            while (it.hasNext() && !mt) {
+                p = it.next();
+                f = p.leadingExpVector();
+                mt = e.multipleOf(f);
+            }
+            if (!mt) {
+                F.add(a); // no thread at this point
+            } else {
+                // System.out.println("dropped " + a.length());
+            }
+        }
+        G = F;
+        if (G.size() <= 1) {
+            return G;
+        }
+        Collections.reverse(G); // important for lex GB
+
+        @SuppressWarnings("unchecked")
+        MiReducerIter<C>[] mirs = (MiReducerIter<C>[]) new MiReducerIter[G.size()];
+        int i = 0;
+        F = new ArrayList<GenPolynomial<C>>(G.size());
+        while (G.size() > 0) {
+            a = G.remove(0);
+            List<GenPolynomial<C>> R = new ArrayList<GenPolynomial<C>>(G.size() + F.size());
+            R.addAll(G);
+            R.addAll(F);
+            // System.out.println("doing " + a.length());
+            mirs[i] = new MiReducerIter<C>(R, a);
+            pool.execute(mirs[i]);
+            i++;
+            F.add(a);
+        }
+        G = F;
+        F = new ArrayList<GenPolynomial<C>>(G.size());
+        for (i = 0; i < mirs.length; i++) {
+            a = mirs[i].getNF();
+            F.add(a);
+        }
+        return F;
+    }
+
+}
+
+
+/**
+ * Reducing worker threads.
+ */
+class ReducerIter<C extends RingElem<C>> implements Runnable {
+
+
+    private final List<GenPolynomial<C>> G;
+
+
+    private final PairList<C> pairlist;
+
+
+    private final Terminator fin;
+
+
+    private final ReductionPar<C> red;
+
+
+    private static final Logger logger = LogManager.getLogger(ReducerIter.class);
+
+
+    ReducerIter(Terminator fin, List<GenPolynomial<C>> G, PairList<C> L) {
+        this.fin = fin;
+        this.fin.initIdle(1);
+        this.G = G;
+        pairlist = L;
+        red = new ReductionPar<C>();
+    }
+
+
+    /**
+     * to string
+     */
+    @Override
+    public String toString() {
+        return "ReducerIter";
+    }
+
+
+    public void run() {
+        Pair<C> pair;
+        GenPolynomial<C> pi, pj, S, H;
+        //boolean set = false;
+        int reduction = 0;
+        int sleeps = 0;
+        while (pairlist.hasNext() || fin.hasJobs()) {
+            while (!pairlist.hasNext()) {
+                // wait
+                //fin.beIdle(); set = true;
+                try {
+                    sleeps++;
+                    if (sleeps % 10 == 0) {
+                        logger.info(" reducer is sleeping");
+                    } else {
+                        logger.debug("r");
+                    }
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    fin.allIdle();
+                    logger.info("shutdown " + fin + " after: " + e);
+                    //throw new RuntimeException("interrupt 1 in pairlist.hasNext loop");
+                    break;
+                }
+                if (Thread.currentThread().isInterrupted()) {
+                    //fin.initIdle(1);
+                    fin.allIdle();
+                    logger.info("shutdown after .isInterrupted(): " + fin);
+                    //throw new RuntimeException("interrupt 2 in pairlist.hasNext loop");
+                    break;
+                }
+                if (!fin.hasJobs()) {
+                    break;
+                }
+            }
+            if (!pairlist.hasNext() && !fin.hasJobs()) {
+                break;
+            }
+            //if ( set ) {
+            //fin.notIdle(); set = false;
+            //}
+
+            fin.notIdle(); // before pairlist get
+            pair = pairlist.removeNext();
+            if (Thread.currentThread().isInterrupted()) {
+                fin.initIdle(1);
+                throw new RuntimeException("interrupt after removeNext");
+            }
+            if (pair == null) {
+                fin.initIdle(1);
+                continue;
+            }
+
+            pi = pair.pi;
+            pj = pair.pj;
+            if (logger.isDebugEnabled()) {
+                logger.debug("pi    = " + pi);
+                logger.debug("pj    = " + pj);
+            }
+
+            S = red.SPolynomial(pi, pj);
+            if (S.isZERO()) {
+                pair.setZero();
+                fin.initIdle(1);
+                continue;
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("ht(S) = " + S.leadingExpVector());
+            }
+
+            H = red.normalform(G, S); //mod
+            reduction++;
+            if (H.isZERO()) {
+                pair.setZero();
+                fin.initIdle(1);
+                continue;
+            }
+            if (logger.isDebugEnabled()) {
+                logger.info("ht(H) = " + H.leadingExpVector());
+            }
+
+            H = H.monic();
+            // System.out.println("H   = " + H);
+            if (H.isONE()) {
+                // putOne not required
+                pairlist.put(H);
+                synchronized (G) {
+                    G.clear();
+                    G.add(H);
+                }
+                fin.allIdle();
+                return;
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("H = " + H);
+            }
+            synchronized (G) {
+                G.add(H);
+            }
+            pairlist.put(H);
+            fin.initIdle(1);
+        }
+        fin.allIdle();
+        logger.info("terminated, done " + reduction + " reductions");
+    }
+}
+
+
+/**
+ * Reducing worker threads for minimal GB.
+ */
+class MiReducerIter<C extends RingElem<C>> implements Runnable {
+
+
+    private final List<GenPolynomial<C>> G;
+
+
+    private GenPolynomial<C> H;
+
+
+    private final ReductionPar<C> red;
+
+
+    private final Semaphore done = new Semaphore(0);
+
+
+    private static final Logger logger = LogManager.getLogger(MiReducerIter.class);
+
+
+    MiReducerIter(List<GenPolynomial<C>> G, GenPolynomial<C> p) {
+        this.G = G;
+        H = p;
+        red = new ReductionPar<C>();
+    }
+
+
+    /**
+     * to string
+     */
+    @Override
+    public String toString() {
+        return "MiReducerIter";
+    }
+
+
+    /**
+     * getNF. Blocks until the normal form is computed.
+     * @return the computed normal form.
+     */
+    public GenPolynomial<C> getNF() {
+        try {
+            done.acquire(); //done.P();
+        } catch (InterruptedException e) {
+            throw new RuntimeException("interrupt in getNF");
+        }
+        return H;
+    }
+
+
+    public void run() {
+        if (logger.isDebugEnabled()) {
+            logger.debug("ht(H) = " + H.leadingExpVector());
+        }
+        try {
+            H = red.normalform(G, H); //mod
+            done.release(); //done.V();
+        } catch (RuntimeException e) {
+            Thread.currentThread().interrupt();
+            //throw new RuntimeException("interrupt in getNF");
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug("ht(H) = " + H.leadingExpVector());
+        }
+        // H = H.monic();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GroebnerBaseParallel.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GroebnerBaseParallel.java
@@ -1,0 +1,519 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.RingElem;
+import edu.jas.util.Terminator;
+
+
+/**
+ * Groebner Base parallel algortihm. Implements a shared memory parallel version
+ * of Groebner bases.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ * 
+ * @see edu.jas.application.GBAlgorithmBuilder
+ * @see edu.jas.gbufd.GBFactory
+ */
+
+public class GroebnerBaseParallel<C extends RingElem<C>> extends GroebnerBaseAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GroebnerBaseParallel.class);
+
+
+    /**
+     * Number of threads to use.
+     */
+    protected final int threads;
+
+
+    /**
+     * Pool of threads to use.
+     */
+    protected transient final ExecutorService pool;
+
+
+    /**
+     * Constructor.
+     */
+    public GroebnerBaseParallel() {
+        this(2);
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     */
+    public GroebnerBaseParallel(int threads) {
+        this(threads, Executors.newFixedThreadPool(threads));
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param red parallelism aware reduction engine
+     */
+    public GroebnerBaseParallel(int threads, Reduction<C> red) {
+        this(threads, Executors.newFixedThreadPool(threads), red);
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param pl pair selection strategy
+     */
+    public GroebnerBaseParallel(int threads, PairList<C> pl) {
+        this(threads, Executors.newFixedThreadPool(threads), new ReductionPar<C>(), pl);
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param pool ThreadPool to use.
+     */
+    public GroebnerBaseParallel(int threads, ExecutorService pool) {
+        this(threads, pool, new ReductionPar<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param pool ThreadPool to use.
+     * @param red Reduction engine
+     */
+    public GroebnerBaseParallel(int threads, ExecutorService pool, Reduction<C> red) {
+        this(threads, pool, red, new OrderedPairlist<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param red Reduction engine
+     * @param pl pair selection strategy
+     */
+    public GroebnerBaseParallel(int threads, Reduction<C> red, PairList<C> pl) {
+        this(threads, Executors.newFixedThreadPool(threads), red, pl);
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param pool ExecutorService to use.
+     * @param red parallelism aware reduction engine
+     * @param pl pair selection strategy
+     */
+    public GroebnerBaseParallel(int threads, ExecutorService pool, Reduction<C> red, PairList<C> pl) {
+        super(red, pl);
+        if (!(red instanceof ReductionPar)) {
+            logger.warn("parallel GB should use parallel aware reduction");
+        }
+        if (threads < 1) {
+            threads = 1;
+        }
+        this.threads = threads;
+        this.pool = pool;
+        int s = ((ThreadPoolExecutor) pool).getCorePoolSize();
+        if (threads != s) {
+            logger.warn("#threads(" + threads + ") and number of pool threads(" + s + ") differ:");
+        }
+    }
+
+
+    /**
+     * Cleanup and terminate ExecutorService.
+     */
+    @Override
+    public void terminate() {
+        if (pool == null) {
+            return;
+        }
+        pool.shutdown();
+        try {
+            while (!pool.isTerminated()) {
+                //logger.info("await");
+                boolean rest = pool.awaitTermination(1000L, TimeUnit.MILLISECONDS);
+            }
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        logger.info(pool.toString());
+    }
+
+
+    /**
+     * Cancel ExecutorService.
+     */
+    @Override
+    public int cancel() {
+        if (pool == null) {
+            return 0;
+        }
+        int s = pool.shutdownNow().size();
+        logger.info(pool.toString());
+        return s;
+    }
+
+
+    /**
+     * Parallel Groebner base using pairlist class.
+     * @param modv number of module variables.
+     * @param F polynomial list.
+     * @return GB(F) a Groebner base of F.
+     */
+    public List<GenPolynomial<C>> GB(int modv, List<GenPolynomial<C>> F) {
+        List<GenPolynomial<C>> G = normalizeZerosOnes(F);
+        G = PolyUtil.<C> monic(G);
+        if (G.size() <= 1) {
+            return G;
+        }
+        GenPolynomialRing<C> ring = G.get(0).ring;
+        if (!ring.coFac.isField()) {
+            throw new IllegalArgumentException("coefficients not from a field");
+        }
+        PairList<C> pairlist = strategy.create(modv, ring);
+        pairlist.put(G);
+        logger.info("start " + pairlist);
+
+        Terminator fin = new Terminator(threads);
+        for (int i = 0; i < threads; i++) {
+            Reducer<C> R = new Reducer<C>(fin, G, pairlist);
+            pool.execute(R);
+        }
+        fin.waitDone();
+        if (Thread.currentThread().isInterrupted()) {
+            throw new RuntimeException("interrupt before minimalGB");
+        }
+        logger.debug("#parallel list = " + G.size());
+        G = minimalGB(G);
+        // not in this context // pool.terminate();
+        logger.info("end   " + pairlist);
+        return G;
+    }
+
+
+    /**
+     * Minimal ordered groebner basis, parallel.
+     * @param Fp a Groebner base.
+     * @return minimalGB(F) a minimal Groebner base of Fp.
+     */
+    @Override
+    public List<GenPolynomial<C>> minimalGB(List<GenPolynomial<C>> Fp) {
+        GenPolynomial<C> a;
+        ArrayList<GenPolynomial<C>> G;
+        G = new ArrayList<GenPolynomial<C>>(Fp.size());
+        ListIterator<GenPolynomial<C>> it = Fp.listIterator();
+        while (it.hasNext()) {
+            a = it.next();
+            if (a.length() != 0) { // always true
+                // already monic  a = a.monic();
+                G.add(a);
+            }
+        }
+        if (G.size() <= 1) {
+            return G;
+        }
+
+        ExpVector e;
+        ExpVector f;
+        GenPolynomial<C> p;
+        ArrayList<GenPolynomial<C>> F;
+        F = new ArrayList<GenPolynomial<C>>(G.size());
+        boolean mt;
+        while (G.size() > 0) {
+            a = G.remove(0);
+            e = a.leadingExpVector();
+
+            it = G.listIterator();
+            mt = false;
+            while (it.hasNext() && !mt) {
+                p = it.next();
+                f = p.leadingExpVector();
+                mt = e.multipleOf(f);
+            }
+            it = F.listIterator();
+            while (it.hasNext() && !mt) {
+                p = it.next();
+                f = p.leadingExpVector();
+                mt = e.multipleOf(f);
+            }
+            if (!mt) {
+                F.add(a); // no thread at this point
+            } else {
+                // System.out.println("dropped " + a.length());
+            }
+        }
+        G = F;
+        if (G.size() <= 1) {
+            return G;
+        }
+        Collections.reverse(G); // important for lex GB
+
+        @SuppressWarnings("unchecked")
+        MiReducer<C>[] mirs = (MiReducer<C>[]) new MiReducer[G.size()];
+        int i = 0;
+        F = new ArrayList<GenPolynomial<C>>(G.size());
+        while (G.size() > 0) {
+            a = G.remove(0);
+            List<GenPolynomial<C>> R = new ArrayList<GenPolynomial<C>>(G.size() + F.size());
+            R.addAll(G);
+            R.addAll(F);
+            // System.out.println("doing " + a.length());
+            mirs[i] = new MiReducer<C>(R, a);
+            pool.execute(mirs[i]);
+            i++;
+            F.add(a);
+        }
+        G = F;
+        F = new ArrayList<GenPolynomial<C>>(G.size());
+        for (i = 0; i < mirs.length; i++) {
+            a = mirs[i].getNF();
+            F.add(a);
+        }
+        return F;
+    }
+
+}
+
+
+/**
+ * Reducing worker threads.
+ */
+class Reducer<C extends RingElem<C>> implements Runnable {
+
+
+    private final List<GenPolynomial<C>> G;
+
+
+    private final PairList<C> pairlist;
+
+
+    private final Terminator fin;
+
+
+    private final ReductionPar<C> red;
+
+
+    private static final Logger logger = LogManager.getLogger(Reducer.class);
+
+
+    Reducer(Terminator fin, List<GenPolynomial<C>> G, PairList<C> L) {
+        this.fin = fin;
+        this.fin.initIdle(1);
+        this.G = G;
+        pairlist = L;
+        red = new ReductionPar<C>();
+    }
+
+
+    /**
+     * to string
+     */
+    @Override
+    public String toString() {
+        return "Reducer";
+    }
+
+
+    public void run() {
+        Pair<C> pair;
+        GenPolynomial<C> pi, pj, S, H;
+        //boolean set = false;
+        int reduction = 0;
+        int sleeps = 0;
+        while (pairlist.hasNext() || fin.hasJobs()) {
+            while (!pairlist.hasNext()) {
+                // wait
+                //fin.beIdle(); set = true;
+                try {
+                    sleeps++;
+                    if (sleeps % 10 == 0) {
+                        logger.info(" reducer is sleeping");
+                    } else {
+                        logger.debug("r");
+                    }
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    fin.allIdle();
+                    logger.info("shutdown " + fin + " after: " + e);
+                    //throw new RuntimeException("interrupt 1 in pairlist.hasNext loop");
+                    break;
+                }
+                if (Thread.currentThread().isInterrupted()) {
+                    //fin.initIdle(1);
+                    fin.allIdle();
+                    logger.info("shutdown after .isInterrupted(): " + fin);
+                    //throw new RuntimeException("interrupt 2 in pairlist.hasNext loop");
+                    break;
+                }
+                if (!fin.hasJobs()) {
+                    break;
+                }
+            }
+            if (!pairlist.hasNext() && !fin.hasJobs()) {
+                break;
+            }
+            //if ( set ) {
+            //fin.notIdle(); set = false;
+            //}
+
+            fin.notIdle(); // before pairlist get
+            pair = pairlist.removeNext();
+            if (Thread.currentThread().isInterrupted()) {
+                fin.initIdle(1);
+                throw new RuntimeException("interrupt after removeNext");
+            }
+            if (pair == null) {
+                fin.initIdle(1);
+                continue;
+            }
+
+            pi = pair.pi;
+            pj = pair.pj;
+            if (logger.isDebugEnabled()) {
+                logger.debug("pi    = " + pi);
+                logger.debug("pj    = " + pj);
+            }
+
+            S = red.SPolynomial(pi, pj);
+            if (S.isZERO()) {
+                pair.setZero();
+                fin.initIdle(1);
+                continue;
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("ht(S) = " + S.leadingExpVector());
+            }
+
+            H = red.normalform(G, S); //mod
+            reduction++;
+            if (H.isZERO()) {
+                pair.setZero();
+                fin.initIdle(1);
+                continue;
+            }
+            if (logger.isDebugEnabled()) {
+                logger.info("ht(H) = " + H.leadingExpVector());
+            }
+
+            H = H.monic();
+            // System.out.println("H   = " + H);
+            if (H.isONE()) {
+                // putOne not required
+                pairlist.put(H);
+                synchronized (G) {
+                    G.clear();
+                    G.add(H);
+                }
+                fin.allIdle();
+                return;
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("H = " + H);
+            }
+            synchronized (G) {
+                G.add(H);
+            }
+            pairlist.put(H);
+            fin.initIdle(1);
+        }
+        fin.allIdle();
+        logger.info("terminated, done " + reduction + " reductions");
+    }
+}
+
+
+/**
+ * Reducing worker threads for minimal GB.
+ */
+class MiReducer<C extends RingElem<C>> implements Runnable {
+
+
+    private final List<GenPolynomial<C>> G;
+
+
+    private GenPolynomial<C> H;
+
+
+    private final ReductionPar<C> red;
+
+
+    private final Semaphore done = new Semaphore(0);
+
+
+    private static final Logger logger = LogManager.getLogger(MiReducer.class);
+
+
+    MiReducer(List<GenPolynomial<C>> G, GenPolynomial<C> p) {
+        this.G = G;
+        H = p;
+        red = new ReductionPar<C>();
+    }
+
+
+    /**
+     * to string
+     */
+    @Override
+    public String toString() {
+        return "MiReducer";
+    }
+
+
+    /**
+     * getNF. Blocks until the normal form is computed.
+     * @return the computed normal form.
+     */
+    public GenPolynomial<C> getNF() {
+        try {
+            done.acquire(); //done.P();
+        } catch (InterruptedException e) {
+            throw new RuntimeException("interrupt in getNF");
+        }
+        return H;
+    }
+
+
+    public void run() {
+        if (logger.isDebugEnabled()) {
+            logger.debug("ht(H) = " + H.leadingExpVector());
+        }
+        try {
+            H = red.normalform(G, H); //mod
+            done.release(); //done.V();
+        } catch (RuntimeException e) {
+            Thread.currentThread().interrupt();
+            //throw new RuntimeException("interrupt in getNF");
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug("ht(H) = " + H.leadingExpVector());
+        }
+        // H = H.monic();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GroebnerBaseSeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GroebnerBaseSeq.java
@@ -1,0 +1,386 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ListIterator;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.structure.RingElem;
+import edu.jas.gb.OrderedPairlist;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+
+
+/**
+ * Groebner Base sequential algorithm.
+ * Implements Groebner bases and GB test.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ *
+ * @see edu.jas.application.GBAlgorithmBuilder
+ * @see edu.jas.gbufd.GBFactory
+ */
+
+public class GroebnerBaseSeq<C extends RingElem<C>> 
+    extends GroebnerBaseAbstract<C>  {
+
+    private static final Logger logger = LogManager.getLogger(GroebnerBaseSeq.class);
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     */
+    public GroebnerBaseSeq() {
+        super();
+    }
+
+
+    /**
+     * Constructor.
+     * @param red Reduction engine
+     */
+    public GroebnerBaseSeq(Reduction<C> red) {
+        super(red);
+    }
+
+
+    /**
+     * Constructor.
+     * @param pl pair selection strategy
+     */
+    public GroebnerBaseSeq(PairList<C> pl) {
+        super(pl);
+    }
+
+
+    /**
+     * Constructor.
+     * @param red Reduction engine
+     * @param pl pair selection strategy
+     */
+    public GroebnerBaseSeq(Reduction<C> red, PairList<C> pl) {
+        super(red,pl);
+    }
+
+
+    /**
+     * Groebner base using pairlist class.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return GB(F) a Groebner base of F.
+     */
+    public List<GenPolynomial<C>> GB( int modv, List<GenPolynomial<C>> F ) {  
+        List<GenPolynomial<C>> G = normalizeZerosOnes(F);
+        G = PolyUtil.<C> monic(G);
+        if ( G.size() <= 1 ) {
+            return G;
+        }
+        GenPolynomialRing<C> ring = G.get(0).ring;
+        if ( ! ring.coFac.isField() ) {
+            throw new IllegalArgumentException("coefficients not from a field");
+        }
+        PairList<C> pairlist = strategy.create( modv, ring ); 
+        pairlist.put(G);
+        logger.info("start " + pairlist); 
+
+        Pair<C> pair;
+        GenPolynomial<C> pi, pj, S, H;
+        while ( pairlist.hasNext() ) {
+            pair = pairlist.removeNext();
+            //logger.debug("pair = " + pair);
+            if ( pair == null ) {
+                continue; 
+            }
+            pi = pair.pi; 
+            pj = pair.pj; 
+            if ( /*false &&*/ debug ) {
+                logger.debug("pi    = " + pi );
+                logger.debug("pj    = " + pj );
+            }
+
+            S = red.SPolynomial( pi, pj );
+            if ( S.isZERO() ) {
+                pair.setZero();
+                continue;
+            }
+            if ( debug ) {
+                logger.debug("ht(S) = " + S.leadingExpVector() );
+            }
+
+            H = red.normalform( G, S );
+            if ( debug ) {
+                //logger.info("pair = " + pair); 
+                //logger.info("ht(S) = " + S.monic()); //.leadingExpVector() );
+                logger.info("ht(H) = " + H.monic()); //.leadingExpVector() );
+            }
+            if ( H.isZERO() ) {
+                pair.setZero();
+                continue;
+            }
+            H = H.monic();
+            if ( debug ) {
+                logger.info("ht(H) = " + H.leadingExpVector() );
+            }
+
+            H = H.monic();
+            if ( H.isONE() ) {
+                G.clear(); G.add( H );
+                pairlist.putOne();
+                logger.info("end " + pairlist); 
+                return G; // since no threads are activated
+            }
+            if ( debug ) {
+                logger.info("H = " + H );
+            }
+            if ( H.length() > 0 ) {
+                //l++;
+                G.add( H );
+                pairlist.put( H );
+            }
+        }
+        logger.debug("#sequential list = " + G.size());
+        G = minimalGB(G);
+        logger.info("end " + pairlist); 
+        return G;
+    }
+
+
+    /**
+     * Extended Groebner base using critical pair class.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return a container for an extended Groebner base of F.
+     */
+    @Override
+    public ExtendedGB<C> 
+        extGB( int modv, List<GenPolynomial<C>> F ) {  
+        if ( F == null || F.isEmpty() ) {
+            throw new IllegalArgumentException("null or empty F not allowed");
+        }
+        List<GenPolynomial<C>> G = new ArrayList<GenPolynomial<C>>();
+        List<List<GenPolynomial<C>>> F2G = new ArrayList<List<GenPolynomial<C>>>();
+        List<List<GenPolynomial<C>>> G2F = new ArrayList<List<GenPolynomial<C>>>();
+        PairList<C> pairlist = null; 
+        boolean oneInGB = false;
+        int len = F.size();
+
+        List<GenPolynomial<C>> row = null;
+        List<GenPolynomial<C>> rows = null;
+        List<GenPolynomial<C>> rowh = null;
+        GenPolynomialRing<C> ring = null;
+        GenPolynomial<C> H;
+        GenPolynomial<C> p;
+
+        int nzlen = 0;
+        for ( GenPolynomial<C> f : F ) { 
+            if ( f.length() > 0 ) {
+                nzlen++;
+            }
+            if ( ring == null ) {
+                ring = f.ring;
+            }
+        }
+        GenPolynomial<C> mone = ring.getONE(); //.negate();
+        int k = 0;
+        ListIterator<GenPolynomial<C>> it = F.listIterator();
+        while ( it.hasNext() ) { 
+            p = it.next();
+            if ( p.length() > 0 ) {
+                row = new ArrayList<GenPolynomial<C>>( nzlen );
+                for ( int j = 0; j < nzlen; j++ ) {
+                    row.add(null);
+                }
+                //C c = p.leadingBaseCoefficient();
+                //c = c.inverse();
+                //p = p.multiply( c );
+                row.set( k, mone ); //.multiply(c) );
+                k++;
+                if ( p.isUnit() ) {
+                    G.clear(); G.add( p );
+                    G2F.clear(); G2F.add( row );
+                    oneInGB = true;
+                    break;
+                }
+                G.add( p );
+                G2F.add( row );
+                if ( pairlist == null ) {
+                    //pairlist = new OrderedPairlist<C>( modv, p.ring );
+                    pairlist = strategy.create( modv, p.ring );
+                    if ( ! p.ring.coFac.isField() ) {
+                        throw new RuntimeException("coefficients not from a field");
+                    }
+                }
+                // putOne not required
+                pairlist.put( p );
+            } else { 
+                len--;
+            }
+        }
+        ExtendedGB<C> exgb;
+        if ( len <= 1 || oneInGB ) {
+            // adjust F2G
+            for ( GenPolynomial<C> f : F ) {
+                row = new ArrayList<GenPolynomial<C>>( G.size() );
+                for ( int j = 0; j < G.size(); j++ ) {
+                    row.add(null);
+                }
+                H = red.normalform( row, G, f );
+                if ( ! H.isZERO() ) {
+                    logger.error("nonzero H = " + H );
+                }
+                F2G.add( row );
+            }
+            exgb = new ExtendedGB<C>(F,G,F2G,G2F);
+            //System.out.println("exgb 1 = " + exgb);
+            return exgb;
+        }
+
+        Pair<C> pair;
+        int i, j;
+        GenPolynomial<C> pi;
+        GenPolynomial<C> pj;
+        GenPolynomial<C> S;
+        GenPolynomial<C> x;
+        GenPolynomial<C> y;
+        //GenPolynomial<C> z;
+        while ( pairlist.hasNext() && ! oneInGB ) {
+            pair = pairlist.removeNext();
+            if ( pair == null ) { 
+                continue; 
+            }
+            i = pair.i; 
+            j = pair.j; 
+            pi = pair.pi; 
+            pj = pair.pj; 
+            if ( debug ) {
+                logger.info("i, pi    = " + i + ", " + pi );
+                logger.info("j, pj    = " + j + ", " + pj );
+            }
+
+            rows = new ArrayList<GenPolynomial<C>>( G.size() );
+            for ( int m = 0; m < G.size(); m++ ) {
+                rows.add(null);
+            }
+            S = red.SPolynomial( rows, i, pi, j, pj );
+            if ( debug ) {
+                logger.debug("is reduction S = " 
+                             + red.isReductionNF( rows, G, ring.getZERO(), S ) );
+            }
+            if ( S.isZERO() ) {
+                // do not add to G2F
+                continue;
+            }
+            if ( debug ) {
+                logger.debug("ht(S) = " + S.leadingExpVector() );
+            }
+
+            rowh = new ArrayList<GenPolynomial<C>>( G.size() );
+            for ( int m = 0; m < G.size(); m++ ) {
+                rowh.add(null);
+            }
+            H = red.normalform( rowh, G, S );
+            if ( debug ) {
+                logger.debug("is reduction H = " 
+                             + red.isReductionNF( rowh, G, S, H ) );
+            }
+            if ( H.isZERO() ) {
+                // do not add to G2F
+                continue;
+            }
+            if ( debug ) {
+                logger.debug("ht(H) = " + H.leadingExpVector() );
+            }
+
+            row = new ArrayList<GenPolynomial<C>>( G.size()+1 );
+            for ( int m = 0; m < G.size(); m++ ) {
+                x = rows.get(m);
+                if ( x != null ) {
+                    //System.out.println("ms = " + m + " " + x);
+                    x = x.negate();
+                }
+                y = rowh.get(m);
+                if ( y != null ) {
+                    y = y.negate();
+                    //System.out.println("mh = " + m + " " + y);
+                }
+                if ( x == null ) {
+                    x = y;
+                } else {
+                    x = x.sum( y );
+                }
+                //System.out.println("mx = " + m + " " + x);
+                row.add( x );
+            }
+            if ( debug ) {
+                logger.debug("is reduction 0+sum(row,G) == H : " 
+                             + red.isReductionNF( row, G, H, ring.getZERO() ) );
+            }
+            row.add( null );
+
+
+            //  H = H.monic();
+            C c = H.leadingBaseCoefficient();
+            c = c.inverse();
+            H = H.multiply( c );
+            row = blas.scalarProduct( mone.multiply(c), row );
+            row.set( G.size(), mone );
+            if ( H.isONE() ) {
+                // G.clear(); 
+                G.add( H );
+                G2F.add( row );
+                oneInGB = true;
+                break; 
+            }
+            if ( debug ) {
+                logger.debug("H = " + H );
+            }
+            G.add( H );
+            pairlist.put( H );
+            G2F.add( row );
+        }
+        if ( debug ) {
+            exgb = new ExtendedGB<C>(F,G,F2G,G2F);
+            logger.info("exgb unnorm = " + exgb);
+        }
+        G2F = normalizeMatrix( F.size(), G2F );
+        if ( debug ) {
+            exgb = new ExtendedGB<C>(F,G,F2G,G2F);
+            logger.info("exgb nonmin = " + exgb);
+            boolean t2 = isReductionMatrix( exgb );
+            logger.info("exgb t2 = " + t2);
+        }
+        exgb = minimalExtendedGB(F.size(),G,G2F);
+        G = exgb.G;
+        G2F = exgb.G2F;
+        logger.debug("#sequential list = " + G.size());
+        logger.info("" + pairlist); 
+        // setup matrices F and F2G
+        for ( GenPolynomial<C> f : F ) {
+            row = new ArrayList<GenPolynomial<C>>( G.size() );
+            for ( int m = 0; m < G.size(); m++ ) {
+                row.add(null);
+            }
+            H = red.normalform( row, G, f );
+            if ( ! H.isZERO() ) {
+                logger.error("nonzero H = " + H );
+            }
+            F2G.add( row );
+        }
+        exgb = new ExtendedGB<C>(F,G,F2G,G2F);
+        if ( debug ) {
+            logger.info("exgb nonmin = " + exgb);
+            boolean t2 = isReductionMatrix( exgb );
+            logger.info("exgb t2 = " + t2);
+        }
+        return exgb;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GroebnerBaseSeqIter.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GroebnerBaseSeqIter.java
@@ -1,0 +1,209 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.ArrayList;
+import java.util.List;
+// import java.util.Collections;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.OrderedPolynomialList;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Groebner Base sequential iterative algorithm. Implements Groebner bases and
+ * GB test.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ * 
+ * @see edu.jas.application.GBAlgorithmBuilder
+ * @see edu.jas.gbufd.GBFactory
+ */
+
+public class GroebnerBaseSeqIter<C extends RingElem<C>> extends GroebnerBaseAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GroebnerBaseSeqIter.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     */
+    public GroebnerBaseSeqIter() {
+        super();
+    }
+
+
+    /**
+     * Constructor.
+     * @param red Reduction engine
+     */
+    public GroebnerBaseSeqIter(Reduction<C> red) {
+        super(red);
+    }
+
+
+    /**
+     * Constructor.
+     * @param pl pair selection strategy
+     */
+    public GroebnerBaseSeqIter(PairList<C> pl) {
+        super(pl);
+    }
+
+
+    /**
+     * Constructor.
+     * @param red Reduction engine
+     * @param pl pair selection strategy
+     */
+    public GroebnerBaseSeqIter(Reduction<C> red, PairList<C> pl) {
+        super(red, pl);
+    }
+
+
+    /**
+     * Groebner base using pairlist class, iterative algorithm.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return GB(F) a Groebner base of F.
+     */
+    public List<GenPolynomial<C>> GB(int modv, List<GenPolynomial<C>> F) {
+        List<GenPolynomial<C>> G = normalizeZerosOnes(F);
+        G = PolyUtil.<C> monic(G);
+        if (G.size() <= 1) {
+            return G;
+        }
+        // sort, no reverse
+        G = OrderedPolynomialList.<C> sort(G);
+        //no: Collections.reverse(G);
+        logger.info("G-sort = " + G);
+        List<GenPolynomial<C>> Gp = new ArrayList<GenPolynomial<C>>();
+        for (GenPolynomial<C> p : G) {
+            if (debug) {
+                logger.info("p = " + p);
+            }
+            GenPolynomial<C> pp = red.normalform(Gp, p);
+            if (pp.isZERO()) {
+                continue;
+            }
+            Gp = GB(modv, Gp, pp);
+            //System.out.println("GB(Gp+p) = " + Gp);
+            if (Gp.size() > 0) {
+                if (Gp.get(0).isONE()) {
+                    return Gp;
+                }
+            }
+        }
+        return Gp;
+    }
+
+
+    /**
+     * Groebner base using pairlist class.
+     * @param modv module variable number.
+     * @param G polynomial list of a Groebner base.
+     * @param f polynomial.
+     * @return GB(G,f) a Groebner base of G+(f).
+     */
+    public List<GenPolynomial<C>> GB(int modv, List<GenPolynomial<C>> G, GenPolynomial<C> f) {
+        List<GenPolynomial<C>> F = new ArrayList<GenPolynomial<C>>(G);
+        GenPolynomial<C> g = f.monic();
+        if (F.isEmpty()) {
+            F.add(g);
+            return F;
+        }
+        if (g.isZERO()) {
+            return F;
+        }
+        if (g.isONE()) {
+            F.clear();
+            F.add(g);
+            return F;
+        }
+        GenPolynomialRing<C> ring = F.get(0).ring;
+        if (!ring.coFac.isField()) {
+            throw new IllegalArgumentException("coefficients not from a field");
+        }
+        G = F;
+        PairList<C> pairlist = strategy.create(modv, ring);
+        pairlist.setList(G);
+        G.add(g);
+        pairlist.put(g);
+        logger.info("start " + pairlist);
+
+        Pair<C> pair;
+        GenPolynomial<C> pi, pj, S, H;
+        while (pairlist.hasNext()) {
+            pair = pairlist.removeNext();
+            //logger.debug("pair = " + pair);
+            if (pair == null) {
+                continue;
+            }
+            pi = pair.pi;
+            pj = pair.pj;
+            if ( /*false &&*/debug) {
+                logger.debug("pi    = " + pi);
+                logger.debug("pj    = " + pj);
+            }
+
+            S = red.SPolynomial(pi, pj);
+            if (S.isZERO()) {
+                pair.setZero();
+                continue;
+            }
+            if (debug) {
+                logger.debug("ht(S) = " + S.leadingExpVector());
+            }
+
+            H = red.normalform(G, S);
+            if (debug) {
+                //logger.info("pair = " + pair); 
+                //logger.info("ht(S) = " + S.monic()); //.leadingExpVector() );
+                logger.info("ht(H) = " + H.monic()); //.leadingExpVector() );
+            }
+            if (H.isZERO()) {
+                pair.setZero();
+                continue;
+            }
+            H = H.monic();
+            if (debug) {
+                logger.info("ht(H) = " + H.leadingExpVector());
+            }
+
+            H = H.monic();
+            if (H.isONE()) {
+                G.clear();
+                G.add(H);
+                pairlist.putOne();
+                logger.info("end " + pairlist);
+                return G; // since no threads are activated
+            }
+            if (debug) {
+                logger.info("H = " + H);
+            }
+            if (H.length() > 0) {
+                //l++;
+                G.add(H);
+                pairlist.put(H);
+            }
+        }
+        logger.debug("#sequential list = " + G.size());
+        G = minimalGB(G);
+        logger.info("end " + pairlist);
+        return G;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GroebnerBaseSeqPairDistributed.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GroebnerBaseSeqPairDistributed.java
@@ -1,0 +1,1071 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.RingElem;
+import edu.jas.util.ChannelFactory;
+import edu.jas.util.DistHashTable;
+import edu.jas.util.DistHashTableServer;
+import edu.jas.util.SocketChannel;
+import edu.jas.util.Terminator;
+
+
+/**
+ * Groebner Base distributed algorithm. Implements a distributed memory parallel
+ * version of Groebner bases. Using pairlist class, distributed tasks do
+ * reduction. Makes some effort to produce the same sequence of critical pairs
+ * as in the sequential version. However already reduced pairs are not rereduced
+ * if new polynomials appear.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ * @deprecated no direct alternative 
+ * @see edu.jas.gb.GroebnerBaseDistributedEC
+ * @see edu.jas.gb.GroebnerBaseDistributedHybridEC
+ */
+@Deprecated
+public class GroebnerBaseSeqPairDistributed<C extends RingElem<C>> extends GroebnerBaseAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GroebnerBaseSeqPairDistributed.class);
+
+
+    /**
+     * Number of threads to use.
+     */
+    protected final int threads;
+
+
+    /**
+     * Default number of threads.
+     */
+    protected static final int DEFAULT_THREADS = 2;
+
+
+    /**
+     * Pool of threads to use.
+     */
+    protected transient final ExecutorService pool;
+
+
+    /**
+     * Default server port.
+     */
+    protected static final int DEFAULT_PORT = 4711;
+
+
+    /**
+     * Server port to use.
+     */
+    protected final int port;
+
+
+    /**
+     * Constructor.
+     */
+    public GroebnerBaseSeqPairDistributed() {
+        this(DEFAULT_THREADS, DEFAULT_PORT);
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     */
+    public GroebnerBaseSeqPairDistributed(int threads) {
+        this(threads, Executors.newFixedThreadPool(threads), DEFAULT_PORT);
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param red parallelism aware reduction engine
+     */
+    public GroebnerBaseSeqPairDistributed(int threads, Reduction<C> red) {
+        this(threads, Executors.newFixedThreadPool(threads), DEFAULT_PORT, red);
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param port server port to use.
+     * @param red parallelism aware reduction engine
+     */
+    public GroebnerBaseSeqPairDistributed(int threads, int port, Reduction<C> red) {
+        this(threads, Executors.newFixedThreadPool(threads), port, red);
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param port server port to use.
+     */
+    public GroebnerBaseSeqPairDistributed(int threads, int port) {
+        this(threads, Executors.newFixedThreadPool(threads), port);
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param pool ExecutorService to use.
+     * @param port server port to use.
+     */
+    public GroebnerBaseSeqPairDistributed(int threads, ExecutorService pool, int port) {
+        this(threads, pool, port, new ReductionPar<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param pool ExecutorService to use.
+     * @param port server port to use.
+     * @param red parallelism aware reduction engine
+     */
+    public GroebnerBaseSeqPairDistributed(int threads, ExecutorService pool, int port, Reduction<C> red) {
+        super(red);
+        if (!(red instanceof ReductionPar)) {
+            logger.warn("parallel GB should use parallel aware reduction");
+        }
+        if (threads < 1) {
+            threads = 1;
+        }
+        this.threads = threads;
+        this.pool = pool;
+        this.port = port;
+    }
+
+
+    /**
+     * Cleanup and terminate ExecutorService.
+     */
+    @Override
+    public void terminate() {
+        if (pool == null) {
+            return;
+        }
+        pool.shutdown();
+        try {
+            while (!pool.isTerminated()) {
+                //logger.info("await");
+                boolean rest = pool.awaitTermination(1000L, TimeUnit.MILLISECONDS);
+            }
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+
+    /**
+     * Distributed Groebner base. Slaves maintain pairlist.
+     * @param modv number of module variables.
+     * @param F polynomial list.
+     * @return GB(F) a Groebner base of F or null, if a IOException occurs.
+     */
+    public List<GenPolynomial<C>> GB(int modv, List<GenPolynomial<C>> F) {
+
+        final int DL_PORT = port + 100;
+        ChannelFactory cf = new ChannelFactory(port);
+        cf.init();
+        DistHashTableServer<Integer> dls = new DistHashTableServer<Integer>(DL_PORT);
+        dls.init();
+        logger.debug("dist-list server running");
+
+        GenPolynomial<C> p;
+        //List<GenPolynomial<C>> G = new ArrayList<GenPolynomial<C>>();
+        CriticalPairList<C> pairlist = null;
+        boolean oneInGB = false;
+        //int l = F.size();
+        @SuppressWarnings("unused")
+        int unused;
+        ListIterator<GenPolynomial<C>> it = F.listIterator();
+        while (it.hasNext()) {
+            p = it.next();
+            if (p.length() > 0) {
+                p = p.monic();
+                if (p.isONE()) {
+                    oneInGB = true;
+                    //G.clear();
+                    //G.add(p);
+                    //return G; must signal termination to others
+                }
+                //if (!oneInGB) {
+                //    //G.add(p);
+                //}
+                if (pairlist == null) {
+                    pairlist = new CriticalPairList<C>(modv, p.ring);
+                }
+                // theList not updated here
+                if (p.isONE()) {
+                    unused = pairlist.putOne();
+                } else {
+                    unused = pairlist.put(p);
+                }
+            } else {
+                //l--;
+            }
+        }
+        //if (l <= 1) {
+        //return G; must signal termination to others
+        //}
+
+        logger.debug("looking for clients");
+        //long t = System.currentTimeMillis();
+        // now in DL, uses resend for late clients
+        //while ( dls.size() < threads ) { sleep(); }
+
+        DistHashTable<Integer, GenPolynomial<C>> theList = new DistHashTable<Integer, GenPolynomial<C>>(
+                        "localhost", DL_PORT);
+        theList.init();
+        List<GenPolynomial<C>> G = pairlist.getList();
+        for (int i = 0; i < G.size(); i++) {
+            // no wait required
+            GenPolynomial<C> nn = theList.put(Integer.valueOf(i), G.get(i));
+            if (nn != null) {
+                logger.info("double polynomials " + i + ", nn = " + nn + ", G(i) = " + G.get(i));
+            }
+        }
+
+        Terminator fin = new Terminator(threads);
+        ReducerServerSeqPair<C> R;
+        for (int i = 0; i < threads; i++) {
+            R = new ReducerServerSeqPair<C>(fin, cf, theList, pairlist);
+            pool.execute(R);
+        }
+        logger.debug("main loop waiting");
+        fin.waitDone();
+        int ps = theList.size();
+        //logger.debug("#distributed list = "+ps);
+        // make sure all polynomials arrived: not needed in master
+        // G = (ArrayList)theList.values();
+        G = pairlist.getList();
+        //logger.debug("#pairlist list = "+G.size());
+        if (ps != G.size()) {
+            logger.info("#distributed list = " + theList.size() + " #pairlist list = " + G.size());
+        }
+        long time = System.currentTimeMillis();
+        List<GenPolynomial<C>> Gp;
+        Gp = minimalGB(G); // not jet distributed but threaded
+        time = System.currentTimeMillis() - time;
+        logger.info("parallel gbmi = " + time);
+        /*
+        time = System.currentTimeMillis();
+        G = GroebnerBase.<C>GBmi(G); // sequential
+        time = System.currentTimeMillis() - time;
+        logger.info("sequential gbmi = " + time);
+        */
+        G = Gp;
+        //logger.info("cf.terminate()");
+        cf.terminate();
+        // no more required // pool.terminate();
+        logger.info("theList.terminate()");
+        theList.terminate();
+        logger.info("dls.terminate()");
+        dls.terminate();
+        logger.info("" + pairlist);
+        return G;
+    }
+
+
+    /**
+     * GB distributed client.
+     * @param host the server runns on.
+     * @throws IOException
+     */
+    public void clientPart(String host) throws IOException {
+
+        ChannelFactory cf = new ChannelFactory(port + 10); // != port for localhost
+        cf.init();
+        SocketChannel pairChannel = cf.getChannel(host, port);
+
+        final int DL_PORT = port + 100;
+        DistHashTable<Integer, GenPolynomial<C>> theList = new DistHashTable<Integer, GenPolynomial<C>>(host,
+                        DL_PORT);
+        theList.init();
+
+        ReducerClientSeqPair<C> R = new ReducerClientSeqPair<C>(pairChannel, theList);
+        R.run();
+
+        pairChannel.close();
+        theList.terminate();
+        cf.terminate();
+        return;
+    }
+
+
+    /**
+     * Minimal ordered groebner basis.
+     * @param Fp a Groebner base.
+     * @return a reduced Groebner base of Fp.
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<GenPolynomial<C>> minimalGB(List<GenPolynomial<C>> Fp) {
+        GenPolynomial<C> a;
+        ArrayList<GenPolynomial<C>> G;
+        G = new ArrayList<GenPolynomial<C>>(Fp.size());
+        ListIterator<GenPolynomial<C>> it = Fp.listIterator();
+        while (it.hasNext()) {
+            a = it.next();
+            if (a.length() != 0) { // always true
+                // already monic  a = a.monic();
+                G.add(a);
+            }
+        }
+        if (G.size() <= 1) {
+            return G;
+        }
+
+        ExpVector e;
+        ExpVector f;
+        GenPolynomial<C> p;
+        ArrayList<GenPolynomial<C>> F;
+        F = new ArrayList<GenPolynomial<C>>(G.size());
+        boolean mt;
+
+        while (G.size() > 0) {
+            a = G.remove(0);
+            e = a.leadingExpVector();
+
+            it = G.listIterator();
+            mt = false;
+            while (it.hasNext() && !mt) {
+                p = it.next();
+                f = p.leadingExpVector();
+                mt = e.multipleOf(f);
+            }
+            it = F.listIterator();
+            while (it.hasNext() && !mt) {
+                p = it.next();
+                f = p.leadingExpVector();
+                mt = e.multipleOf(f);
+            }
+            if (!mt) {
+                F.add(a);
+            } else {
+                // System.out.println("dropped " + a.length());
+            }
+        }
+        G = F;
+        if (G.size() <= 1) {
+            return G;
+        }
+        Collections.reverse(G); // important for lex GB
+
+        MiReducerServerSeqPair<C>[] mirs = (MiReducerServerSeqPair<C>[]) new MiReducerServerSeqPair[G.size()];
+        int i = 0;
+        F = new ArrayList<GenPolynomial<C>>(G.size());
+        while (G.size() > 0) {
+            a = G.remove(0);
+            // System.out.println("doing " + a.length());
+            List<GenPolynomial<C>> R = new ArrayList<GenPolynomial<C>>(G.size() + F.size());
+            R.addAll(G);
+            R.addAll(F);
+            mirs[i] = new MiReducerServerSeqPair<C>(R, a);
+            pool.execute(mirs[i]);
+            i++;
+            F.add(a);
+        }
+        G = F;
+        F = new ArrayList<GenPolynomial<C>>(G.size());
+        for (i = 0; i < mirs.length; i++) {
+            a = mirs[i].getNF();
+            F.add(a);
+        }
+        return F;
+    }
+
+}
+
+
+/**
+ * Distributed server reducing worker threads.
+ * @param <C> coefficient type
+ */
+
+class ReducerServerSeqPair<C extends RingElem<C>> implements Runnable {
+
+
+    private final Terminator pool;
+
+
+    private final ChannelFactory cf;
+
+
+    private SocketChannel pairChannel;
+
+
+    private final DistHashTable<Integer, GenPolynomial<C>> theList;
+
+
+    //private List<GenPolynomial<C>> G;
+    private final CriticalPairList<C> pairlist;
+
+
+    private static final Logger logger = LogManager.getLogger(ReducerServerSeqPair.class);
+
+
+    ReducerServerSeqPair(Terminator fin, ChannelFactory cf, DistHashTable<Integer, GenPolynomial<C>> dl,
+                    CriticalPairList<C> L) {
+        pool = fin;
+        this.cf = cf;
+        theList = dl;
+        //this.G = G;
+        pairlist = L;
+    }
+
+
+    @SuppressWarnings("unchecked")
+    public void run() {
+        logger.debug("reducer server running");
+        try {
+            pairChannel = cf.getChannel();
+        } catch (InterruptedException e) {
+            logger.debug("get pair channel interrupted");
+            e.printStackTrace();
+            return;
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug("pairChannel = " + pairChannel);
+        }
+        CriticalPair<C> pair;
+        //GenPolynomial<C> pi;
+        //GenPolynomial<C> pj;
+        //GenPolynomial<C> S;
+        GenPolynomial<C> H = null;
+        boolean set = false;
+        boolean goon = true;
+        int polIndex = -1;
+        int red = 0;
+        int sleeps = 0;
+
+        // while more requests
+        while (goon) {
+            // receive request
+            logger.debug("receive request");
+            Object req = null;
+            try {
+                req = pairChannel.receive();
+            } catch (IOException e) {
+                goon = false;
+                e.printStackTrace();
+            } catch (ClassNotFoundException e) {
+                goon = false;
+                e.printStackTrace();
+            }
+            //logger.debug("received request, req = " + req);
+            if (req == null) {
+                goon = false;
+                break;
+            }
+            if (!(req instanceof GBSPTransportMessReq)) {
+                goon = false;
+                break;
+            }
+
+            // find pair
+            if (logger.isDebugEnabled()) {
+                logger.debug("find pair");
+                logger.debug("pool.hasJobs() " + pool.hasJobs() + " pairlist.hasNext() " + pairlist.hasNext());
+            }
+            while (!pairlist.hasNext()) { // wait
+                pairlist.update();
+                if (!set) {
+                    pool.beIdle();
+                    set = true;
+                }
+                if (!pool.hasJobs() && !pairlist.hasNext()) {
+                    goon = false;
+                    break;
+                }
+                try {
+                    sleeps++;
+                    if (sleeps % 10 == 0) {
+                        logger.info(" reducer is sleeping");
+                    }
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    goon = false;
+                    break;
+                }
+            }
+            if (!pairlist.hasNext() && !pool.hasJobs()) {
+                goon = false;
+                break; //continue; //break?
+            }
+            if (set) {
+                set = false;
+                pool.notIdle();
+            }
+
+            pair = pairlist.getNext();
+            /*
+             * send pair to client, receive H
+             */
+            if (logger.isDebugEnabled()) {
+                logger.debug("send pair = " + pair);
+                logger.info("theList keys " + theList.keySet());
+            }
+            if (logger.isDebugEnabled()) {
+                logger.info("inWork " + pairlist.inWork());
+            }
+            GBSPTransportMess msg = null;
+            if (pair != null) {
+                msg = new GBSPTransportMessPairIndex(pair);
+            } else {
+                msg = new GBSPTransportMess(); //End();
+                // goon ?= false;
+            }
+            try {
+                pairChannel.send(msg);
+            } catch (IOException e) {
+                e.printStackTrace();
+                goon = false;
+                break;
+            }
+            // use idle time to update pairlist
+            pairlist.update();
+            //logger.debug("#distributed list = "+theList.size());
+            //logger.debug("receive H polynomial");
+            Object rh = null;
+            try {
+                rh = pairChannel.receive();
+            } catch (IOException e) {
+                e.printStackTrace();
+                goon = false;
+                break;
+            } catch (ClassNotFoundException e) {
+                e.printStackTrace();
+                goon = false;
+                break;
+            }
+            if (logger.isDebugEnabled()) {
+                logger.info("received H polynomial rh = " + rh);
+            }
+            if (rh == null) {
+                if (pair != null) {
+                    polIndex = pairlist.record(pair, null);
+                    //pair.setZero();
+                }
+                pairlist.update();
+            } else if (rh instanceof GBSPTransportMessPoly) {
+                // update pair list
+                red++;
+                H = ((GBSPTransportMessPoly<C>) rh).pol;
+                //logger.info("H = " + H);
+                if (H == null) {
+                    if (pair != null) {
+                        polIndex = pairlist.record(pair, null);
+                        //pair.setZero();
+                    }
+                    pairlist.update();
+                } else {
+                    if (H.isZERO()) {
+                        polIndex = pairlist.record(pair, H);
+                        //pair.setZero();
+                    } else {
+                        if (H.isONE()) {
+                            // pool.allIdle();
+                            pairlist.putOne();
+                            theList.put(Integer.valueOf(0), H);
+                            goon = false;
+                            //break;
+                        } else {
+                            polIndex = pairlist.record(pair, H);
+                            // not correct:
+                            // polIndex = pairlist.getList().size(); 
+                            // pairlist.update();
+                            // polIndex = pairlist.put( H );
+                            // use putWait ? but still not all distributed
+                            theList.put(Integer.valueOf(polIndex), H);
+                        }
+                    }
+                }
+            } else {
+                if (pair != null) {
+                    polIndex = pairlist.record(pair, null);
+                    //pair.setZero();
+                }
+                if (logger.isDebugEnabled()) {
+                    logger.debug("invalid message " + rh);
+                }
+            }
+        }
+        logger.info("terminated, done " + red + " reductions");
+
+        /*
+         * send end mark to client
+         */
+        logger.debug("send end");
+        try {
+            pairChannel.send(new GBSPTransportMessEnd());
+        } catch (IOException e) {
+            if (logger.isDebugEnabled()) {
+                e.printStackTrace();
+            }
+        }
+        pool.beIdle();
+        pairChannel.close();
+    }
+
+}
+
+
+/**
+ * Distributed GB transport message.
+ */
+
+class GBSPTransportMess implements Serializable {
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString() {
+        return "" + this.getClass().getName();
+    }
+}
+
+
+/**
+ * Distributed GB transport message for requests.
+ */
+
+class GBSPTransportMessReq extends GBSPTransportMess {
+
+
+    public GBSPTransportMessReq() {
+    }
+}
+
+
+/**
+ * Distributed GB transport message for termination.
+ */
+
+class GBSPTransportMessEnd extends GBSPTransportMess {
+
+
+    public GBSPTransportMessEnd() {
+    }
+}
+
+
+/**
+ * Distributed GB transport message for polynomial.
+ */
+
+class GBSPTransportMessPoly<C extends RingElem<C>> extends GBSPTransportMess {
+
+
+    /**
+     * The polynomial for transport.
+     */
+    public final GenPolynomial<C> pol;
+
+
+    /**
+     * GBSPTransportMessPoly.
+     * @param p polynomial to transfered.
+     */
+    public GBSPTransportMessPoly(GenPolynomial<C> p) {
+        this.pol = p;
+    }
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString() {
+        return super.toString() + "( " + pol + " )";
+    }
+}
+
+
+/**
+ * Distributed GB transport message for pairs.
+ */
+
+class GBSPTransportMessPair<C extends RingElem<C>> extends GBSPTransportMess {
+
+
+    public final CriticalPair<C> pair;
+
+
+    /**
+     * GBSPTransportMessPair.
+     * @param p pair for transfer.
+     */
+    public GBSPTransportMessPair(CriticalPair<C> p) {
+        this.pair = p;
+    }
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString() {
+        return super.toString() + "( " + pair + " )";
+    }
+}
+
+
+/**
+ * Distributed GB transport message for index pairs.
+ */
+
+class GBSPTransportMessPairIndex extends GBSPTransportMess {
+
+
+    public final Integer i;
+
+
+    public final Integer j;
+
+
+    /**
+     * GBSPTransportMessPairIndex.
+     * @param p pair for transport.
+     */
+    public GBSPTransportMessPairIndex(CriticalPair p) {
+        if (p == null) {
+            throw new NullPointerException("pair may not be null");
+        }
+        this.i = Integer.valueOf(p.i);
+        this.j = Integer.valueOf(p.j);
+    }
+
+
+    /**
+     * GBSPTransportMessPairIndex.
+     * @param i first index.
+     * @param j second index.
+     */
+    public GBSPTransportMessPairIndex(int i, int j) {
+        this.i = Integer.valueOf(i);
+        this.j = Integer.valueOf(j);
+    }
+
+
+    /**
+     * GBSPTransportMessPairIndex.
+     * @param i first index.
+     * @param j second index.
+     */
+    public GBSPTransportMessPairIndex(Integer i, Integer j) {
+        this.i = i;
+        this.j = j;
+    }
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString() {
+        return super.toString() + "( " + i + "," + j + " )";
+    }
+}
+
+
+/**
+ * Distributed clients reducing worker threads.
+ */
+
+class ReducerClientSeqPair<C extends RingElem<C>> implements Runnable {
+
+
+    private final SocketChannel pairChannel;
+
+
+    private final DistHashTable<Integer, GenPolynomial<C>> theList;
+
+
+    private final ReductionPar<C> red;
+
+
+    private static final Logger logger = LogManager.getLogger(ReducerClientSeqPair.class);
+
+
+    ReducerClientSeqPair(SocketChannel pc, DistHashTable<Integer, GenPolynomial<C>> dl) {
+        pairChannel = pc;
+        theList = dl;
+        red = new ReductionPar<C>();
+    }
+
+
+    @SuppressWarnings("unchecked")
+    public void run() {
+        if (logger.isDebugEnabled()) {
+            logger.debug("pairChannel = " + pairChannel + "reducer client running");
+        }
+        CriticalPair<C> pair = null;
+        GenPolynomial<C> pi;
+        GenPolynomial<C> pj;
+        GenPolynomial<C> S;
+        GenPolynomial<C> H = null;
+        //boolean set = false;
+        boolean goon = true;
+        int reduction = 0;
+        //int sleeps = 0;
+        Integer pix;
+        Integer pjx;
+
+        while (goon) {
+            /* protocol:
+             * request pair, process pair, send result
+             */
+            // pair = (Pair) pairlist.removeNext();
+            Object req = new GBSPTransportMessReq();
+            if (logger.isDebugEnabled()) {
+                logger.debug("send request = " + req);
+            }
+            try {
+                pairChannel.send(req);
+            } catch (IOException e) {
+                goon = false;
+                e.printStackTrace();
+                break;
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("receive pair, goon = " + goon);
+            }
+            Object pp = null;
+            try {
+                pp = pairChannel.receive();
+            } catch (IOException e) {
+                goon = false;
+                if (logger.isDebugEnabled()) {
+                    e.printStackTrace();
+                }
+                break;
+            } catch (ClassNotFoundException e) {
+                goon = false;
+                e.printStackTrace();
+            }
+            if (logger.isDebugEnabled()) {
+                logger.info("received pair = " + pp);
+            }
+            H = null;
+            if (pp == null) { // should not happen
+                //logger.debug("received pair = " + pp);
+                continue;
+            }
+            if (pp instanceof GBSPTransportMessEnd) {
+                goon = false;
+                continue;
+            }
+            if (pp instanceof GBSPTransportMessPair || pp instanceof GBSPTransportMessPairIndex) {
+                pi = pj = null;
+                if (pp instanceof GBSPTransportMessPair) {
+                    pair = ((GBSPTransportMessPair<C>) pp).pair;
+                    if (pair != null) {
+                        pi = pair.pi;
+                        pj = pair.pj;
+                        //logger.debug("pair: pix = " + pair.i 
+                        //               + ", pjx = " + pair.j);
+                    }
+                }
+                if (pp instanceof GBSPTransportMessPairIndex) {
+                    pix = ((GBSPTransportMessPairIndex) pp).i;
+                    pjx = ((GBSPTransportMessPairIndex) pp).j;
+                    //logger.info("waiting for pix = " + pix); 
+                    pi = theList.getWait(pix);
+                    //logger.info("waiting for pjx = " + pjx); 
+                    pj = theList.getWait(pjx);
+                    //logger.info("pix = " + pix + ", pjx = " +pjx);
+                }
+
+                if (pi != null && pj != null) {
+                    if (logger.isDebugEnabled()) {
+                        logger.info("pi = " + pi.leadingExpVector() + ", pj = " + pj.leadingExpVector());
+                    }
+                    S = red.SPolynomial(pi, pj);
+                    //System.out.println("S   = " + S);
+                    if (S.isZERO()) {
+                        // pair.setZero(); does not work in dist
+                        H = S;
+                    } else {
+                        if (logger.isDebugEnabled()) {
+                            logger.debug("ht(S) = " + S.leadingExpVector());
+                        }
+                        H = red.normalform(theList, S);
+                        reduction++;
+                        if (H.isZERO()) {
+                            // pair.setZero(); does not work in dist
+                        } else {
+                            H = H.monic();
+                            if (logger.isDebugEnabled()) {
+                                logger.info("ht(H) = " + H.leadingExpVector());
+                            }
+                        }
+                    }
+                }
+            } else {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("invalid message = " + pp);
+                }
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+
+            // send H or must send null
+            //logger.debug("#distributed list = "+theList.size());
+            if (logger.isDebugEnabled()) {
+                logger.info("send H polynomial = " + H);
+            }
+            try {
+                pairChannel.send(new GBSPTransportMessPoly<C>(H));
+            } catch (IOException e) {
+                goon = false;
+                e.printStackTrace();
+                break;
+            }
+        }
+        logger.info("terminated, done " + reduction + " reductions");
+        pairChannel.close();
+    }
+}
+
+
+/**
+ * Distributed server reducing worker threads for minimal GB Not jet distributed
+ * but threaded.
+ */
+
+class MiReducerServerSeqPair<C extends RingElem<C>> implements Runnable {
+
+
+    private final List<GenPolynomial<C>> G;
+
+
+    private GenPolynomial<C> H;
+
+
+    private final Semaphore done = new Semaphore(0);
+
+
+    private final Reduction<C> red;
+
+
+    private static final Logger logger = LogManager.getLogger(MiReducerServerSeqPair.class);
+
+
+    MiReducerServerSeqPair(List<GenPolynomial<C>> G, GenPolynomial<C> p) {
+        this.G = G;
+        H = p;
+        red = new ReductionPar<C>();
+    }
+
+
+    /**
+     * getNF. Blocks until the normal form is computed.
+     * @return the computed normal form.
+     */
+    public GenPolynomial<C> getNF() {
+        try {
+            done.acquire(); //done.P();
+        } catch (InterruptedException e) {
+        }
+        return H;
+    }
+
+
+    public void run() {
+        if (logger.isDebugEnabled()) {
+            logger.debug("ht(H) = " + H.leadingExpVector());
+        }
+        H = red.normalform(G, H); //mod
+        done.release(); //done.V();
+        if (logger.isDebugEnabled()) {
+            logger.debug("ht(H) = " + H.leadingExpVector());
+        }
+        // H = H.monic();
+    }
+}
+
+
+/**
+ * Distributed clients reducing worker threads for minimal GB. Not jet used.
+ */
+
+class MiReducerClientSeqPair<C extends RingElem<C>> implements Runnable {
+
+
+    private final List<GenPolynomial<C>> G;
+
+
+    private GenPolynomial<C> H;
+
+
+    private final Reduction<C> red;
+
+
+    private final Semaphore done = new Semaphore(0);
+
+
+    private static final Logger logger = LogManager.getLogger(MiReducerClientSeqPair.class);
+
+
+    MiReducerClientSeqPair(List<GenPolynomial<C>> G, GenPolynomial<C> p) {
+        this.G = G;
+        H = p;
+        red = new ReductionPar<C>();
+    }
+
+
+    /**
+     * getNF. Blocks until the normal form is computed.
+     * @return the computed normal form.
+     */
+    public GenPolynomial<C> getNF() {
+        try {
+            done.acquire(); //done.P();
+        } catch (InterruptedException u) {
+            Thread.currentThread().interrupt();
+        }
+        return H;
+    }
+
+
+    public void run() {
+        if (logger.isDebugEnabled()) {
+            logger.debug("ht(H) = " + H.leadingExpVector());
+        }
+        H = red.normalform(G, H); // mod
+        done.release(); //done.V();
+        if (logger.isDebugEnabled()) {
+            logger.debug("ht(H) = " + H.leadingExpVector());
+        }
+        // H = H.monic();
+    }
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GroebnerBaseSeqPairParallel.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GroebnerBaseSeqPairParallel.java
@@ -1,0 +1,492 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.RingElem;
+import edu.jas.util.Terminator;
+
+
+/**
+ * Groebner Base parallel algorithm. Makes some effort to produce the same
+ * sequence of critical pairs as in the sequential version. However already
+ * reduced pairs are not rereduced if new polynomials appear. Implements a
+ * shared memory parallel version of Groebner bases. Slaves maintain pairlist.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class GroebnerBaseSeqPairParallel<C extends RingElem<C>> extends GroebnerBaseAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GroebnerBaseSeqPairParallel.class);
+
+
+    /**
+     * Number of threads to use.
+     */
+    protected final int threads;
+
+
+    /**
+     * Pool of threads to use.
+     */
+    protected transient final ExecutorService pool;
+
+
+    /**
+     * Constructor.
+     */
+    public GroebnerBaseSeqPairParallel() {
+        this(2);
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     */
+    public GroebnerBaseSeqPairParallel(int threads) {
+        this(threads, Executors.newFixedThreadPool(threads));
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param pool ExecutorService to use.
+     */
+    public GroebnerBaseSeqPairParallel(int threads, ExecutorService pool) {
+        this(threads, pool, new ReductionPar<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param red parallelism aware reduction engine
+     */
+    public GroebnerBaseSeqPairParallel(int threads, Reduction<C> red) {
+        this(threads, Executors.newFixedThreadPool(threads), red);
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param pool ExecutorService to use.
+     * @param red parallelism aware reduction engine
+     */
+    public GroebnerBaseSeqPairParallel(int threads, ExecutorService pool, Reduction<C> red) {
+        super(red);
+        if (!(red instanceof ReductionPar)) {
+            logger.warn("parallel GB should use parallel aware reduction");
+        }
+        if (threads < 1) {
+            threads = 1;
+        }
+        this.threads = threads;
+        this.pool = pool;
+    }
+
+
+    /**
+     * Cleanup and terminate ExecutorService.
+     */
+    @Override
+    public void terminate() {
+        if (pool == null) {
+            return;
+        }
+        pool.shutdown();
+        try {
+            while (!pool.isTerminated()) {
+                //logger.info("await");
+                boolean rest = pool.awaitTermination(1000L, TimeUnit.MILLISECONDS);
+            }
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        logger.info(pool.toString());
+    }
+
+
+    /**
+     * Cancel ExecutorService.
+     */
+    @Override
+    public int cancel() {
+        if (pool == null) {
+            return 0;
+        }
+        int s = pool.shutdownNow().size();
+        logger.info(pool.toString());
+        return s;
+    }
+
+
+    /**
+     * Parallel Groebner base using sequential pair order class. Slaves maintain
+     * pairlist.
+     * @param modv number of module variables.
+     * @param F polynomial list.
+     * @return GB(F) a Groebner base of F.
+     */
+    public List<GenPolynomial<C>> GB(int modv, List<GenPolynomial<C>> F) {
+        GenPolynomial<C> p;
+        List<GenPolynomial<C>> G = new ArrayList<GenPolynomial<C>>();
+        CriticalPairList<C> pairlist = null;
+        int l = F.size();
+        ListIterator<GenPolynomial<C>> it = F.listIterator();
+        while (it.hasNext()) {
+            p = it.next();
+            if (p.length() > 0) {
+                p = p.monic();
+                if (p.isONE()) {
+                    G.clear();
+                    G.add(p);
+                    return G; // since no threads activated jet
+                }
+                G.add(p);
+                if (pairlist == null) {
+                    pairlist = new CriticalPairList<C>(modv, p.ring);
+                    if (!p.ring.coFac.isField()) {
+                        throw new IllegalArgumentException("coefficients not from a field");
+                    }
+                }
+                // putOne not required
+                pairlist.put(p);
+            } else {
+                l--;
+            }
+        }
+        if (l <= 1) {
+            return G; // since no threads activated jet
+        }
+
+        Terminator fin = new Terminator(threads);
+        ReducerSeqPair<C> R;
+        for (int i = 0; i < threads; i++) {
+            R = new ReducerSeqPair<C>(fin, G, pairlist);
+            pool.execute(R);
+        }
+        fin.waitDone();
+        if (Thread.currentThread().isInterrupted()) {
+            throw new RuntimeException("interrupt before minimalGB");
+        }
+        logger.debug("#parallel list = " + G.size());
+        G = minimalGB(G);
+        // not in this context // pool.terminate();
+        logger.info("" + pairlist);
+        return G;
+    }
+
+
+    /**
+     * Minimal ordered groebner basis, parallel.
+     * @param Fp a Groebner base.
+     * @return minimalGB(F) a minimal Groebner base of Fp.
+     */
+    @Override
+    public List<GenPolynomial<C>> minimalGB(List<GenPolynomial<C>> Fp) {
+        GenPolynomial<C> a;
+        ArrayList<GenPolynomial<C>> G;
+        G = new ArrayList<GenPolynomial<C>>(Fp.size());
+        ListIterator<GenPolynomial<C>> it = Fp.listIterator();
+        while (it.hasNext()) {
+            a = it.next();
+            if (a.length() != 0) { // always true
+                // already monic  a = a.monic();
+                G.add(a);
+            }
+        }
+        if (G.size() <= 1) {
+            return G;
+        }
+
+        ExpVector e;
+        ExpVector f;
+        GenPolynomial<C> p;
+        ArrayList<GenPolynomial<C>> F;
+        F = new ArrayList<GenPolynomial<C>>(G.size());
+        boolean mt;
+        while (G.size() > 0) {
+            a = G.remove(0);
+            e = a.leadingExpVector();
+
+            it = G.listIterator();
+            mt = false;
+            while (it.hasNext() && !mt) {
+                p = it.next();
+                f = p.leadingExpVector();
+                mt = e.multipleOf(f);
+            }
+            it = F.listIterator();
+            while (it.hasNext() && !mt) {
+                p = it.next();
+                f = p.leadingExpVector();
+                mt = e.multipleOf(f);
+            }
+            if (!mt) {
+                F.add(a); // no thread at this point
+            } else {
+                // System.out.println("dropped " + a.length());
+            }
+        }
+        G = F;
+        if (G.size() <= 1) {
+            return G;
+        }
+        Collections.reverse(G); // important for lex GB
+
+        @SuppressWarnings("unchecked")
+        MiReducerSeqPair<C>[] mirs = (MiReducerSeqPair<C>[]) new MiReducerSeqPair[G.size()];
+        int i = 0;
+        F = new ArrayList<GenPolynomial<C>>(G.size());
+        while (G.size() > 0) {
+            a = G.remove(0);
+            // System.out.println("doing " + a.length());
+            List<GenPolynomial<C>> R = new ArrayList<GenPolynomial<C>>(G.size() + F.size());
+            R.addAll(G);
+            R.addAll(F);
+            mirs[i] = new MiReducerSeqPair<C>(R, a);
+            pool.execute(mirs[i]);
+            i++;
+            F.add(a);
+        }
+        G = F;
+        F = new ArrayList<GenPolynomial<C>>(G.size());
+        for (i = 0; i < mirs.length; i++) {
+            a = mirs[i].getNF();
+            F.add(a);
+        }
+        return F;
+    }
+
+}
+
+
+/**
+ * Reducing worker threads.
+ */
+class ReducerSeqPair<C extends RingElem<C>> implements Runnable {
+
+
+    private final List<GenPolynomial<C>> G;
+
+
+    private final CriticalPairList<C> pairlist;
+
+
+    private final Terminator fin;
+
+
+    private final ReductionPar<C> red;
+
+
+    private static final Logger logger = LogManager.getLogger(ReducerSeqPair.class);
+
+
+    ReducerSeqPair(Terminator fin, List<GenPolynomial<C>> G, CriticalPairList<C> L) {
+        this.fin = fin;
+        this.G = G;
+        pairlist = L;
+        red = new ReductionPar<C>();
+    }
+
+
+    /**
+     * to string
+     */
+    @Override
+    public String toString() {
+        return "ReducerSeqPair";
+    }
+
+
+    public void run() {
+        CriticalPair<C> pair;
+        GenPolynomial<C> S;
+        GenPolynomial<C> H;
+        boolean set = false;
+        int reduction = 0;
+        int sleeps = 0;
+        while (pairlist.hasNext() || fin.hasJobs()) {
+            while (!pairlist.hasNext()) {
+                pairlist.update();
+                // wait
+                fin.beIdle();
+                set = true;
+                try {
+                    sleeps++;
+                    if (sleeps % 10 == 0) {
+                        logger.info(" reducer is sleeping");
+                    } else {
+                        logger.debug("r");
+                    }
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    fin.allIdle();
+                    logger.info("shutdown " + fin + " after: " + e);
+                    //throw new RuntimeException("interrupt 1 in pairlist.hasNext loop");
+                    break;
+                }
+                if (Thread.currentThread().isInterrupted()) {
+                    fin.allIdle();
+                    logger.info("shutdown after .isInterrupted(): " + fin);
+                    //throw new RuntimeException("interrupt 2 in pairlist.hasNext loop");
+                    break;
+                }
+                if (!fin.hasJobs()) {
+                    break;
+                }
+            }
+            if (!pairlist.hasNext() && !fin.hasJobs()) {
+                break;
+            }
+            if (set) {
+                fin.notIdle();
+                set = false;
+            }
+            pair = pairlist.getNext();
+            if (Thread.currentThread().isInterrupted()) {
+                throw new RuntimeException("interrupt after getNext");
+            }
+            if (pair == null) {
+                pairlist.update();
+                continue;
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("pi = " + pair.pi);
+                logger.debug("pj = " + pair.pj);
+            }
+            S = red.SPolynomial(pair.pi, pair.pj);
+            if (S.isZERO()) {
+                pairlist.record(pair, S);
+                continue;
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("ht(S) = " + S.leadingExpVector());
+            }
+            H = red.normalform(G, S); //mod
+            reduction++;
+            if (H.isZERO()) {
+                pairlist.record(pair, H);
+                continue;
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("ht(H) = " + H.leadingExpVector());
+            }
+            H = H.monic();
+            // System.out.println("H   = " + H);
+            if (H.isONE()) {
+                // pairlist.update( pair, H );
+                pairlist.putOne(); // not really required
+                synchronized (G) {
+                    G.clear();
+                    G.add(H);
+                }
+                fin.allIdle();
+                return;
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("H = " + H);
+            }
+            synchronized (G) {
+                G.add(H);
+            }
+            pairlist.update(pair, H);
+            //pairlist.record( pair, H );
+            //pairlist.update();
+        }
+        logger.info("terminated, done " + reduction + " reductions");
+    }
+}
+
+
+/**
+ * Reducing worker threads for minimal GB.
+ */
+class MiReducerSeqPair<C extends RingElem<C>> implements Runnable {
+
+
+    private final List<GenPolynomial<C>> G;
+
+
+    private GenPolynomial<C> H;
+
+
+    private final ReductionPar<C> red;
+
+
+    private final Semaphore done = new Semaphore(0);
+
+
+    private static final Logger logger = LogManager.getLogger(MiReducerSeqPair.class);
+
+
+    MiReducerSeqPair(List<GenPolynomial<C>> G, GenPolynomial<C> p) {
+        this.G = G;
+        H = p;
+        red = new ReductionPar<C>();
+    }
+
+
+    /**
+     * to string
+     */
+    @Override
+    public String toString() {
+        return "MiReducerSeqpair";
+    }
+
+
+    /**
+     * getNF. Blocks until the normal form is computed.
+     * @return the computed normal form.
+     */
+    public GenPolynomial<C> getNF() {
+        try {
+            done.acquire(); //done.P();
+        } catch (InterruptedException e) {
+            throw new RuntimeException("interrupt in getNF");
+        }
+        return H;
+    }
+
+
+    public void run() {
+        if (logger.isDebugEnabled()) {
+            logger.debug("ht(H) = " + H.leadingExpVector());
+        }
+        try {
+            H = red.normalform(G, H); //mod
+            done.release(); //done.V();
+        } catch (RuntimeException e) {
+            Thread.currentThread().interrupt();
+            //throw new RuntimeException("interrupt in getNF");
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug("ht(H) = " + H.leadingExpVector());
+        }
+        // H = H.monic();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GroebnerBaseSeqPairSeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GroebnerBaseSeqPairSeq.java
@@ -1,0 +1,377 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ListIterator;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Groebner Base sequential algorithm. Implements Groebner bases and GB test.
+ * Uses sequential pair list class.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class GroebnerBaseSeqPairSeq<C extends RingElem<C>> extends GroebnerBaseAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GroebnerBaseSeqPairSeq.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     */
+    public GroebnerBaseSeqPairSeq() {
+        super();
+    }
+
+
+    /**
+     * Constructor.
+     * @param red Reduction engine
+     */
+    public GroebnerBaseSeqPairSeq(Reduction<C> red) {
+        super(red);
+    }
+
+
+    /**
+     * Groebner base using pairlist class.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return GB(F) a Groebner base of F.
+     */
+    public List<GenPolynomial<C>> GB(int modv, List<GenPolynomial<C>> F) {
+        List<GenPolynomial<C>> G = new ArrayList<GenPolynomial<C>>();
+        if (F == null) {
+            return G;
+        }
+        GenPolynomial<C> p;
+        CriticalPairList<C> pairlist = null;
+        int len = F.size();
+        ListIterator<GenPolynomial<C>> it = F.listIterator();
+        while (it.hasNext()) {
+            p = it.next();
+            if (p.length() > 0) {
+                p = p.monic();
+                if (p.isONE()) {
+                    G.clear();
+                    G.add(p);
+                    return G; // since no threads are activated
+                }
+                G.add(p);
+                if (pairlist == null) {
+                    pairlist = new CriticalPairList<C>(modv, p.ring);
+                }
+                // putOne not required
+                pairlist.put(p);
+            } else {
+                len--;
+            }
+        }
+        if (len <= 1) {
+            return G; // since no threads are activated
+        }
+
+        CriticalPair<C> pair;
+        GenPolynomial<C> pi;
+        GenPolynomial<C> pj;
+        GenPolynomial<C> S;
+        GenPolynomial<C> H;
+        while (pairlist.hasNext()) {
+            pair = pairlist.getNext();
+            if (pair == null) {
+                pairlist.update(); // ?
+                continue;
+            }
+            pi = pair.pi;
+            pj = pair.pj;
+            if (debug) {
+                logger.debug("pi    = " + pi);
+                logger.debug("pj    = " + pj);
+            }
+
+            S = red.SPolynomial(pi, pj);
+            if (S.isZERO()) {
+                pairlist.update(pair, S);
+                continue;
+            }
+            if (debug) {
+                logger.debug("ht(S) = " + S.leadingExpVector());
+            }
+
+            H = red.normalform(G, S);
+            if (H.isZERO()) {
+                pairlist.update(pair, H);
+                continue;
+            }
+            if (debug) {
+                logger.debug("ht(H) = " + H.leadingExpVector());
+            }
+
+            H = H.monic();
+            if (H.isONE()) {
+                // pairlist.record( pair, H );
+                G.clear();
+                G.add(H);
+                return G; // since no threads are activated
+            }
+            if (debug) {
+                logger.debug("H = " + H);
+            }
+            G.add(H);
+            pairlist.update(pair, H);
+            //pairlist.update();
+        }
+        logger.debug("#sequential list = " + G.size());
+        G = minimalGB(G);
+        logger.info("" + pairlist);
+        return G;
+    }
+
+
+    /**
+     * Extended Groebner base using critical pair class.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return a container for an extended Groebner base of F.
+     */
+    @Override
+    public ExtendedGB<C> extGB(int modv, List<GenPolynomial<C>> F) {
+        if ( F == null || F.isEmpty() ) {
+            throw new IllegalArgumentException("null or empty F not allowed");
+        }
+        List<GenPolynomial<C>> G = new ArrayList<GenPolynomial<C>>();
+        List<List<GenPolynomial<C>>> F2G = new ArrayList<List<GenPolynomial<C>>>();
+        List<List<GenPolynomial<C>>> G2F = new ArrayList<List<GenPolynomial<C>>>();
+        CriticalPairList<C> pairlist = null;
+        boolean oneInGB = false;
+        int len = F.size();
+
+        List<GenPolynomial<C>> row = null;
+        List<GenPolynomial<C>> rows = null;
+        List<GenPolynomial<C>> rowh = null;
+        GenPolynomialRing<C> ring = null;
+        GenPolynomial<C> H;
+        GenPolynomial<C> p;
+
+        int nzlen = 0;
+        for (GenPolynomial<C> f : F) {
+            if (f.length() > 0) {
+                nzlen++;
+            }
+            if (ring == null) {
+                ring = f.ring;
+            }
+        }
+        GenPolynomial<C> mone = ring.getONE(); //.negate();
+        int k = 0;
+        ListIterator<GenPolynomial<C>> it = F.listIterator();
+        while (it.hasNext()) {
+            p = it.next();
+            if (p.length() > 0) {
+                row = new ArrayList<GenPolynomial<C>>(nzlen);
+                for (int j = 0; j < nzlen; j++) {
+                    row.add(null);
+                }
+                //C c = p.leadingBaseCoefficient();
+                //c = c.inverse();
+                //p = p.multiply( c );
+                row.set(k, mone); //.multiply(c) );
+                k++;
+                if (p.isUnit()) {
+                    G.clear();
+                    G.add(p);
+                    G2F.clear();
+                    G2F.add(row);
+                    oneInGB = true;
+                    break;
+                }
+                G.add(p);
+                G2F.add(row);
+                if (pairlist == null) {
+                    pairlist = new CriticalPairList<C>(modv, p.ring);
+                }
+                // putOne not required
+                pairlist.put(p);
+            } else {
+                len--;
+            }
+        }
+        ExtendedGB<C> exgb;
+        if (len <= 1 || oneInGB) {
+            // adjust F2G
+            for (GenPolynomial<C> f : F) {
+                row = new ArrayList<GenPolynomial<C>>(G.size());
+                for (int j = 0; j < G.size(); j++) {
+                    row.add(null);
+                }
+                H = red.normalform(row, G, f);
+                if (!H.isZERO()) {
+                    logger.error("nonzero H = " + H);
+                }
+                F2G.add(row);
+            }
+            exgb = new ExtendedGB<C>(F, G, F2G, G2F);
+            //System.out.println("exgb 1 = " + exgb);
+            return exgb;
+        }
+
+        CriticalPair<C> pair;
+        int i, j;
+        GenPolynomial<C> pi;
+        GenPolynomial<C> pj;
+        GenPolynomial<C> S;
+        GenPolynomial<C> x;
+        GenPolynomial<C> y;
+        //GenPolynomial<C> z;
+        while (pairlist.hasNext() && !oneInGB) {
+            pair = pairlist.getNext();
+            if (pair == null) {
+                pairlist.update(); // ?
+                continue;
+            }
+            i = pair.i;
+            j = pair.j;
+            pi = pair.pi;
+            pj = pair.pj;
+            if (debug) {
+                logger.info("i, pi    = " + i + ", " + pi);
+                logger.info("j, pj    = " + j + ", " + pj);
+            }
+
+            rows = new ArrayList<GenPolynomial<C>>(G.size());
+            for (int m = 0; m < G.size(); m++) {
+                rows.add(null);
+            }
+            S = red.SPolynomial(rows, i, pi, j, pj);
+            if (debug) {
+                logger.debug("is reduction S = " + red.isReductionNF(rows, G, ring.getZERO(), S));
+            }
+            if (S.isZERO()) {
+                pairlist.update(pair, S);
+                // do not add to G2F
+                continue;
+            }
+            if (debug) {
+                logger.debug("ht(S) = " + S.leadingExpVector());
+            }
+
+            rowh = new ArrayList<GenPolynomial<C>>(G.size());
+            for (int m = 0; m < G.size(); m++) {
+                rowh.add(null);
+            }
+            H = red.normalform(rowh, G, S);
+            if (debug) {
+                logger.debug("is reduction H = " + red.isReductionNF(rowh, G, S, H));
+            }
+            if (H.isZERO()) {
+                pairlist.update(pair, H);
+                // do not add to G2F
+                continue;
+            }
+            if (debug) {
+                logger.debug("ht(H) = " + H.leadingExpVector());
+            }
+
+            row = new ArrayList<GenPolynomial<C>>(G.size() + 1);
+            for (int m = 0; m < G.size(); m++) {
+                x = rows.get(m);
+                if (x != null) {
+                    //System.out.println("ms = " + m + " " + x);
+                    x = x.negate();
+                }
+                y = rowh.get(m);
+                if (y != null) {
+                    y = y.negate();
+                    //System.out.println("mh = " + m + " " + y);
+                }
+                if (x == null) {
+                    x = y;
+                } else {
+                    x = x.sum(y);
+                }
+                //System.out.println("mx = " + m + " " + x);
+                row.add(x);
+            }
+            if (debug) {
+                logger.debug("is reduction 0+sum(row,G) == H : "
+                        + red.isReductionNF(row, G, H, ring.getZERO()));
+            }
+            row.add(null);
+
+
+            //  H = H.monic();
+            C c = H.leadingBaseCoefficient();
+            c = c.inverse();
+            H = H.multiply(c);
+            row = blas.scalarProduct(mone.multiply(c), row);
+            row.set(G.size(), mone);
+            if (H.isONE()) {
+                // pairlist.record( pair, H );
+                // G.clear(); 
+                G.add(H);
+                G2F.add(row);
+                oneInGB = true;
+                break;
+            }
+            if (debug) {
+                logger.debug("H = " + H);
+            }
+            G.add(H);
+            pairlist.update(pair, H);
+            G2F.add(row);
+        }
+        if (debug) {
+            exgb = new ExtendedGB<C>(F, G, F2G, G2F);
+            logger.info("exgb unnorm = " + exgb);
+        }
+        G2F = normalizeMatrix(F.size(), G2F);
+        if (debug) {
+            exgb = new ExtendedGB<C>(F, G, F2G, G2F);
+            logger.info("exgb nonmin = " + exgb);
+            boolean t2 = isReductionMatrix(exgb);
+            logger.info("exgb t2 = " + t2);
+        }
+        exgb = minimalExtendedGB(F.size(), G, G2F);
+        G = exgb.G;
+        G2F = exgb.G2F;
+        logger.debug("#sequential list = " + G.size());
+        logger.info("" + pairlist); 
+        // setup matrices F and F2G
+        for (GenPolynomial<C> f : F) {
+            row = new ArrayList<GenPolynomial<C>>(G.size());
+            for (int m = 0; m < G.size(); m++) {
+                row.add(null);
+            }
+            H = red.normalform(row, G, f);
+            if (!H.isZERO()) {
+                logger.error("nonzero H = " + H);
+            }
+            F2G.add(row);
+        }
+        exgb = new ExtendedGB<C>(F, G, F2G, G2F);
+        if (debug) {
+            logger.info("exgb nonmin = " + exgb);
+            boolean t2 = isReductionMatrix(exgb);
+            logger.info("exgb t2 = " + t2);
+        }
+        return exgb;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GroebnerBaseSigSeqIter.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/GroebnerBaseSigSeqIter.java
@@ -1,0 +1,400 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.OrderedPolynomialList;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Groebner Base signature based sequential iterative algorithm. Implements
+ * Groebner bases after the paper "Signature-based Algorithms to Compute Gröbner
+ * Bases" by Christian Eder and John Perry, ISSAC 2011. Compare the jython+JAS
+ * code in examples/basic_sigbased_gb.py. Originally the Python+Sage code is
+ * from http://www.math.usm.edu/perry/Research/basic_sigbased_gb.py
+ * 
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ * 
+ * @see edu.jas.application.GBAlgorithmBuilder
+ * @see edu.jas.gbufd.GBFactory
+ * @see edu.jas.gb.GroebnerBaseGGVSigSeqIter
+ * @see edu.jas.gb.GroebnerBaseArriSigSeqIter
+ * @see edu.jas.gb.GroebnerBaseF5zSigSeqIter
+ */
+
+public class GroebnerBaseSigSeqIter<C extends RingElem<C>> extends GroebnerBaseAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GroebnerBaseSigSeqIter.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    final SigReductionSeq<C> sred;
+
+
+    /**
+     * Constructor.
+     */
+    public GroebnerBaseSigSeqIter() {
+        this(new SigReductionSeq<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param red Reduction engine
+     */
+    public GroebnerBaseSigSeqIter(SigReductionSeq<C> red) {
+        super();
+        sred = red;
+    }
+
+
+    /**
+     * Groebner base signature iterative algorithm.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return GB(F) a Groebner base of F.
+     */
+    public List<GenPolynomial<C>> GB(int modv, List<GenPolynomial<C>> F) {
+        List<GenPolynomial<C>> G = normalizeZerosOnes(F);
+        G = PolyUtil.<C> monic(G);
+        if (G.size() <= 1) {
+            return G;
+        }
+        // sort, no reverse
+        //  G = OrderedPolynomialList.<C> sort(G);
+        G = OrderedPolynomialList.<C> sortDegree(G);
+        //no: Collections.reverse(G);
+        logger.info("G-sort = " + G);
+        List<GenPolynomial<C>> Gp = new ArrayList<GenPolynomial<C>>();
+        for (GenPolynomial<C> p : G) {
+            if (logger.isInfoEnabled()) {
+                logger.info("p = " + p);
+            }
+            GenPolynomial<C> pp = red.normalform(Gp, p);
+            if (pp.isZERO()) {
+                continue;
+            }
+            Gp = GB(modv, Gp, p);
+            if (Gp.size() > 0) {
+                if (Gp.get(0).isONE()) {
+                    return Gp;
+                }
+            }
+        }
+        return Gp;
+    }
+
+
+    /**
+     * Groebner base iterated.
+     * @param modv module variable number.
+     * @param G polynomial list of a Groebner base.
+     * @param f polynomial.
+     * @return GB(G,f) a Groebner base of G+(f).
+     */
+    public List<GenPolynomial<C>> GB(int modv, List<GenPolynomial<C>> G, GenPolynomial<C> f) {
+        List<GenPolynomial<C>> F = new ArrayList<GenPolynomial<C>>(G);
+        GenPolynomial<C> g = f.monic();
+        if (F.isEmpty()) {
+            F.add(g);
+            return F; // commutative
+        }
+        if (g.isZERO()) {
+            return F;
+        }
+        if (g.isONE()) {
+            F.clear();
+            F.add(g);
+            return F;
+        }
+        GenPolynomialRing<C> ring = F.get(0).ring;
+        if (!ring.coFac.isField()) {
+            throw new IllegalArgumentException("coefficients not from a field");
+        }
+        if (modv != 0) {
+            throw new UnsupportedOperationException("motv != 0 not implemented");
+        }
+        // add signatures
+        List<SigPoly<C>> Gs = new ArrayList<SigPoly<C>>();
+        for (GenPolynomial<C> p : F) {
+            Gs.add(new SigPoly<C>(ring.getZERO(), p));
+        }
+        SigPoly<C> gs = new SigPoly<C>(ring.getONE(), g);
+        Gs.add(gs);
+        //logger.info("Gs = " + Gs);
+        // construct critical pair list
+        List<SigPair<C>> pairlist = new ArrayList<SigPair<C>>();
+        for (SigPoly<C> p : Gs) { // F via continue
+            if (p.poly.equals(g)) {
+                continue;
+            }
+            pairlist.add(newPair(gs, p, Gs));
+        }
+        //logger.info("start " + pairlist.size());
+        logger.info("start " + Gs);
+
+        List<ExpVector> syz = initializeSyz(F, Gs);
+        List<SigPoly<C>> done = new ArrayList<SigPoly<C>>();
+
+        SigPair<C> pair;
+        //SigPoly<C> pi, pj;
+        GenPolynomial<C> S, H, sigma;
+        while (!pairlist.isEmpty()) {
+            pairlist = pruneP(pairlist, syz);
+            if (pairlist.isEmpty()) {
+                continue;
+            }
+            List<SigPair<C>>[] spl = sred.minDegSubset(pairlist);
+            List<SigPair<C>> Sl = spl[0];
+            long mdeg = sred.minimalSigDegree(Sl);
+            pairlist = spl[1];
+            logger.info("treating " + Sl.size() + " signatures of degree " + mdeg);
+            //logger.info("Sl(" + mdeg + ") = " + Sl);
+            while (!Sl.isEmpty()) {
+                //logger.info("Sl_full = " + sred.sigmas(Sl));
+                Sl = pruneS(Sl, syz, done, Gs);
+                if (Sl.isEmpty()) {
+                    continue;
+                }
+                Sl = sred.sortSigma(Sl);
+                //logger.info("Sl_sort = " + Sl);
+                pair = Sl.remove(0);
+                if (pair == null) {
+                    continue;
+                }
+                //logger.info("sigma = " + pair.sigma);
+                S = SPolynomial(pair);
+                SigPoly<C> Ss = new SigPoly<C>(pair.sigma, S);
+                if (S.isZERO()) {
+                    updateSyz(syz, Ss);
+                    done.add(Ss);
+                    continue;
+                }
+                if (debug) {
+                    logger.debug("ht(S) = " + S.leadingExpVector());
+                }
+
+                SigPoly<C> Hs = sigNormalform(F, Gs, Ss);
+                H = Hs.poly;
+                sigma = Hs.sigma;
+                if (debug) {
+                    logger.info("new polynomial = " + Hs); //.leadingExpVector() );
+                }
+                if (H.isZERO()) {
+                    updateSyz(syz, Hs);
+                    done.add(Hs);
+                    continue;
+                }
+                H = H.monic();
+                if (debug) {
+                    logger.info("ht(H) = " + H.leadingExpVector());
+                }
+
+                if (H.isONE()) {
+                    G.clear();
+                    G.add(H);
+                    logger.info("end " + pairlist);
+                    return G; // since no threads are activated
+                }
+                if (sred.isSigRedundant(Gs, Hs)) {
+                    continue;
+                }
+                if (logger.isInfoEnabled()) {
+                    //logger.info("sigma::h = " + sigma + " :: " + ring.toScript(H.leadingExpVector()));
+                    logger.info("sigma::h = " + sigma + " :: " + H.leadingExpVector());
+                }
+                if (H.length() > 0) {
+                    for (SigPoly<C> p : Gs) {
+                        if (p.poly.isZERO()) {
+                            continue;
+                        }
+                        GenPolynomial<C> tau = p.sigma;
+                        GenPolynomial<C>[] mult = SPolynomialFactors(Hs, p);
+                        //System.out.print("sigma = " + sigma + ", tau = " + tau);
+                        //System.out.println(", mult  = " + Arrays.toString(mult));
+                        ExpVector se = sigma.leadingExpVector();
+                        ExpVector te = tau.leadingExpVector();
+                        if (mult[0].multiply(se).equals(mult[1].multiply(te))) {
+                            //logger.info("skip by sigma");
+                            continue;
+                        }
+                        SigPair<C> pp;
+                        //boolean xy = mult[0].multiply(se).compareTo(mult[1].multiply(te)) > 0;
+                        if (mult[0].multiply(se).compareTo(mult[1].multiply(te)) > 0) {
+                            pp = newPair(sigma.multiply(mult[0]), Hs, p, Gs);
+                        } else {
+                            pp = newPair(tau.multiply(mult[1]), p, Hs, Gs);
+                        }
+                        //System.out.println("new_pair " + pp.sigma + ", xy = " + xy + ", sigma = " + sigma + ", tau = " + tau + ", mult  = " + Arrays.toString(mult) + ", m0*se = " + mult[0].multiply(se) + ", m1*te = " + mult[1].multiply(te) );
+                        if (pp.sigma.degree() == mdeg) { // mdeg is sigma.degree()
+                            Sl.add(pp); // do not check contains
+                        } else {
+                            pairlist.add(pp); // do not check contains
+                        }
+                    }
+                    Gs.add(Hs);
+                    done.add(Hs);
+                }
+            }
+        }
+        logger.info("#sequential list before reduction = " + Gs.size());
+        List<GenPolynomial<C>> Gp = sred.polys(Gs);
+        //logger.info("G_full = " + Gp);
+        G = minimalGB(Gp);
+        //G = red.irreducibleSet(Gp);
+        //G = OrderedPolynomialList.<C> sortDegree(G);
+        //logger.info("G_reduced = " + G);
+        logger.info("end " + pairlist);
+        return G;
+    }
+
+
+    /**
+     * S-Polynomial.
+     * @param A monic polynomial.
+     * @param B monic polynomial.
+     * @return spol(A,B) the S-polynomial of the A and B.
+     */
+    GenPolynomial<C> SPolynomial(SigPoly<C> A, SigPoly<C> B) {
+        return sred.SPolynomial(A, B);
+    }
+
+
+    /**
+     * S-Polynomial.
+     * @param P pair.
+     * @return spol(A,B) the S-polynomial of the pair (A,B).
+     */
+    GenPolynomial<C> SPolynomial(SigPair<C> P) {
+        return sred.SPolynomial(P.pi, P.pj);
+    }
+
+
+    /**
+     * S-Polynomial polynomial factors.
+     * @param A monic polynomial.
+     * @param B monic polynomial.
+     * @return polynomials [e,f] such that spol(A,B) = e*a - f*B.
+     */
+    GenPolynomial<C>[] SPolynomialFactors(SigPoly<C> A, SigPoly<C> B) {
+        return sred.SPolynomialFactors(A, B);
+    }
+
+
+    /**
+     * Pair with signature.
+     * @param A polynomial with signature.
+     * @param B polynomial with signature.
+     * @param G polynomial ith signature list.
+     * @return signature pair according to algorithm.
+     */
+    SigPair<C> newPair(SigPoly<C> A, SigPoly<C> B, List<SigPoly<C>> G) {
+        ExpVector e = A.poly.leadingExpVector().lcm(B.poly.leadingExpVector())
+                        .subtract(A.poly.leadingExpVector());
+        return new SigPair<C>(e, A, B, G);
+    }
+
+
+    /**
+     * Pair with signature.
+     * @param s signature for pair.
+     * @param A polynomial with signature.
+     * @param B polynomial with signature.
+     * @param G polynomial ith signature list.
+     * @return signature pair according to algorithm.
+     */
+    SigPair<C> newPair(GenPolynomial<C> s, SigPoly<C> A, SigPoly<C> B, List<SigPoly<C>> G) {
+        return new SigPair<C>(s, A, B, G);
+    }
+
+
+    /**
+     * Top normalform.
+     * @param A polynomial.
+     * @param F polynomial list.
+     * @param G polynomial list.
+     * @return nf(A) with respect to F and G.
+     */
+    SigPoly<C> sigNormalform(List<GenPolynomial<C>> F, List<SigPoly<C>> G, SigPoly<C> A) {
+        return sred.sigNormalform(F, G, A);
+    }
+
+
+    /**
+     * Prune total pair list P.
+     * @param P pair list.
+     * @param syz list of exponent vectors representing syzygies.
+     * @return updated pair list.
+     */
+    List<SigPair<C>> pruneP(List<SigPair<C>> P, List<ExpVector> syz) {
+        if (debug) {
+            logger.debug("unused " + syz);
+        }
+        return P;
+    }
+
+
+    /**
+     * Prune pair list of degree d.
+     * @param S pair list.
+     * @param syz list of exponent vectors representing syzygies.
+     * @param done list of treated polynomials.
+     * @param G polynomial with signature list.
+     * @return updated pair list.
+     */
+    List<SigPair<C>> pruneS(List<SigPair<C>> S, List<ExpVector> syz, List<SigPoly<C>> done,
+                    List<SigPoly<C>> G) {
+        if (debug) {
+            logger.debug("unused " + syz + " " + done + " " + G);
+        }
+        return S;
+    }
+
+
+    /**
+     * Initializes syzygy list.
+     * @param F polynomial list.
+     * @param G polynomial with signature list.
+     * @return list of exponent vectors representing syzygies.
+     */
+    List<ExpVector> initializeSyz(List<GenPolynomial<C>> F, List<SigPoly<C>> G) {
+        if (debug) {
+            logger.debug("unused " + G + " " + F);
+        }
+        List<ExpVector> P = new ArrayList<ExpVector>();
+        return P;
+    }
+
+
+    /**
+     * Update syzygy list.
+     * @param syz list of exponent vectors representing syzygies.
+     * @param r polynomial. <b>Note:</b> szy is modified to represent updated
+     *            list of exponent vectors.
+     */
+    void updateSyz(List<ExpVector> syz, SigPoly<C> r) {
+        if (debug) {
+            logger.debug("unused " + syz + " " + r);
+        }
+        return;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/Katsura.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/Katsura.java
@@ -1,0 +1,184 @@
+/*
+ * Created on 03.10.2004
+ * $Id$
+  */
+
+package edu.jas.gb;
+
+/**
+ * Class to produce a system of equations as defined by Katsura.
+ * 
+ * @author Heinz Kredel
+ *
+ */
+public class Katsura {
+
+   /**
+    * main.
+    */
+    public static void main(String[] args) {
+        if ( args.length == 0 ) {
+           System.out.println("usage: Katsura N <order> <var>");
+           return;
+        }
+        int n = Integer.parseInt(args[0]);
+        Katsura k = null;
+        if ( args.length == 1 ) {               
+           k = new Katsura(n);
+        }
+        if ( args.length == 2 ) {               
+           k = new Katsura("u",n, args[1]);
+        }
+        if ( args.length == 3 ) {               
+           k = new Katsura(args[2],n, args[1]);
+        }
+        System.out.println("#Katsura equations for N = " + n + ":");
+        System.out.println("" + k);
+    }
+
+    final int N;
+    final String var;
+    final String order;
+
+
+    /**
+     * Katsura constructor.
+     * @param n problem size.
+     */
+    public Katsura(int n) {
+           this("u", n);
+    }
+
+
+    /**
+     * Katsura constructor.
+     * @param v name of variables.
+     * @param n problem size.
+     */
+    public Katsura(String v, int n) {
+           this(v, n, "G");
+    }
+
+
+    /**
+     * Katsura constructor.
+     * @param var name of variables.
+     * @param n problem size.
+     * @param order term order letter for output.
+     */
+    public Katsura(String var, int n, String order) {
+           this.var = var;
+           this.N = n;
+           this.order = order;
+    }
+
+
+    String sum1() {
+           StringBuffer s = new StringBuffer();
+           for (int i = -N; i <= N; i++) {
+               s.append(variable(i));
+               if (i < N) {
+                   s.append(" + ");
+               }
+           }
+           s.append(" - 1");
+           return s.toString();
+    }
+
+
+    String sumUm(int m) {
+           StringBuffer s = new StringBuffer();
+           for (int i = -N; i <= N; i++) {
+               s.append(variable(i));
+               s.append("*");
+               s.append(variable(m - i));
+               if (i < N) {
+                  s.append(" + ");
+               }
+           }
+           s.append(" - " + variable(m));
+           return s.toString();
+    }
+
+
+    /**
+     * Generate variable list.
+     * @param order term order letter.
+     * @return polynomial ring description.
+     */
+    public String varList(String order) {
+        return varList("Rat",order);
+    }
+
+
+    /**
+     * Generate variable list.
+     * @param order term order letter.
+     * @param coeff coefficient ring name.
+     * @return polynomial ring description.
+     */
+    public String varList(String coeff, String order) {
+           StringBuffer s = new StringBuffer();
+           s.append(coeff);
+           s.append("(");
+           // for (int i = 0; i <= N; i++) {
+           for (int i = N; i >=0; i--) {
+               s.append(variable(i));
+               if (i > 0) {
+                  s.append(",");
+               }
+           }
+           s.append(")  ");
+           s.append(order);
+           return s.toString();
+    }
+
+
+    /**
+     * toString.
+     * @return Katsura problem as string.
+     */
+    @Override
+     public String toString() {
+           StringBuffer s = new StringBuffer();
+           s.append(varList(order));
+           s.append(System.getProperty("line.separator"));
+           s.append(polyList());
+           return s.toString();
+    }
+
+
+    /**
+     * Generate polynomial list.
+     * @return Katsura polynomials as string.
+     */
+    public String polyList() {
+           StringBuffer s = new StringBuffer();
+           s.append("("+System.getProperty("line.separator"));
+           //for (int m = -N + 1; m <= N - 1; m++) { doubles polynomials
+           for (int m = 0; m <= N - 1; m++) {
+               s.append( sumUm(m) );
+               s.append(","+System.getProperty("line.separator"));
+           }
+           s.append( sum1() );
+           s.append(System.getProperty("line.separator"));
+           s.append(")"+System.getProperty("line.separator"));
+           return s.toString();
+    }
+
+
+    /**
+     * Generate variable string.
+     * @return varaible name as string.
+     */
+    String variable(int i) {
+           if (i < 0) {
+               return variable(-i);
+           }
+           if (i > N) {
+               return "0";
+           }
+           return var + i;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/MiReducerServer.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/MiReducerServer.java
@@ -1,0 +1,128 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+import java.util.List;
+import java.util.concurrent.Semaphore;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.RingElem;
+
+/**
+ * Distributed server reducing worker threads for minimal GB Not jet distributed
+ * but threaded.
+ */
+
+class MiReducerServer<C extends RingElem<C>> implements Runnable {
+
+
+    private final List<GenPolynomial<C>> G;
+
+
+    private GenPolynomial<C> H;
+
+
+    private final Semaphore done = new Semaphore(0);
+
+
+    private final Reduction<C> red;
+
+
+    private static final Logger logger = LogManager.getLogger(MiReducerServer.class);
+
+
+    MiReducerServer(List<GenPolynomial<C>> G, GenPolynomial<C> p) {
+        this.G = G;
+        H = p;
+        red = new ReductionPar<C>();
+    }
+
+
+    /**
+     * getNF. Blocks until the normal form is computed.
+     * @return the computed normal form.
+     */
+    public GenPolynomial<C> getNF() {
+        try {
+            done.acquire(); //done.P();
+        } catch (InterruptedException e) {
+        }
+        return H;
+    }
+
+
+    public void run() {
+        if (logger.isDebugEnabled()) {
+            logger.debug("ht(H) = " + H.leadingExpVector());
+        }
+        H = red.normalform(G, H); //mod
+        done.release(); //done.V();
+        if (logger.isDebugEnabled()) {
+            logger.debug("ht(H) = " + H.leadingExpVector());
+        }
+        // H = H.monic();
+    }
+}
+
+
+/**
+ * Distributed clients reducing worker threads for minimal GB. <b>Note:</b> Not
+ * jet used.
+ */
+
+class MiReducerClient<C extends RingElem<C>> implements Runnable {
+
+
+    private final List<GenPolynomial<C>> G;
+
+
+    private GenPolynomial<C> H;
+
+
+    private final Reduction<C> red;
+
+
+    private final Semaphore done = new Semaphore(0);
+
+
+    private static final Logger logger = LogManager.getLogger(MiReducerClient.class);
+
+
+    MiReducerClient(List<GenPolynomial<C>> G, GenPolynomial<C> p) {
+        this.G = G;
+        H = p;
+        red = new ReductionPar<C>();
+    }
+
+
+    /**
+     * getNF. Blocks until the normal form is computed.
+     * @return the computed normal form.
+     */
+    public GenPolynomial<C> getNF() {
+        try {
+            done.acquire(); //done.P();
+        } catch (InterruptedException u) {
+            Thread.currentThread().interrupt();
+        }
+        return H;
+    }
+
+
+    public void run() {
+        if (logger.isDebugEnabled()) {
+            logger.debug("ht(S) = " + H.leadingExpVector());
+        }
+        H = red.normalform(G, H); //mod
+        done.release(); //done.V();
+        if (logger.isDebugEnabled()) {
+            logger.debug("ht(H) = " + H.leadingExpVector());
+        }
+        // H = H.monic();
+    }
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/OrderedDPairlist.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/OrderedDPairlist.java
@@ -1,0 +1,178 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.Map;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.structure.RingElem;
+
+/**
+ * Pair list management for d-Groebner bases.
+ * Implemented using GenPolynomial, TreeMap and BitSet.
+ * @author Heinz Kredel
+ */
+
+public class OrderedDPairlist<C extends RingElem<C> > 
+    extends OrderedPairlist<C> {
+
+    private static final Logger logger = LogManager.getLogger(OrderedDPairlist.class);
+
+    protected final DReduction<C> dreduction;
+
+
+    /**
+     * Constructor for OrderedDPairlist.
+     * @param r polynomial factory.
+     */
+    public OrderedDPairlist(GenPolynomialRing<C> r) {
+        this(0,r);
+    }
+
+
+    /**
+     * Constructor for OrderedDPairlist.
+     * @param m number of module variables.
+     * @param r polynomial factory.
+     */
+    public OrderedDPairlist(int m, GenPolynomialRing<C> r) {
+        super(m,r);
+        dreduction = new DReductionSeq<C>();
+    }
+
+
+    /**
+     * Create a new PairList.
+     * @param r polynomial ring.
+     */
+    public PairList<C> create(GenPolynomialRing<C> r) {
+        return new OrderedDPairlist<C>(r);
+    }
+
+
+    /**
+     * Create a new PairList.
+     * @param m number of module variables.
+     * @param r polynomial ring.
+     */
+    public PairList<C> create(int m, GenPolynomialRing<C> r) {
+        return new OrderedDPairlist<C>(m,r);
+    }
+
+
+    /**
+     * Remove the next required pair from the pairlist and reduction matrix.
+     * The results of the application of the criterions 3 and 4 to see if the S-polynomial 
+     * is required are recorded in the Pair.
+     * @return the next pair if one exists, otherwise null.
+     */
+    @Override
+    public synchronized Pair<C> removeNext() { 
+        if ( oneInGB ) {
+            return null;
+        }
+        Iterator< Map.Entry<ExpVector,LinkedList<Pair<C>>> > ip 
+            = pairlist.entrySet().iterator();
+
+        Pair<C> pair = null;
+        boolean c = false;
+        int i, j;
+
+        if  ( ip.hasNext() )  {
+            Map.Entry<ExpVector,LinkedList<Pair<C>>> me = ip.next();
+            ExpVector g =  me.getKey();
+            LinkedList<Pair<C>> xl = me.getValue();
+            if ( logger.isInfoEnabled() ) {
+                logger.info("g  = " + g);
+            }
+            pair = null;
+            if ( xl.size() > 0 ) {
+                pair = xl.removeFirst();
+                // xl is also modified in pairlist 
+                i = pair.i; 
+                j = pair.j; 
+                // System.out.println("pair(" + j + "," +i+") ");
+                if ( useCriterion4 ) {
+                    c = dreduction.criterion4( pair.pi, pair.pj, g ); 
+                } else {
+                    c = true;
+                }
+                pair.setUseCriterion4(c);
+                //System.out.println("c4  = " + c);  
+                if ( c ) {
+                    c = criterion3( i, j, g );
+                    //System.out.println("c3  = " + c); 
+                    pair.setUseCriterion3(c);
+                }
+                red.get( j ).clear(i); // set(i,false) jdk1.4
+            }
+            if ( xl.size() == 0 ) {
+                ip.remove(); // = pairlist.remove( g );
+            }
+        }
+        remCount++; // count pairs
+        return pair; 
+    }
+
+
+    /**
+     * GB criterium 3 with coefficient division test.
+     * @return true if the S-polynomial(i,j) is required.
+     */
+    @Override
+    public boolean criterion3(int i, int j, ExpVector eij) {  
+        // assert i < j;
+        boolean s;
+        s = red.get( j ).get(i); 
+        if ( ! s ) { 
+            logger.warn("c3.s false for " + j + " " + i); 
+            return s;
+        }
+        s = true;
+        boolean m;
+        GenPolynomial<C> A;
+        ExpVector ek;
+        C ci = P.get(i).leadingBaseCoefficient();
+        C cj = P.get(j).leadingBaseCoefficient();
+        C c = ci.gcd(cj);
+        for ( int k = 0; k < P.size(); k++ ) {
+            A = P.get( k );
+            ek = A.leadingExpVector();
+            m = eij.multipleOf(ek);
+            if ( m ) {
+                C ck = A.leadingBaseCoefficient();
+                C r = c.remainder(ck);
+                m = r.isZERO();
+            }
+            if ( m ) {
+                if ( k < i ) {
+                    // System.out.println("k < i "+k+" "+i); 
+                    s =    red.get( i ).get(k) 
+                        || red.get( j ).get(k); 
+                }
+                if ( i < k && k < j ) {
+                    // System.out.println("i < k < j "+i+" "+k+" "+j); 
+                    s =    red.get( k ).get(i) 
+                        || red.get( j ).get(k); 
+                }
+                if ( j < k ) {
+                    //System.out.println("j < k "+j+" "+k); 
+                    s =    red.get( k ).get(i) 
+                        || red.get( k ).get(j); 
+                }
+                //System.out.println("s."+k+" = " + s); 
+                if ( ! s ) return s;
+            }
+        }
+        return true;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/OrderedMinPairlist.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/OrderedMinPairlist.java
@@ -1,0 +1,247 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.BitSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Pair list management. The original Buchberger algorithm with criterions using
+ * early pair exclusion. Implemented using GenPolynomial, TreeMap and BitSet.
+ * @author Heinz Kredel
+ */
+
+public class OrderedMinPairlist<C extends RingElem<C>> extends OrderedPairlist<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(OrderedMinPairlist.class);
+
+
+    /**
+     * Constructor.
+     */
+    public OrderedMinPairlist() {
+        super();
+    }
+
+
+    /**
+     * Constructor.
+     * @param r polynomial factory.
+     */
+    public OrderedMinPairlist(GenPolynomialRing<C> r) {
+        this(0, r);
+    }
+
+
+    /**
+     * Constructor.
+     * @param m number of module variables.
+     * @param r polynomial factory.
+     */
+    public OrderedMinPairlist(int m, GenPolynomialRing<C> r) {
+        super(m, r);
+    }
+
+
+    /**
+     * Create a new PairList.
+     * @param r polynomial ring.
+     */
+    @Override
+    public PairList<C> create(GenPolynomialRing<C> r) {
+        return new OrderedMinPairlist<C>(r);
+    }
+
+
+    /**
+     * Create a new PairList.
+     * @param m number of module variables.
+     * @param r polynomial ring.
+     */
+    @Override
+    public PairList<C> create(int m, GenPolynomialRing<C> r) {
+        return new OrderedMinPairlist<C>(m, r);
+    }
+
+
+    /**
+     * Put one Polynomial to the pairlist and reduction matrix.
+     * @param p polynomial.
+     * @return the index of the added polynomial.
+     */
+    @Override
+    public synchronized int put(GenPolynomial<C> p) {
+        putCount++;
+        if (oneInGB) {
+            return P.size() - 1;
+        }
+        ExpVector e = p.leadingExpVector();
+        int l = P.size();
+        BitSet redi = new BitSet();
+        redi.set(0, l); // [0..l-1] = true
+        red.add(redi);
+        P.add(p);
+        for (int j = 0; j < l; j++) {
+            GenPolynomial<C> pj = P.get(j);
+            ExpVector f = pj.leadingExpVector();
+            if (moduleVars > 0) {
+                if (!reduction.moduleCriterion(moduleVars, e, f)) {
+                    red.get(j).clear(l);
+                    continue; // skip pair
+                }
+            }
+            ExpVector g = e.lcm(f);
+            //System.out.println("g  = " + g);  
+            Pair<C> pair = new Pair<C>(pj, p, j, l);
+            boolean c = true;
+            if (useCriterion4) {
+                c = reduction.criterion4(pair.pi, pair.pj, g);
+            }
+            //System.out.println("c4  = " + c);  
+            if (c) {
+                c = criterion3(j, l, g);
+                //System.out.println("c3  = " + c); 
+            }
+            if (!c) { // skip pair
+                red.get(j).clear(l);
+                //System.out.println("c_skip = " + g); 
+                continue;
+            }
+            //multiple pairs under same keys -> list of pairs
+            LinkedList<Pair<C>> xl = pairlist.get(g);
+            if (xl == null) {
+                xl = new LinkedList<Pair<C>>();
+            }
+            //xl.addLast( pair ); // first or last ?
+            xl.addFirst(pair); // first or last ? better for d- e-GBs
+            pairlist.put(g, xl);
+        }
+        // System.out.println("pairlist.keys@put = " + pairlist.keySet() );  
+        return P.size() - 1;
+    }
+
+
+    /**
+     * Remove the next required pair from the pairlist and reduction matrix.
+     * Appy the criterions 3 and 4 to see if the S-polynomial is required.
+     * @return the next pair if one exists, otherwise null.
+     */
+    @Override
+    public synchronized Pair<C> removeNext() {
+        if (oneInGB) {
+            return null;
+        }
+        Iterator<Map.Entry<ExpVector, LinkedList<Pair<C>>>> ip = pairlist.entrySet().iterator();
+
+        Pair<C> pair = null;
+        boolean c = false;
+        int i, j;
+
+        while (!c && ip.hasNext()) {
+            Map.Entry<ExpVector, LinkedList<Pair<C>>> me = ip.next();
+            ExpVector g = me.getKey();
+            LinkedList<Pair<C>> xl = me.getValue();
+            if (logger.isInfoEnabled()) {
+                logger.info("g  = " + g);
+            }
+            pair = null;
+            while (!c && xl.size() > 0) {
+                pair = xl.removeFirst();
+                // xl is also modified in pairlist 
+                i = pair.i;
+                j = pair.j;
+                // System.out.println("pair(" + j + "," +i+") ");
+                if (!red.get(j).get(i)) {
+                    System.out.println("c_y = " + g); // + ", " + red.get(j).get(i)); 
+                    continue;
+                }
+                c = true;
+                if (useCriterion4) {
+                    c = reduction.criterion4(pair.pi, pair.pj, g);
+                }
+                //System.out.println("c4_x = " + c);  
+                if (c) {
+                    c = criterion3(i, j, g);
+                    //System.out.println("c3_x = " + c); 
+                }
+                if (!c) {
+                    //System.out.println("c_x = " + g); 
+                }
+                red.get(j).clear(i); // set(i,false) jdk1.4
+            }
+            if (xl.size() == 0) {
+                ip.remove();
+                // = pairlist.remove( g );
+            }
+        }
+        if (!c) {
+            pair = null;
+        } else {
+            pair.maxIndex(P.size() - 1);
+            remCount++; // count only real pairs
+            if (logger.isDebugEnabled()) {
+                logger.info("pair(" + pair.j + "," + pair.i + ")");
+            }
+        }
+        return pair;
+    }
+
+
+    /**
+     * GB criterium 3.
+     * @return true if the S-polynomial(i,j) is required.
+     */
+    @Override
+    public boolean criterion3(int i, int j, ExpVector eij) {
+        // assert i < j;
+        boolean s;
+        s = red.get(j).get(i);
+        if (!s) {
+            logger.warn("c3.s false for " + j + " " + i);
+            return s;
+        }
+        s = true;
+        boolean m;
+        GenPolynomial<C> A;
+        ExpVector ek;
+        for (int k = 0; k < P.size(); k++) {
+            A = P.get(k);
+            ek = A.leadingExpVector();
+            m = eij.multipleOf(ek) && eij.compareTo(ek) != 0;
+            if (m) {
+                if (k < i) {
+                    // System.out.println("k < i "+k+" "+i); 
+                    s = red.get(i).get(k) || red.get(j).get(k);
+                }
+                if (i < k && k < j) {
+                    // System.out.println("i < k < j "+i+" "+k+" "+j); 
+                    s = red.get(k).get(i) || red.get(j).get(k);
+                }
+                if (j < k) {
+                    //System.out.println("j < k "+j+" "+k); 
+                    s = red.get(k).get(i) || red.get(k).get(j);
+                }
+                //System.out.println("s."+k+" = " + s); 
+                if (!s)
+                    return s;
+            }
+        }
+        return true;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/OrderedPairlist.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/OrderedPairlist.java
@@ -1,0 +1,402 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Pair list management. The original Buchberger algorithm with criterions
+ * following Winkler in SAC-1, Kredel in ALDES/SAC-2, Kredel in MAS. Implemented
+ * using GenPolynomial, TreeMap and BitSet.
+ * @author Heinz Kredel
+ */
+
+public class OrderedPairlist<C extends RingElem<C>> implements PairList<C> {
+
+
+    protected final List<GenPolynomial<C>> P;
+
+
+    protected final SortedMap<ExpVector, LinkedList<Pair<C>>> pairlist;
+
+
+    protected final List<BitSet> red;
+
+
+    protected final GenPolynomialRing<C> ring;
+
+
+    protected final Reduction<C> reduction;
+
+
+    protected boolean oneInGB = false;
+
+
+    protected boolean useCriterion4 = true;
+
+
+    protected int putCount;
+
+
+    protected int remCount;
+
+
+    protected final int moduleVars;
+
+
+    private static final Logger logger = LogManager.getLogger(OrderedPairlist.class);
+
+
+    /**
+     * Constructor.
+     */
+    public OrderedPairlist() {
+        moduleVars = 0;
+        ring = null;
+        P = null;
+        pairlist = null;
+        red = null;
+        reduction = null;
+        putCount = 0;
+        remCount = 0;
+    }
+
+
+    /**
+     * Constructor.
+     * @param r polynomial factory.
+     */
+    public OrderedPairlist(GenPolynomialRing<C> r) {
+        this(0, r);
+    }
+
+
+    /**
+     * Constructor.
+     * @param m number of module variables.
+     * @param r polynomial factory.
+     */
+    public OrderedPairlist(int m, GenPolynomialRing<C> r) {
+        moduleVars = m;
+        ring = r;
+        P = new ArrayList<GenPolynomial<C>>();
+        pairlist = new TreeMap<ExpVector, LinkedList<Pair<C>>>(ring.tord.getAscendComparator());
+        //pairlist = new TreeMap( to.getSugarComparator() );
+        red = new ArrayList<BitSet>();
+        putCount = 0;
+        remCount = 0;
+        if (!ring.isCommutative()) {//ring instanceof GenSolvablePolynomialRing ) {
+            useCriterion4 = false;
+        }
+        reduction = new ReductionSeq<C>();
+    }
+
+
+    /**
+     * Create a new PairList.
+     * @param r polynomial ring.
+     */
+    public PairList<C> create(GenPolynomialRing<C> r) {
+        return new OrderedPairlist<C>(r);
+    }
+
+
+    /**
+     * Create a new PairList.
+     * @param m number of module variables.
+     * @param r polynomial ring.
+     */
+    public PairList<C> create(int m, GenPolynomialRing<C> r) {
+        return new OrderedPairlist<C>(m, r);
+    }
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString() {
+        StringBuffer s = new StringBuffer(this.getClass().getSimpleName() + "(");
+        //s.append("polys="+P.size());
+        s.append("#put=" + putCount);
+        s.append(", #rem=" + remCount);
+        if (pairlist != null && pairlist.size() != 0) {
+            s.append(", size=" + pairlist.size());
+        }
+        if (moduleVars > 0) {
+            s.append(", modv=" + moduleVars);
+        }
+        s.append(")");
+        return s.toString();
+    }
+
+
+    /**
+     * Put one Polynomial to the pairlist and reduction matrix.
+     * @param p polynomial.
+     * @return the index of the added polynomial.
+     */
+    public synchronized int put(GenPolynomial<C> p) {
+        putCount++;
+        if (oneInGB) {
+            return P.size() - 1;
+        }
+        ExpVector e = p.leadingExpVector();
+        int l = P.size();
+        for (int j = 0; j < l; j++) {
+            GenPolynomial<C> pj = P.get(j);
+            ExpVector f = pj.leadingExpVector();
+            if (moduleVars > 0) {
+                if (!reduction.moduleCriterion(moduleVars, e, f)) {
+                    continue; // skip pair
+                }
+            }
+            ExpVector g = e.lcm(f);
+            Pair<C> pair = new Pair<C>(pj, p, j, l);
+            //System.out.println("pair.new      = " + pair);
+            //multiple pairs under same keys -> list of pairs
+            LinkedList<Pair<C>> xl = pairlist.get(g);
+            if (xl == null) {
+                xl = new LinkedList<Pair<C>>();
+            }
+            //xl.addLast( pair ); // first or last ?
+            xl.addFirst(pair); // first or last ? better for d- e-GBs
+            pairlist.put(g, xl);
+        }
+        //System.out.println("pairlist.keys@put = " + pairlist.keySet() );  
+        P.add(p);
+        BitSet redi = new BitSet();
+        redi.set(0, l);
+        red.add(redi);
+        //System.out.println("pairlist.red = " + red); //.get( pair.j )); //pair);
+        //System.out.println("pairlist.key = " + pairlist.keySet() );  
+        return P.size() - 1;
+    }
+
+
+    /**
+     * Put all polynomials in F to the pairlist and reduction matrix.
+     * @param F polynomial list.
+     * @return the index of the last added polynomial.
+     */
+    public int put(List<GenPolynomial<C>> F) {
+        int i = 0;
+        for (GenPolynomial<C> p : F) {
+            i = put(p);
+        }
+        return i;
+    }
+
+
+    /**
+     * Remove the next required pair from the pairlist and reduction matrix.
+     * Appy the criterions 3 and 4 to see if the S-polynomial is required.
+     * @return the next pair if one exists, otherwise null.
+     */
+    public synchronized Pair<C> removeNext() {
+        if (oneInGB) {
+            return null;
+        }
+        Iterator<Map.Entry<ExpVector, LinkedList<Pair<C>>>> ip = pairlist.entrySet().iterator();
+
+        Pair<C> pair = null;
+        boolean c = false;
+        int i, j;
+
+        while (!c && ip.hasNext()) {
+            Map.Entry<ExpVector, LinkedList<Pair<C>>> me = ip.next();
+            ExpVector g = me.getKey();
+            LinkedList<Pair<C>> xl = me.getValue();
+            if (logger.isInfoEnabled()) {
+                logger.info("g  = " + g);
+            }
+            pair = null;
+            while (!c && xl.size() > 0) {
+                pair = xl.removeFirst();
+                // xl is also modified in pairlist 
+                i = pair.i;
+                j = pair.j;
+                // System.out.println("pair(" + j + "," +i+") ");
+                if (useCriterion4) {
+                    c = reduction.criterion4(pair.pi, pair.pj, g);
+                } else {
+                    c = true;
+                }
+                //System.out.println("c4_o  = " + c);  
+                if (c) {
+                    c = criterion3(i, j, g);
+                    //System.out.println("c3_o  = " + c); 
+                }
+                red.get(j).clear(i); // set(i,false) jdk1.4
+            }
+            if (xl.size() == 0) {
+                ip.remove();
+                // = pairlist.remove( g );
+            }
+        }
+        if (!c) {
+            pair = null;
+        } else {
+            pair.maxIndex(P.size() - 1);
+            remCount++; // count only real pairs
+            if (logger.isDebugEnabled()) {
+                logger.info("pair(" + pair.j + "," + pair.i + ")");
+            }
+        }
+        return pair;
+    }
+
+
+    /**
+     * Test if there is possibly a pair in the list.
+     * @return true if a next pair could exist, otherwise false.
+     */
+    public synchronized boolean hasNext() {
+        return pairlist.size() > 0;
+    }
+
+
+    /**
+     * Get the list of polynomials.
+     * @return the polynomial list.
+     */
+    public List<GenPolynomial<C>> getList() {
+        return P;
+    }
+
+
+    /**
+     * Set the list of polynomials.
+     * @param F the polynomial list.
+     */
+    public void setList(List<GenPolynomial<C>> F) {
+        if (!P.isEmpty()) {
+            throw new IllegalArgumentException("P not empty");
+        }
+        P.addAll(F);
+        for (int i = 0; i < P.size(); i++) {
+            BitSet redi = new BitSet();
+            red.add(redi);
+        }
+
+    }
+
+
+    /**
+     * Get the size of the list of polynomials.
+     * @return size of the polynomial list.
+     */
+    public int size() {
+        return P.size();
+    }
+
+
+    /**
+     * Get the number of polynomials put to the pairlist.
+     * @return the number of calls to put.
+     */
+    public synchronized int putCount() {
+        return putCount;
+    }
+
+
+    /**
+     * Get the number of required pairs removed from the pairlist.
+     * @return the number of non null pairs delivered.
+     */
+    public synchronized int remCount() {
+        return remCount;
+    }
+
+
+    /**
+     * Put the ONE-Polynomial to the pairlist.
+     * @param one polynomial. (no more required)
+     * @return the index of the last polynomial.
+     */
+    public synchronized int putOne(GenPolynomial<C> one) {
+        if (one == null) {
+            return P.size() - 1;
+        }
+        if (!one.isONE()) {
+            return P.size() - 1;
+        }
+        return putOne();
+    }
+
+
+    /**
+     * Put the ONE-Polynomial to the pairlist.
+     * @return the index of the last polynomial.
+     */
+    public synchronized int putOne() {
+        putCount++;
+        oneInGB = true;
+        pairlist.clear();
+        P.clear();
+        P.add(ring.getONE());
+        red.clear();
+        logger.info("outOne " + this.toString());
+        return P.size() - 1;
+    }
+
+
+    /**
+     * GB criterium 3.
+     * @return true if the S-polynomial(i,j) is required.
+     */
+    public boolean criterion3(int i, int j, ExpVector eij) {
+        // assert i < j;
+        boolean s = red.get(j).get(i);
+        if (!s) {
+            logger.warn("c3.s false for " + j + " " + i);
+            return s;
+        }
+        // now s = true;
+        for (int k = 0; k < P.size(); k++) {
+            // System.out.println("i , k , j "+i+" "+k+" "+j); 
+            if (i != k && j != k) {
+                GenPolynomial<C> A = P.get(k);
+                ExpVector ek = A.leadingExpVector();
+                boolean m = eij.multipleOf(ek);
+                if (m) {
+                    if (k < i) {
+                        // System.out.println("k < i "+k+" "+i); 
+                        s = red.get(i).get(k) || red.get(j).get(k);
+                    } else if (i < k && k < j) {
+                        // System.out.println("i < k < j "+i+" "+k+" "+j); 
+                        s = red.get(k).get(i) || red.get(j).get(k);
+                    } else if (j < k) {
+                        //System.out.println("j < k "+j+" "+k); 
+                        s = red.get(k).get(i) || red.get(k).get(j);
+                    }
+                    //System.out.println("s."+k+" = " + s); 
+                    if (!s) {
+                        return s;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/OrderedSyzPairlist.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/OrderedSyzPairlist.java
@@ -1,0 +1,304 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Pair list management. For the Buchberger algorithm following the syzygy
+ * criterions by Gebauer &amp; M&ouml;ller. Implemented using GenPolynomial,
+ * TreeMap and BitSet.
+ * @author Heinz Kredel
+ */
+
+public class OrderedSyzPairlist<C extends RingElem<C>> extends OrderedPairlist<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(OrderedSyzPairlist.class);
+
+
+    /**
+     * Constructor.
+     */
+    public OrderedSyzPairlist() {
+        super();
+    }
+
+
+    /**
+     * Constructor.
+     * @param r polynomial factory.
+     */
+    public OrderedSyzPairlist(GenPolynomialRing<C> r) {
+        this(0, r);
+    }
+
+
+    /**
+     * Constructor.
+     * @param m number of module variables.
+     * @param r polynomial factory.
+     */
+    public OrderedSyzPairlist(int m, GenPolynomialRing<C> r) {
+        super(m, r);
+    }
+
+
+    /**
+     * Create a new PairList.
+     * @param r polynomial ring.
+     */
+    @Override
+    public PairList<C> create(GenPolynomialRing<C> r) {
+        return new OrderedSyzPairlist<C>(r);
+    }
+
+
+    /**
+     * Create a new PairList.
+     * @param m number of module variables.
+     * @param r polynomial ring.
+     */
+    @Override
+    public PairList<C> create(int m, GenPolynomialRing<C> r) {
+        return new OrderedSyzPairlist<C>(m, r);
+    }
+
+
+    /**
+     * Put one Polynomial to the pairlist and reduction matrix. Removes all
+     * unnecessary pairs identified by the syzygy criterion and criterion 4.
+     * @param p polynomial.
+     * @return the index of the added polynomial.
+     */
+    @Override
+    public synchronized int put(GenPolynomial<C> p) {
+        putCount++;
+        if (oneInGB) {
+            return P.size() - 1;
+        }
+        ExpVector e = p.leadingExpVector();
+        int ps = P.size();
+        BitSet redi = new BitSet(); // all zeros
+        //redi.set( 0, ps ); // [0..ps-1] = true, i.e. all ones
+        red.add(redi);
+        P.add(p);
+        // remove from existing pairs:
+        List<ExpVector> es = new ArrayList<ExpVector>();
+        for (Map.Entry<ExpVector, LinkedList<Pair<C>>> me : pairlist.entrySet()) {
+            ExpVector g = me.getKey();
+            if (moduleVars > 0) {
+                if (!reduction.moduleCriterion(moduleVars, e, g)) {
+                    continue; // skip pair
+                }
+            }
+            ExpVector ge = g.lcm(e);
+            LinkedList<Pair<C>> ll = me.getValue();
+            if (g.compareTo(ge) == 0) {
+                LinkedList<Pair<C>> lle = new LinkedList<Pair<C>>();
+                for (Pair<C> pair : ll) {
+                    ExpVector eil = pair.pi.leadingExpVector().lcm(e);
+                    if (g.compareTo(eil) == 0) {
+                        continue;
+                    }
+                    ExpVector ejl = pair.pj.leadingExpVector().lcm(e);
+                    if (g.compareTo(ejl) == 0) {
+                        continue;
+                    }
+                    // g == ge && g != eil && g != ejl  
+                    red.get(pair.j).clear(pair.i);
+                    lle.add(pair);
+                }
+                if (lle.size() > 0) {
+                    for (Pair<C> pair : lle) {
+                        ll.remove(pair);
+                    }
+                    if (!es.contains(g)) {
+                        es.add(g);
+                    }
+                }
+            }
+        }
+        for (ExpVector ei : es) {
+            LinkedList<Pair<C>> ll = pairlist.get(ei);
+            if (ll != null && ll.size() == 0) {
+                ll = pairlist.remove(ei);
+            }
+        }
+        // generate new pairs:
+        SortedMap<ExpVector, LinkedList<Pair<C>>> npl = new TreeMap<ExpVector, LinkedList<Pair<C>>>(
+                        ring.tord.getAscendComparator());
+        for (int j = 0; j < ps; j++) {
+            GenPolynomial<C> pj = P.get(j);
+            ExpVector f = pj.leadingExpVector();
+            if (moduleVars > 0) {
+                if (!reduction.moduleCriterion(moduleVars, e, f)) {
+                    //red.get(j).clear(l); 
+                    continue; // skip pair
+                }
+            }
+            ExpVector g = e.lcm(f);
+            Pair<C> pair = new Pair<C>(pj, p, j, ps);
+            //System.out.println("pair.new      = " + pair);
+            //multiple pairs under same keys -> list of pairs
+            LinkedList<Pair<C>> xl = npl.get(g);
+            if (xl == null) {
+                xl = new LinkedList<Pair<C>>();
+            }
+            //xl.addLast( pair ); // first or last ?
+            xl.addFirst(pair); // first or last ? better for d- e-GBs
+            npl.put(g, xl);
+        }
+        //System.out.println("npl.new      = " + npl.keySet());
+        // skip by divisibility:
+        es = new ArrayList<ExpVector>(npl.size());
+        for (ExpVector eil : npl.keySet()) {
+            for (ExpVector ejl : npl.keySet()) {
+                if (eil.compareTo(ejl) == 0) {
+                    continue;
+                }
+                if (eil.multipleOf(ejl)) {
+                    if (!es.contains(eil)) {
+                        es.add(eil);
+                    }
+                }
+            }
+        }
+        //System.out.println("npl.skip div = " + es);
+        for (ExpVector ei : es) {
+            @SuppressWarnings("unused")
+            LinkedList<Pair<C>> ignored = npl.remove(ei);
+        }
+        // skip by criterion 4:
+        if (useCriterion4) {
+            es = new ArrayList<ExpVector>(npl.size());
+            for (Map.Entry<ExpVector, LinkedList<Pair<C>>> me : npl.entrySet()) {
+                ExpVector ei = me.getKey();
+                LinkedList<Pair<C>> exl = me.getValue(); //npl.get( ei );
+                //System.out.println("exl = " + exl ); 
+                boolean c = true;
+                for (Pair<C> pair : exl) {
+                    c = c && reduction.criterion4(pair.pi, pair.pj, pair.e);
+                }
+                if (c) {
+                    if (exl.size() > 1) {
+                        Pair<C> pair = exl.getFirst(); // or exl.getLast();
+                        exl.clear();
+                        exl.add(pair);
+                        //npl.put(ei,exl);
+                    }
+                } else {
+                    if (!es.contains(ei)) {
+                        es.add(ei);
+                    }
+                }
+            }
+            //System.out.println("npl.skip c4  = " + es);
+            for (ExpVector ei : es) {
+                @SuppressWarnings("unused")
+                LinkedList<Pair<C>> ignored = npl.remove(ei);
+            }
+        }
+        // add to existing pairlist:
+        //System.out.println("npl.put new  = " + npl.keySet() );  
+        for (Map.Entry<ExpVector, LinkedList<Pair<C>>> me : npl.entrySet()) {
+            ExpVector ei = me.getKey();
+            LinkedList<Pair<C>> exl = me.getValue(); //npl.get( ei );
+            for (Pair<C> pair : exl) {
+                red.get(pair.j).set(pair.i);
+            }
+            LinkedList<Pair<C>> ex = pairlist.get(ei); // wrong in findbugs
+            if (ex != null) {
+                exl.addAll(ex); // add new pairs first 
+                ex = exl;
+                //ex.addAll(exl); // add old pairs first
+            } else {
+                ex = exl;
+            }
+            pairlist.put(ei, ex); // replace ex
+        }
+        return P.size() - 1;
+    }
+
+
+    /**
+     * Remove the next required pair from the pairlist and reduction matrix.
+     * Appy the criterions 3 and 4 to see if the S-polynomial is required.
+     * @return the next pair if one exists, otherwise null.
+     */
+    @Override
+    public synchronized Pair<C> removeNext() {
+        if (oneInGB) {
+            return null;
+        }
+        Iterator<Map.Entry<ExpVector, LinkedList<Pair<C>>>> ip = pairlist.entrySet().iterator();
+        Pair<C> pair = null;
+        //boolean c = false;
+        int i, j;
+        while (ip.hasNext()) {
+            Map.Entry<ExpVector, LinkedList<Pair<C>>> me = ip.next();
+            ExpVector g = me.getKey();
+            LinkedList<Pair<C>> xl = me.getValue();
+            if (logger.isInfoEnabled())
+                logger.info("g  = " + g);
+            pair = null;
+            while (xl.size() > 0) {
+                pair = xl.removeFirst(); // xl is also modified in pairlist 
+                i = pair.i;
+                j = pair.j;
+                //System.out.println("pair.remove = " + pair );
+                if (!red.get(j).get(i)) { // should not happen
+                    System.out.println("c_red.get(" + j + ").get(" + i + ") = " + g);
+                    pair = null;
+                    continue;
+                }
+                red.get(j).clear(i);
+                break;
+            }
+            if (xl.size() == 0) {
+                ip.remove(); // = pairlist.remove( g );
+            }
+            if (pair != null) {
+                break;
+            }
+        }
+        if (pair != null) {
+            pair.maxIndex(P.size() - 1);
+            remCount++; // count only real pairs
+            if (logger.isDebugEnabled()) {
+                logger.info("pair(" + pair.j + "," + pair.i + ")");
+            }
+        }
+        return pair;
+    }
+
+
+    /**
+     * GB criterium 3.
+     * @return true if the S-polynomial(i,j) is required.
+     */
+    @Override
+    public boolean criterion3(int i, int j, ExpVector eij) {
+        throw new UnsupportedOperationException("not used in " + this.getClass().getName());
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/OrderedWordPairlist.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/OrderedWordPairlist.java
@@ -1,0 +1,367 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.GenWordPolynomial;
+import edu.jas.poly.GenWordPolynomialRing;
+import edu.jas.poly.Word;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Pair list management of word polynomials. Implemented using
+ * GenWordPolynomial, TreeMap and BitSet.
+ * @author Heinz Kredel
+ */
+
+public class OrderedWordPairlist<C extends RingElem<C>> implements WordPairList<C> {
+
+
+    protected final List<GenWordPolynomial<C>> P;
+
+
+    protected final SortedMap<Word, LinkedList<WordPair<C>>> pairlist;
+
+
+    protected final List<BitSet> red;
+
+
+    protected final GenWordPolynomialRing<C> ring;
+
+
+    protected final WordReduction<C> reduction;
+
+
+    protected boolean oneInGB = false;
+
+
+    protected int putCount;
+
+
+    protected int remCount;
+
+
+    private static final Logger logger = LogManager.getLogger(OrderedWordPairlist.class);
+
+
+    /**
+     * Constructor.
+     */
+    public OrderedWordPairlist() {
+        ring = null;
+        P = null;
+        pairlist = null;
+        red = null;
+        reduction = null;
+        putCount = 0;
+        remCount = 0;
+    }
+
+
+    /**
+     * Constructor.
+     * @param r word polynomial factory.
+     */
+    public OrderedWordPairlist(GenWordPolynomialRing<C> r) {
+        ring = r;
+        P = new ArrayList<GenWordPolynomial<C>>();
+        pairlist = new TreeMap<Word, LinkedList<WordPair<C>>>(ring.alphabet.getAscendComparator());
+        red = new ArrayList<BitSet>();
+        putCount = 0;
+        remCount = 0;
+        reduction = new WordReductionSeq<C>();
+    }
+
+
+    /**
+     * Create a new WordPairList.
+     * @param r word polynomial ring.
+     */
+    public WordPairList<C> create(GenWordPolynomialRing<C> r) {
+        return new OrderedWordPairlist<C>(r);
+    }
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString() {
+        StringBuffer s = new StringBuffer(this.getClass().getSimpleName() + "(");
+        //s.append("polys="+P.size());
+        s.append("#put=" + putCount);
+        s.append(", #rem=" + remCount);
+        if (pairlist != null && pairlist.size() != 0) {
+            s.append(", size=" + pairlist.size());
+        }
+        //if (red != null ) {
+        //    s.append(", bitmask=" + red);
+        //}
+        s.append(")");
+        return s.toString();
+    }
+
+
+    /**
+     * Put one Polynomial to the pairlist and reduction matrix.
+     * @param p polynomial.
+     * @return the index of the added polynomial.
+     */
+    public synchronized int put(GenWordPolynomial<C> p) {
+        putCount++;
+        if (oneInGB) {
+            return P.size() - 1;
+        }
+        if (p.isONE()) {
+            return putOne();
+        }
+        Word e = p.leadingWord();
+        Word g;
+        int l = P.size();
+        BitSet redi = new BitSet();
+        //redi.set(0, l); // from -- to
+        for (int j = 0; j < l; j++) {
+            GenWordPolynomial<C> pj = P.get(j);
+            Word f = pj.leadingWord();
+
+            // pj, p
+            g = f.lcm(e);
+            //System.out.println("g(f,g) = " + g);
+            if (g != null) {
+                WordPair<C> pair = new WordPair<C>(pj, p, j, l);
+                //System.out.println("pair.new      = " + pair);
+                //multiple pairs under same keys -> list of pairs
+                LinkedList<WordPair<C>> xl = pairlist.get(g);
+                if (xl == null) {
+                    xl = new LinkedList<WordPair<C>>();
+                }
+                //xl.addLast( pair ); // first or last ?
+                xl.addFirst(pair); // first or last ? better for d- e-GBs
+                pairlist.put(g, xl);
+                redi.set(j); // = red.get(l).set(j);
+            }
+
+            // p, pj
+            g = e.lcm(f);
+            //System.out.println("g(e,f) = " + g);
+            if (g != null) {
+                WordPair<C> pair = new WordPair<C>(p, pj, l, j);
+                //System.out.println("pair.new      = " + pair);
+                //multiple pairs under same keys -> list of pairs
+                LinkedList<WordPair<C>> xl = pairlist.get(g);
+                if (xl == null) {
+                    xl = new LinkedList<WordPair<C>>();
+                }
+                //xl.addLast( pair ); // first or last ?
+                xl.addFirst(pair); // first or last ? better for d- e-GBs
+                pairlist.put(g, xl);
+                red.get(j).set(l);
+            }
+        }
+        red.add(redi);
+        //System.out.println("pairlist.keys@put = " + pairlist.keySet() );  
+        //System.out.println("#pairlist = " + pairlist.size() );  
+        P.add(p);
+        //System.out.println("pairlist.key = " + pairlist.keySet() );  
+        return l; //P.size() - 1;
+    }
+
+
+    /**
+     * Put all word polynomials in F to the pairlist and reduction matrix.
+     * @param F word polynomial list.
+     * @return the index of the last added word polynomial.
+     */
+    public int put(List<GenWordPolynomial<C>> F) {
+        //System.out.println("pairlist.F = " + F );  
+        int i = 0;
+        for (GenWordPolynomial<C> p : F) {
+            i = put(p);
+        }
+        return i;
+    }
+
+
+    /**
+     * Remove the next required pair from the pairlist and reduction matrix.
+     * Appy the criterion 3 to see if the S-polynomial is required.
+     * @return the next pair if one exists, otherwise null.
+     */
+    public synchronized WordPair<C> removeNext() {
+        if (oneInGB) {
+            return null;
+        }
+        Iterator<Map.Entry<Word, LinkedList<WordPair<C>>>> ip = pairlist.entrySet().iterator();
+
+        WordPair<C> pair = null;
+        //boolean c = false;
+        int i, j;
+
+        //while (!c && ip.hasNext()) {
+        if (ip.hasNext()) {
+            Map.Entry<Word, LinkedList<WordPair<C>>> me = ip.next();
+            Word g = me.getKey();
+            LinkedList<WordPair<C>> xl = me.getValue();
+            if (logger.isInfoEnabled()) {
+                logger.info("g  = " + g);
+            }
+            pair = null;
+            //while (!c && xl.size() > 0) {
+            if (xl.size() > 0) {
+                pair = xl.removeFirst();
+                // xl is also modified in pairlist 
+                i = pair.i;
+                j = pair.j;
+                // System.out.println("pair(" + j + "," +i+") ");
+                //c = criterion3(i, j, g); // to check
+                //if ( !c ) {
+                //    System.out.println("criterion 3");
+                //}
+                red.get(j).clear(i);
+            }
+            if (xl.size() == 0) {
+                ip.remove();
+            }
+        }
+        //if (!c) {
+        //    pair = null;
+        //} else {
+        remCount++; // count only real pairs
+        //}
+        return pair;
+    }
+
+
+    /**
+     * Test if there is possibly a pair in the list.
+     * @return true if a next pair could exist, otherwise false.
+     */
+    public synchronized boolean hasNext() {
+        return pairlist.size() > 0;
+    }
+
+
+    /**
+     * Get the list of polynomials.
+     * @return the polynomial list.
+     */
+    public List<GenWordPolynomial<C>> getList() {
+        return P;
+    }
+
+
+    /**
+     * Get the number of polynomials put to the pairlist.
+     * @return the number of calls to put.
+     */
+    public synchronized int putCount() {
+        return putCount;
+    }
+
+
+    /**
+     * Get the number of required pairs removed from the pairlist.
+     * @return the number of non null pairs delivered.
+     */
+    public synchronized int remCount() {
+        return remCount;
+    }
+
+
+    /**
+     * Put the ONE-Polynomial to the pairlist.
+     * @param one polynomial. (no more required)
+     * @return the index of the last polynomial.
+     */
+    public synchronized int putOne(GenWordPolynomial<C> one) {
+        if (one == null) {
+            return P.size() - 1;
+        }
+        if (!one.isONE()) {
+            return P.size() - 1;
+        }
+        return putOne();
+    }
+
+
+    /**
+     * Put the ONE-Polynomial to the pairlist.
+     * @return the index of the last polynomial.
+     */
+    public synchronized int putOne() {
+        putCount++;
+        oneInGB = true;
+        pairlist.clear();
+        P.clear();
+        P.add(ring.getONE());
+        red.clear();
+        return P.size() - 1;
+    }
+
+
+    /**
+     * GB criterium 3.
+     * @return true if the S-polynomial(i,j) is required.
+     */
+    public boolean criterion3(int i, int j, Word eij) {
+        boolean s = red.get(j).get(i);
+        //if (s) {
+        //   logger.warn("c3.s true for " + i + " " + j);
+        //   //return s;
+        //}
+        for (int k = 0; k < P.size(); k++) {
+            // System.out.println("i , k , j "+i+" "+k+" "+j); 
+            if (i != k && j != k) {
+                GenWordPolynomial<C> A = P.get(k);
+                Word ek = A.leadingWord();
+                boolean m = eij.multipleOf(ek);
+                if (m) {
+                    if (i < j) {
+                        if (k < i) {
+                            // System.out.println("k < i "+k+" "+i); 
+                            s = red.get(i).get(k) || red.get(j).get(k);
+                        } else if (i < k && k < j) {
+                            // System.out.println("i < k < j "+i+" "+k+" "+j); 
+                            s = red.get(k).get(i) || red.get(j).get(k);
+                        } else if (j < k) {
+                            //System.out.println("j < k "+j+" "+k); 
+                            s = red.get(k).get(i) || red.get(k).get(j);
+                        }
+                    } else { // j < i
+                        if (k < j) {
+                            //System.out.println("k < j "+k+" "+j); 
+                            s = red.get(k).get(j) || red.get(k).get(i);
+                        } else if (j < k && k < i) {
+                            //System.out.println("j < k < i "+j+" "+k+" "+i); 
+                            s = red.get(j).get(k) || red.get(k).get(i);
+                        } else if (i < k) {
+                            //System.out.println("i < k "+i+" "+k); 
+                            s = red.get(j).get(k) || red.get(i).get(k);
+                        }
+                    }
+                    //System.out.println("s."+k+" = " + s); 
+                    if (!s) {
+                        return s;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/Pair.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/Pair.java
@@ -1,0 +1,216 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+import java.io.Serializable;
+
+import edu.jas.structure.RingElem;
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+
+
+/**
+ * Serializable subclass to hold pairs of polynomials.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+public class Pair<C extends RingElem<C> > extends AbstractPair<C>
+             implements Comparable<Pair> {
+
+
+    protected int n;
+    protected boolean toZero = false;
+    protected boolean useCriterion4 = true;
+    protected boolean useCriterion3 = true;
+
+
+    /**
+     * Pair constructor.
+     * @param a polynomial i.
+     * @param b polynomial j.
+     * @param i first index.
+     * @param j second index.
+     */
+    public Pair(GenPolynomial<C> a, GenPolynomial<C> b, 
+                int i, int j) {
+        this(a,b,i,j,0);
+    }
+
+
+    /**
+     * Pair constructor.
+     * @param a polynomial i.
+     * @param b polynomial j.
+     * @param i first index.
+     * @param j second index.
+     * @param s maximal index.
+     */
+    public Pair(GenPolynomial<C> a, GenPolynomial<C> b, 
+                int i, int j, int s) {
+        this(a.leadingExpVector().lcm(b.leadingExpVector()),a,b,i,j,s);
+    }
+
+
+    /**
+     * Pair constructor.
+     * @param lcm of lt(a) lt(b).
+     * @param a polynomial i.
+     * @param b polynomial j.
+     * @param i first index.
+     * @param j second index.
+     */
+    public Pair(ExpVector lcm, GenPolynomial<C> a, GenPolynomial<C> b, 
+                int i, int j) {
+        this(lcm,a,b,i,j,0);
+    }
+
+
+    /**
+     * Pair constructor.
+     * @param lcm of lt(a) lt(b).
+     * @param a polynomial i.
+     * @param b polynomial j.
+     * @param i first index.
+     * @param j second index.
+     * @param s maximal index.
+     */
+    public Pair(ExpVector lcm, GenPolynomial<C> a, GenPolynomial<C> b, 
+                int i, int j, int s) {
+        super(lcm,a,b,i,j,s);
+        this.n = 0;
+        toZero = false; // ok
+    }
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString() {
+        return super.toString() + "[" + n  
+                           + ", r0=" + toZero  
+                           + ", c4=" + useCriterion4  
+                           + ", c3=" + useCriterion3 
+                           + "]";
+    }
+
+
+    /**
+     * Set removed pair number.
+     * @param n number of this pair generated in OrderedPairlist.
+     */
+    public void pairNumber(int n) {
+        this.n = n;
+    }
+
+
+    /**
+     * Get removed pair number.
+     * @return n number of this pair generated in OrderedPairlist.
+     */
+    public int getPairNumber() {
+        return n;
+    }
+
+
+    /**
+     * Set zero reduction.
+     * The S-polynomial of this Pair was reduced to zero.
+     */
+    public void setZero() {
+        toZero = true;
+    }
+
+
+    /**
+     * Is reduced to zero.
+     * @return true if the S-polynomial of this Pair was reduced to zero, else false.
+     */
+    public boolean isZero() {
+        return toZero;
+    }
+
+
+    /**
+     * equals.
+     * @param ob an Object.
+     * @return true if this is equal to o, else false.
+     */
+    @Override
+     public boolean equals(Object ob) {
+        if ( ! (ob instanceof Pair) ) {
+           return false;
+           // throw new ClassCastException("Pair "+n+" o "+o);
+        }
+        return 0 == compareTo( (Pair)ob );
+    }
+
+
+    /**
+     * compareTo used in TreeMap // not used at moment.
+     * Comparison is based on the number of the pairs.
+     * @param p a Pair.
+     * @return 1 if (this &lt; o), 0 if (this == o), -1 if (this &gt; o).
+     */
+    public int compareTo(Pair p) {
+        int x = p.getPairNumber();
+        if ( n > x ) { 
+           return 1;
+        }
+        if ( n < x ) { 
+           return -1;
+        }
+        return 0;
+    }
+
+
+    /**
+     * Hash code for this Pair.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return (i << 16) + j;
+    }
+
+
+    /**
+     * Set useCriterion4.
+     * @param c boolean value to set.
+     */
+    public void setUseCriterion4(boolean c) {
+        this.useCriterion4 = c;
+    }
+
+
+    /**
+     * Get useCriterion4.
+     * @return boolean value.
+     */
+    public boolean getUseCriterion4() {
+        return this.useCriterion4;
+    }
+
+
+    /**
+     * Set useCriterion3.
+     * @param c boolean value to set.
+     */
+    public void setUseCriterion3(boolean c) {
+        this.useCriterion3 = c;
+    }
+
+
+    /**
+     * Get useCriterion3.
+     * @return boolean value.
+     */
+    public boolean getUseCriterion3() {
+        return this.useCriterion3;
+    }
+
+}
+

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/PairList.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/PairList.java
@@ -1,0 +1,127 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+import java.util.List;
+import java.io.Serializable;
+
+import edu.jas.structure.RingElem;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.TermOrder;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+
+
+/**
+ * Pair list management interface.
+ * @author Heinz Kredel
+ */
+
+public interface PairList<C extends RingElem<C> > extends Serializable {
+
+
+    /**
+     * Create a new PairList.
+     * @param r polynomial ring.
+     */
+    public PairList<C> create(GenPolynomialRing<C> r);
+
+
+    /**
+     * Create a new PairList.
+     * @param m number of module variables.
+     * @param r polynomial ring.
+     */
+    public PairList<C> create(int m, GenPolynomialRing<C> r);
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString();
+
+
+    /**
+     * Put one Polynomial to the pairlist and reduction matrix.
+     * @param p polynomial.
+     * @return the index of the added polynomial.
+     */
+    public int put(GenPolynomial<C> p);
+
+
+    /**
+     * Put all polynomials in F to the pairlist and reduction matrix.
+     * @param F polynomial list.
+     * @return the index of the last added polynomial.
+     */
+    public int put(List<GenPolynomial<C>> F);
+
+
+    /**
+     * Put to ONE-Polynomial to the pairlist.
+     * @return the index of the last polynomial.
+     */
+    public int putOne();
+
+
+    /**
+     * Remove the next required pair from the pairlist and reduction matrix.
+     * Appy the criterions 3 and 4 to see if the S-polynomial is required.
+     * @return the next pair if one exists, otherwise null.
+     */
+    public Pair<C> removeNext();
+
+
+    /**
+     * Test if there is possibly a pair in the list.
+     * @return true if a next pair could exist, otherwise false.
+     */
+    public boolean hasNext();
+
+
+    /**
+     * Get the size of the list of polynomials.
+     * @return size of the polynomial list.
+     */
+    public int size();
+
+
+    /**
+     * Get the list of polynomials.
+     * @return the polynomial list.
+     */
+    public List<GenPolynomial<C>> getList();
+
+
+    /**
+     * Set the list of polynomials.
+     * @param F the polynomial list.
+     */
+    public void setList(List<GenPolynomial<C>> F);
+
+
+    /**
+     * Get the number of polynomials put to the pairlist.
+     * @return the number of calls to put.
+     */
+    public int putCount();
+
+
+    /**
+     * Get the number of required pairs removed from the pairlist.
+     * @return the number of non null pairs delivered.
+     */
+    public int remCount();
+
+
+    /**
+     * GB criterium 3.
+     * @return true if the S-polynomial(i,j) is required.
+     */
+    public boolean criterion3(int i, int j, ExpVector eij);
+
+}
+

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/Reduction.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/Reduction.java
@@ -1,0 +1,182 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.io.Serializable;
+import java.util.List;
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Polynomial Reduction interface. Defines S-Polynomial, normalform, criterion
+ * 4, module criterion and irreducible set.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public interface Reduction<C extends RingElem<C>> extends Serializable {
+
+
+    /**
+     * S-Polynomial.
+     * @param Ap polynomial.
+     * @param Bp polynomial.
+     * @return spol(Ap,Bp) the S-polynomial of Ap and Bp.
+     */
+    public GenPolynomial<C> SPolynomial(GenPolynomial<C> Ap, GenPolynomial<C> Bp);
+
+
+    /**
+     * S-Polynomial with recording.
+     * @param S recording matrix, is modified.
+     * @param i index of Ap in basis list.
+     * @param Ap a polynomial.
+     * @param j index of Bp in basis list.
+     * @param Bp a polynomial.
+     * @return Spol(Ap, Bp), the S-Polynomial for Ap and Bp.
+     */
+    public GenPolynomial<C> SPolynomial(List<GenPolynomial<C>> S, int i, GenPolynomial<C> Ap, int j,
+                    GenPolynomial<C> Bp);
+
+
+    /**
+     * Module criterium.
+     * @param modv number of module variables.
+     * @param A polynomial.
+     * @param B polynomial.
+     * @return true if the module S-polynomial(i,j) is required.
+     */
+    public boolean moduleCriterion(int modv, GenPolynomial<C> A, GenPolynomial<C> B);
+
+
+    /**
+     * Module criterium.
+     * @param modv number of module variables.
+     * @param ei ExpVector.
+     * @param ej ExpVector.
+     * @return true if the module S-polynomial(i,j) is required.
+     */
+    public boolean moduleCriterion(int modv, ExpVector ei, ExpVector ej);
+
+
+    /**
+     * GB criterium 4. Use only for commutative polynomial rings.
+     * @param A polynomial.
+     * @param B polynomial.
+     * @param e = lcm(ht(A),ht(B))
+     * @return true if the S-polynomial(i,j) is required, else false.
+     */
+    public boolean criterion4(GenPolynomial<C> A, GenPolynomial<C> B, ExpVector e);
+
+
+    /**
+     * GB criterium 4. Use only for commutative polynomial rings.
+     * @param A polynomial.
+     * @param B polynomial.
+     * @return true if the S-polynomial(i,j) is required, else false.
+     */
+    public boolean criterion4(GenPolynomial<C> A, GenPolynomial<C> B);
+
+
+    /**
+     * GB criterium 4.
+     * @param ei exponent vector.
+     * @param ej exponent vector.
+     * @param e = lcm(ei,ej)
+     * @return true if the S-polynomial(i,j) is required, else false.
+     */
+    public boolean criterion4(ExpVector ei, ExpVector ej, ExpVector e);
+
+
+    /**
+     * Is top reducible. Condition is lt(B) | lt(A) for some B in F.
+     * @param A polynomial.
+     * @param P polynomial list.
+     * @return true if A is top reducible with respect to P.
+     */
+    public boolean isTopReducible(List<GenPolynomial<C>> P, GenPolynomial<C> A);
+
+
+    /**
+     * Is reducible.
+     * @param A polynomial.
+     * @param P polynomial list.
+     * @return true if A is reducible with respect to P.
+     */
+    public boolean isReducible(List<GenPolynomial<C>> P, GenPolynomial<C> A);
+
+
+    /**
+     * Is in Normalform.
+     * @param A polynomial.
+     * @param P polynomial list.
+     * @return true if A is in normalform with respect to P.
+     */
+    public boolean isNormalform(List<GenPolynomial<C>> P, GenPolynomial<C> A);
+
+
+    /**
+     * Is in Normalform.
+     * @param Pp polynomial list.
+     * @return true if each A in Pp is in normalform with respect to Pp\{A}.
+     */
+    public boolean isNormalform(List<GenPolynomial<C>> Pp);
+
+
+    /**
+     * Normalform.
+     * @param A polynomial.
+     * @param P polynomial list.
+     * @return nf(A) with respect to P.
+     */
+    public GenPolynomial<C> normalform(List<GenPolynomial<C>> P, GenPolynomial<C> A);
+
+
+    /**
+     * Normalform Set.
+     * @param Ap polynomial list.
+     * @param Pp polynomial list.
+     * @return list of nf(a) with respect to Pp for all a in Ap.
+     */
+    public List<GenPolynomial<C>> normalform(List<GenPolynomial<C>> Pp, List<GenPolynomial<C>> Ap);
+
+
+    /**
+     * Normalform with recording.
+     * @param row recording matrix, is modified.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @return nf(Pp,Ap), the normal form of Ap wrt. Pp.
+     */
+    public GenPolynomial<C> normalform(List<GenPolynomial<C>> row, List<GenPolynomial<C>> Pp,
+                    GenPolynomial<C> Ap);
+
+
+    /**
+     * Irreducible set.
+     * @param Pp polynomial list.
+     * @return a list P of polynomials which are in normalform wrt. P and with
+     *         ideal(Pp) = ideal(P).
+     */
+    public List<GenPolynomial<C>> irreducibleSet(List<GenPolynomial<C>> Pp);
+
+
+    /**
+     * Is reduction of normal form.
+     * @param row recording matrix, is modified.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @param Np nf(Pp,Ap), a normal form of Ap wrt. Pp.
+     * @return true, if Np + sum( row[i]*Pp[i] ) == Ap, else false.
+     */
+
+    public boolean isReductionNF(List<GenPolynomial<C>> row, List<GenPolynomial<C>> Pp, GenPolynomial<C> Ap,
+                    GenPolynomial<C> Np);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/ReductionAbstract.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/ReductionAbstract.java
@@ -1,0 +1,535 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.Monomial;
+import edu.jas.poly.ModuleList;
+import edu.jas.poly.PolynomialList;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Polynomial Reduction abstract class. Implements common S-Polynomial,
+ * normalform, criterion 4 module criterion and irreducible set.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public abstract class ReductionAbstract<C extends RingElem<C>> implements Reduction<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(ReductionAbstract.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     */
+    public ReductionAbstract() {
+    }
+
+
+    /**
+     * S-Polynomial.
+     * @param A polynomial.
+     * @param B polynomial.
+     * @return spol(A,B) the S-polynomial of A and B.
+     */
+    public GenPolynomial<C> SPolynomial(GenPolynomial<C> A, GenPolynomial<C> B) {
+        if (B == null || B.isZERO()) {
+            if (A == null) {
+                return B;
+            }
+            return A.ring.getZERO();
+        }
+        if (A == null || A.isZERO()) {
+            return B.ring.getZERO();
+        }
+        if (debug) {
+            if (!A.ring.equals(B.ring)) {
+                logger.error("rings not equal " + A.ring + ", " + B.ring);
+            }
+        }
+        Map.Entry<ExpVector, C> ma = A.leadingMonomial();
+        Map.Entry<ExpVector, C> mb = B.leadingMonomial();
+
+        ExpVector e = ma.getKey();
+        ExpVector f = mb.getKey();
+
+        ExpVector g = e.lcm(f);
+        ExpVector e1 = g.subtract(e);
+        ExpVector f1 = g.subtract(f);
+
+        C a = ma.getValue();
+        C b = mb.getValue();
+
+        //GenPolynomial<C> App = A.multiply(b, e1);
+        //GenPolynomial<C> Bpp = B.multiply(a, f1);
+        //GenPolynomial<C> Cp = App.subtract(Bpp);
+        GenPolynomial<C> Cp = A.scaleSubtractMultiple(b, e1, a, f1, B);
+        return Cp;
+    }
+
+
+    /**
+     * S-Polynomial with recording.
+     * @param S recording matrix, is modified. <b>Note</b> the negative
+     *            S-polynomial is recorded as required by all applications.
+     * @param i index of Ap in basis list.
+     * @param A a polynomial.
+     * @param j index of Bp in basis list.
+     * @param B a polynomial.
+     * @return Spol(A, B), the S-Polynomial for A and B.
+     */
+    public GenPolynomial<C> SPolynomial(List<GenPolynomial<C>> S, int i, GenPolynomial<C> A, int j,
+                    GenPolynomial<C> B) {
+        if (debug) {
+            if (B == null || B.isZERO()) {
+                throw new ArithmeticException("Spol B is zero");
+            }
+            if (A == null || A.isZERO()) {
+                throw new ArithmeticException("Spol A is zero");
+            }
+            if (!A.ring.equals(B.ring)) {
+                logger.error("rings not equal " + A.ring + ", " + B.ring);
+            }
+        }
+        Map.Entry<ExpVector, C> ma = A.leadingMonomial();
+        Map.Entry<ExpVector, C> mb = B.leadingMonomial();
+
+        ExpVector e = ma.getKey();
+        ExpVector f = mb.getKey();
+
+        ExpVector g = e.lcm(f);
+        ExpVector e1 = g.subtract(e);
+        ExpVector f1 = g.subtract(f);
+
+        C a = ma.getValue();
+        C b = mb.getValue();
+
+        //GenPolynomial<C> App = A.multiply(b, e1);
+        //GenPolynomial<C> Bpp = B.multiply(a, f1);
+        //GenPolynomial<C> Cp = App.subtract(Bpp);
+        GenPolynomial<C> Cp = A.scaleSubtractMultiple(b, e1, a, f1, B);
+
+        GenPolynomial<C> zero = A.ring.getZERO();
+        GenPolynomial<C> As = zero.sum(b.negate(), e1);
+        GenPolynomial<C> Bs = zero.sum(a /*correct .negate()*/, f1);
+        S.set(i, As);
+        S.set(j, Bs);
+        return Cp;
+    }
+
+
+    /**
+     * Module criterium.
+     * @param modv number of module variables.
+     * @param A polynomial.
+     * @param B polynomial.
+     * @return true if the module S-polynomial(i,j) is required.
+     */
+    public boolean moduleCriterion(int modv, GenPolynomial<C> A, GenPolynomial<C> B) {
+        if (modv == 0) {
+            return true;
+        }
+        ExpVector ei = A.leadingExpVector();
+        ExpVector ej = B.leadingExpVector();
+        return moduleCriterion(modv, ei, ej);
+    }
+
+
+    /**
+     * Module criterium.
+     * @param modv number of module variables.
+     * @param ei ExpVector.
+     * @param ej ExpVector.
+     * @return true if the module S-polynomial(i,j) is required.
+     */
+    public boolean moduleCriterion(int modv, ExpVector ei, ExpVector ej) {
+        if (modv == 0) {
+            return true;
+        }
+        if (ei.invLexCompareTo(ej, 0, modv) != 0) {
+            return false; // skip pair
+        }
+        return true;
+    }
+
+
+    /**
+     * GB criterium 4. Use only for commutative polynomial rings.
+     * @param A polynomial.
+     * @param B polynomial.
+     * @param e = lcm(ht(A),ht(B))
+     * @return true if the S-polynomial(i,j) is required, else false.
+     */
+    public boolean criterion4(GenPolynomial<C> A, GenPolynomial<C> B, ExpVector e) {
+        if (logger.isInfoEnabled()) {
+            if (!A.ring.equals(B.ring)) {
+                logger.error("rings not equal " + A.ring + ", " + B.ring);
+            }
+            if (!A.ring.isCommutative()) { //B instanceof GenSolvablePolynomial ) {
+                logger.error("GBCriterion4 not applicabable to non-commutative polynomials");
+                return true;
+            }
+        }
+        ExpVector ei = A.leadingExpVector();
+        ExpVector ej = B.leadingExpVector();
+        return criterion4(ei, ej, e);
+    }
+
+
+    /**
+     * GB criterium 4. Use only for commutative polynomial rings.
+     * @param ei exponent vector.
+     * @param ej exponent vector.
+     * @param e = lcm(ei,ej)
+     * @return true if the S-polynomial(i,j) is required, else false.
+     */
+    public boolean criterion4(ExpVector ei, ExpVector ej, ExpVector e) {
+        ExpVector g = ei.sum(ej);
+        ExpVector h = g.subtract(e);
+        int s = h.signum();
+        return s != 0;
+    }
+
+
+    /**
+     * GB criterium 4.
+     * @param A polynomial.
+     * @param B polynomial.
+     * @return true if the S-polynomial(i,j) is required, else false.
+     */
+    public boolean criterion4(GenPolynomial<C> A, GenPolynomial<C> B) {
+        if (logger.isInfoEnabled()) {
+            if (!A.ring.isCommutative() || !B.ring.isCommutative()) { // A instanceof GenSolvablePolynomial
+                logger.error("GBCriterion4 not applicabable to non-commutative polynomials");
+                return true;
+            }
+        }
+        ExpVector ei = A.leadingExpVector();
+        ExpVector ej = B.leadingExpVector();
+        ExpVector e = ei.lcm(ej);
+        return criterion4(ei, ej, e);
+    }
+
+
+    /**
+     * Normalform with respect to marked head terms.
+     * @param Mp leading monomial list.
+     * @param Pp polynomial list.
+     * @param Ap polynomial.
+     * @return nf(Ap) with respect to Mp+Pp.
+     */
+    public GenPolynomial<C> normalformMarked(List<Monomial<C>> Mp, List<GenPolynomial<C>> Pp,
+                    GenPolynomial<C> Ap) {
+        throw new UnsupportedOperationException("not implemented: " + Mp + " " + Pp + " " + Ap);
+    }
+
+
+    /**
+     * Normalform Set.
+     * @param Ap polynomial list.
+     * @param Pp polynomial list.
+     * @return list of nf(a) with respect to Pp for all a in Ap.
+     */
+    public List<GenPolynomial<C>> normalform(List<GenPolynomial<C>> Pp, List<GenPolynomial<C>> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isEmpty()) {
+            return Ap;
+        }
+        ArrayList<GenPolynomial<C>> red = new ArrayList<GenPolynomial<C>>();
+        for (GenPolynomial<C> A : Ap) {
+            A = normalform(Pp, A);
+            red.add(A);
+        }
+        return red;
+    }
+
+
+    /**
+     * Module normalform set.
+     * @param Ap module list.
+     * @param Pp module list.
+     * @return list of nf(a) with respect to Pp for all a in Ap.
+     */
+    public ModuleList<C> normalform(ModuleList<C> Pp, ModuleList<C> Ap) {
+        return normalform(Pp, Ap, false);
+    }
+
+    
+    /**
+     * Module normalform set.
+     * @param Ap module list.
+     * @param Pp module list.
+     * @param top true for TOP term order, false for POT term order.
+     * @return list of nf(a) with respect to Pp for all a in Ap.
+     */
+    public ModuleList<C> normalform(ModuleList<C> Pp, ModuleList<C> Ap, boolean top) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isEmpty()) {
+            return Ap;
+        }
+        int modv = Pp.cols;
+        GenPolynomialRing<C> pfac = Pp.ring.extend(modv, top);
+        logger.debug("extended ring = " + pfac);
+        //System.out.println("extended ring = " + pfac);
+        PolynomialList<C> P = Pp.getPolynomialList(pfac);
+        PolynomialList<C> A = Ap.getPolynomialList(pfac);
+
+        List<GenPolynomial<C>> red = normalform(P.list, A.list);
+        PolynomialList<C> Fr = new PolynomialList<C>(P.ring, red);
+        ModuleList<C> Nr = Fr.getModuleList(modv);
+        return Nr;
+    }
+
+    
+    /**
+     * Is top reducible.
+     * @param A polynomial.
+     * @param P polynomial list.
+     * @return true if A is top reducible with respect to P.
+     */
+    public boolean isTopReducible(List<GenPolynomial<C>> P, GenPolynomial<C> A) {
+        if (P == null || P.isEmpty()) {
+            return false;
+        }
+        if (A == null || A.isZERO()) {
+            return false;
+        }
+        boolean mt = false;
+        ExpVector e = A.leadingExpVector();
+        for (GenPolynomial<C> p : P) {
+            mt = e.multipleOf(p.leadingExpVector());
+            if (mt) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    /**
+     * Is reducible.
+     * @param Ap polynomial.
+     * @param Pp polynomial list.
+     * @return true if Ap is reducible with respect to Pp.
+     */
+    public boolean isReducible(List<GenPolynomial<C>> Pp, GenPolynomial<C> Ap) {
+        return !isNormalform(Pp, Ap);
+    }
+
+
+    /**
+     * Is in Normalform.
+     * @param Ap polynomial.
+     * @param Pp polynomial list.
+     * @return true if Ap is in normalform with respect to Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public boolean isNormalform(List<GenPolynomial<C>> Pp, GenPolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return true;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return true;
+        }
+        int l;
+        GenPolynomial<C>[] P;
+        synchronized (Pp) {
+            l = Pp.size();
+            P = new GenPolynomial[l];
+            //P = Pp.toArray();
+            for (int i = 0; i < Pp.size(); i++) {
+                P[i] = Pp.get(i);
+            }
+        }
+        ExpVector[] htl = new ExpVector[l];
+        GenPolynomial<C>[] p = new GenPolynomial[l];
+        Map.Entry<ExpVector, C> m;
+        int i;
+        int j = 0;
+        for (i = 0; i < l; i++) {
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                j++;
+            }
+        }
+        l = j;
+        boolean mt = false;
+        for (ExpVector e : Ap.getMap().keySet()) {
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Is in Normalform.
+     * @param Pp polynomial list.
+     * @return true if each Ap in Pp is in normalform with respect to Pp\{Ap}.
+     */
+    public boolean isNormalform(List<GenPolynomial<C>> Pp) {
+        if (Pp == null || Pp.isEmpty()) {
+            return true;
+        }
+        GenPolynomial<C> Ap;
+        List<GenPolynomial<C>> P = new LinkedList<GenPolynomial<C>>(Pp);
+        int s = P.size();
+        for (int i = 0; i < s; i++) {
+            Ap = P.remove(i);
+            if (!isNormalform(P, Ap)) {
+                return false;
+            }
+            P.add(Ap);
+        }
+        return true;
+    }
+
+
+    /**
+     * Irreducible set.
+     * @param Pp polynomial list.
+     * @return a list P of monic polynomials which are in normalform wrt. P and
+     *         with ideal(Pp) = ideal(P).
+     */
+    public List<GenPolynomial<C>> irreducibleSet(List<GenPolynomial<C>> Pp) {
+        ArrayList<GenPolynomial<C>> P = new ArrayList<GenPolynomial<C>>();
+        for (GenPolynomial<C> a : Pp) {
+            if (a.length() != 0) {
+                a = a.monic();
+                if (a.isONE()) {
+                    P.clear();
+                    P.add(a);
+                    return P;
+                }
+                P.add(a);
+            }
+        }
+        int l = P.size();
+        if (l <= 1)
+            return P;
+
+        int irr = 0;
+        ExpVector e;
+        ExpVector f;
+        GenPolynomial<C> a;
+        logger.debug("irr = ");
+        while (irr != l) {
+            //it = P.listIterator(); 
+            //a = P.get(0); //it.next();
+            a = P.remove(0);
+            e = a.leadingExpVector();
+            a = normalform(P, a);
+            logger.debug(String.valueOf(irr));
+            if (a.length() == 0) {
+                l--;
+                if (l <= 1) {
+                    return P;
+                }
+            } else {
+                f = a.leadingExpVector();
+                if (f.signum() == 0) {
+                    P = new ArrayList<GenPolynomial<C>>();
+                    P.add(a.monic());
+                    return P;
+                }
+                if (e.equals(f)) {
+                    irr++;
+                } else {
+                    irr = 0;
+                    a = a.monic();
+                }
+                P.add(a);
+            }
+        }
+        //System.out.println();
+        return P;
+    }
+
+
+    /**
+     * Is reduction of normal form.
+     * @param row recording matrix.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @param Np nf(Pp,Ap), a normal form of Ap wrt. Pp.
+     * @return true, if Np + sum( row[i]*Pp[i] ) == Ap, else false.
+     */
+
+    public boolean isReductionNF(List<GenPolynomial<C>> row, List<GenPolynomial<C>> Pp, GenPolynomial<C> Ap,
+                    GenPolynomial<C> Np) {
+        if (row == null && Pp == null) {
+            if (Ap == null) {
+                return Np == null;
+            }
+            return Ap.equals(Np);
+        }
+        if (row == null || Pp == null) {
+            return false;
+        }
+        if (row.size() != Pp.size()) {
+            return false;
+        }
+        GenPolynomial<C> t = Np;
+        //System.out.println("t0 = " + t );
+        GenPolynomial<C> r;
+        GenPolynomial<C> p;
+        for (int m = 0; m < Pp.size(); m++) {
+            r = row.get(m);
+            p = Pp.get(m);
+            if (r != null && p != null) {
+                if (t == null) {
+                    t = r.multiply(p);
+                } else {
+                    t = t.sum(r.multiply(p));
+                }
+            }
+            //System.out.println("r = " + r );
+            //System.out.println("p = " + p );
+        }
+        //System.out.println("t+ = " + t );
+        if (t == null) {
+            if (Ap == null) {
+                return true;
+            }
+            return Ap.isZERO();
+        }
+        r = t.subtract(Ap);
+        boolean z = r.isZERO();
+        if (!z) {
+            logger.info("t = " + t);
+            logger.info("a = " + Ap);
+            logger.info("t-a = " + r);
+        }
+        return z;
+    }
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/ReductionPar.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/ReductionPar.java
@@ -1,0 +1,216 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.List;
+import java.util.Map;
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Polynomial reduction parallel usable algorithm. Implements normalform.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class ReductionPar<C extends RingElem<C>> extends ReductionAbstract<C> {
+
+
+    //private static final Logger logger = LogManager.getLogger(ReductionPar.class);
+
+
+    /**
+     * Constructor.
+     */
+    public ReductionPar() {
+    }
+
+
+    /**
+     * Normalform. Allows concurrent modification of the list.
+     * @param Ap polynomial.
+     * @param Pp polynomial list, concurrent modification allowed.
+     * @return nf(Ap) with respect to Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public GenPolynomial<C> normalform(List<GenPolynomial<C>> Pp, GenPolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        int l;
+        GenPolynomial<C>[] P;
+        synchronized (Pp) { // required, ok in dist
+            l = Pp.size();
+            P = (GenPolynomial<C>[]) new GenPolynomial[l];
+            //P = Pp.values().toArray();
+            for (int i = 0; i < Pp.size(); i++) {
+                P[i] = Pp.get(i);
+            }
+        }
+
+        Map.Entry<ExpVector, C> m;
+        Map.Entry<ExpVector, C> m1;
+        ExpVector e;
+        ExpVector f = null;
+        C a;
+        boolean mt = false;
+        GenPolynomial<C> Rz = Ap.ring.getZERO();
+        GenPolynomial<C> R = Rz.copy();
+        GenPolynomial<C> p = null;
+        //GenPolynomial<C> Q = null;
+        GenPolynomial<C> S = Ap.copy();
+        while (S.length() > 0) {
+            if (Pp.size() != l) {
+                //long t = System.currentTimeMillis();
+                synchronized (Pp) { // required, bad in parallel
+                    l = Pp.size();
+                    P = (GenPolynomial<C>[]) new GenPolynomial[l];
+                    //P = Pp.toArray();
+                    for (int i = 0; i < Pp.size(); i++) {
+                        P[i] = Pp.get(i);
+                    }
+                }
+                //t = System.currentTimeMillis()-t;
+                //logger.info("Pp.toArray() = " + t + " ms, size() = " + l);
+                S = Ap.copy(); // S.add(R)? // restart reduction ?
+                R = Rz.copy();
+            }
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            //System.out.println("S.e = " + e);
+            for (int i = 0; i < P.length; i++) {
+                p = P[i];
+                f = p.leadingExpVector();
+                if (f != null) {
+                    mt = e.multipleOf(f);
+                    if (mt)
+                        break;
+                }
+            }
+            if (!mt) {
+                //logger.debug("irred");
+                //R = R.sum( a, e );
+                //S = S.subtract( a, e ); 
+                R.doPutToMap(e, a);
+                S.doRemoveFromMap(e, a);
+                //System.out.println("R = " + R);
+            } else {
+                //logger.debug("red");
+                m1 = p.leadingMonomial();
+                e = e.subtract(f);
+                a = a.divide(m1.getValue());
+                //Q = p.multiply( a, e );
+                //S = S.subtract( Q );
+                S = S.subtractMultiple(a, e, p);
+            }
+            //System.out.println("S = " + S);
+        }
+        return R;
+    }
+
+
+    /**
+     * Normalform with recording.
+     * @param row recording matrix, is modified.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @return nf(Pp,Ap), the normal form of Ap wrt. Pp.
+     */
+    public GenPolynomial<C> normalform(List<GenPolynomial<C>> row, List<GenPolynomial<C>> Pp,
+                    GenPolynomial<C> Ap) {
+        throw new RuntimeException("normalform with recording not implemented");
+    }
+
+
+    /**
+     * Normalform. Allows concurrent modification of the DHT.
+     * @param Ap polynomial.
+     * @param mp a map from Integers to polynomials, e.g. a distributed hash
+     *            table, concurrent modification allowed.
+     * @return nf(Ap) with respect to Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public GenPolynomial<C> normalform(Map<Integer, GenPolynomial<C>> mp, GenPolynomial<C> Ap) {
+        if (mp == null || mp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        int l;
+        GenPolynomial<C>[] P;
+        //synchronized ( mp ) { // no more required
+        l = mp.size();
+        P = (GenPolynomial<C>[]) new GenPolynomial[l];
+        P = mp.values().toArray(P);
+        l = P.length;
+        //}
+
+        Map.Entry<ExpVector, C> m;
+        Map.Entry<ExpVector, C> m1;
+        ExpVector e;
+        ExpVector f = null;
+        C a;
+        boolean mt = false;
+        GenPolynomial<C> Rz = Ap.ring.getZERO();
+        GenPolynomial<C> R = Rz.copy();
+        GenPolynomial<C> p = null;
+        //GenPolynomial<C> Q = null;
+        GenPolynomial<C> S = Ap.copy();
+        while (S.length() > 0) {
+            if (mp.size() != l) {
+                //long t = System.currentTimeMillis();
+                //synchronized ( mp ) { // no more required, ok in distributed
+                P = mp.values().toArray(P);
+                l = P.length;
+                //}
+                //t = System.currentTimeMillis()-t;
+                //logger.info("Pp.toArray() = " + t + " ms, size() = " + l);
+                //logger.info("Pp.toArray() size() = " + l);
+                S = Ap.copy(); // S.add(R)? // restart reduction ?
+                R = Rz.copy();
+            }
+
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            for (int i = 0; i < P.length; i++) {
+                p = P[i];
+                f = p.leadingExpVector();
+                if (f != null) {
+                    mt = e.multipleOf(f);
+                    if (mt)
+                        break;
+                }
+            }
+            if (!mt) {
+                //logger.debug("irred");
+                //R = R.sum( a, e );
+                //S = S.subtract( a, e ); 
+                R.doPutToMap(e, a);
+                S.doRemoveFromMap(e, a);
+                // System.out.println(" S = " + S);
+            } else {
+                //logger.debug("red");
+                m1 = p.leadingMonomial();
+                e = e.subtract(f);
+                a = a.divide(m1.getValue());
+                //Q = p.multiply( a, e );
+                //S = S.subtract( Q );
+                S = S.subtractMultiple(a, e, p);
+            }
+        }
+        return R;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/ReductionSeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/ReductionSeq.java
@@ -1,0 +1,311 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.Monomial;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Polynomial reduction sequential use algorithm. Implements normalform.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class ReductionSeq<C extends RingElem<C>> // should be FieldElem<C>>
+                extends ReductionAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(ReductionSeq.class);
+
+
+    /**
+     * Constructor.
+     */
+    public ReductionSeq() {
+    }
+
+
+    /**
+     * Normalform.
+     * @param Ap polynomial.
+     * @param Pp polynomial list.
+     * @return nf(Ap) with respect to Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public GenPolynomial<C> normalform(List<GenPolynomial<C>> Pp, GenPolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        if (!Ap.ring.coFac.isField()) {
+            throw new IllegalArgumentException("coefficients not from a field");
+        }
+        Map.Entry<ExpVector, C> m;
+        int l;
+        GenPolynomial<C>[] P;
+        synchronized (Pp) {
+            l = Pp.size();
+            P = new GenPolynomial[l];
+            //P = Pp.toArray();
+            for (int i = 0; i < Pp.size(); i++) {
+                P[i] = Pp.get(i);
+            }
+        }
+        ExpVector[] htl = new ExpVector[l];
+        Object[] lbc = new Object[l]; // want C[]
+        GenPolynomial<C>[] p = new GenPolynomial[l];
+        int i;
+        int j = 0;
+        for (i = 0; i < l; i++) {
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        ExpVector e;
+        C a;
+        boolean mt = false;
+        GenPolynomial<C> R = Ap.ring.getZERO().copy();
+
+        //GenPolynomial<C> T = null;
+        //GenPolynomial<C> Q = null;
+        GenPolynomial<C> S = Ap.copy();
+        while (S.length() > 0) {
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt)
+                    break;
+            }
+            if (!mt) {
+                logger.debug("irred");
+                //R = R.sum( a, e );
+                //S = S.subtract( a, e ); 
+                R.doPutToMap(e, a);
+                S.doRemoveFromMap(e, a);
+                // System.out.println(" S = " + S);
+            } else {
+                e = e.subtract(htl[i]);
+                a = a.divide((C) lbc[i]);
+                //logger.info("red div: e = " + e + ", a = " + a);
+                //Q = p[i].multiply( a, e );
+                //S = S.subtract( Q );
+                S = S.subtractMultiple(a, e, p[i]);
+            }
+        }
+        return R;
+    }
+
+
+    /**
+     * Normalform with respect to marked head terms.
+     * @param Mp leading monomial list.
+     * @param Pp polynomial list.
+     * @param Ap polynomial.
+     * @return nf(Ap) with respect to Mp+Pp.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public GenPolynomial<C> normalformMarked(List<Monomial<C>> Mp, List<GenPolynomial<C>> Pp,
+                    GenPolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Mp == null || Mp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        if (!Ap.ring.coFac.isField()) {
+            throw new IllegalArgumentException("coefficients not from a field");
+        }
+        Map.Entry<ExpVector, C> m;
+        int l;
+        GenPolynomial<C>[] P;
+        Monomial<C>[] M;
+        synchronized (Pp) {
+            l = Pp.size();
+            if (Mp.size() != l) {
+                throw new IllegalArgumentException("#Mp != #Pp: " + l + ", " + Mp.size());
+            }
+            P = new GenPolynomial[l];
+            M = new Monomial[l];
+            //P = Pp.toArray();
+            for (int i = 0; i < Pp.size(); i++) {
+                P[i] = Pp.get(i);
+                M[i] = Mp.get(i);
+            }
+        }
+        ExpVector[] htl = new ExpVector[l];
+        RingElem[] lbc = new RingElem[l];
+        GenPolynomial<C>[] p = new GenPolynomial[l];
+        int i;
+        int j = 0;
+        for (i = 0; i < l; i++) {
+            p[i] = P[i];
+            if (M[i] != null) {
+                p[j] = p[i];
+                htl[j] = M[i].exponent();
+                lbc[j] = M[i].coefficient();
+                j++;
+            }
+        }
+        l = j;
+        ExpVector e, f;
+        C a, b;
+        boolean mt = false;
+        GenPolynomial<C> R = Ap.ring.getZERO().copy();
+        GenPolynomial<C> S = Ap.copy();
+        while (S.length() > 0) {
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            //System.out.println("NF a = " + a + ", e = " + e);
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt)
+                    break;
+            }
+            if (!mt) {
+                logger.debug("irred");
+                R.doAddTo(a, e); // needed, or sum
+                //R.doPutToMap(e, a); // not here
+                //S = S.subtract( a, e ); 
+                S.doRemoveFromMap(e, a);
+                // System.out.println(" S = " + S);
+            } else {
+                //System.out.println("i = "+i+", htl[i] = " + Ap.ring.toScript(htl[i]) + ", lbc[i] = " + lbc[i]  + ", p[i] = " + p[i].ring.toScript(p[i].leadingExpVector()));
+                f = e.subtract(htl[i]);
+                b = a.divide((C) lbc[i]);
+                //logger.info("red div: e = " + e + ", a = " + a + ", f = " + f + ", b = " + b);
+                //Q = p[i].multiply( a, e );
+                //S = S.subtract( Q );
+                S.doRemoveFromMap(e, a);
+                //S.doAddTo(a.negate(), e);
+                S = S.subtractMultiple(b, f, p[i]);
+                if (e.equals(S.leadingExpVector())) {
+                    throw new RuntimeException(
+                                    "something is wrong: ht not descending e = " + e + ", S = " + S);
+                }
+                //System.out.println("NF R = " + R.leadingExpVector() + ", S = " + S.leadingExpVector() + ", e = " + e + ", f = " + f + ", #S = " + S.length());
+            }
+            //System.out.println("NF R = " + R + ", S = " + S);
+        }
+        //System.out.println("NF Ap = " + Ap + " ==> " + R);
+        return R;
+    }
+
+
+    /**
+     * Normalform with recording.
+     * @param row recording matrix, is modified.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @return nf(Pp,Ap), the normal form of Ap wrt. Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public GenPolynomial<C> normalform(List<GenPolynomial<C>> row, List<GenPolynomial<C>> Pp,
+                    GenPolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        if (!Ap.ring.coFac.isField()) {
+            throw new IllegalArgumentException("coefficients not from a field");
+        }
+        int l = Pp.size();
+        GenPolynomial<C>[] P = new GenPolynomial[l];
+        synchronized (Pp) {
+            //P = Pp.toArray();
+            for (int i = 0; i < Pp.size(); i++) {
+                P[i] = Pp.get(i);
+            }
+        }
+        ExpVector[] htl = new ExpVector[l];
+        Object[] lbc = new Object[l]; // want C[]
+        GenPolynomial<C>[] p = new GenPolynomial[l];
+        Map.Entry<ExpVector, C> m;
+        int j = 0;
+        int i;
+        for (i = 0; i < l; i++) {
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        ExpVector e;
+        C a;
+        boolean mt = false;
+        GenPolynomial<C> zero = Ap.ring.getZERO();
+        GenPolynomial<C> R = Ap.ring.getZERO().copy();
+
+        GenPolynomial<C> fac = null;
+        // GenPolynomial<C> T = null;
+        //GenPolynomial<C> Q = null;
+        GenPolynomial<C> S = Ap.copy();
+        while (S.length() > 0) {
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt)
+                    break;
+            }
+            if (!mt) {
+                //logger.debug("irred");
+                //R = R.sum( a, e );
+                //S = S.subtract( a, e ); 
+                R.doPutToMap(e, a);
+                S.doRemoveFromMap(e, a);
+                // System.out.println(" S = " + S);
+            } else {
+                e = e.subtract(htl[i]);
+                //logger.info("red div = " + e);
+                C c = (C) lbc[i];
+                a = a.divide(c);
+                //Q = p[i].multiply( a, e );
+                //S = S.subtract( Q );
+                S = S.subtractMultiple(a, e, p[i]);
+                fac = row.get(i);
+                if (fac == null) {
+                    fac = zero.sum(a, e);
+                } else {
+                    fac = fac.sum(a, e);
+                }
+                row.set(i, fac);
+            }
+        }
+        return R;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/SGBProxy.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/SGBProxy.java
@@ -1,0 +1,317 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.kern.ComputerThreads;
+import edu.jas.kern.PreemptingException;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Groebner bases parallel proxy.
+ * @author Heinz Kredel
+ */
+
+public class SGBProxy<C extends GcdRingElem<C>> extends SolvableGroebnerBaseAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(SGBProxy.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled(); //logger.isInfoEnabled();
+
+
+    /**
+     * GB engines.
+     */
+    public final SolvableGroebnerBaseAbstract<C> e1;
+
+
+    public final SolvableGroebnerBaseAbstract<C> e2;
+
+
+    /**
+     * Thread pool.
+     */
+    protected transient ExecutorService pool;
+
+
+    /**
+     * Proxy constructor.
+     * @param e1 Groebner base engine.
+     * @param e2 Groebner base engine.
+     */
+    public SGBProxy(SolvableGroebnerBaseAbstract<C> e1, SolvableGroebnerBaseAbstract<C> e2) {
+        this.e1 = e1;
+        this.e2 = e2;
+        pool = ComputerThreads.getPool();
+        //System.out.println("pool 2 = "+pool);
+    }
+
+
+    /**
+     * Get the String representation with GB engines.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "SGBProxy[ " + e1.toString() + ", " + e2.toString() + " ]";
+    }
+
+
+    /**
+     * Cleanup and terminate ThreadPool.
+     */
+    @Override
+    public void terminate() {
+        e1.terminate();
+        e2.terminate();
+    }
+
+
+    /**
+     * Cancel ThreadPool.
+     */
+    @Override
+    public int cancel() {
+        int s = e1.cancel();
+        s += e2.cancel();
+        return s;
+    }
+
+
+    /**
+     * Groebner base.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return GB(F) a Groebner base of F.
+     */
+    @Override
+    public List<GenSolvablePolynomial<C>> leftGB(final int modv, final List<GenSolvablePolynomial<C>> F) {
+        if (F == null || F.isEmpty()) {
+            return F;
+        }
+        // parallel case
+        List<GenSolvablePolynomial<C>> G = null;
+        List<Callable<List<GenSolvablePolynomial<C>>>> cs = new ArrayList<Callable<List<GenSolvablePolynomial<C>>>>(
+                        2);
+        cs.add(new Callable<List<GenSolvablePolynomial<C>>>() {
+
+
+            public List<GenSolvablePolynomial<C>> call() {
+                try {
+                    //System.out.println("starting e1 " + e1.getClass().getName());
+                    List<GenSolvablePolynomial<C>> G = e1.leftGB(modv, F);
+                    if (debug) {
+                        logger.info("SGBProxy done e1 " + e1.getClass().getName());
+                    }
+                    return G;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("SGBProxy e1 preempted " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("SGBProxy e1 " + e);
+                    logger.info("Exception SGBProxy F = " + F);
+                    throw new RuntimeException("SGBProxy e1 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        cs.add(new Callable<List<GenSolvablePolynomial<C>>>() {
+
+
+            public List<GenSolvablePolynomial<C>> call() {
+                try {
+                    //System.out.println("starting e2 " + e2.getClass().getName());
+                    List<GenSolvablePolynomial<C>> G = e2.leftGB(modv, F);
+                    if (debug) {
+                        logger.info("SGBProxy done e2 " + e2.getClass().getName());
+                    }
+                    return G;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("SGBProxy e2 preempted " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("SGBProxy e2 " + e);
+                    logger.info("Exception SGBProxy F = " + F);
+                    throw new RuntimeException("SGBProxy e2 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        try {
+            G = pool.invokeAny(cs);
+        } catch (InterruptedException ignored) {
+            logger.info("InterruptedException " + ignored);
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
+            logger.info("ExecutionException " + e);
+            Thread.currentThread().interrupt();
+        }
+        return G;
+    }
+
+
+    /**
+     * Right Groebner base.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return rightGB(F) a Groebner base of F.
+     */
+    @Override
+    public List<GenSolvablePolynomial<C>> rightGB(final int modv, final List<GenSolvablePolynomial<C>> F) {
+        if (F == null || F.isEmpty()) {
+            return F;
+        }
+        // parallel case
+        List<GenSolvablePolynomial<C>> G = null;
+        List<Callable<List<GenSolvablePolynomial<C>>>> cs = new ArrayList<Callable<List<GenSolvablePolynomial<C>>>>(
+                        2);
+        cs.add(new Callable<List<GenSolvablePolynomial<C>>>() {
+
+
+            public List<GenSolvablePolynomial<C>> call() {
+                try {
+                    //System.out.println("starting e1 " + e1.getClass().getName());
+                    List<GenSolvablePolynomial<C>> G = e1.rightGB(modv, F);
+                    if (debug) {
+                        logger.info("SGBProxy done e1 " + e1.getClass().getName());
+                    }
+                    return G;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("SGBProxy e1 preempted " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("SGBProxy e1 " + e);
+                    logger.info("Exception SGBProxy F = " + F);
+                    throw new RuntimeException("SGBProxy e1 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        cs.add(new Callable<List<GenSolvablePolynomial<C>>>() {
+
+
+            public List<GenSolvablePolynomial<C>> call() {
+                try {
+                    //System.out.println("starting e2 " + e2.getClass().getName());
+                    List<GenSolvablePolynomial<C>> G = e2.rightGB(modv, F);
+                    if (debug) {
+                        logger.info("SGBProxy done e2 " + e2.getClass().getName());
+                    }
+                    return G;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("SGBProxy e2 preempted " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("SGBProxy e2 " + e);
+                    logger.info("Exception SGBProxy F = " + F);
+                    throw new RuntimeException("SGBProxy e2 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        try {
+            G = pool.invokeAny(cs);
+        } catch (InterruptedException ignored) {
+            logger.info("InterruptedException " + ignored);
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
+            logger.info("ExecutionException " + e);
+            Thread.currentThread().interrupt();
+        }
+        return G;
+    }
+
+
+    /**
+     * Groebner base.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return twosidedGB(F) a Groebner base of F.
+     */
+    @Override
+    public List<GenSolvablePolynomial<C>> twosidedGB(final int modv, final List<GenSolvablePolynomial<C>> F) {
+        if (F == null || F.isEmpty()) {
+            return F;
+        }
+        // parallel case
+        List<GenSolvablePolynomial<C>> G = null;
+        List<Callable<List<GenSolvablePolynomial<C>>>> cs = new ArrayList<Callable<List<GenSolvablePolynomial<C>>>>(
+                        2);
+        cs.add(new Callable<List<GenSolvablePolynomial<C>>>() {
+
+
+            public List<GenSolvablePolynomial<C>> call() {
+                try {
+                    //System.out.println("starting e1 " + e1.getClass().getName());
+                    List<GenSolvablePolynomial<C>> G = e1.twosidedGB(modv, F);
+                    if (debug) {
+                        logger.info("SGBProxy done e1 " + e1.getClass().getName());
+                    }
+                    return G;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("SGBProxy e1 preempted " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("SGBProxy e1 " + e);
+                    logger.info("Exception SGBProxy F = " + F);
+                    throw new RuntimeException("SGBProxy e1 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        cs.add(new Callable<List<GenSolvablePolynomial<C>>>() {
+
+
+            public List<GenSolvablePolynomial<C>> call() {
+                try {
+                    //System.out.println("starting e2 " + e2.getClass().getName());
+                    List<GenSolvablePolynomial<C>> G = e2.twosidedGB(modv, F);
+                    if (debug) {
+                        logger.info("SGBProxy done e2 " + e2.getClass().getName());
+                    }
+                    return G;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("SGBProxy e2 preempted " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("SGBProxy e2 " + e);
+                    logger.info("Exception SGBProxy F = " + F);
+                    throw new RuntimeException("SGBProxy e2 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        try {
+            G = pool.invokeAny(cs);
+        } catch (InterruptedException ignored) {
+            logger.info("InterruptedException " + ignored);
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
+            logger.info("ExecutionException " + e);
+            Thread.currentThread().interrupt();
+        }
+        return G;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/SigPair.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/SigPair.java
@@ -1,0 +1,122 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.List;
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Serializable subclass to hold pairs of polynomials.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+public class SigPair<C extends RingElem<C>> //extends AbstractSigPair<C>
+                implements Comparable<SigPair<C>> {
+
+
+    public final GenPolynomial<C> sigma;
+
+
+    public final SigPoly<C> pi;
+
+
+    public final SigPoly<C> pj;
+
+
+    public final List<SigPoly<C>> Gs;
+
+
+    /**
+     * SigPair constructor.
+     * @param sig signature of pair.
+     * @param a polynomial i.
+     * @param b polynomial j.
+     */
+    public SigPair(ExpVector sig, SigPoly<C> a, SigPoly<C> b, List<SigPoly<C>> Gs) {
+        this(a.poly.ring.valueOf(sig), a, b, Gs);
+    }
+
+
+    /**
+     * SigPair constructor.
+     * @param sig signature of pair.
+     * @param a polynomial i.
+     * @param b polynomial j.
+     */
+    public SigPair(GenPolynomial<C> sig, SigPoly<C> a, SigPoly<C> b, List<SigPoly<C>> Gs) {
+        this.sigma = sig;
+        pi = a;
+        pj = b;
+        this.Gs = Gs;
+    }
+
+
+    /**
+     * getter for sigma
+     */
+    GenPolynomial<C> getSigma() {
+        return sigma;
+    }
+
+
+    /**
+     * getter for sigma.degree
+     */
+    long getSigmaDegree() {
+        return sigma.degree();
+    }
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString() {
+        return "pair(" + sigma + " @ " + pi + ", " + pj + ")";
+    }
+
+
+    /**
+     * equals.
+     * @param ob an Object.
+     * @return true if this is equal to o, else false.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object ob) {
+        if (!(ob instanceof SigPair)) {
+            return false;
+            // throw new ClassCastException("SigPair "+n+" o "+o);
+        }
+        return 0 == compareTo((SigPair) ob);
+    }
+
+
+    /**
+     * compareTo used in TreeMap // not used at moment. Comparison is based on
+     * the number of the pairs.
+     * @param p a SigPair.
+     * @return 1 if (this &lt; o), 0 if (this == o), -1 if (this &gt; o).
+     */
+    public int compareTo(SigPair<C> p) {
+        return sigma.compareTo(p.sigma);
+    }
+
+
+    /**
+     * Hash code for this SigPair.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return (pi.hashCode() << 16) + pj.hashCode();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/SigPoly.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/SigPoly.java
@@ -1,0 +1,66 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Container for a polynomial and its signature.
+ * @param <C> coefficient type
+ * @param sigma a polynomial signature.
+ * @param poly a polynomial.
+ */
+public class SigPoly<C extends RingElem<C>> {
+
+
+    public final GenPolynomial<C> sigma;
+
+
+    public final GenPolynomial<C> poly;
+
+
+    /**
+     * Constructor.
+     * @param s a polynomial signature.
+     * @param p a polynomial.
+     */
+    public SigPoly(GenPolynomial<C> s, GenPolynomial<C> p) {
+        this.sigma = s;
+        this.poly = p;
+    }
+
+
+    /**
+     * getter for sigma
+     */
+    GenPolynomial<C> getSigma() {
+        return sigma;
+    }
+
+
+    /**
+     * getter for polynomial
+     */
+    GenPolynomial<C> getPoly() {
+        return poly;
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer s = new StringBuffer("sigma(");
+        s.append(sigma.toString() + "):: ");
+        s.append(poly.toString());
+        return s.toString();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/SigReduction.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/SigReduction.java
@@ -1,0 +1,63 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.io.Serializable;
+import java.util.List;
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Polynomial SigReduction interface. Defines S-Polynomial, normalform with
+ * respect to signatures.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public interface SigReduction<C extends RingElem<C>> extends Serializable {
+
+
+    /**
+     * S-Polynomial.
+     * @param Ap polynomial.
+     * @param Bp polynomial.
+     * @return spol(Ap,Bp) the S-polynomial of Ap and Bp.
+     */
+    public GenPolynomial<C> SPolynomial(SigPoly<C> Ap, SigPoly<C> Bp);
+
+
+    /**
+     * Is top reducible. Condition is lt(B) | lt(A) for some B in F or G.
+     * @param A polynomial.
+     * @param F polynomial list.
+     * @param G polynomial list.
+     * @return true if A is top reducible with respect to P.
+     */
+    public boolean isSigReducible(List<SigPoly<C>> F, List<SigPoly<C>> G, SigPoly<C> A);
+
+
+    /**
+     * Is in Normalform.
+     * @param A polynomial.
+     * @param F polynomial list.
+     * @param G polynomial list.
+     * @return true if A is in normalform with respect to F and G.
+     */
+    public boolean isSigNormalform(List<SigPoly<C>> F, List<SigPoly<C>> G, SigPoly<C> A);
+
+
+    /**
+     * Normalform.
+     * @param A polynomial.
+     * @param F polynomial list.
+     * @param G polynomial list.
+     * @return nf(A) with respect to F and G.
+     */
+    public SigPoly<C> sigNormalform(List<GenPolynomial<C>> F, List<SigPoly<C>> G, SigPoly<C> A);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/SigReductionSeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/SigReductionSeq.java
@@ -1,0 +1,487 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Polynomial SigReduction class. Implements common S-Polynomial, normalform
+ * with respect to signatures.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class SigReductionSeq<C extends RingElem<C>> implements SigReduction<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(SigReductionSeq.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    final ReductionAbstract<C> red;
+
+
+    /**
+     * Constructor.
+     */
+    public SigReductionSeq() {
+        red = new ReductionSeq<C>();
+    }
+
+
+    /**
+     * S-Polynomial.
+     * @param A polynomial.
+     * @param B polynomial.
+     * @return spol(A,B) the S-polynomial of A and B.
+     */
+    public GenPolynomial<C> SPolynomial(SigPoly<C> A, SigPoly<C> B) {
+        GenPolynomial<C> s = red.SPolynomial(A.poly, B.poly);
+        return s;
+    }
+
+
+    /**
+     * S-Polynomial factors.
+     * @param A monic polynomial.
+     * @param B monic polynomial.
+     * @return exponent vectors [e,f] such that spol(A,B) = e*a - f*B.
+     */
+    public ExpVector[] SPolynomialExpVectorFactors(SigPoly<C> A, SigPoly<C> B) {
+        Map.Entry<ExpVector, C> ma = A.poly.leadingMonomial();
+        Map.Entry<ExpVector, C> mb = B.poly.leadingMonomial();
+        ExpVector e = ma.getKey();
+        ExpVector f = mb.getKey();
+        ExpVector g = e.lcm(f);
+        ExpVector e1 = g.subtract(e);
+        ExpVector f1 = g.subtract(f);
+        ExpVector[] F = new ExpVector[] { e1, f1 };
+        return F;
+    }
+
+
+    /**
+     * S-Polynomial half.
+     * @param A monic polynomial.
+     * @param B monic polynomial.
+     * @return e*A "half" of an S-polynomial such that spol(A,B) = e*A - f*B.
+     */
+    public GenPolynomial<C> SPolynomialHalf(SigPoly<C> A, SigPoly<C> B) {
+        Map.Entry<ExpVector, C> ma = A.poly.leadingMonomial();
+        Map.Entry<ExpVector, C> mb = B.poly.leadingMonomial();
+        ExpVector e = ma.getKey();
+        ExpVector f = mb.getKey();
+        ExpVector g = e.lcm(f);
+        ExpVector e1 = g.subtract(e);
+        GenPolynomial<C> F = A.poly.multiply(e1);
+        return F;
+    }
+
+
+    /**
+     * S-Polynomial polynomial factors.
+     * @param A monic polynomial.
+     * @param B monic polynomial.
+     * @return polynomials [e,f] such that spol(A,B) = e*a - f*B.
+     */
+    public GenPolynomial<C>[] SPolynomialFactors(SigPoly<C> A, SigPoly<C> B) {
+        ExpVector[] ev = SPolynomialExpVectorFactors(A, B);
+        GenPolynomial<C> e1 = A.poly.ring.valueOf(ev[0]);
+        GenPolynomial<C> f1 = A.poly.ring.valueOf(ev[1]);
+        @SuppressWarnings("unchecked")
+        GenPolynomial<C>[] F = new GenPolynomial[] { e1, f1 };
+        return F;
+    }
+
+
+    /**
+     * Is top reducible. Condition is lt(B) | lt(A) for some B in F or G.
+     * @param A polynomial.
+     * @param F polynomial list.
+     * @param G polynomial list.
+     * @return true if A is top reducible with respect to F and G.
+     */
+    public boolean isSigReducible(List<SigPoly<C>> F, List<SigPoly<C>> G, SigPoly<C> A) {
+        return !isSigNormalform(F, G, A);
+    }
+
+
+    /**
+     * Is in top normalform.
+     * @param A polynomial.
+     * @param F polynomial list.
+     * @param G polynomial list.
+     * @return true if A is in top normalform with respect to F and G.
+     */
+    public boolean isSigNormalform(List<SigPoly<C>> F, List<SigPoly<C>> G, SigPoly<C> A) {
+        if (F.isEmpty() && G.isEmpty()) {
+            return true;
+        }
+        if (A.poly.isZERO()) {
+            return true;
+        }
+        boolean mt = false;
+        for (ExpVector e : A.poly.getMap().keySet()) {
+            for (SigPoly<C> p : F) {
+                ExpVector f = p.poly.leadingExpVector();
+                mt = e.multipleOf(f);
+                if (mt) {
+                    return false;
+                }
+            }
+            for (SigPoly<C> p : G) {
+                if (p.poly.isZERO()) {
+                    continue;
+                }
+                ExpVector f = p.poly.leadingExpVector();
+                mt = e.multipleOf(f);
+                if (mt) {
+                    ExpVector g = e.subtract(f);
+                    GenPolynomial<C> sigma = p.sigma.multiply(g);
+                    if (sigma.leadingExpVector().compareTo(A.sigma.leadingExpVector()) < 0) {
+                        return false;
+                    }
+                    if (sigma.leadingExpVector().compareTo(A.sigma.leadingExpVector()) == 0
+                                    && sigma.leadingBaseCoefficient()
+                                                    .compareTo(A.sigma.leadingBaseCoefficient()) != 0) {
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Is sigma redundant.
+     * @param A polynomial.
+     * @param G polynomial list.
+     * @return true if A is sigma redundant with respect to G.
+     */
+    public boolean isSigRedundant(List<SigPoly<C>> G, SigPoly<C> A) {
+        if (G.isEmpty()) {
+            return false;
+        }
+        ExpVector e = A.sigma.leadingExpVector();
+        if (e == null) {
+            e = A.poly.ring.evzero;
+        }
+        for (SigPoly<C> p : G) {
+            if (p.sigma.isZERO()) {
+                continue;
+            }
+            ExpVector f = p.sigma.leadingExpVector();
+            if (f == null) { // does not happen
+                f = p.poly.ring.evzero;
+            }
+            boolean mt = e.multipleOf(f);
+            if (mt) {
+                ExpVector g = e.subtract(f);
+                ExpVector h = p.poly.leadingExpVector();
+                h = h.sum(g);
+                if (h.compareTo(A.poly.leadingExpVector()) == 0) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+
+    /**
+     * Is sigma redundant, alternative algorithm.
+     * @param A polynomial.
+     * @param G polynomial list.
+     * @return true if A is sigma redundant per alternative algorithm with
+     *         respect to G.
+     */
+    public boolean isSigRedundantAlt(List<SigPoly<C>> G, SigPoly<C> A) {
+        if (G.isEmpty()) {
+            return false;
+        }
+        ExpVector e = A.sigma.leadingExpVector();
+        if (e == null) {
+            e = A.poly.ring.evzero;
+        }
+        for (SigPoly<C> p : G) {
+            if (p.sigma.isZERO()) {
+                continue;
+            }
+            ExpVector f = p.sigma.leadingExpVector();
+            if (f == null) { // does not happen
+                f = p.poly.ring.evzero;
+            }
+            boolean mt = e.multipleOf(f);
+            if (mt) {
+                if (p.poly.isZERO()) {
+                    continue;
+                }
+                ExpVector h = p.poly.leadingExpVector();
+                ExpVector g = A.poly.leadingExpVector();
+                if (g.multipleOf(h)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+
+    /**
+     * Top normalform.
+     * @param A polynomial.
+     * @param F polynomial list.
+     * @param G polynomial list.
+     * @return nf(A) with respect to F and G.
+     */
+    public SigPoly<C> sigNormalform(List<GenPolynomial<C>> F, List<SigPoly<C>> G, SigPoly<C> A) {
+        if (F.isEmpty() && G.isEmpty()) {
+            return A;
+        }
+        if (A.poly.isZERO()) {
+            return A;
+        }
+        List<GenPolynomial<C>> ff = F; //polys(F);
+        GenPolynomial<C> a = A.poly;
+        GenPolynomial<C> sigma = A.sigma;
+        GenPolynomialRing<C> ring = a.ring;
+        boolean reduced = true;
+        while (!a.isZERO() && reduced) {
+            reduced = false;
+            a = red.normalform(ff, a);
+            if (a.isZERO()) {
+                continue;
+            }
+            ExpVector e = a.leadingExpVector();
+            for (SigPoly<C> p : G) {
+                if (p.poly.isZERO()) {
+                    continue;
+                }
+                ExpVector f = p.poly.leadingExpVector();
+                boolean mt = e.multipleOf(f);
+                if (mt) {
+                    ExpVector g = e.subtract(f);
+                    C sc = a.leadingBaseCoefficient().divide(p.poly.leadingBaseCoefficient());
+                    GenPolynomial<C> sigup = p.sigma.multiply(sc, g);
+                    ExpVector se = sigma.leadingExpVector();
+                    if (se == null) {
+                        se = ring.evzero;
+                    }
+                    ExpVector sp = sigup.leadingExpVector();
+                    if (sp == null) {
+                        sp = ring.evzero;
+                    }
+                    //logger.info("sigup, sigma  = " + sigup + ", " + sigma);
+                    boolean sigeq = (sigup.compareTo(sigma) < 0)
+                                    || ((sp.compareTo(se) == 0 && (sigup.leadingBaseCoefficient()
+                                                    .compareTo(sigma.leadingBaseCoefficient()) != 0)));
+                    //logger.info("sigup < sigma = " + sigup.compareTo(sigma));
+                    if (sigeq) {
+                        reduced = true;
+                        a = a.subtractMultiple(sc, g, p.poly);
+                        if (sp.invGradCompareTo(se) == 0) {
+                            sigma = sigma.subtract(sigup);
+                        }
+                        if (a.isZERO()) {
+                            break;
+                        }
+                        e = a.leadingExpVector();
+                    } else {
+                        //logger.info("not reduced: a = " + a + ", p = " + p.poly);
+                    }
+                }
+            }
+        }
+        if (!a.isZERO()) {
+            C ac = a.leadingBaseCoefficient();
+            if (!ac.isONE()) {
+                ac = ac.inverse();
+                a = a.multiply(ac);
+                sigma = sigma.multiply(ac);
+            }
+        }
+        return new SigPoly<C>(sigma, a);
+    }
+
+
+    /**
+     * Top semi-complete normalform.
+     * @param A polynomial.
+     * @param F polynomial list.
+     * @param G polynomial list.
+     * @return nf(A) with respect to F and G.
+     */
+    public SigPoly<C> sigSemiNormalform(List<GenPolynomial<C>> F, List<SigPoly<C>> G, SigPoly<C> A) {
+        if (F.isEmpty() && G.isEmpty()) {
+            return A;
+        }
+        if (A.poly.isZERO()) {
+            return A;
+        }
+        List<GenPolynomial<C>> ff = F; //polys(F);
+        GenPolynomial<C> a = A.poly;
+        GenPolynomial<C> sigma = A.sigma;
+        ExpVector esig = sigma.leadingExpVector();
+        if (esig == null) {
+            logger.info("esig = null");
+            //esig = a.ring.evzero;
+        }
+        //GenPolynomialRing<C> ring = a.ring;
+        boolean reduced = true;
+        while (!a.isZERO() && reduced) {
+            reduced = false;
+            a = red.normalform(ff, a);
+            if (a.isZERO()) {
+                continue;
+            }
+            ExpVector e = a.leadingExpVector();
+            for (SigPoly<C> p : G) {
+                if (p.poly.isZERO()) {
+                    continue;
+                }
+                ExpVector f = p.poly.leadingExpVector();
+                boolean mt = e.multipleOf(f);
+                if (mt) {
+                    ExpVector g = e.subtract(f);
+                    C sc = a.leadingBaseCoefficient().divide(p.poly.leadingBaseCoefficient());
+                    GenPolynomial<C> sigup = p.sigma.multiply(sc, g);
+                    ExpVector eup = sigup.leadingExpVector();
+                    if (eup == null) {
+                        logger.info("eup = null");
+                        //eup = a.ring.evzero;
+                        throw new IllegalArgumentException("eup == null: " + sigup);
+                    }
+
+                    //wrong: boolean sigeq = (sigup.compareTo(sigma) < 0);
+                    boolean sigeq = (eup.compareTo(esig) < 0);
+                    if (sigeq) {
+                        //logger.info("reduced: sigup = " + sigup + ", sigma = " + sigma);
+                        reduced = true;
+                        a = a.subtractMultiple(sc, g, p.poly);
+                        if (a.isZERO()) {
+                            break;
+                        }
+                        e = a.leadingExpVector();
+                    } else {
+                        //logger.info("not reduced: a = " + a + ", p = " + p.poly);
+                    }
+                }
+            }
+        }
+        if (!a.isZERO()) {
+            C ac = a.leadingBaseCoefficient();
+            if (!ac.isONE()) {
+                ac = ac.inverse();
+                a = a.multiply(ac);
+            }
+        }
+        return new SigPoly<C>(sigma, a);
+    }
+
+
+    /**
+     * Select polynomials.
+     * @param F list of signature polynomials.
+     * @return the polynomials in F.
+     */
+    public List<GenPolynomial<C>> polys(List<SigPoly<C>> F) {
+        List<GenPolynomial<C>> ff = new ArrayList<GenPolynomial<C>>();
+        for (SigPoly<C> p : F) {
+            if (!p.poly.isZERO()) {
+                ff.add(p.poly);
+            }
+        }
+        return ff;
+    }
+
+
+    /**
+     * Select signatures.
+     * @param F list of signature polynomials.
+     * @return the signatures in F.
+     */
+    public List<GenPolynomial<C>> sigmas(List<SigPair<C>> F) {
+        List<GenPolynomial<C>> ff = new ArrayList<GenPolynomial<C>>();
+        for (SigPair<C> p : F) {
+            ff.add(p.sigma);
+        }
+        return ff;
+    }
+
+
+    /**
+     * Minimal degree of signatures.
+     * @param F list of signature polynomials.
+     * @return the minimal degree of the signatures in F.
+     */
+    public long minimalSigDegree(List<SigPair<C>> F) {
+        long deg = Long.MAX_VALUE;
+        for (SigPair<C> p : F) {
+            //long d = p.sigma.totalDegree();
+            long d = p.sigma.degree();
+            if (d < deg) {
+                deg = d;
+            }
+        }
+        return deg;
+    }
+
+
+    /**
+     * Select signature polynomials of minimal degree and non minimal degree.
+     * @param F list of signature polynomials.
+     * @return [m,p] where m is the list of signature polynomials of F of
+     *         minimal degree and p contains the rest of the signature
+     *         polynomials with non minimal degree.
+     */
+    public List<SigPair<C>>[] minDegSubset(List<SigPair<C>> F) {
+        long mdeg = minimalSigDegree(F);
+        List<SigPair<C>> ff = new ArrayList<SigPair<C>>();
+        List<SigPair<C>> pp = new ArrayList<SigPair<C>>();
+        for (SigPair<C> p : F) {
+            //if (p.sigma.totalDegree() == mdeg) {
+            if (p.sigma.degree() == mdeg) {
+                ff.add(p);
+            } else {
+                pp.add(p);
+            }
+        }
+        @SuppressWarnings("unchecked")
+        List<SigPair<C>>[] P = new List[2];
+        P[0] = ff;
+        P[1] = pp;
+        return P;
+    }
+
+
+    /**
+     * Sort signature polynomials according to the degree its signatures.
+     * @param F list of signature polynomials.
+     * @return list of signature polynomials sorted by degree of sigma.
+     */
+    public List<SigPair<C>> sortSigma(List<SigPair<C>> F) {
+        //Comparator<SigPair<C>> sigcmp = Comparator.comparing(SigPair::getSigma::degree);
+        Comparator<SigPair<C>> sigcmp = Comparator.comparingLong(SigPair::getSigmaDegree);
+        List<SigPair<C>> ff = F.stream().sorted(sigcmp).collect(Collectors.toList());
+        return ff;
+    }
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/SolvableExtendedGB.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/SolvableExtendedGB.java
@@ -1,0 +1,78 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+import java.util.List;
+
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.GenSolvablePolynomialRing;
+import edu.jas.poly.ModuleList;
+import edu.jas.poly.PolynomialList;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Container for a GB and transformation matrices.
+ * A container for F, G, calG and calF.
+ * Immutable objects.
+ * @param <C> coefficient type
+ * @param F an ideal base.
+ * @param G a Groebner base of F.
+ * @param F2G a transformation matrix from F to G.
+ * @param G2F a transformation matrix from G to F.
+ */
+public class SolvableExtendedGB<C extends RingElem<C>> {
+
+    public final List<GenSolvablePolynomial<C>> F;
+    public final List<GenSolvablePolynomial<C>> G;
+    public final List<List<GenSolvablePolynomial<C>>> F2G;
+    public final List<List<GenSolvablePolynomial<C>>> G2F;
+    public final GenSolvablePolynomialRing<C> ring;
+
+
+    public SolvableExtendedGB( List<GenSolvablePolynomial<C>> F,
+                               List<GenSolvablePolynomial<C>> G,
+                               List<List<GenSolvablePolynomial<C>>> F2G,
+                               List<List<GenSolvablePolynomial<C>>> G2F) {
+        this.F = F;
+        this.G = G;
+        this.F2G = F2G;
+        this.G2F = G2F;
+        GenSolvablePolynomialRing<C> r = null;
+        if ( G != null ) {
+            for ( GenSolvablePolynomial<C> p : G ) {
+                if ( p != null ) {
+                    r = p.ring;
+                    break;
+                }
+            }
+            if ( r != null && r.getVars() == null ) {
+                r.setVars( r.newVars("y") );
+            }
+        }
+        this.ring = r;
+    }
+
+
+    /** Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        PolynomialList<C> P;
+        ModuleList<C> M;
+        StringBuffer s = new StringBuffer("SolvableExtendedGB: \n\n");
+        P = new PolynomialList<C>( ring, F );
+        s.append("F = " + P + "\n\n");
+        P = new PolynomialList<C>( ring, G );
+        s.append("G = " + P + "\n\n");
+        M = new ModuleList<C>( ring, F2G );
+        s.append("F2G = " + M + "\n\n");
+        M = new ModuleList<C>( ring, G2F );
+        s.append("G2F = " + M + "\n");
+        return s.toString();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/SolvableGroebnerBase.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/SolvableGroebnerBase.java
@@ -1,0 +1,220 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.io.Serializable;
+import java.util.List;
+
+import edu.jas.poly.ModuleList;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Solvable Groebner Bases interface. Defines methods for left, right and
+ * twosided Groebner bases and left, right and twosided GB tests.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public interface SolvableGroebnerBase<C extends RingElem<C>> extends Serializable {
+
+
+    /**
+     * Left Groebner base test.
+     * @param F solvable polynomial list.
+     * @return true, if F is a left Groebner base, else false.
+     */
+    public boolean isLeftGB(List<GenSolvablePolynomial<C>> F);
+
+
+    /**
+     * Left Groebner base test.
+     * @param modv number of module variables.
+     * @param F solvable polynomial list.
+     * @return true, if F is a left Groebner base, else false.
+     */
+    public boolean isLeftGB(int modv, List<GenSolvablePolynomial<C>> F);
+
+
+    /**
+     * Twosided Groebner base test.
+     * @param Fp solvable polynomial list.
+     * @return true, if Fp is a two-sided Groebner base, else false.
+     */
+    public boolean isTwosidedGB(List<GenSolvablePolynomial<C>> Fp);
+
+
+    /**
+     * Twosided Groebner base test.
+     * @param modv number of module variables.
+     * @param Fp solvable polynomial list.
+     * @return true, if Fp is a two-sided Groebner base, else false.
+     */
+    public boolean isTwosidedGB(int modv, List<GenSolvablePolynomial<C>> Fp);
+
+
+    /**
+     * Right Groebner base test.
+     * @param F solvable polynomial list.
+     * @return true, if F is a right Groebner base, else false.
+     */
+    public boolean isRightGB(List<GenSolvablePolynomial<C>> F);
+
+
+    /**
+     * Right Groebner base test.
+     * @param modv number of module variables.
+     * @param F solvable polynomial list.
+     * @return true, if F is a right Groebner base, else false.
+     */
+    public boolean isRightGB(int modv, List<GenSolvablePolynomial<C>> F);
+
+
+    /**
+     * Left Groebner base using pairlist class.
+     * @param F solvable polynomial list.
+     * @return leftGB(F) a left Groebner base of F.
+     */
+    public List<GenSolvablePolynomial<C>> leftGB(List<GenSolvablePolynomial<C>> F);
+
+
+    /**
+     * Left Groebner base using pairlist class.
+     * @param modv number of module variables.
+     * @param F solvable polynomial list.
+     * @return leftGB(F) a left Groebner base of F.
+     */
+    public List<GenSolvablePolynomial<C>> leftGB(int modv, List<GenSolvablePolynomial<C>> F);
+
+
+    /**
+     * Solvable Extended Groebner base using critical pair class.
+     * @param F solvable polynomial list.
+     * @return a container for an extended left Groebner base of F.
+     */
+    public SolvableExtendedGB<C> extLeftGB(List<GenSolvablePolynomial<C>> F);
+
+
+    /**
+     * Solvable Extended Groebner base using critical pair class.
+     * @param modv module variable number.
+     * @param F solvable polynomial list.
+     * @return a container for an extended left Groebner base of F.
+     */
+    public SolvableExtendedGB<C> extLeftGB(int modv, List<GenSolvablePolynomial<C>> F);
+
+
+    /**
+     * Left minimal ordered groebner basis.
+     * @param Gp a left Groebner base.
+     * @return leftGBmi(F) a minimal left Groebner base of Gp.
+     */
+    public List<GenSolvablePolynomial<C>> leftMinimalGB(List<GenSolvablePolynomial<C>> Gp);
+
+
+    /**
+     * Twosided Groebner base using pairlist class.
+     * @param Fp solvable polynomial list.
+     * @return tsGB(Fp) a twosided Groebner base of Fp.
+     */
+    public List<GenSolvablePolynomial<C>> twosidedGB(List<GenSolvablePolynomial<C>> Fp);
+
+
+    /**
+     * Twosided Groebner base using pairlist class.
+     * @param modv number of module variables.
+     * @param Fp solvable polynomial list.
+     * @return tsGB(Fp) a twosided Groebner base of Fp.
+     */
+    public List<GenSolvablePolynomial<C>> twosidedGB(int modv, List<GenSolvablePolynomial<C>> Fp);
+
+
+    /**
+     * Right Groebner base using opposite ring left GB.
+     * @param F solvable polynomial list.
+     * @return rightGB(F) a right Groebner base of F.
+     */
+    public List<GenSolvablePolynomial<C>> rightGB(List<GenSolvablePolynomial<C>> F);
+
+
+    /**
+     * Right Groebner base using opposite ring left GB.
+     * @param modv number of module variables.
+     * @param F solvable polynomial list.
+     * @return rightGB(F) a right Groebner base of F.
+     */
+    public List<GenSolvablePolynomial<C>> rightGB(int modv, List<GenSolvablePolynomial<C>> F);
+
+
+    /**
+     * Test if left reduction matrix.
+     * @param exgb an SolvableExtendedGB container.
+     * @return true, if exgb contains a left reduction matrix, else false.
+     */
+    public boolean isLeftReductionMatrix(SolvableExtendedGB<C> exgb);
+
+
+    /**
+     * Test if left reduction matrix.
+     * @param F a solvable polynomial list.
+     * @param G a left Groebner base.
+     * @param Mf a possible left reduction matrix.
+     * @param Mg a possible left reduction matrix.
+     * @return true, if Mg and Mf are left reduction matrices, else false.
+     */
+    public boolean isLeftReductionMatrix(List<GenSolvablePolynomial<C>> F, List<GenSolvablePolynomial<C>> G,
+                    List<List<GenSolvablePolynomial<C>>> Mf, List<List<GenSolvablePolynomial<C>>> Mg);
+
+
+    /**
+     * Module left Groebner base test.
+     * @param M a module basis.
+     * @return true, if M is a left Groebner base, else false.
+     */
+    public boolean isLeftGB(ModuleList<C> M);
+
+
+    /**
+     * Left Groebner base using pairlist class.
+     * @param M a module basis.
+     * @return leftGB(M) a left Groebner base for M.
+     */
+    public ModuleList<C> leftGB(ModuleList<C> M);
+
+
+    /**
+     * Module twosided Groebner base test.
+     * @param M a module basis.
+     * @return true, if M is a twosided Groebner base, else false.
+     */
+    public boolean isTwosidedGB(ModuleList<C> M);
+
+
+    /**
+     * Twosided Groebner base using pairlist class.
+     * @param M a module basis.
+     * @return tsGB(M) a twosided Groebner base for M.
+     */
+    public ModuleList<C> twosidedGB(ModuleList<C> M);
+
+
+    /**
+     * Module right Groebner base test.
+     * @param M a module basis.
+     * @return true, if M is a right Groebner base, else false.
+     */
+    public boolean isRightGB(ModuleList<C> M);
+
+
+    /**
+     * Right Groebner base using pairlist class.
+     * @param M a module basis.
+     * @return rightGB(M) a right Groebner base for M.
+     */
+    public ModuleList<C> rightGB(ModuleList<C> M);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/SolvableGroebnerBaseAbstract.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/SolvableGroebnerBaseAbstract.java
@@ -1,0 +1,1112 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ListIterator;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.GenSolvablePolynomialRing;
+import edu.jas.poly.QLRSolvablePolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.poly.PolynomialList;
+import edu.jas.poly.ModuleList;
+import edu.jas.poly.TermOrder;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.vector.BasicLinAlg;
+
+
+/**
+ * Solvable Groebner Bases abstract class. Implements common left, right and
+ * twosided Groebner bases and left, right and twosided GB tests.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public abstract class SolvableGroebnerBaseAbstract<C extends RingElem<C>> implements SolvableGroebnerBase<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(SolvableGroebnerBaseAbstract.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Solvable reduction engine.
+     */
+    public SolvableReduction<C> sred;
+
+
+    /**
+     * Reduction engine.
+     */
+    public final Reduction<C> red;
+
+
+    /**
+     * Strategy for pair selection.
+     */
+    public final PairList<C> strategy;
+
+
+    /**
+     * Linear algebra engine.
+     */
+    protected final BasicLinAlg<GenPolynomial<C>> blas;
+
+
+    /**
+     * Commutative Groebner bases engine.
+     */
+    public final GroebnerBaseAbstract<C> cbb;
+
+
+    /**
+     * Constructor.
+     */
+    public SolvableGroebnerBaseAbstract() {
+        this(new SolvableReductionSeq<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param sred Solvable reduction engine
+     */
+    public SolvableGroebnerBaseAbstract(SolvableReduction<C> sred) {
+        this(sred, new OrderedPairlist<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param pl pair selection strategy
+     */
+    public SolvableGroebnerBaseAbstract(PairList<C> pl) {
+        this(new SolvableReductionSeq<C>(), pl);
+    }
+
+
+    /**
+     * Constructor.
+     * @param sred Solvable reduction engine
+     * @param pl pair selection strategy
+     */
+    public SolvableGroebnerBaseAbstract(SolvableReduction<C> sred, PairList<C> pl) {
+        this.red = new ReductionSeq<C>();
+        this.sred = sred;
+        this.strategy = pl;
+        blas = new BasicLinAlg<GenPolynomial<C>>();
+        cbb = new GroebnerBaseSeq<C>();
+    }
+
+
+    /**
+     * Normalize polynomial list.
+     * @param A list of polynomials.
+     * @return list of polynomials with zeros removed and ones/units reduced.
+     */
+    public List<GenSolvablePolynomial<C>> normalizeZerosOnes(List<GenSolvablePolynomial<C>> A) {
+        //List<GenPolynomial<C>> a = PolynomialList.<C> castToList(A);
+        //List<GenPolynomial<C>> n = cbb.normalizeZeroOnes(a);
+        //List<GenSolvablePolynomial<C>> N = PolynomialList.<C> castToSolvableList(n);
+        if (A == null) {
+            return A;
+        }
+        List<GenSolvablePolynomial<C>> N = new ArrayList<GenSolvablePolynomial<C>>(A.size());
+        if (A.isEmpty()) {
+            return N;
+        }
+        for (GenSolvablePolynomial<C> p : A) {
+            if (p == null || p.isZERO()) {
+                continue;
+            }
+            if (p.isUnit()) {
+                N.clear();
+                N.add(p.ring.getONE());
+                return N;
+            }
+            N.add((GenSolvablePolynomial<C>) p.abs());
+        }
+        //N.trimToSize();
+        return N;
+    }
+
+
+    /**
+     * Left Groebner base test.
+     * @param F solvable polynomial list.
+     * @return true, if F is a left Groebner base, else false.
+     */
+    public boolean isLeftGB(List<GenSolvablePolynomial<C>> F) {
+        return isLeftGB(0, F, true);
+    }
+
+
+    /**
+     * Left Groebner base test.
+     * @param F solvable polynomial list.
+     * @param b true for simple test, false for GB test.
+     * @return true, if F is a Groebner base, else false.
+     */
+    public boolean isLeftGB(List<GenSolvablePolynomial<C>> F, boolean b) {
+        return isLeftGB(0, F, b);
+    }
+
+
+    /**
+     * Left Groebner base test.
+     * @param modv module variable number.
+     * @param F solvable polynomial list.
+     * @return true, if F is a Groebner base, else false.
+     */
+    public boolean isLeftGB(int modv, List<GenSolvablePolynomial<C>> F) {
+        return isLeftGB(modv, F, true);
+    }
+
+
+    /**
+     * Left Groebner base test.
+     * @param modv module variable number.
+     * @param F solvable polynomial list.
+     * @param b true for simple test, false for GB test.
+     * @return true, if F is a Groebner base, else false.
+     */
+    public boolean isLeftGB(int modv, List<GenSolvablePolynomial<C>> F, boolean b) {
+        if (b) {
+            return isLeftGBsimple(modv, F);
+        }
+        return isLeftGBidem(modv, F);
+    }
+
+
+    /**
+     * Left Groebner base test.
+     * @param modv number of module variables.
+     * @param F solvable polynomial list.
+     * @return true, if F is a left Groebner base, else false.
+     */
+    public boolean isLeftGBsimple(int modv, List<GenSolvablePolynomial<C>> F) {
+        GenSolvablePolynomial<C> pi, pj, s, h;
+        for (int i = 0; i < F.size(); i++) {
+            pi = F.get(i);
+            for (int j = i + 1; j < F.size(); j++) {
+                pj = F.get(j);
+                if (!red.moduleCriterion(modv, pi, pj)) {
+                    continue;
+                }
+                // if ( ! red.criterion4( pi, pj ) ) { continue; }
+                s = sred.leftSPolynomial(pi, pj);
+                if (s.isZERO()) {
+                    continue;
+                }
+                h = sred.leftNormalform(F, s);
+                if (!h.isZERO()) {
+                    logger.info("no left GB: pi = " + pi + ", pj = " + pj);
+                    logger.info("s  = " + s + ", h = " + h);
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Left Groebner base idempotence test.
+     * @param modv module variable number.
+     * @param F solvable polynomial list.
+     * @return true, if F is equal to GB(F), else false.
+     */
+    public boolean isLeftGBidem(int modv, List<GenSolvablePolynomial<C>> F) {
+        if (F == null || F.isEmpty()) {
+            return true;
+        }
+        GenSolvablePolynomialRing<C> pring = F.get(0).ring;
+        List<GenSolvablePolynomial<C>> G = leftGB(modv, F);
+        PolynomialList<C> Fp = new PolynomialList<C>(pring, F);
+        PolynomialList<C> Gp = new PolynomialList<C>(pring, G);
+        return Fp.compareTo(Gp) == 0;
+    }
+
+
+    /**
+     * Twosided Groebner base test.
+     * @param Fp solvable polynomial list.
+     * @return true, if Fp is a two-sided Groebner base, else false.
+     */
+    public boolean isTwosidedGB(List<GenSolvablePolynomial<C>> Fp) {
+        return isTwosidedGB(0, Fp);
+    }
+
+
+    /**
+     * Twosided Groebner base test.
+     * @param modv number of module variables.
+     * @param Fp solvable polynomial list.
+     * @return true, if Fp is a two-sided Groebner base, else false.
+     */
+    public boolean isTwosidedGB(int modv, List<GenSolvablePolynomial<C>> Fp) {
+        if (Fp == null || Fp.size() == 0) { // 0 not 1
+            return true;
+        }
+        if (Fp.size() == 1 && Fp.get(0).isONE()) { 
+            return true;
+        }
+        GenSolvablePolynomialRing<C> ring = Fp.get(0).ring; // assert != null
+        // add also coefficient generators
+        List<GenSolvablePolynomial<C>> X;
+        X = PolynomialList.castToSolvableList(ring.generators(modv)); 
+        logger.info("right multipliers = " + X);
+        List<GenSolvablePolynomial<C>> F = new ArrayList<GenSolvablePolynomial<C>>(Fp.size() * (1 + X.size()));
+        F.addAll(Fp);
+        GenSolvablePolynomial<C> p, q, x, pi, pj, s, h;
+        for (int i = 0; i < Fp.size(); i++) {
+            p = Fp.get(i);
+            for (int j = 0; j < X.size(); j++) {
+                x = X.get(j);
+                if (x.isONE()) {
+                    continue;
+                }
+                q = p.multiply(x);
+                q = sred.leftNormalform(F, q);
+                //System.out.println("is: q generated = " + q + ", p = " + p + ", x = " + x);
+                if (!q.isZERO()) {
+                    return false;
+                    //F.add(q);
+                }
+            }
+        }
+        //System.out.println("F to check = " + F);
+        for (int i = 0; i < F.size(); i++) {
+            pi = F.get(i);
+            for (int j = i + 1; j < F.size(); j++) {
+                pj = F.get(j);
+                if (!red.moduleCriterion(modv, pi, pj)) {
+                    continue;
+                }
+                // if ( ! red.criterion4( pi, pj ) ) { continue; }
+                s = sred.leftSPolynomial(pi, pj);
+                if (s.isZERO()) {
+                    continue;
+                }
+                h = sred.leftNormalform(F, s);
+                if (!h.isZERO()) {
+                    logger.info("is not TwosidedGB: " + h);
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Twosided Groebner base idempotence test.
+     * @param F solvable polynomial list.
+     * @return true, if F is equal to GB(F), else false.
+     */
+    public boolean isTwosidedGBidem(List<GenSolvablePolynomial<C>> F) {
+        return isTwosidedGBidem(0, F);
+    }
+
+
+    /**
+     * Twosided Groebner base idempotence test.
+     * @param modv module variable number.
+     * @param F solvable polynomial list.
+     * @return true, if F is equal to GB(F), else false.
+     */
+    public boolean isTwosidedGBidem(int modv, List<GenSolvablePolynomial<C>> F) {
+        if (F == null || F.isEmpty()) {
+            return true;
+        }
+        GenSolvablePolynomialRing<C> pring = F.get(0).ring;
+        List<GenSolvablePolynomial<C>> G = twosidedGB(modv, F);
+        PolynomialList<C> Fp = new PolynomialList<C>(pring, F);
+        PolynomialList<C> Gp = new PolynomialList<C>(pring, G);
+        return Fp.compareTo(Gp) == 0;
+    }
+
+
+    /**
+     * Right Groebner base test.
+     * @param F solvable polynomial list.
+     * @return true, if F is a right Groebner base, else false.
+     */
+    public boolean isRightGB(List<GenSolvablePolynomial<C>> F) {
+        return isRightGB(0, F);
+    }
+
+
+    /**
+     * Right Groebner base test.
+     * @param modv number of module variables.
+     * @param F solvable polynomial list.
+     * @return true, if F is a right Groebner base, else false.
+     */
+    public boolean isRightGB(int modv, List<GenSolvablePolynomial<C>> F) {
+        GenSolvablePolynomial<C> pi, pj, s, h;
+        for (int i = 0; i < F.size(); i++) {
+            pi = F.get(i);
+            //System.out.println("pi right = " + pi);
+            for (int j = i + 1; j < F.size(); j++) {
+                pj = F.get(j);
+                //System.out.println("pj right = " + pj);
+                if (!red.moduleCriterion(modv, pi, pj)) {
+                    continue;
+                }
+                // if ( ! red.criterion4( pi, pj ) ) { continue; }
+                s = sred.rightSPolynomial(pi, pj);
+                if (s.isZERO()) {
+                    continue;
+                }
+                //System.out.println("s right = " + s);
+                h = sred.rightNormalform(F, s);
+                if (!h.isZERO()) {
+                    logger.info("isRightGB non zero h = " + h + " :: " + h.ring);
+                    logger.info("p" + i + " = " + pi + ", p" + j + " = " + pj);
+                    return false;
+                    //} else {
+                    //logger.info("isRightGB zero h = " + h);
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Right Groebner base idempotence test.
+     * @param F solvable polynomial list.
+     * @return true, if F is equal to GB(F), else false.
+     */
+    public boolean isRightGBidem(List<GenSolvablePolynomial<C>> F) {
+        return isRightGBidem(0, F);
+    }
+
+
+    /**
+     * Right Groebner base idempotence test.
+     * @param modv module variable number.
+     * @param F solvable polynomial list.
+     * @return true, if F is equal to GB(F), else false.
+     */
+    public boolean isRightGBidem(int modv, List<GenSolvablePolynomial<C>> F) {
+        if (F == null || F.isEmpty()) {
+            return true;
+        }
+        GenSolvablePolynomialRing<C> pring = F.get(0).ring;
+        List<GenSolvablePolynomial<C>> G = rightGB(modv, F);
+        PolynomialList<C> Fp = new PolynomialList<C>(pring, F);
+        PolynomialList<C> Gp = new PolynomialList<C>(pring, G);
+        return Fp.compareTo(Gp) == 0;
+    }
+
+
+    /**
+     * Left Groebner base using pairlist class.
+     * @param F solvable polynomial list.
+     * @return leftGB(F) a left Groebner base of F.
+     */
+    public List<GenSolvablePolynomial<C>> leftGB(List<GenSolvablePolynomial<C>> F) {
+        return leftGB(0, F);
+    }
+
+
+    /**
+     * Solvable Extended Groebner base using critical pair class.
+     * @param F solvable polynomial list.
+     * @return a container for an extended left Groebner base of F.
+     */
+    public SolvableExtendedGB<C> extLeftGB(List<GenSolvablePolynomial<C>> F) {
+        return extLeftGB(0, F);
+    }
+
+
+    /**
+     * Solvable Extended Groebner base using critical pair class.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return a container for an extended left Groebner base G of F together
+     *         with back-and-forth transformations.
+     */
+    public SolvableExtendedGB<C> extLeftGB(int modv, List<GenSolvablePolynomial<C>> F) {
+        throw new UnsupportedOperationException("extLeftGB not implemented in "
+                        + this.getClass().getSimpleName());
+    }
+
+
+    /**
+     * Left minimal ordered groebner basis.
+     * @param Gp a left Groebner base.
+     * @return leftGBmi(F) a minimal left Groebner base of Gp.
+     */
+    public List<GenSolvablePolynomial<C>> leftMinimalGB(List<GenSolvablePolynomial<C>> Gp) {
+        ArrayList<GenSolvablePolynomial<C>> G = new ArrayList<GenSolvablePolynomial<C>>();
+        ListIterator<GenSolvablePolynomial<C>> it = Gp.listIterator();
+        for (GenSolvablePolynomial<C> a : Gp) {
+            // a = (SolvablePolynomial) it.next();
+            if (a.length() != 0) { // always true
+                // already monic a = a.monic();
+                G.add(a);
+            }
+        }
+        if (G.size() <= 1) {
+            return G;
+        }
+
+        ExpVector e;
+        ExpVector f;
+        GenSolvablePolynomial<C> a, p;
+        ArrayList<GenSolvablePolynomial<C>> F = new ArrayList<GenSolvablePolynomial<C>>();
+        boolean mt;
+
+        while (G.size() > 0) {
+            a = G.remove(0);
+            e = a.leadingExpVector();
+
+            it = G.listIterator();
+            mt = false;
+            while (it.hasNext() && !mt) {
+                p = it.next();
+                f = p.leadingExpVector();
+                mt = e.multipleOf(f);
+            }
+            it = F.listIterator();
+            while (it.hasNext() && !mt) {
+                p = it.next();
+                f = p.leadingExpVector();
+                mt = e.multipleOf(f);
+            }
+            if (!mt) {
+                F.add(a);
+            } else {
+                // System.out.println("dropped " + a.length());
+            }
+        }
+        G = F;
+        if (G.size() <= 1) {
+            return G;
+        }
+
+        F = new ArrayList<GenSolvablePolynomial<C>>();
+        while (G.size() > 0) {
+            a = G.remove(0);
+            // System.out.println("doing " + a.length());
+            a = sred.leftNormalform(G, a);
+            a = sred.leftNormalform(F, a);
+            F.add(a);
+        }
+        return F;
+    }
+
+
+    /**
+     * Right minimal ordered groebner basis.
+     * @param Gp a right Groebner base.
+     * @return rightGBmi(F) a minimal right Groebner base of Gp.
+     */
+    public List<GenSolvablePolynomial<C>> rightMinimalGB(List<GenSolvablePolynomial<C>> Gp) {
+        ArrayList<GenSolvablePolynomial<C>> G = new ArrayList<GenSolvablePolynomial<C>>();
+        ListIterator<GenSolvablePolynomial<C>> it = Gp.listIterator();
+        for (GenSolvablePolynomial<C> a : Gp) {
+            if (a.length() != 0) { // always true
+                G.add(a);
+            }
+        }
+        if (G.size() <= 1) {
+            return G;
+        }
+
+        ExpVector e;
+        ExpVector f;
+        GenSolvablePolynomial<C> a, p;
+        ArrayList<GenSolvablePolynomial<C>> F = new ArrayList<GenSolvablePolynomial<C>>();
+        boolean mt;
+
+        while (G.size() > 0) {
+            a = G.remove(0);
+            e = a.leadingExpVector();
+
+            it = G.listIterator();
+            mt = false;
+            while (it.hasNext() && !mt) {
+                p = it.next();
+                f = p.leadingExpVector();
+                mt = e.multipleOf(f);
+            }
+            it = F.listIterator();
+            while (it.hasNext() && !mt) {
+                p = it.next();
+                f = p.leadingExpVector();
+                mt = e.multipleOf(f);
+            }
+            if (!mt) {
+                F.add(a);
+            } else {
+                // System.out.println("dropped " + a.length());
+            }
+        }
+        G = F;
+        if (G.size() <= 1) {
+            return G;
+        }
+
+        F = new ArrayList<GenSolvablePolynomial<C>>();
+        while (G.size() > 0) {
+            a = G.remove(0);
+            // System.out.println("doing " + a.length());
+            a = sred.rightNormalform(G, a);
+            a = sred.rightNormalform(F, a);
+            F.add(a);
+        }
+        return F;
+    }
+
+
+    /**
+     * Twosided Groebner base using pairlist class.
+     * @param Fp solvable polynomial list.
+     * @return tsGB(Fp) a twosided Groebner base of Fp.
+     */
+    public List<GenSolvablePolynomial<C>> twosidedGB(List<GenSolvablePolynomial<C>> Fp) {
+        return twosidedGB(0, Fp);
+    }
+
+
+    /**
+     * Right Groebner base using opposite ring left GB.
+     * @param F solvable polynomial list.
+     * @return rightGB(F) a right Groebner base of F.
+     */
+    public List<GenSolvablePolynomial<C>> rightGB(List<GenSolvablePolynomial<C>> F) {
+        return rightGB(0, F);
+    }
+
+
+    /**
+     * Right Groebner base using opposite ring left GB.
+     * @param modv number of module variables.
+     * @param F solvable polynomial list.
+     * @return rightGB(F) a right Groebner base of F.
+     */
+    @SuppressWarnings("unchecked")
+    public List<GenSolvablePolynomial<C>> rightGB(int modv, List<GenSolvablePolynomial<C>> F) {
+        List<GenSolvablePolynomial<C>> G = normalizeZerosOnes(F);
+        if (G.size() <= 1) {
+            return G;
+        }
+        GenSolvablePolynomialRing<C> ring = G.get(0).ring; // assert != null
+        GenSolvablePolynomialRing<C> rring = ring.reverse(true); //true
+        //System.out.println("reversed ring = " + rring);
+        GenSolvablePolynomial<C> q;
+        List<GenSolvablePolynomial<C>> rF;
+        rF = new ArrayList<GenSolvablePolynomial<C>>(F.size());
+        for (GenSolvablePolynomial<C> p : F) {
+            if (p != null) {
+                q = (GenSolvablePolynomial<C>) p.reverse(rring);
+                rF.add(q);
+            }
+        }
+        if (logger.isInfoEnabled()) {
+            PolynomialList<C> pl = new PolynomialList<C>(rring, rF);
+            logger.info("reversed problem = " + pl.toScript());
+        }
+        List<GenSolvablePolynomial<C>> rG = leftGB(modv, rF);
+        if (debug) {
+            //PolynomialList<C> pl = new PolynomialList<C>(rring,rG);
+            //logger.info("reversed GB = " + pl);
+            long t = System.currentTimeMillis();
+            boolean isit = isLeftGB(rG);
+            t = System.currentTimeMillis() - t;
+            logger.info("is left GB = " + isit + ", in " + t + " milliseconds");
+        }
+        //System.out.println("reversed left GB = " + rG);
+        ring = rring.reverse(true); // true
+        G = new ArrayList<GenSolvablePolynomial<C>>(rG.size());
+        for (GenSolvablePolynomial<C> p : rG) {
+            if (p != null) {
+                q = (GenSolvablePolynomial<C>) p.reverse(ring);
+                G.add(q);
+            }
+        }
+        if (debug) {
+            //PolynomialList<C> pl = new PolynomialList<C>(ring,G);
+            //logger.info("GB = " + pl);
+            long t = System.currentTimeMillis();
+            boolean isit = isRightGB(G);
+            t = System.currentTimeMillis() - t;
+            logger.info("is right GB = " + isit + ", in " + t + " milliseconds");
+        }
+        return G;
+    }
+
+
+    /**
+     * Module left Groebner base test.
+     * @param M a module basis.
+     * @return true, if M is a left Groebner base, else false.
+     */
+    public boolean isLeftGB(ModuleList<C> M) {
+        return isLeftGB(M,false);
+    }
+
+
+    /**
+     * Module left Groebner base test.
+     * @param M a module basis.
+     * @param top true for TOP term order, false for POT term order.
+     * @return true, if M is a left Groebner base, else false.
+     */
+    public boolean isLeftGB(ModuleList<C> M, boolean top) {
+        if (M == null || M.list == null) {
+            return true;
+        }
+        if (M.rows == 0 || M.cols == 0) {
+            return true;
+        }
+        int modv = M.cols; // > 0  
+        PolynomialList<C> F = M.getPolynomialList(top);
+        return isLeftGB(modv, F.castToSolvableList());
+    }
+
+
+    /**
+     * Left Groebner base using pairlist class.
+     * @param M a module basis.
+     * @return leftGB(M) a left Groebner base for M.
+     */
+    public ModuleList<C> leftGB(ModuleList<C> M) {
+        return leftGB(M,false);
+    }
+
+
+    /**
+     * Left Groebner base using pairlist class.
+     * @param M a module basis.
+     * @param top true for TOP term order, false for POT term order.
+     * @return leftGB(M) a left Groebner base for M.
+     */
+    @SuppressWarnings("unchecked")
+    public ModuleList<C> leftGB(ModuleList<C> M, boolean top) {
+        ModuleList<C> N = M;
+        if (M == null || M.list == null) {
+            return N;
+        }
+        if (M.rows == 0 || M.cols == 0) {
+            return N;
+        }
+        PolynomialList<C> F = M.getPolynomialList(top);
+        if (debug) {
+            logger.info("F left +++++++++++++++++++ \n" + F);
+        }
+        GenSolvablePolynomialRing<C> sring = (GenSolvablePolynomialRing<C>) F.ring;
+        int modv = M.cols;
+        List<GenSolvablePolynomial<C>> G = leftGB(modv, F.castToSolvableList());
+        F = new PolynomialList<C>(sring, G);
+        if (debug) {
+            logger.info("G left +++++++++++++++++++ \n" + F);
+        }
+        N = F.getModuleList(modv);
+        return N;
+    }
+
+
+    /**
+     * Module twosided Groebner base test.
+     * @param M a module basis.
+     * @return true, if M is a twosided Groebner base, else false.
+     */
+    public boolean isTwosidedGB(ModuleList<C> M) {
+        return isTwosidedGB(M,false);
+    }
+
+
+    /**
+     * Module twosided Groebner base test.
+     * @param M a module basis.
+     * @param top true for TOP term order, false for POT term order.
+     * @return true, if M is a twosided Groebner base, else false.
+     */
+    public boolean isTwosidedGB(ModuleList<C> M, boolean top) {
+        if (M == null || M.list == null) {
+            return true;
+        }
+        if (M.rows == 0 || M.cols == 0) {
+            return true;
+        }
+        PolynomialList<C> F = M.getPolynomialList(top);
+        int modv = M.cols; // > 0  
+        return isTwosidedGB(modv, F.castToSolvableList());
+    }
+
+
+    /**
+     * Twosided Groebner base using pairlist class.
+     * @param M a module basis.
+     * @return twosidedGB(M) a twosided Groebner base for M.
+     */
+    public ModuleList<C> twosidedGB(ModuleList<C> M) {
+        return twosidedGB(M,false);
+    }
+
+
+    /**
+     * Twosided Groebner base using pairlist class.
+     * @param M a module basis.
+     * @param top true for TOP term order, false for POT term order.
+     * @return tsGB(M) a twosided Groebner base for M.
+     */
+    @SuppressWarnings("unchecked")
+    public ModuleList<C> twosidedGB(ModuleList<C> M, boolean top) {
+        ModuleList<C> N = M;
+        if (M == null || M.list == null) {
+            return N;
+        }
+        if (M.rows == 0 || M.cols == 0) {
+            return N;
+        }
+        PolynomialList<C> F = M.getPolynomialList(top);
+        GenSolvablePolynomialRing<C> sring = (GenSolvablePolynomialRing<C>) F.ring;
+        int modv = M.cols;
+        List<GenSolvablePolynomial<C>> G = twosidedGB(modv, F.castToSolvableList());
+        F = new PolynomialList<C>(sring, G);
+        N = F.getModuleList(modv);
+        return N;
+    }
+
+
+    /**
+     * Module right Groebner base test.
+     * @param M a module basis.
+     * @return true, if M is a right Groebner base, else false.
+     */
+    public boolean isRightGB(ModuleList<C> M) {
+        return isRightGB(M,false);
+    }
+
+
+    /**
+     * Module right Groebner base test.
+     * @param M a module basis.
+     * @param top true for TOP term order, false for POT term order.
+     * @return true, if M is a right Groebner base, else false.
+     */
+    public boolean isRightGB(ModuleList<C> M, boolean top) {
+        if (M == null || M.list == null) {
+            return true;
+        }
+        if (M.rows == 0 || M.cols == 0) {
+            return true;
+        }
+        if (top) {
+            logger.warn("computation of rightGB with TOP not possible");
+        }
+        int modv = M.cols; // > 0  
+        PolynomialList<C> F = M.getPolynomialList(top);
+        //System.out.println("F test = " + F);
+        return isRightGB(modv, F.castToSolvableList());
+    }
+
+
+    /**
+     * Right Groebner base using pairlist class.
+     * @param M a module basis.
+     * @return rightGB(M) a right Groebner base for M.
+     */
+    @SuppressWarnings("unchecked")
+    public ModuleList<C> rightGB(ModuleList<C> M) { // boolean top
+        ModuleList<C> N = M;
+        if (M == null || M.list == null) {
+            return N;
+        }
+        if (M.rows == 0 || M.cols == 0) {
+            return N;
+        }
+        if (debug) {
+            logger.info("M ====================== \n" + M);
+        }
+        TermOrder to = M.ring.tord;
+        if (to.getSplit() <= M.ring.nvar) {
+            throw new IllegalArgumentException("extended TermOrders not supported for rightGBs: " + to);
+        }
+        List<List<GenSolvablePolynomial<C>>> mlist = M.castToSolvableList();
+        GenSolvablePolynomialRing<C> sring = (GenSolvablePolynomialRing<C>) M.ring;
+        GenSolvablePolynomialRing<C> rring = sring.reverse(true); //true
+        sring = rring.reverse(true); // true
+
+        List<List<GenSolvablePolynomial<C>>> nlist = new ArrayList<List<GenSolvablePolynomial<C>>>(M.rows);
+        for (List<GenSolvablePolynomial<C>> row : mlist) {
+            List<GenSolvablePolynomial<C>> nrow = new ArrayList<GenSolvablePolynomial<C>>(row.size());
+            for (GenSolvablePolynomial<C> elem : row) {
+                GenSolvablePolynomial<C> nelem = (GenSolvablePolynomial<C>) elem.reverse(rring);
+                nrow.add(nelem);
+            }
+            nlist.add(nrow);
+        }
+        ModuleList<C> rM = new ModuleList<C>(rring, nlist);
+        if (debug) {
+            logger.info("rM -------------------- \n" + rM);
+        }
+        ModuleList<C> rMg = leftGB(rM); // top ?
+        if (debug) {
+            logger.info("rMg -------------------- \n" + rMg);
+            logger.info("isLeftGB(rMg) ---------- " + isLeftGB(rMg));
+        }
+        mlist = rMg.castToSolvableList();
+        nlist = new ArrayList<List<GenSolvablePolynomial<C>>>(rMg.rows);
+        for (List<GenSolvablePolynomial<C>> row : mlist) {
+            List<GenSolvablePolynomial<C>> nrow = new ArrayList<GenSolvablePolynomial<C>>(row.size());
+            for (GenSolvablePolynomial<C> elem : row) {
+                GenSolvablePolynomial<C> nelem = (GenSolvablePolynomial<C>) elem.reverse(sring);
+                nrow.add(nelem);
+            }
+            nlist.add(nrow);
+        }
+        ModuleList<C> Mg = new ModuleList<C>(sring, nlist);
+        if (debug) {
+            logger.info("Mg -------------------- \n" + Mg);
+            logger.info("isRightGB(Mg) --------- " + isRightGB(Mg));
+        }
+        return Mg;
+    }
+
+
+    /**
+     * Test if left reduction matrix.
+     * @param exgb an SolvableExtendedGB container.
+     * @return true, if exgb contains a left reduction matrix, else false.
+     */
+    public boolean isLeftReductionMatrix(SolvableExtendedGB<C> exgb) {
+        if (exgb == null) {
+            return true;
+        }
+        return isLeftReductionMatrix(exgb.F, exgb.G, exgb.F2G, exgb.G2F);
+    }
+
+
+    /**
+     * Test if left reduction matrix.
+     * @param F a solvable polynomial list.
+     * @param G a left Groebner base.
+     * @param Mf a possible left reduction matrix.
+     * @param Mg a possible left reduction matrix.
+     * @return true, if Mg and Mf are left reduction matrices, else false.
+     */
+    public boolean isLeftReductionMatrix(List<GenSolvablePolynomial<C>> F, List<GenSolvablePolynomial<C>> G,
+                    List<List<GenSolvablePolynomial<C>>> Mf, List<List<GenSolvablePolynomial<C>>> Mg) {
+        // no more check G and Mg: G * Mg[i] == 0
+        // check F and Mg: F * Mg[i] == G[i]
+        int k = 0;
+        for (List<GenSolvablePolynomial<C>> row : Mg) {
+            boolean t = sred.isLeftReductionNF(row, F, G.get(k), null);
+            if (!t) {
+                System.out.println("row = " + row);
+                System.out.println("F   = " + F);
+                System.out.println("Gk  = " + G.get(k));
+                logger.info("F isLeftReductionMatrix s, k = " + F.size() + ", " + k);
+                return false;
+            }
+            k++;
+        }
+        // check G and Mf: G * Mf[i] == F[i]
+        k = 0;
+        for (List<GenSolvablePolynomial<C>> row : Mf) {
+            boolean t = sred.isLeftReductionNF(row, G, F.get(k), null);
+            if (!t) {
+                logger.error("G isLeftReductionMatrix s, k = " + G.size() + ", " + k);
+                return false;
+            }
+            k++;
+        }
+        return true;
+    }
+
+
+    /**
+     * Ideal common zero test.
+     * @return -1, 0 or 1 if dimension(this) &eq; -1, 0 or &ge; 1.
+     */
+    public int commonZeroTest(List<GenSolvablePolynomial<C>> A) {
+        List<GenPolynomial<C>> cA = PolynomialList.<C> castToList(A);
+        return cbb.commonZeroTest(cA);
+    }
+
+
+    /**
+     * Univariate head term degrees.
+     * @param A list of solvable polynomials.
+     * @return a list of the degrees of univariate head terms.
+     */
+    public List<Long> univariateDegrees(List<GenSolvablePolynomial<C>> A) {
+        List<GenPolynomial<C>> cA = PolynomialList.<C> castToList(A);
+        return cbb.univariateDegrees(cA);
+    }
+
+
+    /**
+     * Construct univariate solvable polynomial of minimal degree in variable i
+     * of a zero dimensional ideal(G).
+     * @param i variable index.
+     * @param G list of solvable polynomials, a monic reduced left Gr&ouml;bner
+     *            base of a zero dimensional ideal.
+     * @return univariate solvable polynomial of minimal degree in variable i in
+     *         ideal_left(G)
+     */
+    public GenSolvablePolynomial<C> constructUnivariate(int i, List<GenSolvablePolynomial<C>> G) {
+        if (G == null || G.size() == 0) {
+            throw new IllegalArgumentException("G may not be null or empty");
+        }
+        List<Long> ud = univariateDegrees(G);
+        if (ud.size() <= i) {
+            //logger.info("univ pol, ud = " + ud);
+            throw new IllegalArgumentException("ideal(G) not zero dimensional " + ud);
+        }
+        int ll = 0;
+        Long di = ud.get(i);
+        if (di != null) {
+            ll = (int) (long) di;
+        } else {
+            throw new IllegalArgumentException("ideal(G) not zero dimensional");
+        }
+        long vsdim = 1;
+        for (Long d : ud) {
+            if (d != null) {
+                vsdim *= d;
+            }
+        }
+        logger.info("univariate construction, deg = " + ll + ", vsdim = " + vsdim);
+        GenSolvablePolynomialRing<C> pfac = G.get(0).ring;
+        RingFactory<C> cfac = pfac.coFac;
+
+        GenPolynomialRing<C> cpfac = new GenPolynomialRing<C>(cfac, ll, new TermOrder(TermOrder.INVLEX));
+        GenSolvablePolynomialRing<GenPolynomial<C>> rfac = new GenSolvablePolynomialRing<GenPolynomial<C>>(
+                        cpfac, pfac); // relations
+        GenSolvablePolynomial<GenPolynomial<C>> P = rfac.getZERO();
+        for (int k = 0; k < ll; k++) {
+            GenSolvablePolynomial<GenPolynomial<C>> Pp = rfac.univariate(i, k);
+            GenPolynomial<C> cp = cpfac.univariate(cpfac.nvar - 1 - k);
+            Pp = Pp.multiply(cp);
+            P = (GenSolvablePolynomial<GenPolynomial<C>>) P.sum(Pp);
+        }
+        if (debug) {
+            logger.info("univariate construction, P = " + P);
+            logger.info("univariate construction, deg_*(G) = " + ud);
+            //throw new RuntimeException("check");
+        }
+        GroebnerBaseAbstract<C> bbc = new GroebnerBaseSeq<C>();
+        GenSolvablePolynomial<C> X;
+        GenSolvablePolynomial<C> XP;
+        // solve system of linear equations for the coefficients of the univariate polynomial
+        List<GenPolynomial<C>> ls;
+        int z = -1;
+        do {
+            //System.out.println("ll  = " + ll);
+            GenSolvablePolynomial<GenPolynomial<C>> Pp = rfac.univariate(i, ll);
+            GenPolynomial<C> cp = cpfac.univariate(cpfac.nvar - 1 - ll);
+            Pp = Pp.multiply(cp);
+            P = (GenSolvablePolynomial<GenPolynomial<C>>) P.sum(Pp);
+            X = pfac.univariate(i, ll);
+            XP = sred.leftNormalform(G, X);
+            //System.out.println("XP = " + XP);
+            GenSolvablePolynomial<GenPolynomial<C>> XPp = PolyUtil.<C> toRecursive(rfac, XP);
+            GenSolvablePolynomial<GenPolynomial<C>> XPs = (GenSolvablePolynomial<GenPolynomial<C>>) XPp
+                            .sum(P);
+            ls = new ArrayList<GenPolynomial<C>>(XPs.getMap().values());
+            //System.out.println("ls,1 = " + ls);
+            ls = red.irreducibleSet(ls);
+            z = bbc.commonZeroTest(ls);
+            if (z != 0) {
+                ll++;
+                if (ll > vsdim) {
+                    logger.info("univariate construction, P = " + P);
+                    logger.info("univariate construction, nf(P) = " + XP);
+                    logger.info("G = " + G);
+                    throw new ArithmeticException(
+                                    "univariate polynomial degree greater than vector space dimansion");
+                }
+                cpfac = cpfac.extend(1);
+                rfac = new GenSolvablePolynomialRing<GenPolynomial<C>>(cpfac, pfac);
+                P = PolyUtil.<C> extendCoefficients(rfac, P, 0, 0L);
+                XPp = PolyUtil.<C> extendCoefficients(rfac, XPp, 0, 1L);
+                P = (GenSolvablePolynomial<GenPolynomial<C>>) P.sum(XPp);
+            }
+        } while (z != 0); // && ll <= 5 && !XP.isZERO()
+        // construct result polynomial
+        String var = pfac.getVars()[pfac.nvar - 1 - i];
+        GenSolvablePolynomialRing<C> ufac = new GenSolvablePolynomialRing<C>(cfac, 1, new TermOrder(
+                        TermOrder.INVLEX), new String[] { var });
+        GenSolvablePolynomial<C> pol = ufac.univariate(0, ll);
+        for (GenPolynomial<C> pc : ls) {
+            ExpVector e = pc.leadingExpVector();
+            if (e == null) {
+                continue;
+            }
+            int[] v = e.dependencyOnVariables();
+            if (v == null || v.length == 0) {
+                continue;
+            }
+            int vi = v[0];
+            C tc = pc.trailingBaseCoefficient();
+            tc = tc.negate();
+            GenSolvablePolynomial<C> pi = ufac.univariate(0, ll - 1 - vi);
+            pi = pi.multiply(tc);
+            pol = (GenSolvablePolynomial<C>) pol.sum(pi);
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("univariate construction, pol = " + pol);
+        }
+        return pol;
+    }
+
+
+    /**
+     * Construct univariate solvable polynomials of minimal degree in all
+     * variables in zero dimensional left ideal(G).
+     * @return list of univariate polynomial of minimal degree in each variable
+     *         in ideal_left(G)
+     */
+    public List<GenSolvablePolynomial<C>> constructUnivariate(List<GenSolvablePolynomial<C>> G) {
+        List<GenSolvablePolynomial<C>> univs = new ArrayList<GenSolvablePolynomial<C>>();
+        if (G == null || G.isEmpty()) {
+            return univs;
+        }
+        for (int i = G.get(0).ring.nvar - 1; i >= 0; i--) {
+            GenSolvablePolynomial<C> u = constructUnivariate(i, G);
+            univs.add(u);
+        }
+        return univs;
+    }
+
+
+    /**
+     * Cleanup and terminate ThreadPool.
+     */
+    public void terminate() {
+        logger.info("terminate not implemented");
+        //throw new RuntimeException("get a stack trace");
+    }
+
+
+    /**
+     * Cancel ThreadPool.
+     */
+    public int cancel() {
+        logger.info("cancel not implemented");
+        return 0;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/SolvableGroebnerBaseParallel.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/SolvableGroebnerBaseParallel.java
@@ -1,0 +1,711 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.GenSolvablePolynomialRing;
+import edu.jas.poly.PolynomialList;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.RingElem;
+import edu.jas.util.Terminator;
+
+
+/**
+ * Solvable Groebner Base parallel algorithm. Implements a shared memory
+ * parallel version of Groebner bases. Threads maintain pairlist.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class SolvableGroebnerBaseParallel<C extends RingElem<C>> extends SolvableGroebnerBaseAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(SolvableGroebnerBaseParallel.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Number of threads to use.
+     */
+    protected final int threads;
+
+
+    /**
+     * Pool of threads to use.
+     */
+    protected transient final ExecutorService pool;
+
+
+    /**
+     * Constructor.
+     */
+    public SolvableGroebnerBaseParallel() {
+        this(2);
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     */
+    public SolvableGroebnerBaseParallel(int threads) {
+        this(threads, Executors.newFixedThreadPool(threads));
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param pool ExecutorService to use.
+     */
+    public SolvableGroebnerBaseParallel(int threads, ExecutorService pool) {
+        this(threads, pool, new SolvableReductionPar<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param sred parallelism aware reduction engine
+     */
+    public SolvableGroebnerBaseParallel(int threads, SolvableReduction<C> sred) {
+        this(threads, Executors.newFixedThreadPool(threads), sred);
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param pl pair selection strategy
+     */
+    public SolvableGroebnerBaseParallel(int threads, PairList<C> pl) {
+        this(threads, Executors.newFixedThreadPool(threads), new SolvableReductionPar<C>(), pl);
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param sred parallelism aware reduction engine
+     * @param pl pair selection strategy
+     */
+    public SolvableGroebnerBaseParallel(int threads, SolvableReduction<C> sred, PairList<C> pl) {
+        this(threads, Executors.newFixedThreadPool(threads), sred, pl);
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param pool ExecutorService to use.
+     * @param sred parallelism aware reduction engine
+     */
+    public SolvableGroebnerBaseParallel(int threads, ExecutorService pool, SolvableReduction<C> sred) {
+        this(threads, pool, sred, new OrderedPairlist<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param pool ExecutorService to use.
+     * @param sred parallelism aware reduction engine
+     * @param pl pair selection strategy
+     */
+    public SolvableGroebnerBaseParallel(int threads, ExecutorService pool, SolvableReduction<C> sred,
+                    PairList<C> pl) {
+        super(sred, pl);
+        if (!(sred instanceof SolvableReductionPar)) {
+            logger.warn("parallel GB should use parallel aware reduction");
+        }
+        if (threads < 1) {
+            threads = 1;
+        }
+        this.threads = threads;
+        this.pool = pool;
+    }
+
+
+    /**
+     * Cleanup and terminate ExecutorService.
+     */
+    @Override
+    public void terminate() {
+        if (pool == null) {
+            return;
+        }
+        pool.shutdown();
+        try {
+            while (!pool.isTerminated()) {
+                //logger.info("await");
+                boolean rest = pool.awaitTermination(1000L, TimeUnit.MILLISECONDS);
+            }
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        logger.info(pool.toString());
+    }
+
+
+    /**
+     * Cancel ExecutorService.
+     */
+    @Override
+    public int cancel() {
+        if (pool == null) {
+            return 0;
+        }
+        int s = pool.shutdownNow().size();
+        logger.info(pool.toString());
+        return s;
+    }
+
+
+    /**
+     * Parallel Groebner base using sequential pair order class. Threads
+     * maintain pairlist.
+     * @param modv number of module variables.
+     * @param F polynomial list.
+     * @return GB(F) a Groebner base of F.
+     */
+    public List<GenSolvablePolynomial<C>> leftGB(int modv, List<GenSolvablePolynomial<C>> F) {
+        List<GenSolvablePolynomial<C>> G = normalizeZerosOnes(F);
+        G = PolynomialList.castToSolvableList(PolyUtil.<C> monic(PolynomialList.castToList(G)));
+        if (G.size() <= 1) {
+            return G;
+        }
+        GenSolvablePolynomialRing<C> ring = G.get(0).ring;
+        if (!ring.coFac.isField() && ring.coFac.isCommutative()) {
+            throw new IllegalArgumentException("coefficients not from a field");
+        }
+        PairList<C> pairlist = strategy.create(modv, ring);
+        pairlist.put(PolynomialList.castToList(G));
+        logger.info("start " + pairlist);
+
+        Terminator fin = new Terminator(threads);
+        LeftSolvableReducer<C> R;
+        for (int i = 0; i < threads; i++) {
+            R = new LeftSolvableReducer<C>(fin, G, pairlist);
+            pool.execute(R);
+        }
+        fin.waitDone();
+        logger.debug("#parallel list = " + G.size());
+        G = leftMinimalGB(G);
+        // not in this context // pool.terminate();
+        logger.info("end   " + pairlist);
+        return G;
+    }
+
+
+    /**
+     * Minimal ordered groebner basis, parallel.
+     * @param Fp a Groebner base.
+     * @return minimalGB(F) a minimal Groebner base of Fp.
+     */
+    @Override
+    public List<GenSolvablePolynomial<C>> leftMinimalGB(List<GenSolvablePolynomial<C>> Fp) {
+        GenSolvablePolynomial<C> a;
+        ArrayList<GenSolvablePolynomial<C>> G;
+        G = new ArrayList<GenSolvablePolynomial<C>>(Fp.size());
+        ListIterator<GenSolvablePolynomial<C>> it = Fp.listIterator();
+        while (it.hasNext()) {
+            a = it.next();
+            if (a.length() != 0) { // always true
+                // already monic  a = a.monic();
+                G.add(a);
+            }
+        }
+        if (G.size() <= 1) {
+            return G;
+        }
+
+        ExpVector e;
+        ExpVector f;
+        GenSolvablePolynomial<C> p;
+        ArrayList<GenSolvablePolynomial<C>> F;
+        F = new ArrayList<GenSolvablePolynomial<C>>(G.size());
+        boolean mt;
+        while (G.size() > 0) {
+            a = G.remove(0);
+            e = a.leadingExpVector();
+
+            it = G.listIterator();
+            mt = false;
+            while (it.hasNext() && !mt) {
+                p = it.next();
+                f = p.leadingExpVector();
+                mt = e.multipleOf(f);
+            }
+            it = F.listIterator();
+            while (it.hasNext() && !mt) {
+                p = it.next();
+                f = p.leadingExpVector();
+                mt = e.multipleOf(f);
+            }
+            if (!mt) {
+                F.add(a); // no thread at this point
+            } else {
+                // System.out.println("dropped " + a.length());
+            }
+        }
+        G = F;
+        if (G.size() <= 1) {
+            return G;
+        }
+
+        @SuppressWarnings("unchecked")
+        SolvableMiReducer<C>[] mirs = (SolvableMiReducer<C>[]) new SolvableMiReducer[G.size()];
+        int i = 0;
+        F = new ArrayList<GenSolvablePolynomial<C>>(G.size());
+        while (G.size() > 0) {
+            a = G.remove(0);
+            // System.out.println("doing " + a.length());
+            List<GenSolvablePolynomial<C>> R = new ArrayList<GenSolvablePolynomial<C>>(G.size() + F.size());
+            R.addAll(G);
+            R.addAll(F);
+            mirs[i] = new SolvableMiReducer<C>(R, a);
+            pool.execute(mirs[i]);
+            i++;
+            F.add(a);
+        }
+        G = F;
+        F = new ArrayList<GenSolvablePolynomial<C>>(G.size());
+        for (i = 0; i < mirs.length; i++) {
+            a = mirs[i].getNF();
+            F.add(a);
+        }
+        return F;
+    }
+
+
+    /**
+     * Solvable Extended Groebner base using critical pair class.
+     * @param modv module variable number.
+     * @param F solvable polynomial list.
+     * @return a container for an extended left Groebner base of F.
+     */
+    @Override
+    public SolvableExtendedGB<C> extLeftGB(int modv, List<GenSolvablePolynomial<C>> F) {
+        throw new UnsupportedOperationException("parallel extLeftGB not implemented");
+    }
+
+
+    /**
+     * Twosided Groebner base using pairlist class.
+     * @param modv number of module variables.
+     * @param Fp solvable polynomial list.
+     * @return tsGB(Fp) a twosided Groebner base of F.
+     */
+    @SuppressWarnings("unchecked")
+    public List<GenSolvablePolynomial<C>> twosidedGB(int modv, List<GenSolvablePolynomial<C>> Fp) {
+        List<GenSolvablePolynomial<C>> G = normalizeZerosOnes(Fp);
+        G = PolynomialList.castToSolvableList(PolyUtil.<C> monic(PolynomialList.castToList(G)));
+        if (G.size() < 1) { // 0 not 1
+            return G;
+        }
+        if (G.size() <= 1) { 
+            if (G.get(0).isONE()) {
+                return G; 
+            }
+        }
+        GenSolvablePolynomialRing<C> ring = G.get(0).ring;
+        if (!ring.coFac.isField() && ring.coFac.isCommutative()) {
+            throw new IllegalArgumentException("coefficients not from a field");
+        }
+        // add also coefficient generators
+        List<GenSolvablePolynomial<C>> X;
+        X = PolynomialList.castToSolvableList(ring.generators(modv)); 
+        logger.info("right multipliers = " + X);
+        List<GenSolvablePolynomial<C>> F = new ArrayList<GenSolvablePolynomial<C>>(G.size() * (1 + X.size()));
+        F.addAll(G); 
+        GenSolvablePolynomial<C> p, x, q;
+        for (int i = 0; i < F.size(); i++) { // F changes
+            p = F.get(i);
+            for (int j = 0; j < X.size(); j++) {
+                x = X.get(j);
+                if (x.isONE()) {
+                    continue;
+                }
+                q = p.multiply(x);
+                q = sred.leftNormalform(F, q);
+                if (!q.isZERO()) {
+                    q = q.monic();
+                    if (q.isONE()) {
+                        G.clear();
+                        G.add(q);
+                        return G;
+                    } 
+                    F.add(q);
+                }
+            }
+        }
+        //System.out.println("F generated = " + F);
+        G = F;
+        if (G.size() <= 1) { // 1 okay here
+            return G;
+        }
+        PairList<C> pairlist = strategy.create(modv, ring);
+        pairlist.put(PolynomialList.castToList(G));
+        logger.info("start " + pairlist);
+
+        Terminator fin = new Terminator(threads);
+        TwosidedSolvableReducer<C> R;
+        for (int i = 0; i < threads; i++) {
+            R = new TwosidedSolvableReducer<C>(fin, modv, X, G, pairlist);
+            pool.execute(R);
+        }
+        fin.waitDone();
+        logger.debug("#parallel list = " + G.size());
+        G = leftMinimalGB(G);
+        // not in this context // pool.terminate();
+        logger.info("end   " + pairlist);
+        return G;
+    }
+
+}
+
+
+/**
+ * Reducing left worker threads.
+ * @param <C> coefficient type
+ */
+class LeftSolvableReducer<C extends RingElem<C>> implements Runnable {
+
+
+    private final List<GenSolvablePolynomial<C>> G;
+
+
+    private final PairList<C> pairlist;
+
+
+    private final Terminator pool;
+
+
+    private final SolvableReductionPar<C> sred;
+
+
+    private static final Logger logger = LogManager.getLogger(LeftSolvableReducer.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    LeftSolvableReducer(Terminator fin, List<GenSolvablePolynomial<C>> G, PairList<C> L) {
+        pool = fin;
+        this.G = G;
+        pairlist = L;
+        sred = new SolvableReductionPar<C>();
+    }
+
+
+    @SuppressWarnings("unchecked")
+    public void run() {
+        Pair<C> pair;
+        GenSolvablePolynomial<C> S;
+        GenSolvablePolynomial<C> H;
+        boolean set = false;
+        int reduction = 0;
+        int sleeps = 0;
+        while (pairlist.hasNext() || pool.hasJobs()) {
+            while (!pairlist.hasNext()) {
+                // wait
+                pool.beIdle();
+                set = true;
+                try {
+                    sleeps++;
+                    if (sleeps % 10 == 0) {
+                        logger.info(" reducer is sleeping");
+                    } else {
+                        logger.debug("r");
+                    }
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    pool.allIdle();
+                    logger.info("shutdown " + pool + " after: " + e);
+                    //throw new RuntimeException("interrupt 1 in pairlist.hasNext loop");
+                    break;
+                }
+                if (Thread.currentThread().isInterrupted()) {
+                    //pool.initIdle(1);
+                    pool.allIdle();
+                    logger.info("shutdown after .isInterrupted(): " + pool);
+                    //throw new RuntimeException("interrupt 2 in pairlist.hasNext loop");
+                    break;
+                }
+                if (!pool.hasJobs()) {
+                    break;
+                }
+            }
+            if (!pairlist.hasNext() && !pool.hasJobs()) {
+                break;
+            }
+            if (set) {
+                pool.notIdle();
+                set = false;
+            }
+            pair = pairlist.removeNext();
+            if (pair == null) {
+                continue;
+            }
+            if (debug) {
+                logger.debug("pi = " + pair.pi);
+                logger.debug("pj = " + pair.pj);
+            }
+            S = sred.leftSPolynomial((GenSolvablePolynomial<C>) pair.pi, (GenSolvablePolynomial<C>) pair.pj);
+            if (S.isZERO()) {
+                continue;
+            }
+            if (debug) {
+                logger.debug("ht(S) = " + S.leadingExpVector());
+            }
+            H = sred.leftNormalform(G, S); //mod
+            reduction++;
+            if (H.isZERO()) {
+                continue;
+            }
+            if (debug) {
+                logger.debug("ht(H) = " + H.leadingExpVector());
+            }
+            H = H.monic();
+            // System.out.println("H   = " + H);
+            if (H.isONE()) {
+                pairlist.putOne(); // not really required
+                synchronized (G) {
+                    G.clear();
+                    G.add(H);
+                }
+                pool.allIdle();
+                return;
+            }
+            if (debug) {
+                logger.debug("H = " + H);
+            }
+            synchronized (G) {
+                G.add(H);
+            }
+            pairlist.put(H);
+        }
+        logger.info("terminated, done " + reduction + " reductions");
+    }
+}
+
+
+/**
+ * Reducing twosided worker threads.
+ * @param <C> coefficient type
+ */
+class TwosidedSolvableReducer<C extends RingElem<C>> implements Runnable {
+
+
+    private final List<GenSolvablePolynomial<C>> X;
+
+
+    private final List<GenSolvablePolynomial<C>> G;
+
+
+    private final PairList<C> pairlist;
+
+
+    private final int modv;
+
+
+    private final Terminator pool;
+
+
+    private final SolvableReductionPar<C> sred;
+
+
+    private static final Logger logger = LogManager.getLogger(TwosidedSolvableReducer.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    TwosidedSolvableReducer(Terminator fin, int modv, List<GenSolvablePolynomial<C>> X,
+                    List<GenSolvablePolynomial<C>> G, PairList<C> L) {
+        pool = fin;
+        this.modv = modv;
+        this.X = X;
+        this.G = G;
+        pairlist = L;
+        sred = new SolvableReductionPar<C>();
+    }
+
+
+    public void run() {
+        GenSolvablePolynomial<C> p, x, S, H;
+        Pair<C> pair;
+        boolean set = false;
+        int reduction = 0;
+        int sleeps = 0;
+        logger.debug("modv = " + modv); // avoid "unused"
+        while (pairlist.hasNext() || pool.hasJobs()) {
+            while (!pairlist.hasNext()) {
+                // wait
+                pool.beIdle();
+                set = true;
+                try {
+                    sleeps++;
+                    if (sleeps % 10 == 0) {
+                        logger.info(" reducer is sleeping");
+                    } else {
+                        logger.debug("r");
+                    }
+                    Thread.sleep(50);
+                } catch (InterruptedException e) {
+                    break;
+                }
+                if (!pool.hasJobs()) {
+                    break;
+                }
+            }
+            if (!pairlist.hasNext() && !pool.hasJobs()) {
+                break;
+            }
+            if (set) {
+                pool.notIdle();
+                set = false;
+            }
+            pair = pairlist.removeNext();
+            if (pair == null) {
+                continue;
+            }
+            if (debug) {
+                logger.debug("pi = " + pair.pi);
+                logger.debug("pj = " + pair.pj);
+            }
+            S = sred.leftSPolynomial((GenSolvablePolynomial<C>) pair.pi, (GenSolvablePolynomial<C>) pair.pj);
+            if (S.isZERO()) {
+                continue;
+            }
+            if (debug) {
+                logger.debug("ht(S) = " + S.leadingExpVector());
+            }
+            H = sred.leftNormalform(G, S); //mod
+            reduction++;
+            if (H.isZERO()) {
+                continue;
+            }
+            if (debug) {
+                logger.debug("ht(H) = " + H.leadingExpVector());
+            }
+            H = H.monic();
+            // System.out.println("H   = " + H);
+            if (H.isONE()) {
+                pairlist.putOne(); // not really required
+                synchronized (G) {
+                    G.clear();
+                    G.add(H);
+                }
+                pool.allIdle();
+                return;
+            }
+            if (debug) {
+                logger.debug("H = " + H);
+            }
+            synchronized (G) {
+                G.add(H);
+            }
+            pairlist.put(H);
+            for (int j = 0; j < X.size(); j++) {
+                x = X.get(j);
+                p = H.multiply(x);
+                p = sred.leftNormalform(G, p);
+                if (!p.isZERO()) {
+                    p = p.monic();
+                    if (p.isONE()) {
+                        synchronized (G) {
+                            G.clear();
+                            G.add(p);
+                        }
+                        pool.allIdle();
+                        return;
+                    }
+                    synchronized (G) {
+                        G.add(p);
+                    }
+                    pairlist.put(p);
+                }
+            }
+        }
+        logger.info("terminated, done " + reduction + " reductions");
+    }
+}
+
+
+/**
+ * Reducing worker threads for minimal GB.
+ * @param <C> coefficient type
+ */
+class SolvableMiReducer<C extends RingElem<C>> implements Runnable {
+
+
+    private final List<GenSolvablePolynomial<C>> G;
+
+
+    private GenSolvablePolynomial<C> H;
+
+
+    private final SolvableReductionPar<C> sred;
+
+
+    private final Semaphore done = new Semaphore(0);
+
+
+    private static final Logger logger = LogManager.getLogger(SolvableMiReducer.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    SolvableMiReducer(List<GenSolvablePolynomial<C>> G, GenSolvablePolynomial<C> p) {
+        this.G = G;
+        H = p;
+        sred = new SolvableReductionPar<C>();
+    }
+
+
+    /**
+     * getNF. Blocks until the normal form is computed.
+     * @return the computed normal form.
+     */
+    public GenSolvablePolynomial<C> getNF() {
+        try {
+            done.acquire(); //done.P();
+        } catch (InterruptedException e) {
+        }
+        return H;
+    }
+
+
+    public void run() {
+        if (debug) {
+            logger.debug("ht(H) = " + H.leadingExpVector());
+        }
+        H = sred.leftNormalform(G, H); //mod
+        done.release(); //done.V();
+        if (debug) {
+            logger.debug("ht(H) = " + H.leadingExpVector());
+        }
+        // H = H.monic();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/SolvableGroebnerBaseSeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/SolvableGroebnerBaseSeq.java
@@ -1,0 +1,801 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ListIterator;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.GenSolvablePolynomialRing;
+import edu.jas.poly.QLRSolvablePolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.poly.PolynomialList;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Solvable Groebner bases sequential algorithms. Implements common left, right
+ * and twosided Groebner bases and left, right and twosided GB tests.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class SolvableGroebnerBaseSeq<C extends RingElem<C>> extends SolvableGroebnerBaseAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(SolvableGroebnerBaseSeq.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     */
+    public SolvableGroebnerBaseSeq() {
+        super();
+    }
+
+
+    /**
+     * Constructor.
+     * @param sred Solvable reduction engine
+     */
+    public SolvableGroebnerBaseSeq(SolvableReduction<C> sred) {
+        super(sred);
+    }
+
+
+    /**
+     * Constructor.
+     * @param pl pair selection strategy
+     */
+    public SolvableGroebnerBaseSeq(PairList<C> pl) {
+        super(pl);
+    }
+
+
+    /**
+     * Constructor.
+     * @param sred Solvable reduction engine
+     * @param pl pair selection strategy
+     */
+    public SolvableGroebnerBaseSeq(SolvableReduction<C> sred, PairList<C> pl) {
+        super(sred, pl);
+    }
+
+
+    /**
+     * Left Groebner base using pairlist class.
+     * @param modv number of module variables.
+     * @param F solvable polynomial list.
+     * @return leftGB(F) a left Groebner base of F.
+     */
+    @SuppressWarnings("unchecked")
+    public List<GenSolvablePolynomial<C>> leftGB(int modv, List<GenSolvablePolynomial<C>> F) {
+        List<GenSolvablePolynomial<C>> G = normalizeZerosOnes(F);
+        G = PolynomialList.castToSolvableList(PolyUtil.<C> monic(PolynomialList.castToList(G)));
+        if (G.size() <= 1) {
+            return G;
+        }
+        GenSolvablePolynomialRing<C> ring = G.get(0).ring;
+        if (!ring.coFac.isField() && ring.coFac.isCommutative()) {
+            throw new IllegalArgumentException("coefficients not from a field: " + ring.coFac.toScript());
+        }
+        PairList<C> pairlist = strategy.create(modv, ring);
+        pairlist.put(PolynomialList.castToList(G));
+        logger.info("start " + pairlist);
+
+        GenSolvablePolynomial<C> pi, pj, S, H;
+        Pair<C> pair;
+        while (pairlist.hasNext()) {
+            pair = pairlist.removeNext();
+            if (pair == null) {
+                continue;
+            }
+            pi = (GenSolvablePolynomial<C>) pair.pi;
+            pj = (GenSolvablePolynomial<C>) pair.pj;
+            if (debug) {
+                logger.info("pi    = " + pi.leadingExpVector());
+                logger.info("pj    = " + pj.leadingExpVector());
+            }
+
+            S = sred.leftSPolynomial(pi, pj);
+            if (S.isZERO()) {
+                pair.setZero();
+                continue;
+            }
+            if (debug) {
+                logger.info("ht(S) = " + S.leadingExpVector());
+            }
+
+            H = sred.leftNormalform(G, S);
+            if (H.isZERO()) {
+                pair.setZero();
+                continue;
+            }
+            if (debug) {
+                logger.info("ht(H) = " + H.leadingExpVector());
+                //logger.info("ht(H) = " + H.leadingExpVector() + ", lc(H) = " + H.leadingBaseCoefficient().toScript());
+            }
+
+            H = H.monic();
+            if (H.isONE()) {
+                G.clear();
+                G.add(H);
+                return G; // since no threads are activated
+            }
+            if (debug) {
+                // logger.info("H = " + H);
+                logger.info("#monic(H) = " + H.length());
+            }
+            if (H.length() > 0) {
+                //l++;
+                G.add(H);
+                pairlist.put(H);
+            }
+        }
+        logger.debug("#sequential list = " + G.size());
+        G = leftMinimalGB(G);
+        logger.info("end " + pairlist);
+        return G;
+    }
+
+
+    /**
+     * Solvable Extended Groebner base using critical pair class.
+     * @param modv module variable number.
+     * @param F solvable polynomial list.
+     * @return a container for an extended left Groebner base of F.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public SolvableExtendedGB<C> extLeftGB(int modv, List<GenSolvablePolynomial<C>> F) {
+        if (F == null || F.isEmpty()) {
+            throw new IllegalArgumentException("null or empty F not allowed");
+        }
+        List<GenSolvablePolynomial<C>> G = new ArrayList<GenSolvablePolynomial<C>>();
+        List<List<GenSolvablePolynomial<C>>> F2G = new ArrayList<List<GenSolvablePolynomial<C>>>();
+        List<List<GenSolvablePolynomial<C>>> G2F = new ArrayList<List<GenSolvablePolynomial<C>>>();
+        PairList<C> pairlist = null;
+        boolean oneInGB = false;
+        int len = F.size();
+
+        List<GenSolvablePolynomial<C>> row = null;
+        List<GenSolvablePolynomial<C>> rows = null;
+        List<GenSolvablePolynomial<C>> rowh = null;
+        GenSolvablePolynomialRing<C> ring = null;
+        GenSolvablePolynomial<C> p, H;
+
+        int nzlen = 0;
+        for (GenSolvablePolynomial<C> f : F) {
+            if (f.length() > 0) {
+                nzlen++;
+            }
+            if (ring == null) {
+                ring = f.ring;
+            }
+        }
+        GenSolvablePolynomial<C> mone = ring.getONE(); //.negate();
+        int k = 0;
+        ListIterator<GenSolvablePolynomial<C>> it = F.listIterator();
+        while (it.hasNext()) {
+            p = it.next();
+            if (p.length() > 0) {
+                row = new ArrayList<GenSolvablePolynomial<C>>(nzlen);
+                for (int j = 0; j < nzlen; j++) {
+                    row.add(null);
+                }
+                //C c = p.leadingBaseCoefficient();
+                //c = c.inverse();
+                //p = p.multiply( c );
+                row.set(k, mone); //.multiply(c) );
+                k++;
+                if (p.isUnit()) {
+                    G.clear();
+                    G.add(p);
+                    G2F.clear();
+                    G2F.add(row);
+                    oneInGB = true;
+                    break;
+                }
+                G.add(p);
+                G2F.add(row);
+                if (pairlist == null) {
+                    //pairlist = new CriticalPairList<C>( modv, p.ring );
+                    pairlist = strategy.create(modv, p.ring);
+                }
+                // putOne not required
+                pairlist.put(p);
+            } else {
+                len--;
+            }
+        }
+        SolvableExtendedGB<C> exgb;
+        if (len <= 1 || oneInGB) {
+            // adjust F2G
+            for (GenSolvablePolynomial<C> f : F) {
+                row = new ArrayList<GenSolvablePolynomial<C>>(G.size());
+                for (int j = 0; j < G.size(); j++) {
+                    row.add(null);
+                }
+                H = sred.leftNormalform(row, G, f);
+                if (!H.isZERO()) {
+                    logger.error("nonzero H = " + H);
+                }
+                F2G.add(row);
+            }
+            exgb = new SolvableExtendedGB<C>(F, G, F2G, G2F);
+            //System.out.println("exgb 1 = " + exgb);
+            return exgb;
+        }
+        logger.info("start " + pairlist);
+
+        Pair<C> pair;
+        int i, j;
+        GenSolvablePolynomial<C> pi, pj, S, x, y;
+        //GenPolynomial<C> z;
+        while (pairlist.hasNext() && !oneInGB) {
+            pair = pairlist.removeNext();
+            if (pair == null) {
+                //pairlist.update(); // ?
+                continue;
+            }
+            i = pair.i;
+            j = pair.j;
+            pi = (GenSolvablePolynomial<C>) pair.pi;
+            pj = (GenSolvablePolynomial<C>) pair.pj;
+            if (debug) {
+                logger.info("i, pi    = " + i + ", " + pi);
+                logger.info("j, pj    = " + j + ", " + pj);
+            }
+
+            rows = new ArrayList<GenSolvablePolynomial<C>>(G.size());
+            for (int m = 0; m < G.size(); m++) {
+                rows.add(null);
+            }
+            S = sred.leftSPolynomial(rows, i, pi, j, pj);
+            if (debug) {
+                logger.debug("is reduction S = " + sred.isLeftReductionNF(rows, G, ring.getZERO(), S));
+            }
+            if (S.isZERO()) {
+                pair.setZero();
+                //pairlist.update( pair, S );
+                // do not add to G2F
+                continue;
+            }
+            if (debug) {
+                logger.debug("ht(S) = " + S.leadingExpVector());
+            }
+
+            rowh = new ArrayList<GenSolvablePolynomial<C>>(G.size());
+            for (int m = 0; m < G.size(); m++) {
+                rowh.add(null);
+            }
+            H = sred.leftNormalform(rowh, G, S);
+            if (debug) {
+                //System.out.println("H = " + H);
+                logger.debug("is reduction H = " + sred.isLeftReductionNF(rowh, G, S, H));
+            }
+            if (H.isZERO()) {
+                pair.setZero();
+                //pairlist.update( pair, H );
+                // do not add to G2F
+                continue;
+            }
+            if (debug) {
+                logger.debug("ht(H) = " + H.leadingExpVector());
+            }
+
+            row = new ArrayList<GenSolvablePolynomial<C>>(G.size() + 1);
+            for (int m = 0; m < G.size(); m++) {
+                x = rows.get(m);
+                if (x != null) {
+                    //System.out.println("ms = " + m + " " + x);
+                    x = (GenSolvablePolynomial<C>) x.negate();
+                }
+                y = rowh.get(m);
+                if (y != null) {
+                    y = (GenSolvablePolynomial<C>) y.negate();
+                    //System.out.println("mh = " + m + " " + y);
+                }
+                if (x == null) {
+                    x = y;
+                } else {
+                    x = (GenSolvablePolynomial<C>) x.sum(y);
+                }
+                //System.out.println("mx = " + m + " " + x);
+                row.add(x);
+            }
+            if (debug) {
+                logger.debug("is reduction 0+sum(row,G) == H : "
+                                + sred.isLeftReductionNF(row, G, H, ring.getZERO()));
+            }
+            row.add(null);
+
+            //  H = H.monic();
+            C c = H.leadingBaseCoefficient();
+            c = c.inverse();
+            H = H.multiply(c);
+            // 1*c*row, leads to wrong method dispatch:
+            row = PolynomialList.<C> castToSolvableList(blas.scalarProduct(mone.multiply(c),
+                            PolynomialList.<C> castToList(row)));
+            row.set(G.size(), mone);
+            if (H.isONE()) {
+                // pairlist.record( pair, H );
+                // G.clear(); 
+                G.add(H);
+                G2F.add(row);
+                oneInGB = true;
+                break;
+            }
+            if (debug) {
+                logger.debug("H = " + H);
+            }
+            G.add(H);
+            //pairlist.update( pair, H );
+            pairlist.put(H);
+            G2F.add(row);
+        }
+        if (debug) {
+            exgb = new SolvableExtendedGB<C>(F, G, F2G, G2F);
+            logger.info("exgb unnorm = " + exgb);
+        }
+        G2F = normalizeMatrix(F.size(), G2F);
+        if (debug) {
+            exgb = new SolvableExtendedGB<C>(F, G, F2G, G2F);
+            logger.info("exgb nonmin = " + exgb);
+            boolean t2 = isLeftReductionMatrix(exgb);
+            logger.debug("exgb t2 = " + t2);
+        }
+        exgb = minimalSolvableExtendedGB(F.size(), G, G2F);
+        G = exgb.G;
+        G2F = exgb.G2F;
+        logger.debug("#sequential list = " + G.size());
+        logger.info("end " + pairlist);
+        // setup matrices F and F2G
+        for (GenSolvablePolynomial<C> f : F) {
+            row = new ArrayList<GenSolvablePolynomial<C>>(G.size());
+            for (int m = 0; m < G.size(); m++) {
+                row.add(null);
+            }
+            H = sred.leftNormalform(row, G, f);
+            if (!H.isZERO()) {
+                logger.error("nonzero H = " + H);
+            }
+            F2G.add(row);
+        }
+        logger.info("extGB end");
+        return new SolvableExtendedGB<C>(F, G, F2G, G2F);
+    }
+
+
+    /**
+     * Twosided Groebner base using pairlist class.
+     * @param modv number of module variables.
+     * @param Fp solvable polynomial list.
+     * @return tsGB(Fp) a twosided Groebner base of Fp.
+     */
+    @SuppressWarnings("unchecked")
+    public List<GenSolvablePolynomial<C>> twosidedGB(int modv, List<GenSolvablePolynomial<C>> Fp) {
+        List<GenSolvablePolynomial<C>> F = normalizeZerosOnes(Fp);
+        F = PolynomialList.castToSolvableList(PolyUtil.<C> monic(PolynomialList.castToList(F)));
+        if (F.size() < 1) { // 0 not 1
+            return F;
+        }
+        if (F.size() == 1 && F.get(0).isONE()) {
+            return F;
+        }
+        GenSolvablePolynomialRing<C> ring = F.get(0).ring;
+        if (!ring.coFac.isField() && ring.coFac.isCommutative()) {
+            throw new IllegalArgumentException("coefficients not from a field");
+        }
+        // add also coefficient generators
+        List<GenSolvablePolynomial<C>> X;
+        X = PolynomialList.castToSolvableList(ring.generators(modv)); 
+        logger.info("right multipliers = " + X);
+        List<GenSolvablePolynomial<C>> G = new ArrayList<GenSolvablePolynomial<C>>(F.size() * (1 + X.size()));
+        G.addAll(F);
+        logger.info("right multipy: G = " + G);
+        GenSolvablePolynomial<C> p, q;
+        for (int i = 0; i < G.size(); i++) { // G changes
+            p = G.get(i);
+            for (GenSolvablePolynomial<C> x : X) {
+                //x = X.get(j);
+                if (x.isONE()) {
+                    continue;
+                }
+                q = p.multiply(x);
+                logger.info("right multipy: p = " + p + ", x = " + x + ", q = " + q);
+                q = sred.leftNormalform(G, q);
+                q = q.monic();
+                logger.info("right multipy: red(q) = " + q);
+                if (!q.isZERO()) {
+                    //System.out.println("q generating: = " + q + ", p = " + p + ", x = " + x);
+                    if (q.isONE()) {
+                        //System.out.println("G generated so far: " + G);
+                        G.clear();
+                        G.add(q);
+                        return G; // since no threads are activated
+                    }
+                    if (!G.contains(q)) { // why?
+                       G.add(q);
+                    } else {
+                       logger.info("right multipy contained: q = " + q);
+                    } 
+                }
+            }
+        }
+        if (G.size() <= 1) { // 1 ok
+            return G; // since no threads are activated
+        }
+        //System.out.println("G generated = " + G);
+        PairList<C> pairlist = strategy.create(modv, ring);
+        pairlist.put(PolynomialList.castToList(G));
+        logger.info("twosided start " + pairlist);
+
+        Pair<C> pair;
+        GenSolvablePolynomial<C> pi, pj, S, H;
+        while (pairlist.hasNext()) {
+            pair = pairlist.removeNext();
+            if (pair == null) {
+                continue;
+            }
+
+            pi = (GenSolvablePolynomial<C>) pair.pi;
+            pj = (GenSolvablePolynomial<C>) pair.pj;
+            if (debug) {
+                logger.debug("pi    = " + pi);
+                logger.debug("pj    = " + pj);
+            }
+
+            S = sred.leftSPolynomial(pi, pj);
+            if (S.isZERO()) {
+                pair.setZero();
+                continue;
+            }
+            if (debug) {
+                logger.debug("ht(S) = " + S.leadingExpVector());
+            }
+
+            H = sred.leftNormalform(G, S);
+            if (H.isZERO()) {
+                pair.setZero();
+                continue;
+            }
+            if (debug) {
+                logger.debug("ht(H) = " + H.leadingExpVector());
+            }
+
+            H = H.monic();
+            if (H.isONE()) {
+                G.clear();
+                G.add(H);
+                return G; // since no threads are activated
+            }
+            if (debug) {
+                logger.debug("H = " + H);
+            }
+            if (H.length() > 0) {
+                G.add(H);
+                pairlist.put(H);
+                //System.out.println("H generated = " + H);
+                for (GenSolvablePolynomial<C> x : X) {
+                    //x = X.get(j);
+                    if (x.isONE()) {
+                        continue;
+                    }
+                    q = H.multiply(x);
+                    p = sred.leftNormalform(G, q);
+                    if (!p.isZERO()) {
+                        //System.out.println("p generated = " + p + ", x = " + x);
+                        p = p.monic();
+                        if (p.isONE()) {
+                            G.clear();
+                            G.add(p);
+                            return G; // since no threads are activated
+                        }
+                        G.add(p);
+                        pairlist.put(p);
+                    }
+                }
+                //System.out.println("G generated = " + G);
+            }
+        }
+        logger.debug("#sequential list = " + G.size());
+        G = leftMinimalGB(G);
+        logger.info("twosided end " + pairlist);
+        return G;
+    }
+
+
+    /**
+     * Normalize M. Make all rows the same size and make certain column elements
+     * zero.
+     * @param M a reduction matrix.
+     * @return normalized M.
+     */
+    public List<List<GenSolvablePolynomial<C>>> normalizeMatrix(int flen,
+                    List<List<GenSolvablePolynomial<C>>> M) {
+        if (M == null) {
+            return M;
+        }
+        if (M.size() == 0) {
+            return M;
+        }
+        List<List<GenSolvablePolynomial<C>>> N = new ArrayList<List<GenSolvablePolynomial<C>>>();
+        List<List<GenSolvablePolynomial<C>>> K = new ArrayList<List<GenSolvablePolynomial<C>>>();
+        int len = M.get(M.size() - 1).size(); // longest row
+        // pad / extend rows
+        for (List<GenSolvablePolynomial<C>> row : M) {
+            List<GenSolvablePolynomial<C>> nrow = new ArrayList<GenSolvablePolynomial<C>>(row);
+            for (int i = row.size(); i < len; i++) {
+                nrow.add(null);
+            }
+            N.add(nrow);
+        }
+        // System.out.println("norm N fill = " + N);
+        // make zero columns
+        int k = flen;
+        for (int i = 0; i < N.size(); i++) { // 0
+            List<GenSolvablePolynomial<C>> row = N.get(i);
+            if (debug) {
+                logger.info("row = " + row);
+            }
+            K.add(row);
+            if (i < flen) { // skip identity part
+                continue;
+            }
+            List<GenSolvablePolynomial<C>> xrow;
+            GenSolvablePolynomial<C> a;
+            //System.out.println("norm i = " + i);
+            for (int j = i + 1; j < N.size(); j++) {
+                List<GenSolvablePolynomial<C>> nrow = N.get(j);
+                //System.out.println("nrow j = " +j + ", " + nrow);
+                if (k < nrow.size()) { // always true
+                    a = nrow.get(k);
+                    //System.out.println("k, a = " + k + ", " + a);
+                    if (a != null && !a.isZERO()) { // a*row + nrow, leads to wrong method dispatch
+                        List<GenPolynomial<C>> yrow = blas.scalarProduct(a,
+                                        PolynomialList.<C> castToList(row));
+                        yrow = blas.vectorAdd(yrow, PolynomialList.<C> castToList(nrow));
+                        xrow = PolynomialList.<C> castToSolvableList(yrow);
+                        N.set(j, xrow);
+                    }
+                }
+            }
+            k++;
+        }
+        //System.out.println("norm K reduc = " + K);
+        // truncate 
+        N.clear();
+        for (List<GenSolvablePolynomial<C>> row : K) {
+            List<GenSolvablePolynomial<C>> tr = new ArrayList<GenSolvablePolynomial<C>>();
+            for (int i = 0; i < flen; i++) {
+                tr.add(row.get(i));
+            }
+            N.add(tr);
+        }
+        K = N;
+        //System.out.println("norm K trunc = " + K);
+        return K;
+    }
+
+
+    /**
+     * Test if M is a left reduction matrix.
+     * @param exgb an SolvableExtendedGB container.
+     * @return true, if exgb contains a left reduction matrix, else false.
+     */
+    @Override
+    public boolean isLeftReductionMatrix(SolvableExtendedGB<C> exgb) {
+        if (exgb == null) {
+            return true;
+        }
+        return isLeftReductionMatrix(exgb.F, exgb.G, exgb.F2G, exgb.G2F);
+    }
+
+
+    /**
+     * Minimal solvable extended groebner basis.
+     * @param Gp a left Groebner base.
+     * @param M a left reduction matrix, is modified.
+     * @return a (partially) reduced left Groebner base of Gp in a container.
+     */
+    public SolvableExtendedGB<C> minimalSolvableExtendedGB(int flen, List<GenSolvablePolynomial<C>> Gp,
+                    List<List<GenSolvablePolynomial<C>>> M) {
+        if (Gp == null) {
+            return null; //new SolvableExtendedGB<C>(null,Gp,null,M);
+        }
+        if (Gp.size() <= 1) {
+            return new SolvableExtendedGB<C>(null, Gp, null, M);
+        }
+        List<GenSolvablePolynomial<C>> G;
+        List<GenSolvablePolynomial<C>> F;
+        G = new ArrayList<GenSolvablePolynomial<C>>(Gp);
+        F = new ArrayList<GenSolvablePolynomial<C>>(Gp.size());
+
+        List<List<GenSolvablePolynomial<C>>> Mg;
+        List<List<GenSolvablePolynomial<C>>> Mf;
+        Mg = new ArrayList<List<GenSolvablePolynomial<C>>>(M.size());
+        Mf = new ArrayList<List<GenSolvablePolynomial<C>>>(M.size());
+        List<GenSolvablePolynomial<C>> row;
+        for (List<GenSolvablePolynomial<C>> r : M) {
+            // must be copied also
+            row = new ArrayList<GenSolvablePolynomial<C>>(r);
+            Mg.add(row);
+        }
+        row = null;
+
+        GenSolvablePolynomial<C> a;
+        ExpVector e;
+        ExpVector f;
+        GenSolvablePolynomial<C> p;
+        boolean mt;
+        ListIterator<GenSolvablePolynomial<C>> it;
+        ArrayList<Integer> ix = new ArrayList<Integer>();
+        ArrayList<Integer> jx = new ArrayList<Integer>();
+        int k = 0;
+        //System.out.println("flen, Gp, M = " + flen + ", " + Gp.size() + ", " + M.size() );
+        while (G.size() > 0) {
+            a = G.remove(0);
+            e = a.leadingExpVector();
+
+            it = G.listIterator();
+            mt = false;
+            while (it.hasNext() && !mt) {
+                p = it.next();
+                f = p.leadingExpVector();
+                mt = e.multipleOf(f);
+            }
+            it = F.listIterator();
+            while (it.hasNext() && !mt) {
+                p = it.next();
+                f = p.leadingExpVector();
+                mt = e.multipleOf(f);
+            }
+            //System.out.println("k, mt = " + k + ", " + mt);
+            if (!mt) {
+                F.add(a);
+                ix.add(k);
+            } else { // drop polynomial and corresponding row and column
+                // F.add( a.ring.getZERO() );
+                jx.add(k);
+            }
+            k++;
+        }
+        if (debug) {
+            logger.debug("ix, #M, jx = " + ix + ", " + Mg.size() + ", " + jx);
+        }
+        int fix = -1; // copied polys
+        // copy Mg to Mf as indicated by ix
+        for (int i = 0; i < ix.size(); i++) {
+            int u = ix.get(i);
+            if (u >= flen && fix == -1) {
+                fix = Mf.size();
+            }
+            //System.out.println("copy u, fix = " + u + ", " + fix);
+            if (u >= 0) {
+                row = Mg.get(u);
+                Mf.add(row);
+            }
+        }
+        if (F.size() <= 1 || fix == -1) {
+            return new SolvableExtendedGB<C>(null, F, null, Mf);
+        }
+        // must return, since extended normalform has not correct order of polys
+        /*
+        G = F;
+        F = new ArrayList<GenSolvablePolynomial<C>>( G.size() );
+        List<GenSolvablePolynomial<C>> temp;
+        k = 0;
+        final int len = G.size();
+        while ( G.size() > 0 ) {
+            a = G.remove(0);
+            if ( k >= fix ) { // dont touch copied polys
+               row = Mf.get( k );
+               //System.out.println("doing k = " + k + ", " + a);
+               // must keep order, but removed polys missing
+               temp = new ArrayList<GenPolynomial<C>>( len );
+               temp.addAll( F );
+               temp.add( a.ring.getZERO() ); // ??
+               temp.addAll( G );
+               //System.out.println("row before = " + row);
+               a = sred.leftNormalform( row, temp, a );
+               //System.out.println("row after  = " + row);
+            }
+            F.add( a );
+            k++;
+        }
+        // does Mf need renormalization?
+        */
+        return new SolvableExtendedGB<C>(null, F, null, Mf);
+    }
+
+
+    /**
+     * Right Groebner base via right reduction using pairlist
+     * class. Overides rightGB() via opposite ring.
+     * @param modv number of module variables.
+     * @param F solvable polynomial list.
+     * @return rightGB(F) a right Groebner base of F.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public List<GenSolvablePolynomial<C>> rightGB(int modv, List<GenSolvablePolynomial<C>> F) {
+        List<GenSolvablePolynomial<C>> G = normalizeZerosOnes(F);
+        G = PolynomialList.castToSolvableList(PolyUtil.<C> monic(PolynomialList.castToList(G)));
+        if (G.size() <= 1) {
+            return G;
+        }
+        GenSolvablePolynomialRing<C> ring = G.get(0).ring;
+        if (!ring.coFac.isField() && ring.coFac.isCommutative()) {
+            throw new IllegalArgumentException("coefficients not from a field");
+        }
+        PairList<C> pairlist = strategy.create(modv, ring);
+        pairlist.put(PolynomialList.castToList(G));
+        logger.info("start " + pairlist);
+
+        GenSolvablePolynomial<C> pi, pj, S, H;
+        Pair<C> pair;
+        while (pairlist.hasNext()) {
+            pair = pairlist.removeNext();
+            if (pair == null) {
+                continue;
+            }
+            pi = (GenSolvablePolynomial<C>) pair.pi;
+            pj = (GenSolvablePolynomial<C>) pair.pj;
+            if (debug) {
+                logger.info("pi    = " + pi);
+                logger.info("pj    = " + pj);
+            }
+
+            S = sred.rightSPolynomial(pi, pj);
+            if (S.isZERO()) {
+                pair.setZero();
+                continue;
+            }
+            if (debug) {
+                logger.info("ht(S) = " + S.leadingExpVector());
+            }
+
+            H = sred.rightNormalform(G, S);
+            if (H.isZERO()) {
+                pair.setZero();
+                continue;
+            }
+            if (debug) {
+                logger.info("ht(H) = " + H.leadingExpVector());
+            }
+
+            H = H.monic();
+            if (H.isONE()) {
+                G.clear();
+                G.add(H);
+                return G; // since no threads are activated
+            }
+            if (debug) {
+                logger.info("H = " + H);
+            }
+            if (H.length() > 0) {
+                //l++;
+                G.add(H);
+                pairlist.put(H);
+            }
+        }
+        logger.debug("#sequential list = " + G.size());
+        G = rightMinimalGB(G);
+        logger.info("end " + pairlist);
+        return G;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/SolvableGroebnerBaseSeqPairParallel.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/SolvableGroebnerBaseSeqPairParallel.java
@@ -1,0 +1,704 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.GenSolvablePolynomialRing;
+import edu.jas.poly.PolynomialList;
+import edu.jas.structure.RingElem;
+import edu.jas.util.Terminator;
+
+
+/**
+ * Solvable Groebner Base parallel algorithm. Makes some effort to produce the
+ * same sequence of critical pairs as in the sequential version. However already
+ * reduced pairs are not rereduced if new polynomials appear. Implements a
+ * shared memory parallel version of Groebner bases. Threads maintain pairlist.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class SolvableGroebnerBaseSeqPairParallel<C extends RingElem<C>> extends
+                SolvableGroebnerBaseAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(SolvableGroebnerBaseSeqPairParallel.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Number of threads to use.
+     */
+    protected final int threads;
+
+
+    /**
+     * Pool of threads to use.
+     */
+    protected transient final ExecutorService pool;
+
+
+    /**
+     * Constructor.
+     */
+    public SolvableGroebnerBaseSeqPairParallel() {
+        this(2);
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     */
+    public SolvableGroebnerBaseSeqPairParallel(int threads) {
+        this(threads, Executors.newFixedThreadPool(threads));
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param pool ExecutorService to use.
+     */
+    public SolvableGroebnerBaseSeqPairParallel(int threads, ExecutorService pool) {
+        this(threads, pool, new SolvableReductionPar<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param red parallelism aware reduction engine
+     */
+    public SolvableGroebnerBaseSeqPairParallel(int threads, SolvableReduction<C> red) {
+        this(threads, Executors.newFixedThreadPool(threads), red);
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param pool ExecutorService to use.
+     * @param sred parallelism aware reduction engine
+     */
+    public SolvableGroebnerBaseSeqPairParallel(int threads, ExecutorService pool, SolvableReduction<C> sred) {
+        super(sred);
+        if (!(sred instanceof SolvableReductionPar)) {
+            logger.warn("parallel GB should use parallel aware reduction");
+        }
+        if (threads < 1) {
+            threads = 1;
+        }
+        this.threads = threads;
+        this.pool = pool;
+    }
+
+
+    /**
+     * Cleanup and terminate ExecutorService.
+     */
+    @Override
+    public void terminate() {
+        if (pool == null) {
+            return;
+        }
+        pool.shutdown();
+        try {
+            while (!pool.isTerminated()) {
+                //logger.info("await");
+                boolean rest = pool.awaitTermination(1000L, TimeUnit.MILLISECONDS);
+            }
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        logger.info(pool.toString());
+    }
+
+
+    /**
+     * Cancel ExecutorService.
+     */
+    @Override
+    public int cancel() {
+        if (pool == null) {
+            return 0;
+        }
+        int s = pool.shutdownNow().size();
+        logger.info(pool.toString());
+        return s;
+    }
+
+
+    /**
+     * Parallel Groebner base using sequential pair order class. Threads
+     * maintain pairlist.
+     * @param modv number of module variables.
+     * @param F polynomial list.
+     * @return GB(F) a Groebner base of F.
+     */
+    public List<GenSolvablePolynomial<C>> leftGB(int modv, List<GenSolvablePolynomial<C>> F) {
+        GenSolvablePolynomial<C> p;
+        List<GenSolvablePolynomial<C>> G = new ArrayList<GenSolvablePolynomial<C>>();
+        CriticalPairList<C> pairlist = null;
+        int l = F.size();
+        ListIterator<GenSolvablePolynomial<C>> it = F.listIterator();
+        while (it.hasNext()) {
+            p = it.next();
+            if (p.length() > 0) {
+                p = p.monic();
+                if (p.isONE()) {
+                    G.clear();
+                    G.add(p);
+                    return G; // since no threads activated jet
+                }
+                G.add(p);
+                if (pairlist == null) {
+                    pairlist = new CriticalPairList<C>(modv, p.ring);
+                    if (!p.ring.coFac.isField()) {
+                        throw new IllegalArgumentException("coefficients not from a field");
+                    }
+                }
+                // putOne not required
+                pairlist.put(p);
+            } else {
+                l--;
+            }
+        }
+        if (l <= 1) {
+            return G; // since no threads activated jet
+        }
+
+        Terminator fin = new Terminator(threads);
+        LeftSolvableReducerSeqPair<C> R;
+        for (int i = 0; i < threads; i++) {
+            R = new LeftSolvableReducerSeqPair<C>(fin, G, pairlist);
+            pool.execute(R);
+        }
+        fin.waitDone();
+        logger.debug("#parallel list = " + G.size());
+        G = leftMinimalGB(G);
+        // not in this context // pool.terminate();
+        logger.info("" + pairlist);
+        return G;
+    }
+
+
+    /**
+     * Minimal ordered groebner basis, parallel.
+     * @param Fp a Groebner base.
+     * @return minimalGB(F) a minimal Groebner base of Fp.
+     */
+    @Override
+    public List<GenSolvablePolynomial<C>> leftMinimalGB(List<GenSolvablePolynomial<C>> Fp) {
+        GenSolvablePolynomial<C> a;
+        ArrayList<GenSolvablePolynomial<C>> G;
+        G = new ArrayList<GenSolvablePolynomial<C>>(Fp.size());
+        ListIterator<GenSolvablePolynomial<C>> it = Fp.listIterator();
+        while (it.hasNext()) {
+            a = it.next();
+            if (a.length() != 0) { // always true
+                // already monic  a = a.monic();
+                G.add(a);
+            }
+        }
+        if (G.size() <= 1) {
+            return G;
+        }
+
+        ExpVector e;
+        ExpVector f;
+        GenSolvablePolynomial<C> p;
+        ArrayList<GenSolvablePolynomial<C>> F;
+        F = new ArrayList<GenSolvablePolynomial<C>>(G.size());
+        boolean mt;
+        while (G.size() > 0) {
+            a = G.remove(0);
+            e = a.leadingExpVector();
+
+            it = G.listIterator();
+            mt = false;
+            while (it.hasNext() && !mt) {
+                p = it.next();
+                f = p.leadingExpVector();
+                mt = e.multipleOf(f);
+            }
+            it = F.listIterator();
+            while (it.hasNext() && !mt) {
+                p = it.next();
+                f = p.leadingExpVector();
+                mt = e.multipleOf(f);
+            }
+            if (!mt) {
+                F.add(a); // no thread at this point
+            } else {
+                // System.out.println("dropped " + a.length());
+            }
+        }
+        G = F;
+        if (G.size() <= 1) {
+            return G;
+        }
+
+        @SuppressWarnings("unchecked")
+        SolvableMiReducerSeqPair<C>[] mirs = (SolvableMiReducerSeqPair<C>[]) new SolvableMiReducerSeqPair[G
+                        .size()];
+        int i = 0;
+        F = new ArrayList<GenSolvablePolynomial<C>>(G.size());
+        while (G.size() > 0) {
+            a = G.remove(0);
+            // System.out.println("doing " + a.length());
+            List<GenSolvablePolynomial<C>> R = new ArrayList<GenSolvablePolynomial<C>>(G.size() + F.size());
+            R.addAll(G);
+            R.addAll(F);
+            mirs[i] = new SolvableMiReducerSeqPair<C>(R, a);
+            pool.execute(mirs[i]);
+            i++;
+            F.add(a);
+        }
+        G = F;
+        F = new ArrayList<GenSolvablePolynomial<C>>(G.size());
+        for (i = 0; i < mirs.length; i++) {
+            a = mirs[i].getNF();
+            F.add(a);
+        }
+        return F;
+    }
+
+
+    /**
+     * Solvable Extended Groebner base using critical pair class.
+     * @param modv module variable number.
+     * @param F solvable polynomial list.
+     * @return a container for an extended left Groebner base of F.
+     */
+    public SolvableExtendedGB<C> extLeftGB(int modv, List<GenSolvablePolynomial<C>> F) {
+        throw new UnsupportedOperationException("parallel extLeftGB not implemented");
+    }
+
+
+    /**
+     * Twosided Groebner base using pairlist class.
+     * @param modv number of module variables.
+     * @param Fp solvable polynomial list.
+     * @return tsGB(Fp) a twosided Groebner base of F.
+     */
+    public List<GenSolvablePolynomial<C>> twosidedGB(int modv, List<GenSolvablePolynomial<C>> Fp) {
+        if (Fp == null || Fp.size() == 0) { // 0 not 1
+            return new ArrayList<GenSolvablePolynomial<C>>();
+        }
+        GenSolvablePolynomialRing<C> ring = Fp.get(0).ring; // assert != null
+        // add also coefficient generators
+        List<GenSolvablePolynomial<C>> X;
+        X = PolynomialList.castToSolvableList(ring.generators(modv)); 
+        logger.info("right multipliers = " + X);
+        List<GenSolvablePolynomial<C>> F = new ArrayList<GenSolvablePolynomial<C>>(Fp.size() * (1 + X.size()));
+        F.addAll(Fp);
+        GenSolvablePolynomial<C> p, x, q;
+        for (int i = 0; i < F.size(); i++) { // F changes
+            p = F.get(i);
+            for (int j = 0; j < X.size(); j++) {
+                x = X.get(j);
+                if (x.isONE()) {
+                    continue;
+                }
+                q = p.multiply(x);
+                q = sred.leftNormalform(F, q);
+                if (!q.isZERO()) {
+                    F.add(q);
+                }
+            }
+        }
+        //System.out.println("F generated = " + F);
+        List<GenSolvablePolynomial<C>> G = new ArrayList<GenSolvablePolynomial<C>>();
+        CriticalPairList<C> pairlist = null;
+        int l = F.size();
+        ListIterator<GenSolvablePolynomial<C>> it = F.listIterator();
+        while (it.hasNext()) {
+            p = it.next();
+            if (p.length() > 0) {
+                p = p.monic();
+                if (p.isONE()) {
+                    G.clear();
+                    G.add(p);
+                    return G; // since no threads are activated
+                }
+                G.add(p);
+                if (pairlist == null) {
+                    pairlist = new CriticalPairList<C>(modv, p.ring);
+                    if (!p.ring.coFac.isField()) {
+                        throw new IllegalArgumentException("coefficients not from a field");
+                    }
+                }
+                // putOne not required
+                pairlist.put(p);
+            } else {
+                l--;
+            }
+        }
+        //System.out.println("G to check = " + G);
+        if (l <= 1) { // 1 ok
+            return G; // since no threads are activated
+        }
+        Terminator fin = new Terminator(threads);
+        TwosidedSolvableReducerSeqPair<C> R;
+        for (int i = 0; i < threads; i++) {
+            R = new TwosidedSolvableReducerSeqPair<C>(fin, X, G, pairlist);
+            pool.execute(R);
+        }
+        fin.waitDone();
+        logger.debug("#parallel list = " + G.size());
+        G = leftMinimalGB(G);
+        // not in this context // pool.terminate();
+        logger.info("" + pairlist);
+        return G;
+    }
+
+}
+
+
+/**
+ * Reducing left worker threads.
+ * @param <C> coefficient type
+ */
+class LeftSolvableReducerSeqPair<C extends RingElem<C>> implements Runnable {
+
+
+    private final List<GenSolvablePolynomial<C>> G;
+
+
+    private final CriticalPairList<C> pairlist;
+
+
+    private final Terminator pool;
+
+
+    private final SolvableReductionPar<C> sred;
+
+
+    private static final Logger logger = LogManager.getLogger(LeftSolvableReducerSeqPair.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    LeftSolvableReducerSeqPair(Terminator fin, List<GenSolvablePolynomial<C>> G, CriticalPairList<C> L) {
+        pool = fin;
+        this.G = G;
+        pairlist = L;
+        sred = new SolvableReductionPar<C>();
+    }
+
+
+    @SuppressWarnings("unchecked")
+    public void run() {
+        CriticalPair<C> pair;
+        GenSolvablePolynomial<C> S;
+        GenSolvablePolynomial<C> H;
+        boolean set = false;
+        int reduction = 0;
+        int sleeps = 0;
+        while (pairlist.hasNext() || pool.hasJobs()) {
+            while (!pairlist.hasNext()) {
+                pairlist.update();
+                // wait
+                pool.beIdle();
+                set = true;
+                try {
+                    sleeps++;
+                    if (sleeps % 10 == 0) {
+                        logger.info(" reducer is sleeping");
+                    } else {
+                        logger.debug("r");
+                    }
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    break;
+                }
+                if (!pool.hasJobs()) {
+                    break;
+                }
+            }
+            if (!pairlist.hasNext() && !pool.hasJobs()) {
+                break;
+            }
+            if (set) {
+                pool.notIdle();
+                set = false;
+            }
+            pair = pairlist.getNext();
+            if (pair == null) {
+                pairlist.update();
+                continue;
+            }
+            if (debug) {
+                logger.debug("pi = " + pair.pi);
+                logger.debug("pj = " + pair.pj);
+            }
+            S = sred.leftSPolynomial((GenSolvablePolynomial<C>) pair.pi, (GenSolvablePolynomial<C>) pair.pj);
+            if (S.isZERO()) {
+                pairlist.record(pair, S);
+                continue;
+            }
+            if (debug) {
+                logger.debug("ht(S) = " + S.leadingExpVector());
+            }
+            H = sred.leftNormalform(G, S); //mod
+            reduction++;
+            if (H.isZERO()) {
+                pairlist.record(pair, H);
+                continue;
+            }
+            if (debug) {
+                logger.debug("ht(H) = " + H.leadingExpVector());
+            }
+            H = H.monic();
+            // System.out.println("H   = " + H);
+            if (H.isONE()) {
+                // pairlist.update( pair, H );
+                pairlist.putOne(); // not really required
+                synchronized (G) {
+                    G.clear();
+                    G.add(H);
+                }
+                pool.allIdle();
+                return;
+            }
+            if (debug) {
+                logger.debug("H = " + H);
+            }
+            synchronized (G) {
+                G.add(H);
+            }
+            pairlist.update(pair, H);
+            //pairlist.record( pair, H );
+            //pairlist.update();
+        }
+        logger.info("terminated, done " + reduction + " reductions");
+    }
+}
+
+
+/**
+ * Reducing twosided worker threads.
+ * @param <C> coefficient type
+ */
+class TwosidedSolvableReducerSeqPair<C extends RingElem<C>> implements Runnable {
+
+
+    private final List<GenSolvablePolynomial<C>> X;
+
+
+    private final List<GenSolvablePolynomial<C>> G;
+
+
+    private final CriticalPairList<C> pairlist;
+
+
+    private final Terminator pool;
+
+
+    private final SolvableReductionPar<C> sred;
+
+
+    private static final Logger logger = LogManager.getLogger(TwosidedSolvableReducerSeqPair.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    TwosidedSolvableReducerSeqPair(Terminator fin, List<GenSolvablePolynomial<C>> X,
+                    List<GenSolvablePolynomial<C>> G, CriticalPairList<C> L) {
+        pool = fin;
+        this.X = X;
+        this.G = G;
+        pairlist = L;
+        sred = new SolvableReductionPar<C>();
+    }
+
+
+    public void run() {
+        GenSolvablePolynomial<C> p, x;
+        CriticalPair<C> pair;
+        GenSolvablePolynomial<C> S;
+        GenSolvablePolynomial<C> H;
+        boolean set = false;
+        int reduction = 0;
+        int sleeps = 0;
+        while (pairlist.hasNext() || pool.hasJobs()) {
+            while (!pairlist.hasNext()) {
+                pairlist.update();
+                // wait
+                pool.beIdle();
+                set = true;
+                try {
+                    sleeps++;
+                    if (sleeps % 10 == 0) {
+                        logger.info(" reducer is sleeping");
+                    } else {
+                        logger.debug("r");
+                    }
+                    Thread.sleep(50);
+                } catch (InterruptedException e) {
+                    break;
+                }
+                if (!pool.hasJobs()) {
+                    break;
+                }
+            }
+            if (!pairlist.hasNext() && !pool.hasJobs()) {
+                break;
+            }
+            if (set) {
+                pool.notIdle();
+                set = false;
+            }
+            pair = pairlist.getNext();
+            if (pair == null) {
+                pairlist.update();
+                continue;
+            }
+            if (debug) {
+                logger.debug("pi = " + pair.pi);
+                logger.debug("pj = " + pair.pj);
+            }
+            S = sred.leftSPolynomial((GenSolvablePolynomial<C>) pair.pi, (GenSolvablePolynomial<C>) pair.pj);
+            if (S.isZERO()) {
+                pairlist.record(pair, S);
+                continue;
+            }
+            if (debug) {
+                logger.debug("ht(S) = " + S.leadingExpVector());
+            }
+            H = sred.leftNormalform(G, S); //mod
+            reduction++;
+            if (H.isZERO()) {
+                pairlist.record(pair, H);
+                continue;
+            }
+            if (debug) {
+                logger.debug("ht(H) = " + H.leadingExpVector());
+            }
+            H = H.monic();
+            // System.out.println("H   = " + H);
+            if (H.isONE()) {
+                // pairlist.update( pair, H );
+                pairlist.putOne(); // not really required
+                synchronized (G) {
+                    G.clear();
+                    G.add(H);
+                }
+                pool.allIdle();
+                return;
+            }
+            if (debug) {
+                logger.debug("H = " + H);
+            }
+            synchronized (G) {
+                G.add(H);
+            }
+            pairlist.update(pair, H);
+            for (int j = 0; j < X.size(); j++) {
+                x = X.get(j);
+                if (x.isONE()) {
+                    continue;
+                }
+                p = H.multiply(x);
+                p = sred.leftNormalform(G, p);
+                if (!p.isZERO()) {
+                    p = p.monic();
+                    if (p.isONE()) {
+                        synchronized (G) {
+                            G.clear();
+                            G.add(p);
+                        }
+                        pool.allIdle();
+                        return;
+                    }
+                    synchronized (G) {
+                        G.add(p);
+                    }
+                    pairlist.put(p);
+                }
+            }
+        }
+        logger.info("terminated, done " + reduction + " reductions");
+    }
+}
+
+
+/**
+ * Reducing worker threads for minimal GB.
+ * @param <C> coefficient type
+ */
+class SolvableMiReducerSeqPair<C extends RingElem<C>> implements Runnable {
+
+
+    private final List<GenSolvablePolynomial<C>> G;
+
+
+    private GenSolvablePolynomial<C> H;
+
+
+    private final SolvableReductionPar<C> sred;
+
+
+    private final Semaphore done = new Semaphore(0);
+
+
+    private static final Logger logger = LogManager.getLogger(SolvableMiReducerSeqPair.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    SolvableMiReducerSeqPair(List<GenSolvablePolynomial<C>> G, GenSolvablePolynomial<C> p) {
+        this.G = G;
+        H = p;
+        sred = new SolvableReductionPar<C>();
+    }
+
+
+    /**
+     * getNF. Blocks until the normal form is computed.
+     * @return the computed normal form.
+     */
+    public GenSolvablePolynomial<C> getNF() {
+        try {
+            done.acquire(); //done.P();
+        } catch (InterruptedException e) {
+        }
+        return H;
+    }
+
+
+    public void run() {
+        if (debug) {
+            logger.debug("ht(H) = " + H.leadingExpVector());
+        }
+        H = sred.leftNormalform(G, H); //mod
+        done.release(); //done.V();
+        if (debug) {
+            logger.debug("ht(H) = " + H.leadingExpVector());
+        }
+        // H = H.monic();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/SolvableReduction.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/SolvableReduction.java
@@ -1,0 +1,166 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.io.Serializable;
+import java.util.List;
+
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Solvable polynomial Reduction interface. Defines S-Polynomial, normalform and
+ * irreducible set.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public interface SolvableReduction<C extends RingElem<C>> extends Serializable {
+
+
+    /**
+     * Left S-Polynomial.
+     * @param Ap solvable polynomial.
+     * @param Bp solvable polynomial.
+     * @return left-spol(Ap,Bp) the left S-polynomial of Ap and Bp.
+     */
+    public GenSolvablePolynomial<C> leftSPolynomial(GenSolvablePolynomial<C> Ap, GenSolvablePolynomial<C> Bp);
+
+
+    /**
+     * S-Polynomial with recording.
+     * @param S recording matrix, is modified.
+     * @param i index of Ap in basis list.
+     * @param Ap a polynomial.
+     * @param j index of Bp in basis list.
+     * @param Bp a polynomial.
+     * @return leftSpol(Ap, Bp), the left S-Polynomial for Ap and Bp.
+     */
+    public GenSolvablePolynomial<C> leftSPolynomial(List<GenSolvablePolynomial<C>> S, int i,
+                    GenSolvablePolynomial<C> Ap, int j, GenSolvablePolynomial<C> Bp);
+
+
+    /**
+     * Left Normalform.
+     * @param Ap solvable polynomial.
+     * @param Pp solvable polynomial list.
+     * @return left-nf(Ap) with respect to Pp.
+     */
+    public GenSolvablePolynomial<C> leftNormalform(List<GenSolvablePolynomial<C>> Pp,
+                    GenSolvablePolynomial<C> Ap);
+
+
+    /**
+     * LeftNormalform with recording.
+     * @param row recording matrix, is modified.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @return nf(Pp,Ap), the left normal form of Ap wrt. Pp.
+     */
+    public GenSolvablePolynomial<C> leftNormalform(List<GenSolvablePolynomial<C>> row,
+                    List<GenSolvablePolynomial<C>> Pp, GenSolvablePolynomial<C> Ap);
+
+
+    /**
+     * Left Normalform Set.
+     * @param Ap solvable polynomial list.
+     * @param Pp solvable polynomial list.
+     * @return list of left-nf(a) with respect to Pp for all a in Ap.
+     */
+    public List<GenSolvablePolynomial<C>> leftNormalform(List<GenSolvablePolynomial<C>> Pp,
+                    List<GenSolvablePolynomial<C>> Ap);
+
+
+    /**
+     * Left irreducible set.
+     * @param Pp solvable polynomial list.
+     * @return a list P of solvable polynomials which are in normalform wrt. P.
+     */
+    public List<GenSolvablePolynomial<C>> leftIrreducibleSet(List<GenSolvablePolynomial<C>> Pp);
+
+
+    /**
+     * Is reduction of normal form.
+     * @param row recording matrix, is modified.
+     * @param Pp a solvable polynomial list for reduction.
+     * @param Ap a solvable polynomial.
+     * @param Np nf(Pp,Ap), a left normal form of Ap wrt. Pp.
+     * @return true, if Np + sum( row[i]*Pp[i] ) == Ap, else false.
+     */
+
+    public boolean isLeftReductionNF(List<GenSolvablePolynomial<C>> row, List<GenSolvablePolynomial<C>> Pp,
+                    GenSolvablePolynomial<C> Ap, GenSolvablePolynomial<C> Np);
+
+
+    /**
+     * Right S-Polynomial.
+     * @param Ap solvable polynomial.
+     * @param Bp solvable polynomial.
+     * @return right-spol(Ap,Bp) the right S-polynomial of Ap and Bp.
+     */
+    public GenSolvablePolynomial<C> rightSPolynomial(GenSolvablePolynomial<C> Ap, GenSolvablePolynomial<C> Bp);
+
+
+    /**
+     * Right Normalform.
+     * @param Ap solvable polynomial.
+     * @param Pp solvable polynomial list.
+     * @return right-nf(Ap) with respect to Pp.
+     */
+    public GenSolvablePolynomial<C> rightNormalform(List<GenSolvablePolynomial<C>> Pp,
+                    GenSolvablePolynomial<C> Ap);
+
+
+    /**
+     * RightNormalform with recording.
+     * @param row recording matrix, is modified.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @return nf(Pp,Ap), the right normal form of Ap wrt. Pp.
+     */
+    public GenSolvablePolynomial<C> rightNormalform(List<GenSolvablePolynomial<C>> row,
+                    List<GenSolvablePolynomial<C>> Pp, GenSolvablePolynomial<C> Ap);
+
+
+    /**
+     * Is top reducible. Condition is lt(B) | lt(A) for some B in F.
+     * Is left right symetric.
+     * @param A polynomial.
+     * @param P polynomial list.
+     * @return true if A is top reducible with respect to P.
+     */
+    public boolean isTopReducible(List<GenSolvablePolynomial<C>> P, GenSolvablePolynomial<C> A);
+
+
+    /**
+     * Is reducible. Is left right symetric.
+     * @param A polynomial.
+     * @param P polynomial list.
+     * @return true if A is reducible with respect to P.
+     */
+    public boolean isReducible(List<GenSolvablePolynomial<C>> P, GenSolvablePolynomial<C> A);
+
+
+    /**
+     * Is in normalform. Is left right symetric.
+     * @param A polynomial.
+     * @param P polynomial list.
+     * @return true if A is in normalform with respect to P.
+     */
+    public boolean isNormalform(List<GenSolvablePolynomial<C>> P, GenSolvablePolynomial<C> A);
+
+
+    /**
+     * Two-sided Normalform.
+     * @param Ap solvable polynomial.
+     * @param Pp solvable polynomial list.
+     * @return two-sided-nf(Ap) with respect to Pp.
+     */
+    public GenSolvablePolynomial<C> normalform(List<GenSolvablePolynomial<C>> Pp,
+                    GenSolvablePolynomial<C> Ap);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/SolvableReductionAbstract.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/SolvableReductionAbstract.java
@@ -1,0 +1,446 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.ModuleList;
+import edu.jas.poly.PolynomialList;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.GenSolvablePolynomialRing;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Solvable polynomial Reduction abstract class. Implements common left, right
+ * S-Polynomial, left normalform and left irreducible set.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public abstract class SolvableReductionAbstract<C extends RingElem<C>> implements SolvableReduction<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(SolvableReductionAbstract.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     */
+    public SolvableReductionAbstract() {
+    }
+
+
+    /**
+     * Left S-Polynomial.
+     * @param Ap solvable polynomial.
+     * @param Bp solvable polynomial.
+     * @return left-spol(Ap,Bp) the left S-polynomial of Ap and Bp.
+     */
+    public GenSolvablePolynomial<C> leftSPolynomial(GenSolvablePolynomial<C> Ap, GenSolvablePolynomial<C> Bp) {
+        if (logger.isInfoEnabled()) {
+            if (Bp == null || Bp.isZERO()) {
+                if (Ap != null) {
+                    return Ap.ring.getZERO();
+                }
+                return null;
+            }
+            if (Ap == null || Ap.isZERO()) {
+                return Bp.ring.getZERO();
+            }
+            if (!Ap.ring.equals(Bp.ring)) {
+                logger.error("rings not equal");
+            }
+        }
+        Map.Entry<ExpVector, C> ma = Ap.leadingMonomial();
+        Map.Entry<ExpVector, C> mb = Bp.leadingMonomial();
+
+        ExpVector e = ma.getKey();
+        ExpVector f = mb.getKey();
+
+        ExpVector g = e.lcm(f);
+        ExpVector e1 = g.subtract(e);
+        ExpVector f1 = g.subtract(f);
+
+        C a = ma.getValue();
+        C b = mb.getValue();
+
+        GenSolvablePolynomial<C> App = Ap.multiplyLeft(b, e1);
+        GenSolvablePolynomial<C> Bpp = Bp.multiplyLeft(a, f1);
+        GenSolvablePolynomial<C> Cp = (GenSolvablePolynomial<C>) App.subtract(Bpp);
+        return Cp;
+    }
+
+
+    /**
+     * S-Polynomial with recording.
+     * @param S recording matrix, is modified.
+     * @param i index of Ap in basis list.
+     * @param Ap a polynomial.
+     * @param j index of Bp in basis list.
+     * @param Bp a polynomial.
+     * @return leftSpol(Ap, Bp), the left S-Polynomial for Ap and Bp.
+     */
+    public GenSolvablePolynomial<C> leftSPolynomial(List<GenSolvablePolynomial<C>> S, int i,
+                    GenSolvablePolynomial<C> Ap, int j, GenSolvablePolynomial<C> Bp) {
+        if (debug /*logger.isInfoEnabled()*/) {
+            if (Bp == null || Bp.isZERO()) {
+                throw new ArithmeticException("Spol B is zero");
+            }
+            if (Ap == null || Ap.isZERO()) {
+                throw new ArithmeticException("Spol A is zero");
+            }
+            if (!Ap.ring.equals(Bp.ring)) {
+                logger.error("rings not equal");
+            }
+        }
+        Map.Entry<ExpVector, C> ma = Ap.leadingMonomial();
+        Map.Entry<ExpVector, C> mb = Bp.leadingMonomial();
+
+        ExpVector e = ma.getKey();
+        ExpVector f = mb.getKey();
+
+        ExpVector g = e.lcm(f);
+        ExpVector e1 = g.subtract(e);
+        ExpVector f1 = g.subtract(f);
+
+        C a = ma.getValue();
+        C b = mb.getValue();
+
+        GenSolvablePolynomial<C> App = Ap.multiplyLeft(b, e1);
+        GenSolvablePolynomial<C> Bpp = Bp.multiplyLeft(a, f1);
+        GenSolvablePolynomial<C> Cp = (GenSolvablePolynomial<C>) App.subtract(Bpp);
+
+        GenSolvablePolynomial<C> zero = Ap.ring.getZERO();
+        GenSolvablePolynomial<C> As = (GenSolvablePolynomial<C>) zero.sum(b.negate(), e1);
+        GenSolvablePolynomial<C> Bs = (GenSolvablePolynomial<C>) zero.sum(a, f1);
+        S.set(i, As);
+        S.set(j, Bs);
+        return Cp;
+    }
+
+
+    /**
+     * Left Normalform Set.
+     * @param Ap solvable polynomial list.
+     * @param Pp solvable polynomial list.
+     * @return list of left-nf(a) with respect to Pp for all a in Ap.
+     */
+    public List<GenSolvablePolynomial<C>> leftNormalform(List<GenSolvablePolynomial<C>> Pp,
+                    List<GenSolvablePolynomial<C>> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isEmpty()) {
+            return Ap;
+        }
+        ArrayList<GenSolvablePolynomial<C>> red = new ArrayList<GenSolvablePolynomial<C>>();
+        for (GenSolvablePolynomial<C> A : Ap) {
+            A = leftNormalform(Pp, A);
+            red.add(A);
+        }
+        return red;
+    }
+
+
+    /**
+     * Module left normalform set.
+     * @param Ap module list.
+     * @param Pp module list.
+     * @return list of left-nf(a) with respect to Pp for all a in Ap.
+     */
+    public ModuleList<C> leftNormalform(ModuleList<C> Pp, ModuleList<C> Ap) {
+        return leftNormalform(Pp, Ap, false);
+    }
+
+    
+    /**
+     * Module left normalform set.
+     * @param Ap module list.
+     * @param Pp module list.
+     * @param top true for TOP term order, false for POT term order.
+     * @return list of left-nf(a) with respect to Pp for all a in Ap.
+     */
+    public ModuleList<C> leftNormalform(ModuleList<C> Pp, ModuleList<C> Ap, boolean top) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isEmpty()) {
+            return Ap;
+        }
+        GenSolvablePolynomialRing<C> sring = (GenSolvablePolynomialRing<C>) Pp.ring;
+        int modv = Pp.cols;
+        GenSolvablePolynomialRing<C> pfac = sring.extend(modv, top);
+        logger.debug("extended ring = " + pfac.toScript());
+        //System.out.println("extended ring = " + pfac.toScript());
+        PolynomialList<C> P = Pp.getPolynomialList(pfac);
+        PolynomialList<C> A = Ap.getPolynomialList(pfac);
+        //System.out.println("P = " + P.toScript());
+
+        List<GenSolvablePolynomial<C>> red = leftNormalform(P.castToSolvableList(), A.castToSolvableList());
+        PolynomialList<C> Fr = new PolynomialList<C>(pfac, red);
+        ModuleList<C> Nr = Fr.getModuleList(modv);
+        return Nr;
+    }
+
+    
+    /**
+     * Left irreducible set.
+     * @param Pp solvable polynomial list.
+     * @return a list P of solvable polynomials which are in normalform wrt. P.
+     */
+    public List<GenSolvablePolynomial<C>> leftIrreducibleSet(List<GenSolvablePolynomial<C>> Pp) {
+        ArrayList<GenSolvablePolynomial<C>> P = new ArrayList<GenSolvablePolynomial<C>>();
+        for (GenSolvablePolynomial<C> a : Pp) {
+            if (a.length() != 0) {
+                a = a.monic();
+                P.add(a);
+            }
+        }
+        int l = P.size();
+        if (l <= 1)
+            return P;
+
+        int irr = 0;
+        ExpVector e;
+        ExpVector f;
+        GenSolvablePolynomial<C> a;
+        Iterator<GenSolvablePolynomial<C>> it;
+        logger.debug("irr = ");
+        while (irr != l) {
+            it = P.listIterator();
+            a = it.next();
+            P.remove(0);
+            e = a.leadingExpVector();
+            a = leftNormalform(P, a);
+            logger.debug(String.valueOf(irr));
+            if (a.length() == 0) {
+                l--;
+                if (l <= 1) {
+                    return P;
+                }
+            } else {
+                f = a.leadingExpVector();
+                if (f.signum() == 0) {
+                    P = new ArrayList<GenSolvablePolynomial<C>>();
+                    P.add(a.monic());
+                    return P;
+                }
+                if (e.equals(f)) {
+                    irr++;
+                } else {
+                    irr = 0;
+                    a = a.monic();
+                }
+                P.add(a);
+            }
+        }
+        //System.out.println();
+        return P;
+    }
+
+
+    /**
+     * Is reduction of normal form.
+     * @param row recording matrix.
+     * @param Pp a solvable polynomial list for reduction.
+     * @param Ap a solvable polynomial.
+     * @param Np nf(Pp,Ap), a left normal form of Ap wrt. Pp.
+     * @return true, if Np + sum( row[i]*Pp[i] ) == Ap, else false.
+     */
+    @SuppressWarnings("unchecked")
+    public boolean isLeftReductionNF(List<GenSolvablePolynomial<C>> row, List<GenSolvablePolynomial<C>> Pp,
+                    GenSolvablePolynomial<C> Ap, GenSolvablePolynomial<C> Np) {
+        if (row == null && Pp == null) {
+            if (Ap == null) {
+                return Np == null;
+            }
+            return Ap.equals(Np);
+        }
+        if (row == null || Pp == null) {
+            return false;
+        }
+        if (row.size() != Pp.size()) {
+            return false;
+        }
+        GenSolvablePolynomial<C> t = Np;
+        GenSolvablePolynomial<C> r;
+        GenSolvablePolynomial<C> p;
+        for (int m = 0; m < Pp.size(); m++) {
+            r = row.get(m);
+            p = Pp.get(m);
+            if (r != null && p != null) {
+                if (t == null) {
+                    t = r.multiply(p);
+                } else {
+                    t = (GenSolvablePolynomial<C>) t.sum(r.multiply(p));
+                }
+            }
+            //System.out.println("r = " + r );
+            //System.out.println("p = " + p );
+        }
+        if (debug) {
+            logger.info("t = " + t);
+            logger.info("a = " + Ap);
+        }
+        if (t == null) {
+            if (Ap == null) {
+                return true;
+            }
+            return Ap.isZERO();
+        }
+        t = (GenSolvablePolynomial<C>) t.subtract(Ap);
+        return t.isZERO();
+    }
+
+
+    /**
+     * Right S-Polynomial.
+     * @param Ap solvable polynomial.
+     * @param Bp solvable polynomial.
+     * @return right-spol(Ap,Bp) the right S-polynomial of Ap and Bp.
+     */
+    @SuppressWarnings("unchecked")
+    public GenSolvablePolynomial<C> rightSPolynomial(GenSolvablePolynomial<C> Ap, GenSolvablePolynomial<C> Bp) {
+        if (logger.isInfoEnabled()) {
+            if (Bp == null || Bp.isZERO()) {
+                if (Ap != null) {
+                    return Ap.ring.getZERO();
+                }
+                return null;
+            }
+            if (Ap == null || Ap.isZERO()) {
+                return Bp.ring.getZERO();
+            }
+            if (!Ap.ring.equals(Bp.ring)) {
+                logger.error("rings not equal");
+            }
+        }
+        ExpVector e = Ap.leadingExpVector();
+        ExpVector f = Bp.leadingExpVector();
+
+        ExpVector g = e.lcm(f);
+        ExpVector e1 = g.subtract(e);
+        ExpVector f1 = g.subtract(f);
+
+        GenSolvablePolynomial<C> App = Ap.multiply(e1);
+        GenSolvablePolynomial<C> Bpp = Bp.multiply(f1);
+
+        C a = App.leadingBaseCoefficient();
+        C b = Bpp.leadingBaseCoefficient();
+        App = App.multiply(b);
+        Bpp = Bpp.multiply(a);
+
+        GenSolvablePolynomial<C> Cp = (GenSolvablePolynomial<C>) App.subtract(Bpp);
+        return Cp;
+    }
+
+
+    /**
+     * Is top reducible. Is left right symmetric.
+     * @param A solvable polynomial.
+     * @param P solvable polynomial list.
+     * @return true if A is top reducible with respect to P.
+     */
+    public boolean isTopReducible(List<GenSolvablePolynomial<C>> P, GenSolvablePolynomial<C> A) {
+        if (P == null || P.isEmpty()) {
+            return false;
+        }
+        if (A == null || A.isZERO()) {
+            return false;
+        }
+        boolean mt = false;
+        ExpVector e = A.leadingExpVector();
+        for (GenSolvablePolynomial<C> p : P) {
+            mt = e.multipleOf(p.leadingExpVector());
+            if (mt) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    /**
+     * Is reducible. Is left right symmetric.
+     * @param Ap solvable polynomial.
+     * @param Pp solvable polynomial list.
+     * @return true if Ap is reducible with respect to Pp.
+     */
+    public boolean isReducible(List<GenSolvablePolynomial<C>> Pp, GenSolvablePolynomial<C> Ap) {
+        return !isNormalform(Pp, Ap);
+    }
+
+
+    /**
+     * Is in Normalform. Is left right symmetric.
+     * @param Ap polynomial.
+     * @param Pp polynomial list.
+     * @return true if Ap is in normalform with respect to Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public boolean isNormalform(List<GenSolvablePolynomial<C>> Pp, GenSolvablePolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return true;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return true;
+        }
+        GenSolvablePolynomial<C>[] P = new GenSolvablePolynomial[0];
+        synchronized (Pp) {
+            P = Pp.toArray(P);
+        }
+        int l = P.length;
+        ExpVector[] htl = new ExpVector[l];
+        GenSolvablePolynomial<C>[] p = new GenSolvablePolynomial[l];
+        ExpVector f;
+        int i;
+        int j = 0;
+        for (i = 0; i < l; i++) {
+            p[i] = P[i];
+            f = p[i].leadingExpVector();
+            if (f != null) {
+                p[j] = p[i];
+                htl[j] = f;
+                j++;
+            }
+        }
+        l = j;
+        boolean mt = false;
+        for (ExpVector e : Ap.getMap().keySet()) {
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Two-sided Normalform.
+     * @param Ap solvable polynomial.
+     * @param Pp solvable polynomial list.
+     * @return two-sided-nf(Ap) with respect to Pp.
+     */
+    public GenSolvablePolynomial<C> normalform(List<GenSolvablePolynomial<C>> Pp,
+                    GenSolvablePolynomial<C> Ap) {
+        throw new UnsupportedOperationException("two-sided normalform not implemented");
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/SolvableReductionPar.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/SolvableReductionPar.java
@@ -1,0 +1,233 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.List;
+import java.util.Map;
+
+// import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Solvable polynomial Reduction parallel usable algorithm. Implements left
+ * normalform.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class SolvableReductionPar<C extends RingElem<C>> extends SolvableReductionAbstract<C> {
+
+
+    //private static final Logger logger = LogManager.getLogger(SolvableReductionPar.class);
+
+
+    /**
+     * Constructor.
+     */
+    public SolvableReductionPar() {
+    }
+
+
+    /**
+     * Left Normalform.
+     * @param Ap solvable polynomial.
+     * @param Pp solvable polynomial list.
+     * @return left-nf(Ap) with respect to Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public GenSolvablePolynomial<C> leftNormalform(List<GenSolvablePolynomial<C>> Pp,
+                    GenSolvablePolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        int l;
+        Map.Entry<ExpVector, C> m;
+        GenSolvablePolynomial<C>[] P;
+        synchronized (Pp) {
+            l = Pp.size();
+            P = (GenSolvablePolynomial<C>[]) new GenSolvablePolynomial[l];
+            //P = Pp.toArray();
+            for (int j = 0; j < Pp.size(); j++) {
+                P[j] = Pp.get(j);
+            }
+        }
+        ExpVector e;
+        ExpVector f = null;
+        C a;
+        boolean mt = false;
+        GenSolvablePolynomial<C> Rz = Ap.ring.getZERO().copy();
+        GenSolvablePolynomial<C> R = Ap.ring.getZERO().copy();
+
+        GenSolvablePolynomial<C> p = null;
+        GenSolvablePolynomial<C> Q = null;
+        GenSolvablePolynomial<C> S = Ap.copy();
+        while (S.length() > 0) {
+            if (Pp.size() != l) {
+                //long t = System.currentTimeMillis();
+                synchronized (Pp) { // required, bad in parallel
+                    l = Pp.size();
+                    P = (GenSolvablePolynomial<C>[]) new GenSolvablePolynomial[l];
+                    //P = Pp.toArray();
+                    for (int i = 0; i < Pp.size(); i++) {
+                        P[i] = Pp.get(i);
+                    }
+                }
+                //t = System.currentTimeMillis()-t;
+                //logger.info("Pp.toArray() = " + t + " ms, size() = " + l);
+                S = Ap.copy(); // S.add(R)? // restart reduction ?
+                R = Rz.copy();
+            }
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            for (int i = 0; i < P.length; i++) {
+                p = P[i];
+                f = p.leadingExpVector();
+                if (f != null) {
+                    mt = e.multipleOf(f);
+                    if (mt)
+                        break;
+                }
+            }
+            if (!mt) {
+                //logger.debug("irred");
+                //R = (GenSolvablePolynomial<C>) R.sum(a, e);
+                //S = (GenSolvablePolynomial<C>) S.subtract(a, e);
+                R.doPutToMap(e, a);
+                S.doRemoveFromMap(e, a);
+                // System.out.println(" S = " + S);
+            } else {
+                //logger.debug("red");
+                e = e.subtract(f);
+                Q = p.multiplyLeft(e);
+                a = a.divide(Q.leadingBaseCoefficient());
+                //Q = Q.multiplyLeft(a);
+                //S = (GenSolvablePolynomial<C>) S.subtract(Q);
+                S = S.subtractMultiple(a, Q);
+            }
+        }
+        return R;
+    }
+
+
+    /**
+     * LeftNormalform with recording.
+     * @param row recording matrix, is modified.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @return nf(Pp,Ap), the left normal form of Ap wrt. Pp.
+     */
+    public GenSolvablePolynomial<C> leftNormalform(List<GenSolvablePolynomial<C>> row,
+                    List<GenSolvablePolynomial<C>> Pp, GenSolvablePolynomial<C> Ap) {
+        throw new UnsupportedOperationException("normalform with recording not implemented");
+    }
+
+
+    /**
+     * Right Normalform.
+     * @param Ap solvable polynomial.
+     * @param Pp solvable polynomial list.
+     * @return right-nf(Ap) with respect to Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public GenSolvablePolynomial<C> rightNormalform(List<GenSolvablePolynomial<C>> Pp,
+                    GenSolvablePolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        int l;
+        Map.Entry<ExpVector, C> m;
+        GenSolvablePolynomial<C>[] P;
+        synchronized (Pp) {
+            l = Pp.size();
+            P = (GenSolvablePolynomial<C>[]) new GenSolvablePolynomial[l];
+            //P = Pp.toArray();
+            for (int j = 0; j < Pp.size(); j++) {
+                P[j] = Pp.get(j);
+            }
+        }
+        ExpVector e;
+        ExpVector f = null;
+        C a;
+        boolean mt = false;
+        GenSolvablePolynomial<C> Rz = Ap.ring.getZERO().copy();
+        GenSolvablePolynomial<C> R = Ap.ring.getZERO().copy();
+
+        GenSolvablePolynomial<C> p = null;
+        GenSolvablePolynomial<C> Q = null;
+        GenSolvablePolynomial<C> S = Ap.copy();
+        while (S.length() > 0) {
+            if (Pp.size() != l) {
+                //long t = System.currentTimeMillis();
+                synchronized (Pp) { // required, bad in parallel
+                    l = Pp.size();
+                    P = (GenSolvablePolynomial<C>[]) new GenSolvablePolynomial[l];
+                    //P = Pp.toArray();
+                    for (int i = 0; i < Pp.size(); i++) {
+                        P[i] = Pp.get(i);
+                    }
+                }
+                //t = System.currentTimeMillis()-t;
+                //logger.info("Pp.toArray() = " + t + " ms, size() = " + l);
+                S = Ap.copy(); // S.add(R)? // restart reduction ?
+                R = Rz.copy();
+            }
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            for (int i = 0; i < P.length; i++) {
+                p = P[i];
+                f = p.leadingExpVector();
+                if (f != null) {
+                    mt = e.multipleOf(f);
+                    if (mt)
+                        break;
+                }
+            }
+            if (!mt) {
+                //logger.debug("irred");
+                //R = (GenSolvablePolynomial<C>) R.sum(a, e);
+                //S = (GenSolvablePolynomial<C>) S.subtract(a, e);
+                R.doPutToMap(e, a);
+                S.doRemoveFromMap(e, a);
+                // System.out.println(" S = " + S);
+            } else {
+                //logger.debug("red");
+                e = e.subtract(f);
+                Q = p.multiply(e); // p * (a e) TODO
+                a = a.divide(Q.leadingBaseCoefficient());
+                Q = Q.multiply(a); // p * (e a) !!
+                S = (GenSolvablePolynomial<C>) S.subtract(Q);
+                //S = S.subtractMultiple(Q, a);
+            }
+        }
+        return R;
+    }
+
+
+    /**
+     * RightNormalform with recording.
+     * @param row recording matrix, is modified.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @return nf(Pp,Ap), the right normal form of Ap wrt. Pp.
+     */
+    public GenSolvablePolynomial<C> rightNormalform(List<GenSolvablePolynomial<C>> row,
+                    List<GenSolvablePolynomial<C>> Pp, GenSolvablePolynomial<C> Ap) {
+        throw new UnsupportedOperationException("normalform with recording not implemented");
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/SolvableReductionSeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/SolvableReductionSeq.java
@@ -1,0 +1,412 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Solvable polynomial Reduction algorithm. Implements left, right normalform.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class SolvableReductionSeq<C extends RingElem<C>> extends SolvableReductionAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(SolvableReductionSeq.class);
+
+
+    /**
+     * Constructor.
+     */
+    public SolvableReductionSeq() {
+    }
+
+
+    /**
+     * Left Normalform.
+     * @param Ap solvable polynomial.
+     * @param Pp solvable polynomial list.
+     * @return left-nf(Ap) with respect to Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public GenSolvablePolynomial<C> leftNormalform(List<GenSolvablePolynomial<C>> Pp,
+                    GenSolvablePolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        Map.Entry<ExpVector, C> m;
+        GenSolvablePolynomial<C>[] P = new GenSolvablePolynomial[0];
+        synchronized (Pp) {
+            P = Pp.toArray(P);
+        }
+        int l = P.length;
+        int i;
+        ExpVector[] htl = new ExpVector[l];
+        //C[] lbc = (C[]) new RingElem[l];
+        GenSolvablePolynomial<C>[] p = new GenSolvablePolynomial[l];
+        int j = 0;
+        for (i = 0; i < l; i++) {
+            if (P[i] == null) {
+                continue;
+            }
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                //lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        ExpVector e; //, f;
+        C a, b;
+        boolean mt = false;
+        GenSolvablePolynomial<C> R = Ap.ring.getZERO().copy();
+        GenSolvablePolynomial<C> Q = null;
+        GenSolvablePolynomial<C> S = Ap.copy();
+        GenSolvablePolynomial<C> Sp;
+        while (S.length() > 0) {
+            m = S.leadingMonomial();
+            e = m.getKey();
+            if (logger.isDebugEnabled()) {
+                logger.debug("red, e = " + e);
+            }
+            a = m.getValue();
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt)
+                    break;
+            }
+            if (!mt) {
+                //logger.debug("irred");
+                //R = (GenSolvablePolynomial<C>) R.sum(a, e);
+                //S = (GenSolvablePolynomial<C>) S.subtract(a, e);
+                R.doPutToMap(e, a);
+                S.doRemoveFromMap(e, a);
+                // System.out.println(" S = " + S);
+            } else {
+                //f = e;
+                e = e.subtract(htl[i]);
+                //logger.debug("red div = " + e);
+                Q = p[i].multiplyLeft(e);
+                b = a;
+                a = a.divide(Q.leadingBaseCoefficient());
+                //Q = Q.multiplyLeft(a);
+                //S = (GenSolvablePolynomial<C>) S.subtract(Q);
+                ExpVector g1 = S.leadingExpVector();
+                Sp = S;
+                S = S.subtractMultiple(a, Q);
+                //S = S.subtractMultiple(a, e, p[i]);
+                ExpVector g2 = S.leadingExpVector();
+                if (g1.equals(g2)) {
+                    logger.info("g1.equals(g2): Pp       = " + Pp);
+                    logger.info("g1.equals(g2): Ap       = " + Ap);
+                    logger.info("g1.equals(g2): p[i]     = " + p[i]);
+                    logger.info("g1.equals(g2): Q        = " + Q);
+                    logger.info("g1.equals(g2): R        = " + R);
+                    logger.info("g1.equals(g2): Sp       = " + Sp);
+                    logger.info("g1.equals(g2): S        = " + S);
+                    throw new RuntimeException("g1.equals(g2): " + g1 + ", a = " + a + ", b = " + b);
+                }
+            }
+        }
+        return R;
+    }
+
+
+    /**
+     * LeftNormalform with recording.
+     * @param row recording matrix, is modified.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @return nf(Pp,Ap), the left normal form of Ap wrt. Pp.
+     */
+    @SuppressWarnings({ "cast", "unchecked" })
+    public GenSolvablePolynomial<C> leftNormalform(List<GenSolvablePolynomial<C>> row,
+                    List<GenSolvablePolynomial<C>> Pp, GenSolvablePolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        GenSolvablePolynomial<C>[] P = new GenSolvablePolynomial[0];
+        synchronized (Pp) {
+            P = Pp.toArray(P);
+        }
+        int l = P.length;
+        ExpVector[] htl = new ExpVector[l];
+        //C[] lbc = (C[]) new RingElem[l];
+        GenSolvablePolynomial<C>[] p = (GenSolvablePolynomial<C>[]) new GenSolvablePolynomial[l];
+        Map.Entry<ExpVector, C> m;
+        int j = 0;
+        int i;
+        for (i = 0; i < l; i++) {
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                //lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        ExpVector e;
+        C a;
+        boolean mt = false;
+        //GenSolvablePolynomial<C> zero = Ap.ring.getZERO();
+        GenSolvablePolynomial<C> R = Ap.ring.getZERO().copy();
+
+        GenSolvablePolynomial<C> fac = null;
+        GenSolvablePolynomial<C> Q = null;
+        GenSolvablePolynomial<C> S = Ap.copy();
+        while (S.length() > 0) {
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt)
+                    break;
+            }
+            if (!mt) {
+                //logger.debug("irred");
+                //R = (GenSolvablePolynomial<C>) R.sum(a, e);
+                //S = (GenSolvablePolynomial<C>) S.subtract(a, e);
+                R.doPutToMap(e, a);
+                S.doRemoveFromMap(e, a);
+                // System.out.println(" S = " + S);
+            } else {
+                e = e.subtract(htl[i]);
+                //logger.info("red div = " + e);
+                //a = a.divide( (C)lbc[i] );
+                //Q = p[i].multiplyLeft( a, e );
+                Q = p[i].multiplyLeft(e);
+                a = a.divide(Q.leadingBaseCoefficient());
+                //Q = Q.multiplyLeft(a);
+                //S = (GenSolvablePolynomial<C>) S.subtract(Q);
+                ExpVector g1 = S.leadingExpVector();
+                S = S.subtractMultiple(a, Q);
+                ExpVector g2 = S.leadingExpVector();
+                if (g1.equals(g2)) {
+                    throw new RuntimeException("g1.equals(g2): " + g1 + ", a = " + a + ", lc(S) = "
+                                    + S.leadingBaseCoefficient());
+                }
+                fac = row.get(i);
+                if (fac == null) {
+                    //fac = (GenSolvablePolynomial<C>) zero.sum(a, e);
+                    fac = Ap.ring.valueOf(a, e);
+                } else { 
+                    //fac = (GenSolvablePolynomial<C>) fac.sum(a, e);
+                    fac.doAddTo(a, e);
+                }
+                row.set(i, fac);
+            }
+        }
+        return R;
+    }
+
+
+    /**
+     * Right Normalform.
+     * @param Ap solvable polynomial.
+     * @param Pp solvable polynomial list.
+     * @return right-nf(Ap) with respect to Pp.
+     */
+    @SuppressWarnings({ "cast", "unchecked" })
+    public GenSolvablePolynomial<C> rightNormalform(List<GenSolvablePolynomial<C>> Pp,
+                    GenSolvablePolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        int l;
+        Map.Entry<ExpVector, C> m;
+        GenSolvablePolynomial<C>[] P;
+        synchronized (Pp) {
+            l = Pp.size();
+            P = (GenSolvablePolynomial<C>[]) new GenSolvablePolynomial[l];
+            //P = Pp.toArray();
+            for (int j = 0; j < Pp.size(); j++) {
+                P[j] = Pp.get(j);
+            }
+        }
+        int i;
+        ExpVector[] htl = new ExpVector[l];
+        //C[] lbc = (C[]) new RingElem[l];
+        GenSolvablePolynomial<C>[] p = (GenSolvablePolynomial<C>[]) new GenSolvablePolynomial[l];
+        int j = 0;
+        for (i = 0; i < l; i++) {
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                //lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        ExpVector e;
+        C a;
+        boolean mt = false;
+        GenSolvablePolynomial<C> R = Ap.ring.getZERO().copy();
+
+        //GenSolvablePolynomial<C> T = null;
+        GenSolvablePolynomial<C> Q = null;
+        GenSolvablePolynomial<C> S = Ap.copy();
+        while (S.length() > 0) {
+            m = S.leadingMonomial();
+            e = m.getKey();
+            //logger.info("red = " + e);
+            a = m.getValue();
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt)
+                    break;
+            }
+            if (!mt) {
+                //logger.debug("irred");
+                //R = (GenSolvablePolynomial<C>) R.sum(a, e);
+                //S = (GenSolvablePolynomial<C>) S.subtract(a, e);
+                R.doPutToMap(e, a);
+                S.doRemoveFromMap(e, a);
+                // System.out.println(" S = " + S);
+            } else {
+                //logger.debug("red");
+                e = e.subtract(htl[i]);
+                //a = a.divide( (C)lbc[i] );
+                Q = p[i].multiply(e); // p_i * (a e) TODO
+                a = a.divide(Q.leadingBaseCoefficient());
+                Q = Q.multiply(a); // p_i * (e a) !!
+                ExpVector g1 = S.leadingExpVector();
+                S = (GenSolvablePolynomial<C>) S.subtract(Q);
+                //S = S.subtractMultiple(Q, a);
+                ExpVector g2 = S.leadingExpVector();
+                if (g1.equals(g2)) {
+                    throw new RuntimeException("g1.equals(g2): " + g1 + ", a = " + a + ", lc(S) = "
+                                    + S.leadingBaseCoefficient());
+                }
+            }
+        }
+        return R;
+    }
+
+
+    /**
+     * RightNormalform with recording.
+     * @param row recording matrix, is modified.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @return nf(Pp,Ap), the right normal form of Ap wrt. Pp.
+     */
+    @SuppressWarnings({ "cast", "unchecked" })
+    public GenSolvablePolynomial<C> rightNormalform(List<GenSolvablePolynomial<C>> row,
+                    List<GenSolvablePolynomial<C>> Pp, GenSolvablePolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        int l = Pp.size();
+        GenSolvablePolynomial<C>[] P = (GenSolvablePolynomial<C>[]) new GenSolvablePolynomial[l];
+        synchronized (Pp) {
+            //P = Pp.toArray();
+            for (int i = 0; i < Pp.size(); i++) {
+                P[i] = Pp.get(i);
+            }
+        }
+        ExpVector[] htl = new ExpVector[l];
+        //C[] lbc = (C[]) new RingElem[l];
+        GenSolvablePolynomial<C>[] p = (GenSolvablePolynomial<C>[]) new GenSolvablePolynomial[l];
+        Map.Entry<ExpVector, C> m;
+        int j = 0;
+        int i;
+        for (i = 0; i < l; i++) {
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                //lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        ExpVector e;
+        C a;
+        boolean mt = false;
+        GenSolvablePolynomial<C> zero = Ap.ring.getZERO();
+        GenSolvablePolynomial<C> R = Ap.ring.getZERO().copy();
+
+        GenSolvablePolynomial<C> fac = null;
+        // GenSolvablePolynomial<C> T = null;
+        GenSolvablePolynomial<C> Q = null;
+        GenSolvablePolynomial<C> S = Ap.copy();
+        while (S.length() > 0) {
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt)
+                    break;
+            }
+            if (!mt) {
+                //logger.debug("irred");
+                //R = (GenSolvablePolynomial<C>) R.sum(a, e);
+                //S = (GenSolvablePolynomial<C>) S.subtract(a, e);
+                R.doPutToMap(e, a);
+                S.doRemoveFromMap(e, a);
+            } else {
+                e = e.subtract(htl[i]);
+                //logger.info("red div = " + e);
+                //a = a.divide( (C)lbc[i] );
+                //Q = p[i].multiply( a, e );
+                Q = p[i].multiply(e); // p_i * (a e) TODO
+                a = a.divide(Q.leadingBaseCoefficient());
+                Q = Q.multiply(a); // p_i * (e a)
+                ExpVector g1 = S.leadingExpVector();
+                S = (GenSolvablePolynomial<C>) S.subtract(Q);
+                //S = S.subtractMultiple(Q, a);
+                ExpVector g2 = S.leadingExpVector();
+                if (g1.equals(g2)) {
+                    throw new RuntimeException("g1.equals(g2): " + g1 + ", a = " + a + ", lc(S) = "
+                                    + S.leadingBaseCoefficient());
+                }
+                fac = row.get(i);
+                if (fac == null) {
+                    //fac = (GenSolvablePolynomial<C>) zero.sum(a, e);
+                    fac = Ap.ring.valueOf(a, e);
+                } else { 
+                    //fac = (GenSolvablePolynomial<C>) fac.sum(a, e);
+                    fac.doAddTo(a, e);
+                }
+                row.set(i, fac);
+            }
+        }
+        return R;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/WordGroebnerBase.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/WordGroebnerBase.java
@@ -1,0 +1,48 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.io.Serializable;
+import java.util.List;
+
+import edu.jas.poly.GenWordPolynomial;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Non-commutative Groebner Bases interface for GenWordPolynomials. Defines
+ * methods for Groebner bases and GB test.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public interface WordGroebnerBase<C extends RingElem<C>> extends Serializable {
+
+
+    /**
+     * Groebner base test.
+     * @param F word polynomial list.
+     * @return true, if F is a Groebner base, else false.
+     */
+    public boolean isGB(List<GenWordPolynomial<C>> F);
+
+
+    /**
+     * Groebner base using pairlist class.
+     * @param F word polynomial list.
+     * @return GB(F) a non-commutative Groebner base of F.
+     */
+    public List<GenWordPolynomial<C>> GB(List<GenWordPolynomial<C>> F);
+
+
+    /**
+     * Minimal ordered groebner basis.
+     * @param Gp a Word Groebner base.
+     * @return a reduced Word Groebner base of Gp.
+     */
+    public List<GenWordPolynomial<C>> minimalGB(List<GenWordPolynomial<C>> Gp);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/WordGroebnerBaseAbstract.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/WordGroebnerBaseAbstract.java
@@ -1,0 +1,383 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.GenWordPolynomial;
+import edu.jas.poly.GenWordPolynomialRing;
+import edu.jas.poly.Word;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Non-commutative Groebner Bases abstract class. Implements common Groebner
+ * bases and GB test methods.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public abstract class WordGroebnerBaseAbstract<C extends RingElem<C>> implements WordGroebnerBase<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(WordGroebnerBaseAbstract.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Reduction engine.
+     */
+    public final WordReduction<C> red;
+
+
+    /**
+     * Strategy for pair selection.
+     */
+    public final WordPairList<C> strategy;
+
+
+    /**
+     * Constructor.
+     */
+    public WordGroebnerBaseAbstract() {
+        this(new WordReductionSeq<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param red Word Reduction engine
+     */
+    public WordGroebnerBaseAbstract(WordReduction<C> red) {
+        this(red, new OrderedWordPairlist<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param red Word Reduction engine
+     * @param pl Word pair selection strategy
+     */
+    public WordGroebnerBaseAbstract(WordReduction<C> red, WordPairList<C> pl) {
+        this.red = red;
+        this.strategy = pl;
+    }
+
+
+    /**
+     * Get the String representation with GB engines.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName();
+    }
+
+
+    /**
+     * Normalize polynomial list.
+     * @param A list of polynomials.
+     * @return list of polynomials with zeros removed and ones/units reduced.
+     */
+    public List<GenWordPolynomial<C>> normalizeZerosOnes(List<GenWordPolynomial<C>> A) {
+        if (A == null) {
+            return A;
+        }
+        List<GenWordPolynomial<C>> N = new ArrayList<GenWordPolynomial<C>>(A.size());
+        if (A.isEmpty()) {
+            return N;
+        }
+        for (GenWordPolynomial<C> p : A) {
+            if (p == null || p.isZERO()) {
+                continue;
+            }
+            if (p.isUnit()) {
+                N.clear();
+                N.add(p.ring.getONE());
+                return N;
+            }
+            N.add(p.abs());
+        }
+        //N.trimToSize();
+        return N;
+    }
+
+
+    /**
+     * Common zero test, test if univariate leading words exist for all
+     * variables.
+     * @param F polynomial list.
+     * @return -1, 0 or 1 if "dimension"(ideal(F)) &eq; -1, 0 or &ge; 1.
+     */
+    public int commonZeroTest(List<GenWordPolynomial<C>> F) {
+        if (F == null || F.isEmpty()) {
+            return 1;
+        }
+        GenWordPolynomialRing<C> pfac = F.get(0).ring;
+        if (pfac.alphabet.length() <= 0) {
+            return -1;
+        }
+        Set<String> v = new HashSet<String>(); // for non reduced GBs
+        for (GenWordPolynomial<C> p : F) {
+            if (p.isZERO()) {
+                continue;
+            }
+            if (p.isConstant()) { // for non-monic lists
+                return -1;
+            }
+            Word e = p.leadingWord();
+            if (e == null) {
+                continue;
+            }
+            SortedMap<String, Integer> u = e.dependencyOnVariables();
+            if (u == null) {
+                continue;
+            }
+            if (u.size() == 1) {
+                v.add(u.firstKey());
+            }
+        }
+        if (pfac.alphabet.length() == v.size()) {
+            return 0;
+        }
+        return 1;
+    }
+
+
+    /**
+     * Univariate head term degrees.
+     * @param A list of polynomials.
+     * @return a list of the degrees of univariate head terms.
+     */
+    public List<Long> univariateDegrees(List<GenWordPolynomial<C>> A) {
+        List<Long> ud = new ArrayList<Long>();
+        if (A == null || A.size() == 0) {
+            return ud;
+        }
+        GenWordPolynomialRing<C> pfac = A.get(0).ring;
+        if (pfac.alphabet.length() <= 0) {
+            return ud;
+        }
+        SortedMap<String, Long> v = new TreeMap<String, Long>(); // for non reduced GBs
+        for (GenWordPolynomial<C> p : A) {
+            Word e = p.leadingWord();
+            if (e == null) {
+                continue;
+            }
+            SortedMap<String, Integer> u = e.dependencyOnVariables();
+            if (u == null) {
+                continue;
+            }
+            if (u.size() == 1) {
+                Long d = v.get(u.firstKey());
+                if (d == null) { // record only once
+                    v.put(u.firstKey(), Long.valueOf(u.get(u.firstKey())));
+                }
+            }
+        }
+        ud.addAll(v.values());
+        //Collections.reverse(ud);
+        return ud;
+    }
+
+
+    /**
+     * Word Groebner base test.
+     * @param F Word polynomial list.
+     * @return true, if F is a Groebner base, else false.
+     */
+    public boolean isGB(List<GenWordPolynomial<C>> F) {
+        if (F == null || F.size() <= 1) {
+            return true;
+        }
+        for (int i = 0; i < F.size(); i++) {
+            GenWordPolynomial<C> pi = F.get(i);
+            for (int j = i + 1; j < F.size(); j++) {
+                GenWordPolynomial<C> pj = F.get(j);
+                List<GenWordPolynomial<C>> S = red.SPolynomials(pi, pj);
+                for (GenWordPolynomial<C> s : S) {
+                    //System.out.println("s-pol("+i+","+j+"): " + s.leadingWord());
+                    GenWordPolynomial<C> h = red.normalform(F, s);
+                    if (!h.isZERO()) {
+                        logger.info("no GB: pi = " + pi + ", pj = " + pj);
+                        logger.info("s  = " + s + ", h = " + h);
+                        return false;
+                    }
+                }
+                S = red.SPolynomials(pj, pi);
+                for (GenWordPolynomial<C> s : S) {
+                    //System.out.println("s-pol("+j+","+i+"): " + s.leadingWord());
+                    GenWordPolynomial<C> h = red.normalform(F, s);
+                    if (!h.isZERO()) {
+                        logger.info("no GB: pj = " + pj + ", pi = " + pi);
+                        logger.info("s  = " + s + ", h = " + h);
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Groebner base using pairlist class.
+     * @param F polynomial list.
+     * @return GB(F) a Groebner base of F.
+     */
+    public abstract List<GenWordPolynomial<C>> GB(List<GenWordPolynomial<C>> F);
+
+
+    /**
+     * Minimal ordered Groebner basis.
+     * @param Gp a Groebner base.
+     * @return a reduced Groebner base of Gp.
+     */
+    public List<GenWordPolynomial<C>> minimalGB(List<GenWordPolynomial<C>> Gp) {
+        if (Gp == null || Gp.size() <= 1) {
+            return Gp;
+        }
+        // remove zero polynomials
+        List<GenWordPolynomial<C>> G = new ArrayList<GenWordPolynomial<C>>(Gp.size());
+        for (GenWordPolynomial<C> a : Gp) {
+            if (a != null && !a.isZERO()) { // always true in GB()
+                // already positive a = a.abs();
+                G.add(a);
+            }
+        }
+        if (G.size() <= 1) {
+            return G;
+        }
+        // remove top reducible polynomials
+        GenWordPolynomial<C> a;
+        List<GenWordPolynomial<C>> F;
+        F = new ArrayList<GenWordPolynomial<C>>(G.size());
+        while (G.size() > 0) {
+            a = G.remove(0);
+            if (red.isTopReducible(G, a) || red.isTopReducible(F, a)) {
+                // drop polynomial 
+                if (debug) {
+                    System.out.println("dropped " + a);
+                    List<GenWordPolynomial<C>> ff;
+                    ff = new ArrayList<GenWordPolynomial<C>>(G);
+                    ff.addAll(F);
+                    a = red.normalform(ff, a);
+                    if (!a.isZERO()) {
+                        System.out.println("error, nf(a) " + a);
+                    }
+                }
+            } else {
+                F.add(a);
+            }
+        }
+        G = F;
+        if (G.size() <= 1) {
+            return G;
+        }
+        // reduce remaining polynomials
+        Collections.reverse(G); // important for lex GB
+        int len = G.size();
+        if (debug) {
+            System.out.println("#G " + len);
+            for (GenWordPolynomial<C> aa : G) {
+                System.out.println("aa = " + aa.length() + ", lt = " + aa.getMap().keySet());
+            }
+        }
+        int i = 0;
+        while (i < len) {
+            a = G.remove(0);
+            if (debug) {
+                System.out.println("doing " + a.length() + ", lt = " + a.leadingWord());
+            }
+            a = red.normalform(G, a);
+            G.add(a); // adds as last
+            i++;
+        }
+        return G;
+    }
+
+
+    /**
+     * Test for minimal ordered Groebner basis.
+     * @param Gp an ideal base.
+     * @return true, if Gp is a reduced minimal Groebner base.
+     */
+    public boolean isMinimalGB(List<GenWordPolynomial<C>> Gp) {
+        if (Gp == null || Gp.size() == 0) {
+            return true;
+        }
+        // test for zero polynomials
+        for (GenWordPolynomial<C> a : Gp) {
+            if (a == null || a.isZERO()) {
+                if (debug) {
+                    logger.debug("zero polynomial " + a);
+                }
+                return false;
+            }
+        }
+        // test for top reducible polynomials
+        List<GenWordPolynomial<C>> G = new ArrayList<GenWordPolynomial<C>>(Gp);
+        List<GenWordPolynomial<C>> F = new ArrayList<GenWordPolynomial<C>>(G.size());
+        while (G.size() > 0) {
+            GenWordPolynomial<C> a = G.remove(0);
+            if (red.isTopReducible(G, a) || red.isTopReducible(F, a)) {
+                if (debug) {
+                    logger.debug("top reducible polynomial " + a);
+                }
+                return false;
+            }
+            F.add(a);
+        }
+        G = F;
+        if (G.size() <= 1) {
+            return true;
+        }
+        // test reducibility of polynomials
+        int len = G.size();
+        int i = 0;
+        while (i < len) {
+            GenWordPolynomial<C> a = G.remove(0);
+            if (!red.isNormalform(G, a)) {
+                if (debug) {
+                    logger.debug("reducible polynomial " + a);
+                }
+                return false;
+            }
+            G.add(a); // re-adds as last
+            i++;
+        }
+        return true;
+    }
+
+
+    /**
+     * Cleanup and terminate ThreadPool.
+     */
+    public void terminate() {
+        logger.info("terminate not implemented");
+    }
+
+
+    /**
+     * Cancel ThreadPool.
+     */
+    public int cancel() {
+        logger.info("cancel not implemented");
+        return 0;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/WordGroebnerBaseSeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/WordGroebnerBaseSeq.java
@@ -1,0 +1,161 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.GenWordPolynomial;
+import edu.jas.poly.GenWordPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Non-commutative word Groebner Base sequential algorithm. Implements Groebner
+ * bases and GB test.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class WordGroebnerBaseSeq<C extends RingElem<C>> extends WordGroebnerBaseAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(WordGroebnerBaseSeq.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     */
+    public WordGroebnerBaseSeq() {
+        super();
+    }
+
+
+    /**
+     * Constructor.
+     * @param red Reduction engine
+     */
+    public WordGroebnerBaseSeq(WordReduction<C> red) {
+        super(red);
+    }
+
+
+    /**
+     * Constructor.
+     * @param red Reduction engine
+     * @param pl pair selection strategy
+     */
+    public WordGroebnerBaseSeq(WordReduction<C> red, WordPairList<C> pl) {
+        super(red, pl);
+    }
+
+
+    /**
+     * Word Groebner base using word pairlist class.
+     * @param F word polynomial list.
+     * @return GB(F) a finite non-commutative Groebner base of F, if it exists.
+     */
+    @Override
+    public List<GenWordPolynomial<C>> GB(List<GenWordPolynomial<C>> F) {
+        List<GenWordPolynomial<C>> G = normalizeZerosOnes(F);
+        G = PolyUtil.<C> wordMonic(G);
+        if (G.size() <= 1) {
+            return G;
+        }
+        GenWordPolynomialRing<C> ring = G.get(0).ring;
+        if (!ring.coFac.isField()) {
+            throw new IllegalArgumentException("coefficients not from a field");
+        }
+        //Collections.sort(G);
+        OrderedWordPairlist<C> pairlist = (OrderedWordPairlist<C>) strategy.create(ring);
+        pairlist.put(G);
+        logger.info("start " + pairlist);
+
+        WordPair<C> pair;
+        GenWordPolynomial<C> pi;
+        GenWordPolynomial<C> pj;
+        List<GenWordPolynomial<C>> S;
+        GenWordPolynomial<C> H;
+        while (pairlist.hasNext()) {
+            pair = pairlist.removeNext();
+            //logger.debug("pair = " + pair);
+            if (pair == null) {
+                continue;
+            }
+            pi = pair.pi;
+            pj = pair.pj;
+            if (debug) {
+                logger.info("pi   = " + pi + ", pj = " + pj);
+                //logger.info("pj    = " + pj);
+            }
+
+            S = red.SPolynomials(pi, pj);
+            if (S.isEmpty()) {
+                continue;
+            }
+            for (GenWordPolynomial<C> s : S) {
+                if (s.isZERO()) {
+                    //pair.setZero();
+                    continue;
+                }
+                if (debug) {
+                    logger.info("ht(S) = " + s.leadingWord());
+                }
+                boolean t = pairlist.criterion3(pair.i, pair.j, s.leadingWord());
+                //System.out.println("criterion3(" + pair.i + "," + pair.j + ") = " + t);
+                //if ( !t ) {
+                //    continue;  
+                //}
+
+                H = red.normalform(G, s);
+                if (debug) {
+                    //logger.info("pair = " + pair); 
+                    //logger.info("ht(S) = " + S.monic()); //.leadingWord() );
+                    logger.info("ht(H) = " + H.monic()); //.leadingWord() );
+                }
+                if (H.isZERO()) {
+                    //pair.setZero();
+                    continue;
+                }
+                if (!t) {
+                    logger.info("criterion3(" + pair.i + "," + pair.j + ") wrong: " + s.leadingWord()
+                                    + " --> " + H.leadingWord());
+                }
+
+                H = H.monic();
+                if (debug) {
+                    logger.info("ht(H) = " + H.leadingWord());
+                }
+                if (H.isONE()) {
+                    G.clear();
+                    G.add(H);
+                    return G; // since no threads are activated
+                }
+                if (debug) {
+                    logger.info("H = " + H);
+                }
+                if (H.length() > 0) {
+                    //l++;
+                    G.add(H);
+                    pairlist.put(H);
+                }
+            }
+        }
+        //logger.info("#sequential list = " + G.size());
+        G = minimalGB(G);
+        logger.info("end   " + pairlist);
+        //Collections.sort(G);
+        //Collections.reverse(G);
+        return G;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/WordPair.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/WordPair.java
@@ -1,0 +1,120 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import edu.jas.poly.GenWordPolynomial;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Serializable subclass to hold pairs of word polynomials.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+public class WordPair<C extends RingElem<C>> implements Comparable<WordPair> {
+
+
+    public final GenWordPolynomial<C> pi;
+
+
+    public final GenWordPolynomial<C> pj;
+
+
+    public final int i;
+
+
+    public final int j;
+
+
+    protected int n;
+
+
+    /**
+     * WordPair constructor.
+     * @param a word polynomial i.
+     * @param b word polynomial j.
+     * @param i first index.
+     * @param j second index.
+     */
+    public WordPair(GenWordPolynomial<C> a, GenWordPolynomial<C> b, int i, int j) {
+        pi = a;
+        pj = b;
+        this.i = i;
+        this.j = j;
+        this.n = 0;
+    }
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString() {
+        return "wordPair(" + i + "," + j + ",{" + pi.length() + "," + pj.length() + "}," + n + ")";
+    }
+
+
+    /**
+     * Set removed pair number.
+     * @param n number of this pair generated in OrderedPairlist.
+     */
+    public void pairNumber(int n) {
+        this.n = n;
+    }
+
+
+    /**
+     * Get removed pair number.
+     * @return n number of this pair generated in OrderedPairlist.
+     */
+    public int getPairNumber() {
+        return n;
+    }
+
+
+    /**
+     * equals.
+     * @param ob an Object.
+     * @return true if this is equal to o, else false.
+     */
+    @Override
+    public boolean equals(Object ob) {
+        if (!(ob instanceof WordPair)) {
+            return false;
+            // throw new ClassCastException("Pair "+n+" o "+o);
+        }
+        return 0 == compareTo((WordPair) ob);
+    }
+
+
+    /**
+     * compareTo used in TreeMap // not used at moment. Comparison is based on
+     * the number of the pairs.
+     * @param p a WordPair.
+     * @return 1 if (this &lt; o), 0 if (this == o), -1 if (this &gt; o).
+     */
+    public int compareTo(WordPair p) {
+        int x = p.getPairNumber();
+        if (n > x) {
+            return 1;
+        }
+        if (n < x) {
+            return -1;
+        }
+        return 0;
+    }
+
+
+    /**
+     * Hash code for this WordPair.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return (i << 16) + j;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/WordPairList.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/WordPairList.java
@@ -1,0 +1,95 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.List;
+
+import edu.jas.poly.GenWordPolynomial;
+import edu.jas.poly.GenWordPolynomialRing;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * WordPair list management interface.
+ * @author Heinz Kredel
+ */
+
+public interface WordPairList<C extends RingElem<C>> {
+
+
+    /**
+     * Create a new WordPairList.
+     * @param r word polynomial ring.
+     */
+    public WordPairList<C> create(GenWordPolynomialRing<C> r);
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString();
+
+
+    /**
+     * Put one Word Polynomial to the pairlist and reduction matrix.
+     * @param p word polynomial.
+     * @return the index of the added word polynomial.
+     */
+    public int put(GenWordPolynomial<C> p);
+
+
+    /**
+     * Put all word polynomials in F to the pairlist and reduction matrix.
+     * @param F word polynomial list.
+     * @return the index of the last added word polynomial.
+     */
+    public int put(List<GenWordPolynomial<C>> F);
+
+
+    /**
+     * Put to ONE-Polynomial to the pairlist.
+     * @return the index of the last polynomial.
+     */
+    public int putOne();
+
+
+    /**
+     * Remove the next required pair from the pairlist and reduction matrix.
+     * Appy the criterions 3 and 4 to see if the S-polynomial is required.
+     * @return the next pair if one exists, otherwise null.
+     */
+    public WordPair<C> removeNext();
+
+
+    /**
+     * Test if there is possibly a pair in the list.
+     * @return true if a next pair could exist, otherwise false.
+     */
+    public boolean hasNext();
+
+
+    /**
+     * Get the list of word polynomials.
+     * @return the word polynomial list.
+     */
+    public List<GenWordPolynomial<C>> getList();
+
+
+    /**
+     * Get the number of polynomials put to the pairlist.
+     * @return the number of calls to put.
+     */
+    public int putCount();
+
+
+    /**
+     * Get the number of required pairs removed from the pairlist.
+     * @return the number of non null pairs delivered.
+     */
+    public int remCount();
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/WordReduction.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/WordReduction.java
@@ -1,0 +1,177 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.io.Serializable;
+import java.util.List;
+
+import edu.jas.poly.GenWordPolynomial;
+import edu.jas.poly.Word;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Polynomial WordReduction interface. Defines S-Polynomial, normalform, module
+ * criterion and irreducible set.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public interface WordReduction<C extends RingElem<C>> extends Serializable {
+
+
+    /**
+     * S-Polynomials of non-commutative polynomials.
+     * @param Ap word polynomial.
+     * @param Bp word polynomial.
+     * @return list of all spol(Ap,Bp) the S-polynomials of Ap and Bp.
+     */
+    public List<GenWordPolynomial<C>> SPolynomials(GenWordPolynomial<C> Ap, GenWordPolynomial<C> Bp);
+
+
+    /**
+     * S-Polynomials of non-commutative polynomials.
+     * @param a leading base coefficient of B.
+     * @param l1 word.
+     * @param A word polynomial.
+     * @param r1 word.
+     * @param b leading base coefficient of A.
+     * @param l2 word.
+     * @param B word polynomial.
+     * @param r2 word.
+     * @return list of all spol(Ap,Bp) the S-polynomials of Ap and Bp.
+     */
+    public GenWordPolynomial<C> SPolynomial(C a, Word l1, GenWordPolynomial<C> A, Word r1, C b, Word l2,
+                    GenWordPolynomial<C> B, Word r2);
+
+
+    /**
+     * Is top reducible. Condition is lt(B) | lt(A) for some B in F.
+     * @param A polynomial.
+     * @param P polynomial list.
+     * @return true if A is top reducible with respect to P.
+     */
+    public boolean isTopReducible(List<GenWordPolynomial<C>> P, GenWordPolynomial<C> A);
+
+
+    /**
+     * Is reducible.
+     * @param A polynomial.
+     * @param P polynomial list.
+     * @return true if A is reducible with respect to P.
+     */
+    public boolean isReducible(List<GenWordPolynomial<C>> P, GenWordPolynomial<C> A);
+
+
+    /**
+     * Is in Normalform.
+     * @param A polynomial.
+     * @param P polynomial list.
+     * @return true if A is in normalform with respect to P.
+     */
+    public boolean isNormalform(List<GenWordPolynomial<C>> P, GenWordPolynomial<C> A);
+
+
+    /**
+     * Is in Normalform.
+     * @param Pp polynomial list.
+     * @return true if each A in Pp is in normalform with respect to Pp\{A}.
+     */
+    public boolean isNormalform(List<GenWordPolynomial<C>> Pp);
+
+
+    /**
+     * Normalform.
+     * @param A polynomial.
+     * @param P polynomial list.
+     * @return nf(A) with respect to P.
+     */
+    public GenWordPolynomial<C> normalform(List<GenWordPolynomial<C>> P, GenWordPolynomial<C> A);
+
+
+    /**
+     * Normalform Set.
+     * @param Ap polynomial list.
+     * @param Pp polynomial list.
+     * @return list of nf(a) with respect to Pp for all a in Ap.
+     */
+    public List<GenWordPolynomial<C>> normalform(List<GenWordPolynomial<C>> Pp, List<GenWordPolynomial<C>> Ap);
+
+
+    /**
+     * Normalform with left and right recording.
+     * @param lrow left recording matrix, is modified.
+     * @param rrow right recording matrix, is modified.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @return nf(Pp,Ap), the normal form of Ap wrt. Pp.
+     */
+    public GenWordPolynomial<C> normalform(List<GenWordPolynomial<C>> lrow, List<GenWordPolynomial<C>> rrow,
+                    List<GenWordPolynomial<C>> Pp, GenWordPolynomial<C> Ap);
+
+
+    /**
+     * Normalform with left recording.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @return nf(Pp,Ap), the left normal form of Ap wrt. Pp.
+     */
+    public GenWordPolynomial<C> leftNormalform(List<GenWordPolynomial<C>> Pp, GenWordPolynomial<C> Ap);
+
+
+    /**
+     * Normalform with left recording.
+     * @param lrow left recording matrix, is modified.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @return nf(Pp,Ap), the left normal form of Ap wrt. Pp.
+     */
+    public GenWordPolynomial<C> leftNormalform(List<GenWordPolynomial<C>> lrow, 
+                                    List<GenWordPolynomial<C>> Pp, GenWordPolynomial<C> Ap);
+
+
+    /**
+     * Irreducible set.
+     * @param Pp polynomial list.
+     * @return a list P of polynomials which are in normalform wrt. P and with
+     *         ideal(Pp) = ideal(P).
+     */
+    public List<GenWordPolynomial<C>> irreducibleSet(List<GenWordPolynomial<C>> Pp);
+
+
+    /**
+     * Is reduction of normal form.
+     * @param lrow left recording matrix.
+     * @param rrow right recording matrix.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @param Np nf(Pp,Ap), a normal form of Ap wrt. Pp.
+     * @return true, if Np + sum( row[i]*Pp[i] ) == Ap, else false.
+     */
+    public boolean isReductionNF(List<GenWordPolynomial<C>> lrow, List<GenWordPolynomial<C>> rrow,
+                    List<GenWordPolynomial<C>> Pp, GenWordPolynomial<C> Ap, GenWordPolynomial<C> Np);
+
+
+    /**
+     * Right normalform with recording.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @return nf(Pp,Ap), the right normal form of Ap wrt. Pp.
+     */
+    public GenWordPolynomial<C> rightNormalform(List<GenWordPolynomial<C>> Pp, GenWordPolynomial<C> Ap);
+
+
+    /**
+     * Right normalform with recording.
+     * @param rrow right recording matrix, is modified.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @return nf(Pp,Ap), the right normal form of Ap wrt. Pp.
+     */
+    public GenWordPolynomial<C> rightNormalform(List<GenWordPolynomial<C>> rrow, 
+                List<GenWordPolynomial<C>> Pp, GenWordPolynomial<C> Ap);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/WordReductionAbstract.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/WordReductionAbstract.java
@@ -1,0 +1,376 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.GenWordPolynomial;
+import edu.jas.poly.Overlap;
+import edu.jas.poly.OverlapList;
+import edu.jas.poly.Word;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Polynomial word reduction abstract class. Implements common S-Polynomial,
+ * normalform, module criterion and irreducible set.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public abstract class WordReductionAbstract<C extends RingElem<C>> implements WordReduction<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(WordReductionAbstract.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     */
+    public WordReductionAbstract() {
+    }
+
+
+    /**
+     * S-Polynomials of non-commutative polynomials.
+     * @param Ap word polynomial.
+     * @param Bp word polynomial.
+     * @return list of all spol(Ap,Bp) the S-polynomials of Ap and Bp.
+     */
+    public List<GenWordPolynomial<C>> SPolynomials(GenWordPolynomial<C> Ap, GenWordPolynomial<C> Bp) {
+        List<GenWordPolynomial<C>> sp = new ArrayList<GenWordPolynomial<C>>();
+        if (Bp == null || Bp.isZERO()) {
+            if (Ap == null) {
+                sp.add(Bp);
+                return sp;
+            }
+            sp.add(Ap.ring.getZERO());
+            return sp;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            sp.add(Bp.ring.getZERO());
+            return sp;
+        }
+        Map.Entry<Word, C> ma = Ap.leadingMonomial();
+        Map.Entry<Word, C> mb = Bp.leadingMonomial();
+        Word e = ma.getKey();
+        Word f = mb.getKey();
+        C a = ma.getValue();
+        C b = mb.getValue();
+        OverlapList oll = e.overlap(f);
+        if (oll.ols.isEmpty()) {
+            return sp;
+        }
+        for (Overlap ol : oll.ols) {
+            GenWordPolynomial<C> s = SPolynomial(ol, b, Ap, a, Bp);
+            sp.add(s);
+        }
+        return sp;
+    }
+
+
+    /**
+     * S-Polynomials of non-commutative polynomials.
+     * @param a leading base coefficient of B.
+     * @param l1 word.
+     * @param A word polynomial.
+     * @param r1 word.
+     * @param b leading base coefficient of A.
+     * @param l2 word.
+     * @param B word polynomial.
+     * @param r2 word.
+     * @return list of all spol(Ap,Bp) the S-polynomials of Ap and Bp.
+     */
+    public GenWordPolynomial<C> SPolynomial(C a, Word l1, GenWordPolynomial<C> A, Word r1, C b, Word l2,
+                    GenWordPolynomial<C> B, Word r2) {
+        C one = A.ring.coFac.getONE();
+        GenWordPolynomial<C> s1 = A.multiply(a, l1, one, r1);
+        GenWordPolynomial<C> s2 = B.multiply(b, l2, one, r2);
+        GenWordPolynomial<C> s = s1.subtract(s2);
+        return s;
+    }
+
+
+    /**
+     * S-Polynomials of non-commutative polynomials.
+     * @param ol Overlap tuple.
+     * @param a leading base coefficient of B.
+     * @param A word polynomial.
+     * @param b leading base coefficient of A.
+     * @param B word polynomial.
+     * @return list of all spol(Ap,Bp) the S-polynomials of Ap and Bp.
+     */
+    public GenWordPolynomial<C> SPolynomial(Overlap ol, C a, GenWordPolynomial<C> A, C b,
+                    GenWordPolynomial<C> B) {
+        C one = A.ring.coFac.getONE();
+        GenWordPolynomial<C> s1 = A.multiply(a, ol.l1, one, ol.r1);
+        GenWordPolynomial<C> s2 = B.multiply(b, ol.l2, one, ol.r2);
+        GenWordPolynomial<C> s = s1.subtract(s2);
+        return s;
+    }
+
+
+    /**
+     * Normalform Set.
+     * @param Ap polynomial list.
+     * @param Pp polynomial list.
+     * @return list of nf(a) with respect to Pp for all a in Ap.
+     */
+    public List<GenWordPolynomial<C>> normalform(List<GenWordPolynomial<C>> Pp, List<GenWordPolynomial<C>> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isEmpty()) {
+            return Ap;
+        }
+        ArrayList<GenWordPolynomial<C>> red = new ArrayList<GenWordPolynomial<C>>();
+        for (GenWordPolynomial<C> A : Ap) {
+            A = normalform(Pp, A);
+            red.add(A);
+        }
+        return red;
+    }
+
+
+    /**
+     * Is top reducible.
+     * @param A polynomial.
+     * @param P polynomial list.
+     * @return true if A is top reducible with respect to P.
+     */
+    public boolean isTopReducible(List<GenWordPolynomial<C>> P, GenWordPolynomial<C> A) {
+        if (P == null || P.isEmpty()) {
+            return false;
+        }
+        if (A == null || A.isZERO()) {
+            return false;
+        }
+        boolean mt = false;
+        Word e = A.leadingWord();
+        for (GenWordPolynomial<C> p : P) {
+            mt = e.multipleOf(p.leadingWord());
+            if (mt) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    /**
+     * Is reducible.
+     * @param Ap polynomial.
+     * @param Pp polynomial list.
+     * @return true if Ap is reducible with respect to Pp.
+     */
+    public boolean isReducible(List<GenWordPolynomial<C>> Pp, GenWordPolynomial<C> Ap) {
+        return !isNormalform(Pp, Ap);
+    }
+
+
+    /**
+     * Is in Normalform.
+     * @param Ap polynomial.
+     * @param Pp polynomial list.
+     * @return true if Ap is in normalform with respect to Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public boolean isNormalform(List<GenWordPolynomial<C>> Pp, GenWordPolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return true;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return true;
+        }
+        int l;
+        GenWordPolynomial<C>[] P;
+        synchronized (Pp) {
+            l = Pp.size();
+            P = new GenWordPolynomial[l];
+            //P = Pp.toArray();
+            for (int i = 0; i < Pp.size(); i++) {
+                P[i] = Pp.get(i);
+            }
+        }
+        Word[] htl = new Word[l];
+        GenWordPolynomial<C>[] p = new GenWordPolynomial[l];
+        Map.Entry<Word, C> m;
+        int i;
+        int j = 0;
+        for (i = 0; i < l; i++) {
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                j++;
+            }
+        }
+        l = j;
+        boolean mt = false;
+        for (Word e : Ap.getMap().keySet()) {
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Is in Normalform.
+     * @param Pp polynomial list.
+     * @return true if each Ap in Pp is in normalform with respect to Pp\{Ap}.
+     */
+    public boolean isNormalform(List<GenWordPolynomial<C>> Pp) {
+        if (Pp == null || Pp.isEmpty()) {
+            return true;
+        }
+        GenWordPolynomial<C> Ap;
+        List<GenWordPolynomial<C>> P = new LinkedList<GenWordPolynomial<C>>(Pp);
+        int s = P.size();
+        for (int i = 0; i < s; i++) {
+            Ap = P.remove(i);
+            if (!isNormalform(P, Ap)) {
+                return false;
+            }
+            P.add(Ap);
+        }
+        return true;
+    }
+
+
+    /**
+     * Irreducible set.
+     * @param Pp polynomial list.
+     * @return a list P of monic polynomials which are in normalform wrt. P and
+     *         with ideal(Pp) = ideal(P).
+     */
+    public List<GenWordPolynomial<C>> irreducibleSet(List<GenWordPolynomial<C>> Pp) {
+        ArrayList<GenWordPolynomial<C>> P = new ArrayList<GenWordPolynomial<C>>();
+        for (GenWordPolynomial<C> a : Pp) {
+            if (a.length() != 0) {
+                a = a.monic();
+                if (a.isONE()) {
+                    P.clear();
+                    P.add(a);
+                    return P;
+                }
+                P.add(a);
+            }
+        }
+        int l = P.size();
+        if (l <= 1)
+            return P;
+
+        int irr = 0;
+        Word e;
+        Word f;
+        GenWordPolynomial<C> a;
+        logger.debug("irr = ");
+        while (irr != l) {
+            //it = P.listIterator(); 
+            //a = P.get(0); //it.next();
+            a = P.remove(0);
+            e = a.leadingWord();
+            a = normalform(P, a);
+            logger.debug(String.valueOf(irr));
+            if (a.length() == 0) {
+                l--;
+                if (l <= 1) {
+                    return P;
+                }
+            } else {
+                f = a.leadingWord();
+                if (f.signum() == 0) {
+                    P = new ArrayList<GenWordPolynomial<C>>();
+                    P.add(a.monic());
+                    return P;
+                }
+                if (e.equals(f)) {
+                    irr++;
+                } else {
+                    irr = 0;
+                    a = a.monic();
+                }
+                P.add(a);
+            }
+        }
+        //System.out.println();
+        return P;
+    }
+
+
+    /**
+     * Is reduction of normal form.
+     * @param lrow left recording matrix.
+     * @param rrow right recording matrix.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @param Np nf(Pp,Ap), a normal form of Ap wrt. Pp.
+     * @return true, if Np + sum( row[i]*Pp[i] ) == Ap, else false.
+     */
+    public boolean isReductionNF(List<GenWordPolynomial<C>> lrow, List<GenWordPolynomial<C>> rrow,
+                    List<GenWordPolynomial<C>> Pp, GenWordPolynomial<C> Ap, GenWordPolynomial<C> Np) {
+        if (lrow == null && rrow == null && Pp == null) {
+            if (Ap == null) {
+                return (Np == null);
+            }
+            return Ap.equals(Np);
+        }
+        if (lrow == null || rrow == null || Pp == null) {
+            return false;
+        }
+        if (lrow.size() != Pp.size() || rrow.size() != Pp.size()) {
+            return false;
+        }
+        GenWordPolynomial<C> t = Np;
+        //System.out.println("t0 = " + t );
+        GenWordPolynomial<C> r, rl, rr;
+        GenWordPolynomial<C> p;
+        for (int m = 0; m < Pp.size(); m++) {
+            rl = lrow.get(m);
+            rr = rrow.get(m);
+            p = Pp.get(m);
+            if (rl != null && rr != null && p != null) {
+                if (t == null) {
+                    t = p.multiply(rl, rr);
+                } else {
+                    t = t.sum(p.multiply(rl, rr));
+                }
+            }
+            //System.out.println("r = " + r );
+            //System.out.println("p = " + p );
+        }
+        //System.out.println("t+ = " + t );
+        if (t == null) {
+            if (Ap == null) {
+                return true;
+            }
+            return Ap.isZERO();
+        }
+        r = t.subtract(Ap);
+        boolean z = r.isZERO();
+        if (!z) {
+            logger.info("t = " + t);
+            logger.info("a = " + Ap);
+            logger.info("t-a = " + r);
+        }
+        return z;
+    }
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/WordReductionSeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/WordReductionSeq.java
@@ -1,0 +1,531 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gb;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.GenWordPolynomial;
+import edu.jas.poly.Word;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Polynomial word reduction sequential use algorithm. Implements normalform.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class WordReductionSeq<C extends RingElem<C>> // should be FieldElem<C>>
+                extends WordReductionAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(WordReductionSeq.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     */
+    public WordReductionSeq() {
+    }
+
+
+    /**
+     * Normalform.
+     * @param Ap polynomial.
+     * @param Pp polynomial list.
+     * @return nf(Ap) with respect to Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public GenWordPolynomial<C> normalform(List<GenWordPolynomial<C>> Pp, GenWordPolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        if (!Ap.ring.coFac.isField()) {
+            throw new IllegalArgumentException("coefficients not from a field");
+        }
+        Map.Entry<Word, C> m;
+        int l;
+        GenWordPolynomial<C>[] P;
+        synchronized (Pp) {
+            l = Pp.size();
+            P = new GenWordPolynomial[l];
+            //P = Pp.toArray();
+            for (int i = 0; i < Pp.size(); i++) {
+                P[i] = Pp.get(i);
+            }
+        }
+        Word[] htl = new Word[l];
+        C[] lbc = (C[]) new RingElem[l]; // want C[]
+        GenWordPolynomial<C>[] p = new GenWordPolynomial[l];
+        int i;
+        int j = 0;
+        for (i = 0; i < l; i++) {
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        Word e, f, g;
+        C a;
+        boolean mt = false;
+        GenWordPolynomial<C> R = Ap.ring.getZERO();
+        C cone = Ap.ring.coFac.getONE();
+
+        //GenWordPolynomial<C> T = null;
+        GenWordPolynomial<C> Q = null;
+        GenWordPolynomial<C> S = Ap;
+        while (S.length() > 0) {
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt)
+                    break;
+            }
+            if (!mt) {
+                //logger.debug("irred");
+                //T = new OrderedMapPolynomial( a, e );
+                R = R.sum(a, e);
+                S = S.subtract(a, e);
+                // System.out.println(" S = " + S);
+            } else {
+                Word[] elr = e.divideWord(htl[i]);
+                g = e;
+                e = elr[0];
+                f = elr[1];
+                if (debug) {
+                    logger.info("red divideWord: e = " + e + ", f = " + f);
+                }
+                a = a.divide(lbc[i]);
+                Q = p[i].multiply(a, e, cone, f);
+                S = S.subtract(Q);
+                if (!S.isZERO() && g.equals(S.leadingWord())) {
+                    throw new RuntimeException("HT(S) not descending");
+                }
+            }
+        }
+        return R;
+    }
+
+
+    /**
+     * Normalform with left and right recording.
+     * @param lrow left recording matrix, is modified.
+     * @param rrow right recording matrix, is modified.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @return nf(Pp,Ap), the normal form of Ap wrt. Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public GenWordPolynomial<C> normalform(List<GenWordPolynomial<C>> lrow, List<GenWordPolynomial<C>> rrow,
+                    List<GenWordPolynomial<C>> Pp, GenWordPolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        if (!Ap.ring.coFac.isField()) {
+            throw new IllegalArgumentException("coefficients not from a field");
+        }
+        int l = Pp.size();
+        GenWordPolynomial<C>[] P = new GenWordPolynomial[l];
+        synchronized (Pp) {
+            //P = Pp.toArray();
+            for (int i = 0; i < Pp.size(); i++) {
+                P[i] = Pp.get(i);
+            }
+        }
+        Word[] htl = new Word[l];
+        C[] lbc = (C[]) new RingElem[l];
+        GenWordPolynomial<C>[] p = new GenWordPolynomial[l];
+        Map.Entry<Word, C> m;
+        int j = 0;
+        int i;
+        for (i = 0; i < l; i++) {
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        Word e, g;
+        C a, b, lc, rc;
+        boolean mt = false;
+        GenWordPolynomial<C> zero = Ap.ring.getZERO();
+        GenWordPolynomial<C> one = Ap.ring.getONE();
+        GenWordPolynomial<C> R = Ap.ring.getZERO();
+        C cone = Ap.ring.coFac.getONE();
+        // ensure polynomials at each index
+        for (i = 0; i < lrow.size(); i++) {
+            GenWordPolynomial<C> w = lrow.get(i);
+            if (w == null) {
+                lrow.set(i, zero);
+            }
+            w = rrow.get(i);
+            if (w == null) {
+                rrow.set(i, zero);
+            }
+        }
+
+        GenWordPolynomial<C> fac = null;
+        // GenWordPolynomial<C> T = null;
+        GenWordPolynomial<C> Q = null;
+        GenWordPolynomial<C> S = Ap;
+        while (S.length() > 0) {
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt)
+                    break;
+            }
+            if (!mt) {
+                //logger.debug("irred");
+                R = R.sum(a, e);
+                S = S.subtract(a, e);
+                // System.out.println("S = " + S);
+            } else {
+                g = e;
+                Word[] elr = e.divideWord(htl[i]);
+                e = elr[0];
+                Word f = elr[1];
+                if (debug) {
+                    logger.info("redRec divideWord: e = " + e + ", f = " + f + ", htl = " + htl[i]);
+                }
+                C c = lbc[i];
+                b = a.divide(c);
+                if (e.isONE()) { // todo simplify multiply
+                    lc = cone;
+                    rc = b;
+                } else {
+                    lc = b;
+                    rc = cone;
+                }
+                Q = p[i].multiply(lc, e, rc, f);
+                S = S.subtract(Q);
+                //logger.info("redRec: S = " + S + ", R = " + R + ", Q = " + Q);
+                if (!S.isZERO() && g.equals(S.leadingWord())) {
+                    System.out.println("divideWord: e = " + e + ", f = " + f);
+                    System.out.println("R = " + R);
+                    System.out.println("Q = " + Q + ", a = " + a + ", b = " + b + ", c = " + c);
+                    throw new RuntimeException("HT(S) not descending, S = " + S);
+                }
+                // left row
+                fac = lrow.get(i);
+                boolean doset = true;
+                if (!lc.isONE() || !e.isONE()) {
+                    if (!fac.coefficient(e).isZERO()) {
+                        logger.warn("e exists in polynomial: " + fac + ", e = " + e + ", lc = " + lc);
+                        logger.warn("f = " + f + ", rc = " + rc);
+                        logger.warn("S = " + S + ", R = " + R);
+                    }
+                    fac = fac.sum(lc, e);
+                    doset = false;
+                }
+                //logger.info("redRec: left = " + fac + ", lc = " + lc + ", e = " + e);
+                lrow.set(i, fac);
+                // right row
+                fac = rrow.get(i);
+                if (!rc.isONE() || !f.isONE() || doset) {
+                    if (!fac.coefficient(f).isZERO()) {
+                        logger.warn("f exists in polynomial: " + fac + ", f = " + f + ", rc = " + rc);
+                        logger.warn("e = " + e + ", lc = " + lc);
+                        logger.warn("S = " + S + ", R = " + R);
+                    }
+                    fac = fac.sum(rc, f);
+                }
+                //logger.info("redRec: right = " + fac + ", rc = " + rc + ", f = " + f);
+                rrow.set(i, fac);
+            }
+        }
+        // set factor to one if other non-zero
+        for (i = 0; i < lrow.size(); i++) {
+            GenWordPolynomial<C> lw = lrow.get(i);
+            GenWordPolynomial<C> rw = rrow.get(i);
+            if (!lw.isZERO() && rw.isZERO()) {
+                rrow.set(i, one);
+            }
+            if (lw.isZERO() && !rw.isZERO()) {
+                lrow.set(i, one);
+            }
+        }
+        return R;
+    }
+
+
+    /**
+     * Left normalform with recording.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @return nf(Pp,Ap), the left normal form of Ap wrt. Pp.
+     */
+    public GenWordPolynomial<C> leftNormalform(List<GenWordPolynomial<C>> Pp, GenWordPolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        List<GenWordPolynomial<C>> lrow = new ArrayList<GenWordPolynomial<C>>(Pp.size());
+        for (int i = 0; i < Pp.size(); i++) {
+            lrow.add(Ap.ring.getZERO());
+        }
+        GenWordPolynomial<C> r = leftNormalform(lrow, Pp, Ap);
+        return r;
+    }
+
+
+    /**
+     * Left normalform with recording.
+     * @param lrow left recording matrix, is modified.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @return nf(Pp,Ap), the left normal form of Ap wrt. Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public GenWordPolynomial<C> leftNormalform(List<GenWordPolynomial<C>> lrow,
+                    List<GenWordPolynomial<C>> Pp, GenWordPolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        if (!Ap.ring.coFac.isField()) {
+            throw new IllegalArgumentException("coefficients not from a field");
+        }
+        int l = Pp.size();
+        GenWordPolynomial<C>[] P = new GenWordPolynomial[l];
+        synchronized (Pp) {
+            //P = Pp.toArray();
+            for (int i = 0; i < Pp.size(); i++) {
+                P[i] = Pp.get(i);
+            }
+        }
+        Word[] htl = new Word[l];
+        C[] lbc = (C[]) new RingElem[l]; // want C[]
+        GenWordPolynomial<C>[] p = new GenWordPolynomial[l];
+        Map.Entry<Word, C> m;
+        int j = 0;
+        int i;
+        for (i = 0; i < l; i++) {
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        Word e;
+        C a;
+        boolean mt = false;
+        GenWordPolynomial<C> zero = Ap.ring.getZERO();
+        GenWordPolynomial<C> R = Ap.ring.getZERO();
+        C cone = Ap.ring.coFac.getONE();
+
+        GenWordPolynomial<C> fac = null;
+        // GenWordPolynomial<C> T = null;
+        GenWordPolynomial<C> Q = null;
+        GenWordPolynomial<C> S = Ap;
+        while (S.length() > 0) {
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt)
+                    break;
+            }
+            if (!mt) {
+                //logger.info("irred_1");
+                R = R.sum(a, e);
+                S = S.subtract(a, e);
+                // System.out.println(" S = " + S);
+            } else {
+                Word g = e;
+                Word[] elr = e.divideWord(htl[i]);
+                e = elr[0];
+                Word f = elr[1];
+                if (debug) {
+                    logger.info("redRec divideWord: e = " + e + ", f = " + f);
+                }
+                if (f.isONE()) {
+                    C c = lbc[i];
+                    //System.out.println("a = " + a + ", c = " + c);
+                    a = a.divide(c);
+                    //System.out.println("a/c = " + a);
+                    Q = p[i].multiply(a, e, cone, f);
+                    S = S.subtract(Q);
+                    // left row
+                    fac = lrow.get(i);
+                    if (fac == null) {
+                        fac = zero.sum(a, e);
+                    } else {
+                        fac = fac.sum(a, e);
+                    }
+                    lrow.set(i, fac);
+                } else {
+                    //logger.info("irred_2");
+                    R = R.sum(a, g);
+                    S = S.subtract(a, g);
+                }
+            }
+        }
+        return R;
+    }
+
+
+    /**
+     * Right normalform with recording.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @return nf(Pp,Ap), the right normal form of Ap wrt. Pp.
+     */
+    public GenWordPolynomial<C> rightNormalform(List<GenWordPolynomial<C>> Pp, GenWordPolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        List<GenWordPolynomial<C>> lrow = new ArrayList<GenWordPolynomial<C>>(Pp.size());
+        for (int i = 0; i < Pp.size(); i++) {
+            lrow.add(Ap.ring.getZERO());
+        }
+        GenWordPolynomial<C> r = rightNormalform(lrow, Pp, Ap);
+        return r;
+    }
+
+
+    /**
+     * Right normalform with recording.
+     * @param rrow right recording matrix, is modified.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @return nf(Pp,Ap), the right normal form of Ap wrt. Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public GenWordPolynomial<C> rightNormalform(List<GenWordPolynomial<C>> rrow,
+                    List<GenWordPolynomial<C>> Pp, GenWordPolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        if (!Ap.ring.coFac.isField()) {
+            throw new IllegalArgumentException("coefficients not from a field");
+        }
+        int l = Pp.size();
+        GenWordPolynomial<C>[] P = new GenWordPolynomial[l];
+        synchronized (Pp) {
+            //P = Pp.toArray();
+            for (int i = 0; i < Pp.size(); i++) {
+                P[i] = Pp.get(i);
+            }
+        }
+        Word[] htl = new Word[l];
+        C[] lbc = (C[]) new RingElem[l]; // want C[]
+        GenWordPolynomial<C>[] p = new GenWordPolynomial[l];
+        Map.Entry<Word, C> m;
+        int j = 0;
+        int i;
+        for (i = 0; i < l; i++) {
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        Word e;
+        C a;
+        boolean mt = false;
+        GenWordPolynomial<C> zero = Ap.ring.getZERO();
+        GenWordPolynomial<C> R = Ap.ring.getZERO();
+        C cone = Ap.ring.coFac.getONE();
+
+        GenWordPolynomial<C> fac = null;
+        // GenWordPolynomial<C> T = null;
+        GenWordPolynomial<C> Q = null;
+        GenWordPolynomial<C> S = Ap;
+        while (S.length() > 0) {
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt)
+                    break;
+            }
+            if (!mt) {
+                //logger.info("irred_1");
+                R = R.sum(a, e);
+                S = S.subtract(a, e);
+                // System.out.println(" S = " + S);
+            } else {
+                Word g = e;
+                Word[] elr = e.divideWord(htl[i]);
+                e = elr[0];
+                Word f = elr[1];
+                if (debug) {
+                    logger.info("redRec divideWord: e = " + e + ", f = " + f);
+                }
+                if (e.isONE()) {
+                    C c = lbc[i];
+                    //System.out.println("a = " + a + ", c = " + c);
+                    a = a.divide(c);
+                    //System.out.println("a/c = " + a);
+                    Q = p[i].multiply(cone, e, a, f);
+                    S = S.subtract(Q);
+                    // left row
+                    fac = rrow.get(i);
+                    if (fac == null) {
+                        fac = zero.sum(a, f);
+                    } else {
+                        fac = fac.sum(a, f);
+                    }
+                    rrow.set(i, fac);
+                } else {
+                    //logger.info("irred_2");
+                    R = R.sum(a, g);
+                    S = S.subtract(a, g);
+                }
+            }
+        }
+        return R;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/package.html
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gb/package.html
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "../DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>Groebner bases classes</title>
+  </head>
+
+  <body>
+    <h1>Groebner bases package.</h1>
+
+<p>
+  This package contains classes for polynomial and solvable polynomial
+  reduction, Groebner bases and ideal arithmetic as well as thread
+  parallel and distributed versions of Buchbergers algorithm,
+  e.g. <code>ReductionSeq</code>, <code>GroebnerBaseAbstract</code>,
+  <code>GroebnerBaseSeq</code>, <code>GroebnerBaseParallel</code> and
+  <code>GroebnerBaseDistributed</code>.  Moreover there are Groebner
+  bases in polynomial rings over principal ideal domains and Euclidean
+  domains, so called D- and E-Groebner bases, see
+  <code>DGroebnerBaseSeq</code> and <code>EGroebnerBaseSeq</code>.
+  The latest additions include free non-commutative polynomial
+  reduction, S-polynomials and two-sided Groebner bases, see
+  <code>WordReductionSeq</code> and <code>WordGroebnerBaseSeq</code>.
+</p>
+
+
+    <hr />
+    <address><a href="mailto:kredel at rz.uni-mannheim.de">Heinz Kredel</a></address>
+<p>
+<!-- Created: Wed Mar  1 12:29:04 CET 2006 -->
+<!-- hhmts start -->
+Last modified: Fri Sep 21 21:46:36 CEST 2012
+<!-- hhmts end -->
+</p>
+<p>$Id$ 
+</p>
+  </body>
+</html>

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbmod/ModGroebnerBase.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbmod/ModGroebnerBase.java
@@ -1,0 +1,51 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbmod;
+
+
+import java.util.List;
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.ModuleList;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Module Groebner Bases interface. Defines Groebner bases and GB test.
+ * @author Heinz Kredel
+ * @deprecated use respective methods from GroebnerBase 
+ */
+@Deprecated
+public interface ModGroebnerBase<C extends RingElem<C>> {
+
+
+    /**
+     * Module Groebner base test.
+     */
+    public boolean isGB(int modv, List<GenPolynomial<C>> F);
+
+
+    /**
+     * isGB.
+     * @param M a module basis.
+     * @return true, if M is a Groebner base, else false.
+     */
+    public boolean isGB(ModuleList<C> M);
+
+
+    /**
+     * Groebner base using pairlist class.
+     */
+    public List<GenPolynomial<C>> GB(int modv, List<GenPolynomial<C>> F);
+
+
+    /**
+     * GB.
+     * @param M a module basis.
+     * @return GB(M), a Groebner base of M.
+     */
+    public ModuleList<C> GB(ModuleList<C> M);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbmod/ModGroebnerBaseAbstract.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbmod/ModGroebnerBaseAbstract.java
@@ -1,0 +1,88 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbmod;
+
+
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.ModuleList;
+import edu.jas.poly.PolynomialList;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Module Groebner Bases abstract class. Implements Groebner bases and GB test.
+ * @author Heinz Kredel
+ * @deprecated use respective methods from GroebnerBaseAbstract
+ */
+@Deprecated
+public abstract class ModGroebnerBaseAbstract<C extends GcdRingElem<C>> implements ModGroebnerBase<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(ModGroebnerBaseAbstract.class);
+
+
+    /**
+     * isGB.
+     * @param M a module basis.
+     * @return true, if M is a Groebner base, else false.
+     */
+    public boolean isGB(ModuleList<C> M) {
+        if (M == null || M.list == null) {
+            return true;
+        }
+        if (M.rows == 0 || M.cols == 0) {
+            return true;
+        }
+        PolynomialList<C> F = M.getPolynomialList();
+        int modv = M.cols; // > 0  
+        return isGB(modv, F.list);
+    }
+
+
+    /**
+     * GB.
+     * @param M a module basis.
+     * @return GB(M), a Groebner base of M.
+     */
+    public ModuleList<C> GB(ModuleList<C> M) {
+        ModuleList<C> N = M;
+        if (M == null || M.list == null) {
+            return N;
+        }
+        if (M.rows == 0 || M.cols == 0) {
+            return N;
+        }
+
+        PolynomialList<C> F = M.getPolynomialList();
+        int modv = M.cols;
+        List<GenPolynomial<C>> G = GB(modv, F.list);
+        F = new PolynomialList<C>(F.ring, G);
+        N = F.getModuleList(modv);
+        return N;
+    }
+
+
+    /**
+     * Cleanup and terminate ThreadPool.
+     */
+    public void terminate() {
+        logger.info("terminate not implemented");
+    }
+
+
+    /**
+     * Cancel ThreadPool.
+     */
+    public int cancel() {
+        logger.info("cancel not implemented");
+        return 0;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbmod/ModGroebnerBasePar.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbmod/ModGroebnerBasePar.java
@@ -1,0 +1,62 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbmod;
+
+
+import edu.jas.gb.GroebnerBaseAbstract;
+import edu.jas.gbufd.GBFactory;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Module Groebner Bases sequential algorithm. Implements Groebner bases and GB
+ * test.
+ * @author Heinz Kredel
+ * @deprecated use respective methods from GroebnerBaseParallel 
+ */
+@Deprecated
+public class ModGroebnerBasePar<C extends GcdRingElem<C>> extends ModGroebnerBaseSeq<C> {
+
+
+    //private static final Logger logger = LogManager.getLogger(ModGroebnerBasePar.class);
+
+
+    /**
+     * Constructor.
+     * @param cf coefficient ring.
+     */
+    public ModGroebnerBasePar(RingFactory<C> cf) {
+        this(GBFactory.getProxy(cf));
+    }
+
+
+    /**
+     * Constructor.
+     * @param bb Groebner base algorithm.
+     */
+    public ModGroebnerBasePar(GroebnerBaseAbstract<C> bb) {
+        super(bb);
+    }
+
+
+    /**
+     * Cleanup and terminate ThreadPool.
+     */
+    @Override
+    public void terminate() {
+        bb.terminate();
+    }
+
+
+    /**
+     * Cancel ThreadPool.
+     */
+    @Override
+    public int cancel() {
+        return bb.cancel();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbmod/ModGroebnerBaseSeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbmod/ModGroebnerBaseSeq.java
@@ -1,0 +1,69 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbmod;
+
+
+import java.util.List;
+
+import edu.jas.gb.GroebnerBaseAbstract;
+import edu.jas.gbufd.GBFactory;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Module Groebner Bases sequential algorithm. Implements Groebner bases and GB
+ * test.
+ * @author Heinz Kredel
+ * @deprecated use respective methods from GroebnerBaseSeq
+ */
+@Deprecated
+public class ModGroebnerBaseSeq<C extends GcdRingElem<C>> extends ModGroebnerBaseAbstract<C> {
+
+
+    //private static final Logger logger = LogManager.getLogger(ModGroebnerBaseSeq.class);
+
+
+    /**
+     * Used Groebner base algorithm.
+     */
+    protected final GroebnerBaseAbstract<C> bb;
+
+
+    /**
+     * Constructor.
+     * @param cf coefficient ring.
+     */
+    public ModGroebnerBaseSeq(RingFactory<C> cf) {
+        this(GBFactory.getImplementation(cf));
+    }
+
+
+    /**
+     * Constructor.
+     * @param bb Groebner base algorithm.
+     */
+    public ModGroebnerBaseSeq(GroebnerBaseAbstract<C> bb) {
+        this.bb = bb;
+    }
+
+
+    /**
+     * Module Groebner base test.
+     */
+    public boolean isGB(int modv, List<GenPolynomial<C>> F) {
+        return bb.isGB(modv, F);
+    }
+
+
+    /**
+     * Groebner base using pairlist class.
+     */
+    public List<GenPolynomial<C>> GB(int modv, List<GenPolynomial<C>> F) {
+        return bb.GB(modv, F);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbmod/ModSolvableGroebnerBase.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbmod/ModSolvableGroebnerBase.java
@@ -1,0 +1,128 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbmod;
+
+
+import java.io.Serializable;
+import java.util.List;
+
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.ModuleList;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Module solvable Groebner Bases interface. Defines modull solvabe Groebner
+ * bases and GB test.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ * @deprecated use respective methods from SolvableGroebnerBase 
+ */
+@Deprecated
+public interface ModSolvableGroebnerBase<C extends RingElem<C>> extends Serializable {
+
+
+    /**
+     * Module left Groebner base test.
+     * @param modv number of modul variables.
+     * @param F a module basis.
+     * @return true, if F is a left Groebner base, else false.
+     */
+    public boolean isLeftGB(int modv, List<GenSolvablePolynomial<C>> F);
+
+
+    /**
+     * Module left Groebner base test.
+     * @param M a module basis.
+     * @return true, if M is a left Groebner base, else false.
+     */
+    public boolean isLeftGB(ModuleList<C> M);
+
+
+    /**
+     * Left Groebner base using pairlist class.
+     * @param modv number of modul variables.
+     * @param F a module basis.
+     * @return leftGB(F) a left Groebner base for F.
+     */
+    public List<GenSolvablePolynomial<C>> leftGB(int modv, List<GenSolvablePolynomial<C>> F);
+
+
+    /**
+     * Left Groebner base using pairlist class.
+     * @param M a module basis.
+     * @return leftGB(M) a left Groebner base for M.
+     */
+    public ModuleList<C> leftGB(ModuleList<C> M);
+
+
+    /**
+     * Module twosided Groebner base test.
+     * @param modv number of modul variables.
+     * @param F a module basis.
+     * @return true, if F is a twosided Groebner base, else false.
+     */
+    public boolean isTwosidedGB(int modv, List<GenSolvablePolynomial<C>> F);
+
+
+    /**
+     * Module twosided Groebner base test.
+     * @param M a module basis.
+     * @return true, if M is a twosided Groebner base, else false.
+     */
+    public boolean isTwosidedGB(ModuleList<C> M);
+
+
+    /**
+     * Twosided Groebner base using pairlist class.
+     * @param modv number of modul variables.
+     * @param F a module basis.
+     * @return tsGB(F) a twosided Groebner base for F.
+     */
+    public List<GenSolvablePolynomial<C>> twosidedGB(int modv, List<GenSolvablePolynomial<C>> F);
+
+
+    /**
+     * Twosided Groebner base using pairlist class.
+     * @param M a module basis.
+     * @return tsGB(M) a twosided Groebner base for M.
+     */
+    public ModuleList<C> twosidedGB(ModuleList<C> M);
+
+
+    /**
+     * Module right Groebner base test.
+     * @param modv number of modul variables.
+     * @param F a module basis.
+     * @return true, if F is a right Groebner base, else false.
+     */
+    public boolean isRightGB(int modv, List<GenSolvablePolynomial<C>> F);
+
+
+    /**
+     * Module right Groebner base test.
+     * @param M a module basis.
+     * @return true, if M is a right Groebner base, else false.
+     */
+    public boolean isRightGB(ModuleList<C> M);
+
+
+    /**
+     * Right Groebner base using pairlist class.
+     * @param modv number of modul variables.
+     * @param F a module basis.
+     * @return rightGB(F) a right Groebner base for F.
+     */
+    public List<GenSolvablePolynomial<C>> rightGB(int modv, List<GenSolvablePolynomial<C>> F);
+
+
+    /**
+     * Right Groebner base using pairlist class.
+     * @param M a module basis.
+     * @return rightGB(M) a right Groebner base for M.
+     */
+    public ModuleList<C> rightGB(ModuleList<C> M);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbmod/ModSolvableGroebnerBaseAbstract.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbmod/ModSolvableGroebnerBaseAbstract.java
@@ -1,0 +1,228 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbmod;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.GenSolvablePolynomialRing;
+import edu.jas.poly.ModuleList;
+import edu.jas.poly.PolynomialList;
+import edu.jas.poly.TermOrder;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Module solvable Groebner Bases abstract class. Implements module solvable
+ * Groebner bases and GB test.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ * @deprecated use respective methods from SolvableGroebnerBaseAbstract
+ */
+@Deprecated
+public abstract class ModSolvableGroebnerBaseAbstract<C extends RingElem<C>> implements
+                ModSolvableGroebnerBase<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(ModSolvableGroebnerBaseAbstract.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Module left Groebner base test.
+     * @param M a module basis.
+     * @return true, if M is a left Groebner base, else false.
+     */
+    public boolean isLeftGB(ModuleList<C> M) {
+        if (M == null || M.list == null) {
+            return true;
+        }
+        if (M.rows == 0 || M.cols == 0) {
+            return true;
+        }
+        int modv = M.cols; // > 0  
+        PolynomialList<C> F = M.getPolynomialList();
+        return isLeftGB(modv, F.castToSolvableList());
+    }
+
+
+    /**
+     * Left Groebner base using pairlist class.
+     * @param M a module basis.
+     * @return leftGB(M) a left Groebner base for M.
+     */
+    @SuppressWarnings("unchecked")
+    public ModuleList<C> leftGB(ModuleList<C> M) {
+        ModuleList<C> N = M;
+        if (M == null || M.list == null) {
+            return N;
+        }
+        if (M.rows == 0 || M.cols == 0) {
+            return N;
+        }
+        PolynomialList<C> F = M.getPolynomialList();
+        if (debug) {
+            logger.info("F left +++++++++++++++++++ \n" + F);
+        }
+        GenSolvablePolynomialRing<C> sring = (GenSolvablePolynomialRing<C>) F.ring;
+        int modv = M.cols;
+        List<GenSolvablePolynomial<C>> G = leftGB(modv, F.castToSolvableList());
+        F = new PolynomialList<C>(sring, G);
+        if (debug) {
+            logger.info("G left +++++++++++++++++++ \n" + F);
+        }
+        N = F.getModuleList(modv);
+        return N;
+    }
+
+
+    /**
+     * Module twosided Groebner base test.
+     * @param M a module basis.
+     * @return true, if M is a twosided Groebner base, else false.
+     */
+    public boolean isTwosidedGB(ModuleList<C> M) {
+        if (M == null || M.list == null) {
+            return true;
+        }
+        if (M.rows == 0 || M.cols == 0) {
+            return true;
+        }
+        PolynomialList<C> F = M.getPolynomialList();
+        int modv = M.cols; // > 0  
+        return isTwosidedGB(modv, F.castToSolvableList());
+    }
+
+
+    /**
+     * Twosided Groebner base using pairlist class.
+     * @param M a module basis.
+     * @return tsGB(M) a twosided Groebner base for M.
+     */
+    @SuppressWarnings("unchecked")
+    public ModuleList<C> twosidedGB(ModuleList<C> M) {
+        ModuleList<C> N = M;
+        if (M == null || M.list == null) {
+            return N;
+        }
+        if (M.rows == 0 || M.cols == 0) {
+            return N;
+        }
+        PolynomialList<C> F = M.getPolynomialList();
+        GenSolvablePolynomialRing<C> sring = (GenSolvablePolynomialRing<C>) F.ring;
+        int modv = M.cols;
+        List<GenSolvablePolynomial<C>> G = twosidedGB(modv, F.castToSolvableList());
+        F = new PolynomialList<C>(sring, G);
+        N = F.getModuleList(modv);
+        return N;
+    }
+
+
+    /**
+     * Module right Groebner base test.
+     * @param M a module basis.
+     * @return true, if M is a right Groebner base, else false.
+     */
+    public boolean isRightGB(ModuleList<C> M) {
+        if (M == null || M.list == null) {
+            return true;
+        }
+        if (M.rows == 0 || M.cols == 0) {
+            return true;
+        }
+        int modv = M.cols; // > 0  
+        PolynomialList<C> F = M.getPolynomialList();
+        //System.out.println("F test = " + F);
+        return isRightGB(modv, F.castToSolvableList());
+    }
+
+
+    /**
+     * Right Groebner base using pairlist class.
+     * @param M a module basis.
+     * @return rightGB(M) a right Groebner base for M.
+     */
+    @SuppressWarnings("unchecked")
+    public ModuleList<C> rightGB(ModuleList<C> M) {
+        ModuleList<C> N = M;
+        if (M == null || M.list == null) {
+            return N;
+        }
+        if (M.rows == 0 || M.cols == 0) {
+            return N;
+        }
+        if (debug) {
+            logger.info("M ====================== \n" + M);
+        }
+        TermOrder to = M.ring.tord;
+        if (to.getSplit() <= M.ring.nvar) {
+            throw new IllegalArgumentException("extended TermOrders not supported for rightGBs: " + to);
+        }
+        List<List<GenSolvablePolynomial<C>>> mlist = M.castToSolvableList();
+        GenSolvablePolynomialRing<C> sring = (GenSolvablePolynomialRing<C>) M.ring;
+        GenSolvablePolynomialRing<C> rring = sring.reverse(true); //true
+        sring = rring.reverse(true); // true
+
+        List<List<GenSolvablePolynomial<C>>> nlist = new ArrayList<List<GenSolvablePolynomial<C>>>(M.rows);
+        for (List<GenSolvablePolynomial<C>> row : mlist) {
+            List<GenSolvablePolynomial<C>> nrow = new ArrayList<GenSolvablePolynomial<C>>(row.size());
+            for (GenSolvablePolynomial<C> elem : row) {
+                GenSolvablePolynomial<C> nelem = (GenSolvablePolynomial<C>) elem.reverse(rring);
+                nrow.add(nelem);
+            }
+            nlist.add(nrow);
+        }
+        ModuleList<C> rM = new ModuleList<C>(rring, nlist);
+        if (debug) {
+            logger.info("rM -------------------- \n" + rM);
+        }
+        ModuleList<C> rMg = leftGB(rM);
+        if (debug) {
+            logger.info("rMg -------------------- \n" + rMg);
+            logger.info("isLeftGB(rMg) ---------- " + isLeftGB(rMg));
+        }
+        mlist = rMg.castToSolvableList();
+        nlist = new ArrayList<List<GenSolvablePolynomial<C>>>(rMg.rows);
+        for (List<GenSolvablePolynomial<C>> row : mlist) {
+            List<GenSolvablePolynomial<C>> nrow = new ArrayList<GenSolvablePolynomial<C>>(row.size());
+            for (GenSolvablePolynomial<C> elem : row) {
+                GenSolvablePolynomial<C> nelem = (GenSolvablePolynomial<C>) elem.reverse(sring);
+                nrow.add(nelem);
+            }
+            nlist.add(nrow);
+        }
+        ModuleList<C> Mg = new ModuleList<C>(sring, nlist);
+        if (debug) {
+            logger.info("Mg -------------------- \n" + Mg);
+            logger.info("isRightGB(Mg) --------- " + isRightGB(Mg));
+        }
+        return Mg;
+    }
+
+
+    /**
+     * Cleanup and terminate ThreadPool.
+     */
+    public void terminate() {
+        logger.info("terminate not implemented");
+    }
+
+
+    /**
+     * Cancel ThreadPool.
+     */
+    public int cancel() {
+        logger.info("cancel not implemented");
+        return 0;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbmod/ModSolvableGroebnerBasePar.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbmod/ModSolvableGroebnerBasePar.java
@@ -1,0 +1,68 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbmod;
+
+
+// import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+import edu.jas.gb.SolvableGroebnerBaseAbstract;
+import edu.jas.gbufd.SGBFactory;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Module solvable Groebner Bases parallel class. Implements module solvable
+ * Groebner bases and GB test.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ * @deprecated use respective methods from SolvableGroebnerBaseParallel
+ */
+@Deprecated
+public class ModSolvableGroebnerBasePar<C extends GcdRingElem<C>> extends ModSolvableGroebnerBaseSeq<C> {
+
+
+    //private static final Logger logger = LogManager.getLogger(ModSolvableGroebnerBasePar.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     * @param cf coefficient ring.
+     */
+    public ModSolvableGroebnerBasePar(RingFactory<C> cf) {
+        this(SGBFactory.getProxy(cf));
+    }
+
+
+    /**
+     * Constructor.
+     * @param sbb parallel solvable Groebner base algorithm.
+     */
+    public ModSolvableGroebnerBasePar(SolvableGroebnerBaseAbstract<C> sbb) {
+        super(sbb);
+    }
+
+
+    /**
+     * Cleanup and terminate ThreadPool.
+     */
+    @Override
+    public void terminate() {
+        sbb.terminate();
+    }
+
+
+    /**
+     * Cancel ThreadPool.
+     */
+    @Override
+    public int cancel() {
+        return sbb.cancel();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbmod/ModSolvableGroebnerBaseSeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbmod/ModSolvableGroebnerBaseSeq.java
@@ -1,0 +1,129 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbmod;
+
+
+import java.util.List;
+
+// import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+import edu.jas.gb.SolvableGroebnerBaseAbstract;
+import edu.jas.gbufd.SGBFactory;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Module solvable Groebner Bases sequential class. Implements module solvable
+ * Groebner bases and GB test.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ * @deprecated use respective methods from SolvableGroebnerBaseSeq
+ */
+@Deprecated
+public class ModSolvableGroebnerBaseSeq<C extends GcdRingElem<C>> extends ModSolvableGroebnerBaseAbstract<C> {
+
+
+    //private static final Logger logger = LogManager.getLogger(ModSolvableGroebnerBaseSeq.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Used Solvable Groebner base algorithm.
+     */
+    protected final SolvableGroebnerBaseAbstract<C> sbb;
+
+
+    /**
+     * Constructor.
+     * @param cf coefficient ring.
+     */
+    public ModSolvableGroebnerBaseSeq(RingFactory<C> cf) {
+        this(SGBFactory.getImplementation(cf));
+    }
+
+
+    /**
+     * Constructor.
+     * @param sbb solvable Groebner base implementation.
+     */
+    public ModSolvableGroebnerBaseSeq(SolvableGroebnerBaseAbstract<C> sbb) {
+        this.sbb = sbb;
+    }
+
+
+    /**
+     * Module left Groebner base test.
+     * @param modv number of modul variables.
+     * @param F a module basis.
+     * @return true, if F is a left Groebner base, else false.
+     */
+    public boolean isLeftGB(int modv, List<GenSolvablePolynomial<C>> F) {
+        return sbb.isLeftGB(modv, F);
+    }
+
+
+    /**
+     * Left Groebner base using pairlist class.
+     * @param modv number of modul variables.
+     * @param F a module basis.
+     * @return leftGB(F) a left Groebner base for F.
+     */
+    public List<GenSolvablePolynomial<C>> leftGB(int modv, List<GenSolvablePolynomial<C>> F) {
+        return sbb.leftGB(modv, F);
+    }
+
+
+    /**
+     * Module twosided Groebner base test.
+     * @param modv number of modul variables.
+     * @param F a module basis.
+     * @return true, if F is a twosided Groebner base, else false.
+     */
+    public boolean isTwosidedGB(int modv, List<GenSolvablePolynomial<C>> F) {
+        return sbb.isTwosidedGB(modv, F);
+    }
+
+
+    /**
+     * Twosided Groebner base using pairlist class.
+     * @param modv number of modul variables.
+     * @param F a module basis.
+     * @return tsGB(F) a twosided Groebner base for F.
+     */
+    public List<GenSolvablePolynomial<C>> twosidedGB(int modv, List<GenSolvablePolynomial<C>> F) {
+        return sbb.twosidedGB(modv, F);
+    }
+
+
+    /**
+     * Module right Groebner base test.
+     * @param modv number of modul variables.
+     * @param F a module basis.
+     * @return true, if F is a right Groebner base, else false.
+     */
+    public boolean isRightGB(int modv, List<GenSolvablePolynomial<C>> F) {
+        return sbb.isRightGB(modv, F);
+    }
+
+
+    /**
+     * Right Groebner base using pairlist class.
+     * @param modv number of modul variables.
+     * @param F a module basis.
+     * @return rightGB(F) a right Groebner base for F.
+     */
+    public List<GenSolvablePolynomial<C>> rightGB(int modv, List<GenSolvablePolynomial<C>> F) {
+        if (modv == 0) {
+            return sbb.rightGB(modv, F);
+        }
+        throw new UnsupportedOperationException("modv != 0 not jet implemented");
+        // return sbb.rightGB(modv,F);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbmod/package.html
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbmod/package.html
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "../DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>Module Groebner base classes</title>
+  </head>
+
+  <body>
+    <h1>Module Groebner base package.</h1>
+
+<p>
+  This package is deprecated. It contained classes for module Groebner
+  bases and syzygies over polynomials and solvable polynomials,
+  e.g. <code>ModGroebnerBase</code> or <code>SolvableSyzygy</code>.
+  The methods of <code>Mod*GroebnerBase</code> have been refactored to
+  <code>*GroebnerBase</code> methods in package
+  <code>edu.jas.gb</code>.  The classes <code>Syzygy*</code> and
+  <code>SolvableSyzygy*</code> have been moved to package
+  <code>edu.jas.gbufd</code>.
+</p>
+
+
+    <hr />
+    <address><a href="mailto:kredel at rz.uni-mannheim.de">Heinz Kredel</a></address>
+<p>
+<!-- Created: Wed Mar  1 12:29:04 CET 2006 -->
+<!-- hhmts start -->
+Last modified: Mon Jul 27 21:52:26 CEST 2015
+<!-- hhmts end -->
+</p>
+<p>$Id$ 
+</p>
+  </body>
+</html>

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/CharacteristicSet.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/CharacteristicSet.java
@@ -1,0 +1,50 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.io.Serializable;
+import java.util.List;
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Characteristic Set interface. Defines methods for Characteristic Sets and
+ * tests.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+public interface CharacteristicSet<C extends GcdRingElem<C>> extends Serializable {
+
+
+    /**
+     * Characteristic set. According to the implementing algorithm (simple, Wu, etc).
+     * @param A list of generic polynomials.
+     * @return charSet(A) with at most one polynomial per main variable.
+     */
+    public List<GenPolynomial<C>> characteristicSet(List<GenPolynomial<C>> A);
+
+
+    /**
+     * Characteristic set test.
+     * @param A list of generic polynomials.
+     * @return true, if A is (at least a simple) characteristic set, else false.
+     */
+    public boolean isCharacteristicSet(List<GenPolynomial<C>> A);
+
+
+    /**
+     * Characteristic set reduction. Pseudo remainder wrt. the main variable.
+     * With further pseudo reduction of the leading coefficient depending on the implementing algorithm.
+     * @param P generic polynomial.
+     * @param A list of generic polynomials as characteristic set.
+     * @return characteristicSetRemainder(A,P) or 
+     *         characteristicSetReductionCoeff(A,characteristicSetRemainder(A,P)) depending on the algorithm.
+     */
+    public GenPolynomial<C> characteristicSetReduction(List<GenPolynomial<C>> A, GenPolynomial<C> P);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/CharacteristicSetSimple.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/CharacteristicSetSimple.java
@@ -1,0 +1,187 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.OrderedPolynomialList;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.ufd.GCDFactory;
+import edu.jas.ufd.GreatestCommonDivisorAbstract;
+
+
+/**
+ * Characteristic Set class acccording to the simple algorithm, where the
+ * leading coefficients are <strong>not</strong> rereduced. Implements methods
+ * for Characteristic Sets and tests.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+public class CharacteristicSetSimple<C extends GcdRingElem<C>> implements CharacteristicSet<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(CharacteristicSetSimple.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Characteristic set. According to the simple algorithm. The leading
+     * coefficients are <strong>not</strong> rereduced.
+     * @param A list of generic polynomials.
+     * @return charSetWu(A).
+     */
+    public List<GenPolynomial<C>> characteristicSet(List<GenPolynomial<C>> A) {
+        List<GenPolynomial<C>> S = new ArrayList<GenPolynomial<C>>();
+        if (A == null || A.isEmpty()) {
+            return S;
+        }
+        GenPolynomialRing<C> pfac = A.get(0).ring;
+        if (pfac.nvar <= 1) { // take gcd
+            GreatestCommonDivisorAbstract<C> ufd = GCDFactory.<C> getImplementation(pfac.coFac);
+            GenPolynomial<C> g = ufd.gcd(A).monic();
+            logger.info("charSet base gcd = " + g);
+            S.add(g);
+            return S;
+        }
+        // sort polynomials according to the main variable
+        GenPolynomialRing<GenPolynomial<C>> rfac = pfac.recursive(1);
+        List<GenPolynomial<GenPolynomial<C>>> positiveDeg = new ArrayList<GenPolynomial<GenPolynomial<C>>>();
+        List<GenPolynomial<C>> zeroDeg = new ArrayList<GenPolynomial<C>>();
+        for (GenPolynomial<C> f : A) {
+            if (f.isZERO()) {
+                continue;
+            }
+            f = f.monic();
+            if (f.isONE()) {
+                S.add(f);
+                return S;
+            }
+            GenPolynomial<GenPolynomial<C>> fr = PolyUtil.<C> recursive(rfac, f);
+            if (fr.degree(0) == 0) {
+                zeroDeg.add(fr.leadingBaseCoefficient());
+            } else {
+                positiveDeg.add(fr);
+            }
+        }
+        if (positiveDeg.isEmpty() && zeroDeg.isEmpty()) {
+            return S;
+        }
+        // do pseudo division wrt. the main variable
+        OrderedPolynomialList<GenPolynomial<C>> opl = new OrderedPolynomialList<GenPolynomial<C>>(rfac,
+                        positiveDeg);
+        List<GenPolynomial<GenPolynomial<C>>> pd = new ArrayList<GenPolynomial<GenPolynomial<C>>>(opl.list);
+        Collections.reverse(pd); // change OrderedPolynomialList to avoid
+        if (debug) {
+            logger.info("positive degrees: " + pd);
+        }
+        //System.out.println("positive degrees: " + pd);
+        //System.out.println("zero     degrees: " + zeroDeg);
+        while (pd.size() > 1) {
+            GenPolynomial<GenPolynomial<C>> fr = pd.remove(0);
+            GenPolynomial<GenPolynomial<C>> qr = pd.get(0); // = get(1)
+            logger.info("pseudo remainder by deg = " + qr.degree() + " in variable " + rfac.getVars()[0]);
+            GenPolynomial<GenPolynomial<C>> rr = PolyUtil.<C> recursiveSparsePseudoRemainder(fr, qr);
+            if (rr.isZERO()) {
+                logger.warn("variety is reducible");
+                // replace qr by gcd(qr,fr) ?
+                continue;
+            }
+            if (rr.degree(0) == 0) {
+                zeroDeg.add(rr.leadingBaseCoefficient().monic());
+            } else {
+                pd.add(rr);
+                pd = OrderedPolynomialList.sort(rfac, pd);
+                Collections.reverse(pd); // avoid
+            }
+        }
+        // recursion for degree zero polynomials
+        List<GenPolynomial<C>> Sp = characteristicSet(zeroDeg); // recursion
+        for (GenPolynomial<C> f : Sp) {
+            GenPolynomial<C> fp = f.extend(pfac, 0, 0L);
+            S.add(fp);
+        }
+        //logger.info("charSet recursion, Sp = " + Sp);
+        if (pd.isEmpty()) {
+            return S;
+        }
+        GenPolynomial<GenPolynomial<C>> rr = pd.get(0);
+        GenPolynomial<C> sr = PolyUtil.<C> distribute(pfac, rr);
+        sr = sr.monic();
+        // no rereduction of leading coefficient wrt. characteristic set.
+        S.add(0, sr);
+        return S;
+    }
+
+
+    /**
+     * Characteristic set test.
+     * @param A list of generic polynomials.
+     * @return true, if A is (at least a simple) characteristic set, else false.
+     */
+    public boolean isCharacteristicSet(List<GenPolynomial<C>> A) {
+        if (A == null || A.isEmpty()) {
+            return true; // ?
+        }
+        GenPolynomialRing<C> pfac = A.get(0).ring;
+        if (pfac.nvar <= 1) {
+            return A.size() <= 1;
+        }
+        if (pfac.nvar < A.size()) {
+            return false;
+        }
+        // select polynomials according to the main variable
+        GenPolynomialRing<GenPolynomial<C>> rfac = pfac.recursive(1);
+        List<GenPolynomial<C>> zeroDeg = new ArrayList<GenPolynomial<C>>();
+        int positiveDeg = 0;
+        for (GenPolynomial<C> f : A) {
+            if (f.isZERO()) {
+                return false;
+            }
+            //f = f.monic();
+            GenPolynomial<GenPolynomial<C>> fr = PolyUtil.<C> recursive(rfac, f);
+            if (fr.degree(0) == 0) {
+                zeroDeg.add(fr.leadingBaseCoefficient());
+            } else {
+                positiveDeg++;
+                if (positiveDeg > 1) {
+                    return false;
+                }
+            }
+        }
+        return isCharacteristicSet(zeroDeg);
+    }
+
+
+    /**
+     * Characteristic set reduction. Pseudo remainder wrt. the main variable.
+     * @param P generic polynomial.
+     * @param A list of generic polynomials as characteristic set.
+     * @return characteristicSetRemainder(A,P)
+     */
+    public GenPolynomial<C> characteristicSetReduction(List<GenPolynomial<C>> A, GenPolynomial<C> P) {
+        if (A == null || A.isEmpty()) {
+            return P.monic();
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        GenPolynomial<C> R = PolyGBUtil.<C> topPseudoRemainder(A, P);
+        R = R.monic();
+        //System.out.println("remainder, R = " + R);
+        return R;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/CharacteristicSetWu.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/CharacteristicSetWu.java
@@ -1,0 +1,210 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.OrderedPolynomialList;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.ufd.GCDFactory;
+import edu.jas.ufd.GreatestCommonDivisorAbstract;
+
+
+/**
+ * Characteristic Set class acccording to Wu. Implements methods for
+ * Characteristic Sets and tests.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+public class CharacteristicSetWu<C extends GcdRingElem<C>> implements CharacteristicSet<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(CharacteristicSetWu.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Characteristic set. According to Wu's algorithm with rereduction of
+     * leading coefficients.
+     * @param A list of generic polynomials.
+     * @return charSetWu(A).
+     */
+    public List<GenPolynomial<C>> characteristicSet(List<GenPolynomial<C>> A) {
+        List<GenPolynomial<C>> S = new ArrayList<GenPolynomial<C>>();
+        if (A == null || A.isEmpty()) {
+            return S;
+        }
+        GenPolynomialRing<C> pfac = A.get(0).ring;
+        if (pfac.nvar <= 1) { // take gcd
+            GreatestCommonDivisorAbstract<C> ufd = GCDFactory.<C> getImplementation(pfac.coFac);
+            GenPolynomial<C> g = ufd.gcd(A).monic();
+            logger.info("charSet base gcd = " + g);
+            S.add(g);
+            return S;
+        }
+        // sort polynomials according to the main variable
+        GenPolynomialRing<GenPolynomial<C>> rfac = pfac.recursive(1);
+        List<GenPolynomial<GenPolynomial<C>>> positiveDeg = new ArrayList<GenPolynomial<GenPolynomial<C>>>();
+        List<GenPolynomial<C>> zeroDeg = new ArrayList<GenPolynomial<C>>();
+        for (GenPolynomial<C> f : A) {
+            if (f.isZERO()) {
+                continue;
+            }
+            f = f.monic();
+            if (f.isONE()) {
+                S.add(f);
+                return S;
+            }
+            GenPolynomial<GenPolynomial<C>> fr = PolyUtil.<C> recursive(rfac, f);
+            if (fr.degree(0) == 0) {
+                zeroDeg.add(fr.leadingBaseCoefficient());
+            } else {
+                positiveDeg.add(fr);
+            }
+        }
+        if (positiveDeg.isEmpty() && zeroDeg.isEmpty()) {
+            return S;
+        }
+        // do pseudo division wrt. the main variable
+        OrderedPolynomialList<GenPolynomial<C>> opl = new OrderedPolynomialList<GenPolynomial<C>>(rfac,
+                        positiveDeg);
+        List<GenPolynomial<GenPolynomial<C>>> pd = new ArrayList<GenPolynomial<GenPolynomial<C>>>(opl.list);
+        Collections.reverse(pd); // change OrderedPolynomialList to avoid
+        if (debug) {
+            logger.info("positive degrees: " + pd);
+        }
+        //System.out.println("positive degrees: " + pd);
+        //System.out.println("zero     degrees: " + zeroDeg);
+        while (pd.size() > 1) {
+            GenPolynomial<GenPolynomial<C>> fr = pd.remove(0);
+            GenPolynomial<GenPolynomial<C>> qr = pd.get(0); // = get(1)
+            logger.info("pseudo remainder by deg = " + qr.degree() + " in variable " + rfac.getVars()[0]);
+            GenPolynomial<GenPolynomial<C>> rr = PolyUtil.<C> recursiveSparsePseudoRemainder(fr, qr);
+            if (rr.isZERO()) {
+                logger.warn("variety is reducible " + fr + " reduces to zero mod " + pd);
+                // replace qr by gcd(qr,fr) ?
+                continue;
+            }
+            if (rr.degree(0) == 0) {
+                zeroDeg.add(rr.leadingBaseCoefficient().monic());
+            } else {
+                pd.add(rr);
+                pd = OrderedPolynomialList.sort(rfac, pd);
+                Collections.reverse(pd); // avoid
+            }
+        }
+        // recursion for degree zero polynomials
+        List<GenPolynomial<C>> Sp = characteristicSet(zeroDeg); // recursion
+        for (GenPolynomial<C> f : Sp) {
+            GenPolynomial<C> fp = f.extend(pfac, 0, 0L);
+            S.add(fp);
+        }
+        //logger.info("charSet recursion, Sp = " + Sp);
+        if (pd.isEmpty()) {
+            return S;
+        }
+        // rereduction of leading coefficient wrt. characteristic set according to Wu
+        GenPolynomial<GenPolynomial<C>> rr = pd.get(0);
+        GenPolynomial<C> sr = PolyUtil.<C> distribute(pfac, rr);
+        sr = PolyGBUtil.<C> topCoefficientPseudoRemainder(Sp, sr);
+        logger.info("charSet rereduced sr = " + sr);
+        if (sr.isZERO()) {
+            return S;
+        }
+        long d = sr.degree(pfac.nvar - 1);
+        //System.out.println("deg(sr): " + d + ", degv(sr): " + sr.leadingExpVector());
+        if (d == 0) { // deg zero, invalid characteristic set, restart
+            S.add(0, sr);
+            logger.warn("reducible characteristic set, restarting with S = " + S);
+            return characteristicSet(S);
+        }
+        sr = sr.monic();
+        S.add(0, sr);
+        return S;
+    }
+
+
+    /**
+     * Characteristic set test.
+     * @param A list of generic polynomials.
+     * @return true, if A is (at least a simple) characteristic set, else false.
+     */
+    public boolean isCharacteristicSet(List<GenPolynomial<C>> A) {
+        if (A == null || A.isEmpty()) {
+            return true; // ?
+        }
+        GenPolynomialRing<C> pfac = A.get(0).ring;
+        if (pfac.nvar <= 1) {
+            //System.out.println("CS: pfac = " + pfac + ", A = " + A + ", A.size() = " + A.size());
+            return A.size() <= 1;
+        }
+        if (pfac.nvar < A.size()) {
+            logger.info("not CS: pfac = " + pfac + ", A = " + A);
+            return false;
+        }
+        // select polynomials according to the main variable
+        GenPolynomialRing<GenPolynomial<C>> rfac = pfac.recursive(1);
+        List<GenPolynomial<C>> zeroDeg = new ArrayList<GenPolynomial<C>>();
+        int positiveDeg = 0;
+        for (GenPolynomial<C> f : A) {
+            if (f.isZERO()) {
+                logger.info("not CS: f = " + f);
+                return false;
+            }
+            //f = f.monic();
+            GenPolynomial<GenPolynomial<C>> fr = PolyUtil.<C> recursive(rfac, f);
+            if (fr.degree(0) == 0) {
+                zeroDeg.add(fr.leadingBaseCoefficient());
+            } else {
+                positiveDeg++;
+                if (positiveDeg > 1) {
+                    logger.info("not CS: f = " + f + ", positiveDeg = " + positiveDeg);
+                    return false;
+                }
+            }
+        }
+        return isCharacteristicSet(zeroDeg);
+    }
+
+
+    /**
+     * Characteristic set reduction. Pseudo remainder wrt. the main variable
+     * with further pseudo reduction of the leading coefficient.
+     * @param P generic polynomial.
+     * @param A list of generic polynomials as characteristic set.
+     * @return 
+     *         characteristicSetReductionCoeff(A,characteristicSetRemainder(A,P))
+     */
+    public GenPolynomial<C> characteristicSetReduction(List<GenPolynomial<C>> A, GenPolynomial<C> P) {
+        if (A == null || A.isEmpty()) {
+            return P.monic();
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        GenPolynomial<C> R = PolyGBUtil.<C> topPseudoRemainder(A, P);
+        //System.out.println("remainder, R = " + R);
+        if (R.isZERO()) {
+            return R;
+        }
+        List<GenPolynomial<C>> Ap = PolyGBUtil.<C> zeroDegrees(A);
+        //System.out.println("Ap = " + Ap);
+        R = PolyGBUtil.<C> topCoefficientPseudoRemainder(Ap, R);
+        //System.out.println("R = " + R);
+        return R;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/Examples.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/Examples.java
@@ -1,0 +1,216 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.jas.arith.BigRational;
+import edu.jas.arith.ModInteger;
+import edu.jas.arith.ModIntegerRing;
+import edu.jas.gb.GroebnerBase;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.GenPolynomialTokenizer;
+import edu.jas.poly.PolynomialList;
+import edu.jas.poly.TermOrder;
+
+
+/**
+ * Examples for Groebner base usage.
+ * @author Christoph Zengler
+ * @author Heinz Kredel
+ */
+public class Examples {
+
+
+    /**
+     * main.
+     */
+    public static void main(String[] args) {
+        //example1();
+        //example2();
+        //example3();
+        exampleGB();
+        //exampleGB1();
+        //exampleGBTrinks();
+    }
+
+
+    /**
+     * example1. Coefficients in Boolean residue class ring.
+     * 
+     */
+    public static void example1() {
+        // moved to edu.jas.application.Examples
+    }
+
+
+    /*
+     * example2. Coefficients in Boolean residue class ring with cuppling of
+     * variables.
+     * 
+     */
+    public static void example2() {
+        // moved to edu.jas.application.Examples
+    }
+
+
+    /**
+     * example3. Coefficients in Boolean ring and additional idempotent
+     * generators.
+     * 
+     */
+    public static void example3() {
+        String[] vars = { "v3", "v2", "v1" };
+
+        ModIntegerRing z2 = new ModIntegerRing(2);
+        GenPolynomialRing<ModInteger> z2p = new GenPolynomialRing<ModInteger>(z2, vars.length, new TermOrder(
+                        TermOrder.INVLEX), vars);
+        List<GenPolynomial<ModInteger>> fieldPolynomials = new ArrayList<GenPolynomial<ModInteger>>();
+
+        //add v1^2 + v1, v2^2 + v2, v3^2 + v3 to fieldPolynomials
+        for (int i = 0; i < vars.length; i++) {
+            GenPolynomial<ModInteger> var = z2p.univariate(i);
+            fieldPolynomials.add(var.multiply(var).sum(var));
+        }
+
+
+        List<GenPolynomial<ModInteger>> polynomials = new ArrayList<GenPolynomial<ModInteger>>();
+
+        GenPolynomial<ModInteger> v1 = z2p.univariate(0);
+        GenPolynomial<ModInteger> v2 = z2p.univariate(1);
+        GenPolynomial<ModInteger> v3 = z2p.univariate(2);
+        GenPolynomial<ModInteger> notV1 = v1.sum(z2p.ONE);
+        GenPolynomial<ModInteger> notV2 = v2.sum(z2p.ONE);
+        GenPolynomial<ModInteger> notV3 = v3.sum(z2p.ONE);
+
+        //v1*v2
+        GenPolynomial<ModInteger> p1 = v1.multiply(v2);
+
+        //v1*v2 + v1 + v2 + 1
+        GenPolynomial<ModInteger> p2 = notV1.multiply(notV2);
+
+        //v1*v3 + v1 + v3 + 1
+        GenPolynomial<ModInteger> p3 = notV1.multiply(notV3);
+
+        polynomials.add(p1);
+        polynomials.add(p2);
+        polynomials.add(p3);
+
+        polynomials.addAll(fieldPolynomials);
+
+        //GroebnerBase<ModInteger> gb = new GroebnerBaseSeq<ModInteger>();
+        GroebnerBase<ModInteger> gb = GBFactory.getImplementation(z2);
+
+        List<GenPolynomial<ModInteger>> G = gb.GB(polynomials);
+
+        System.out.println(G);
+    }
+
+
+    /**
+     * Example GBase.
+     * 
+     */
+    @SuppressWarnings("unchecked")
+    static public void exampleGB1() {
+        BigRational coeff = new BigRational();
+        GroebnerBase<BigRational> gb = GBFactory.getImplementation(coeff);
+
+        String exam = "(x1,x2,y) G " + "( " + "( x1 + x2 - 10 ), ( 2 x1 - x2 + 4 ) " + ") ";
+        Reader source = new StringReader(exam);
+        GenPolynomialTokenizer parser = new GenPolynomialTokenizer(source);
+        PolynomialList<BigRational> F = null;
+
+        try {
+            F = (PolynomialList<BigRational>) parser.nextPolynomialSet();
+        } catch (ClassCastException e) {
+            e.printStackTrace();
+            return;
+        } catch (IOException e) {
+            e.printStackTrace();
+            return;
+        }
+        System.out.println("F = " + F);
+
+        List<GenPolynomial<BigRational>> G = gb.GB(F.list);
+
+        PolynomialList<BigRational> trinks = new PolynomialList<BigRational>(F.ring, G);
+        System.out.println("G = " + trinks);
+    }
+
+
+    /**
+     * Example GBase.
+     * 
+     */
+    @SuppressWarnings("unchecked")
+    static public void exampleGB() {
+        BigRational coeff = new BigRational();
+        GroebnerBase<BigRational> gb = GBFactory.getImplementation(coeff);
+
+        String exam = "(x,y) G " + "( " + "( y - ( x^2 - 1 ) ) " + ") ";
+        Reader source = new StringReader(exam);
+        GenPolynomialTokenizer parser = new GenPolynomialTokenizer(source);
+        PolynomialList<BigRational> F = null;
+
+        try {
+            F = (PolynomialList<BigRational>) parser.nextPolynomialSet();
+        } catch (ClassCastException e) {
+            e.printStackTrace();
+            return;
+        } catch (IOException e) {
+            e.printStackTrace();
+            return;
+        }
+        System.out.println("F = " + F);
+
+        List<GenPolynomial<BigRational>> G = gb.GB(F.list);
+
+        PolynomialList<BigRational> trinks = new PolynomialList<BigRational>(F.ring, G);
+        System.out.println("G = " + trinks);
+    }
+
+
+    /**
+     * Example Trinks GBase.
+     * 
+     */
+    @SuppressWarnings("unchecked")
+    static public void exampleGBTrinks() {
+        BigRational coeff = new BigRational();
+        GroebnerBase<BigRational> bb = GBFactory.getImplementation(coeff);
+
+        String exam = "(B,S,T,Z,P,W) L " + "( " + "( 45 P + 35 S - 165 B - 36 ), "
+                        + "( 35 P + 40 Z + 25 T - 27 S ), " + "( 15 W + 25 S P + 30 Z - 18 T - 165 B**2 ), "
+                        + "( - 9 W + 15 T P + 20 S Z ), " + "( P W + 2 T Z - 11 B**3 ), "
+                        + "( 99 W - 11 B S + 3 B**2 ), " + "( B**2 + 33/50 B + 2673/10000 ) " + ") ";
+        Reader source = new StringReader(exam);
+        GenPolynomialTokenizer parser = new GenPolynomialTokenizer(source);
+        PolynomialList<BigRational> F = null;
+
+        try {
+            F = (PolynomialList<BigRational>) parser.nextPolynomialSet();
+        } catch (ClassCastException e) {
+            e.printStackTrace();
+            return;
+        } catch (IOException e) {
+            e.printStackTrace();
+            return;
+        }
+        System.out.println("F = " + F);
+
+        List<GenPolynomial<BigRational>> G = bb.GB(F.list);
+
+        PolynomialList<BigRational> trinks = new PolynomialList<BigRational>(F.ring, G);
+        System.out.println("G = " + trinks);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/GBFactory.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/GBFactory.java
@@ -1,0 +1,600 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.arith.BigInteger;
+import edu.jas.arith.BigRational;
+import edu.jas.arith.ModInt;
+import edu.jas.arith.ModIntRing;
+import edu.jas.arith.ModInteger;
+import edu.jas.arith.ModIntegerRing;
+import edu.jas.arith.ModLong;
+import edu.jas.arith.ModLongRing;
+import edu.jas.arith.Product;
+import edu.jas.arith.ProductRing;
+import edu.jas.gb.DGroebnerBaseSeq;
+import edu.jas.gb.EGroebnerBaseSeq;
+import edu.jas.gb.GBProxy;
+import edu.jas.gb.GroebnerBaseAbstract;
+import edu.jas.gb.GroebnerBaseParallel;
+import edu.jas.gb.GroebnerBaseSeq;
+import edu.jas.gb.OrderedMinPairlist;
+import edu.jas.gb.OrderedPairlist;
+import edu.jas.gb.OrderedSyzPairlist;
+import edu.jas.gb.PairList;
+import edu.jas.gb.ReductionSeq;
+import edu.jas.kern.ComputerThreads;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.ufd.Quotient;
+import edu.jas.ufd.QuotientRing;
+
+
+/**
+ * Groebner bases algorithms factory. Select appropriate Groebner bases engine
+ * based on the coefficient types.
+ * <p>
+ * <b>Usage:</b> To create objects that implement the <code>GroebnerBase</code>
+ * interface use the <code>GBFactory</code>. It will select an appropriate
+ * implementation based on the types of polynomial coefficients C. The method to
+ * obtain an implementation is <code>getImplementation()</code>.
+ * <code>getImplementation()</code> returns an object of a class which
+ * implements the <code>GroebnerBase</code> interface, more precisely an object
+ * of abstract class <code>GroebnerBaseAbstract</code>.
+ * 
+ * <pre>
+ * GroebnerBase&lt;CT&gt; engine;
+ * engine = GBFactory.&lt;CT&gt; getImplementation(cofac);
+ * c = engine.GB(A);
+ * </pre>
+ * <p>
+ * For example, if the coefficient type is BigInteger, the usage looks like
+ * 
+ * <pre>
+ * BigInteger cofac = new BigInteger();
+ * GroebnerBase&lt;BigInteger&gt; engine;
+ * engine = GBFactory.getImplementation(cofac);
+ * c = engine.GB(A);
+ * </pre>
+ * 
+ * @author Heinz Kredel
+ *
+ * @see edu.jas.gb.GroebnerBase
+ * @see edu.jas.application.GBAlgorithmBuilder
+ */
+
+public class GBFactory {
+
+
+    private static final Logger logger = LogManager.getLogger(GBFactory.class);
+
+
+    /**
+     * Algorithm indicators: igb = integerGB, egb = e-GB, dgb = d-GB, qgb =
+     * fraction coefficients GB, ffgb = fraction free GB.
+     */
+    public static enum Algo {
+        igb, egb, dgb, qgb, ffgb
+    };
+
+
+    /**
+     * Protected factory constructor.
+     */
+    protected GBFactory() {
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, no factory case.
+     * @return GB algorithm implementation for field coefficients.
+     */
+    public static <C extends GcdRingElem<C>> GroebnerBaseAbstract<C> getImplementation() {
+        logger.warn("no coefficent factory given, assuming field coeffcients");
+        GroebnerBaseAbstract<C> bba = new GroebnerBaseSeq<C>();
+        return bba;
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case ModLong.
+     * @param fac ModLongRing.
+     * @return GB algorithm implementation.
+     */
+    public static GroebnerBaseAbstract<ModLong> getImplementation(ModLongRing fac) {
+        return getImplementation(fac, new OrderedPairlist<ModLong>());
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case ModLong.
+     * @param fac ModLongRing.
+     * @param pl pair selection strategy
+     * @return GB algorithm implementation.
+     */
+    public static GroebnerBaseAbstract<ModLong> getImplementation(ModLongRing fac, PairList<ModLong> pl) {
+        GroebnerBaseAbstract<ModLong> bba;
+        if (fac.isField()) {
+            bba = new GroebnerBaseSeq<ModLong>(pl);
+        } else {
+            bba = new GroebnerBasePseudoSeq<ModLong>(fac, pl);
+        }
+        return bba;
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case ModInt.
+     * @param fac ModIntRing.
+     * @return GB algorithm implementation.
+     */
+    public static GroebnerBaseAbstract<ModInt> getImplementation(ModIntRing fac) {
+        return getImplementation(fac, new OrderedPairlist<ModInt>());
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case ModInt.
+     * @param fac ModIntRing.
+     * @param pl pair selection strategy
+     * @return GB algorithm implementation.
+     */
+    public static GroebnerBaseAbstract<ModInt> getImplementation(ModIntRing fac, PairList<ModInt> pl) {
+        GroebnerBaseAbstract<ModInt> bba;
+        if (fac.isField()) {
+            bba = new GroebnerBaseSeq<ModInt>(pl);
+        } else {
+            bba = new GroebnerBasePseudoSeq<ModInt>(fac, pl);
+        }
+        return bba;
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case ModInteger.
+     * @param fac ModIntegerRing.
+     * @return GB algorithm implementation.
+     */
+    public static GroebnerBaseAbstract<ModInteger> getImplementation(ModIntegerRing fac) {
+        return getImplementation(fac, new OrderedPairlist<ModInteger>());
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case ModInteger.
+     * @param fac ModIntegerRing.
+     * @param pl pair selection strategy
+     * @return GB algorithm implementation.
+     */
+    public static GroebnerBaseAbstract<ModInteger> getImplementation(ModIntegerRing fac,
+                    PairList<ModInteger> pl) {
+        GroebnerBaseAbstract<ModInteger> bba;
+        if (fac.isField()) {
+            bba = new GroebnerBaseSeq<ModInteger>(pl);
+        } else {
+            bba = new GroebnerBasePseudoSeq<ModInteger>(fac, pl);
+        }
+        return bba;
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case BigInteger.
+     * @param fac BigInteger.
+     * @return GB algorithm implementation.
+     */
+    public static GroebnerBaseAbstract<BigInteger> getImplementation(BigInteger fac) {
+        return getImplementation(fac, Algo.igb);
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case BigInteger.
+     * @param fac BigInteger.
+     * @param a algorithm, a = igb, egb, dgb.
+     * @return GB algorithm implementation.
+     */
+    public static GroebnerBaseAbstract<BigInteger> getImplementation(BigInteger fac, Algo a) {
+        return getImplementation(fac, a, new OrderedPairlist<BigInteger>());
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case BigInteger.
+     * @param fac BigInteger.
+     * @param pl pair selection strategy
+     * @return GB algorithm implementation.
+     */
+    public static GroebnerBaseAbstract<BigInteger> getImplementation(BigInteger fac,
+                    PairList<BigInteger> pl) {
+        return getImplementation(fac, Algo.igb, pl);
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case BigInteger.
+     * @param fac BigInteger.
+     * @param a algorithm, a = igb, egb, dgb.
+     * @param pl pair selection strategy
+     * @return GB algorithm implementation.
+     */
+    public static GroebnerBaseAbstract<BigInteger> getImplementation(BigInteger fac, Algo a,
+                    PairList<BigInteger> pl) {
+        GroebnerBaseAbstract<BigInteger> bba;
+        switch (a) {
+        case igb:
+            bba = new GroebnerBasePseudoSeq<BigInteger>(fac, pl);
+            break;
+        case egb:
+            bba = new EGroebnerBaseSeq<BigInteger>(); // pl not suitable
+            break;
+        case dgb:
+            bba = new DGroebnerBaseSeq<BigInteger>(); // pl not suitable
+            break;
+        default:
+            throw new IllegalArgumentException("algorithm not available for BigInteger " + a);
+        }
+        return bba;
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case BigRational.
+     * @param fac BigRational.
+     * @return GB algorithm implementation.
+     */
+    public static GroebnerBaseAbstract<BigRational> getImplementation(BigRational fac) {
+        return getImplementation(fac, Algo.qgb);
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case BigRational.
+     * @param fac BigRational.
+     * @param a algorithm, a = qgb, ffgb.
+     * @return GB algorithm implementation.
+     */
+    public static GroebnerBaseAbstract<BigRational> getImplementation(BigRational fac, Algo a) {
+        return getImplementation(fac, a, new OrderedPairlist<BigRational>());
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case BigRational.
+     * @param fac BigRational.
+     * @param pl pair selection strategy
+     * @return GB algorithm implementation.
+     */
+    public static GroebnerBaseAbstract<BigRational> getImplementation(BigRational fac,
+                    PairList<BigRational> pl) {
+        return getImplementation(fac, Algo.qgb, pl);
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case BigRational.
+     * @param fac BigRational.
+     * @param a algorithm, a = qgb, ffgb.
+     * @param pl pair selection strategy
+     * @return GB algorithm implementation.
+     */
+    public static GroebnerBaseAbstract<BigRational> getImplementation(BigRational fac, Algo a,
+                    PairList<BigRational> pl) {
+        GroebnerBaseAbstract<BigRational> bba;
+        switch (a) {
+        case qgb:
+            bba = new GroebnerBaseSeq<BigRational>(pl);
+            break;
+        case ffgb:
+            PairList<BigInteger> pli;
+            if (pl instanceof OrderedMinPairlist) {
+                pli = new OrderedMinPairlist<BigInteger>();
+            } else if (pl instanceof OrderedSyzPairlist) {
+                pli = new OrderedSyzPairlist<BigInteger>();
+            } else {
+                pli = new OrderedPairlist<BigInteger>();
+            }
+            bba = new GroebnerBaseRational<BigRational>(pli); // pl not possible
+            break;
+        default:
+            throw new IllegalArgumentException(
+                            "algorithm not available for " + fac.toScriptFactory() + ", Algo = " + a);
+        }
+        return bba;
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case Quotient
+     * coefficients.
+     * @param fac QuotientRing.
+     * @return GB algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C>> GroebnerBaseAbstract<Quotient<C>> getImplementation(
+                    QuotientRing<C> fac) {
+        return getImplementation(fac, Algo.qgb);
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case Quotient
+     * coefficients.
+     * @param fac QuotientRing.
+     * @param a algorithm, a = qgb, ffgb.
+     * @return GB algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C>> GroebnerBaseAbstract<Quotient<C>> getImplementation(
+                    QuotientRing<C> fac, Algo a) {
+        return getImplementation(fac, a, new OrderedPairlist<Quotient<C>>());
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case Quotient
+     * coefficients.
+     * @param fac QuotientRing.
+     * @param pl pair selection strategy
+     * @return GB algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C>> GroebnerBaseAbstract<Quotient<C>> getImplementation(
+                    QuotientRing<C> fac, PairList<Quotient<C>> pl) {
+        return getImplementation(fac, Algo.qgb, pl);
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case Quotient
+     * coefficients.
+     * @param fac QuotientRing.
+     * @param a algorithm, a = qgb, ffgb.
+     * @param pl pair selection strategy
+     * @return GB algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C>> GroebnerBaseAbstract<Quotient<C>> getImplementation(
+                    QuotientRing<C> fac, Algo a, PairList<Quotient<C>> pl) {
+        GroebnerBaseAbstract<Quotient<C>> bba;
+        switch (a) {
+        case qgb:
+            bba = new GroebnerBaseSeq<Quotient<C>>(new ReductionSeq<Quotient<C>>(), pl);
+            break;
+        case ffgb:
+            PairList<GenPolynomial<C>> pli;
+            if (pl instanceof OrderedMinPairlist) {
+                pli = new OrderedMinPairlist<GenPolynomial<C>>();
+            } else if (pl instanceof OrderedSyzPairlist) {
+                pli = new OrderedSyzPairlist<GenPolynomial<C>>();
+            } else {
+                pli = new OrderedPairlist<GenPolynomial<C>>();
+            }
+            bba = new GroebnerBaseQuotient<C>(fac, pli); // pl not possible
+            break;
+        default:
+            throw new IllegalArgumentException("algorithm not available for Quotient " + a);
+        }
+        return bba;
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case (recursive)
+     * polynomial.
+     * @param fac GenPolynomialRing&lt;C&gt;.
+     * @return GB algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C>> GroebnerBaseAbstract<GenPolynomial<C>> getImplementation(
+                    GenPolynomialRing<C> fac) {
+        return getImplementation(fac, Algo.igb);
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case (recursive)
+     * polynomial.
+     * @param fac GenPolynomialRing&lt;C&gt;.
+     * @param a algorithm, a = igb or egb, dgb if fac is univariate over a
+     *            field.
+     * @return GB algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C>> GroebnerBaseAbstract<GenPolynomial<C>> getImplementation(
+                    GenPolynomialRing<C> fac, Algo a) {
+        return getImplementation(fac, a, new OrderedPairlist<GenPolynomial<C>>());
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case (recursive)
+     * polynomial.
+     * @param fac GenPolynomialRing&lt;C&gt;.
+     * @param pl pair selection strategy
+     * @return GB algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C>> GroebnerBaseAbstract<GenPolynomial<C>> getImplementation(
+                    GenPolynomialRing<C> fac, PairList<GenPolynomial<C>> pl) {
+        return getImplementation(fac, Algo.igb, pl);
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case (recursive)
+     * polynomial.
+     * @param fac GenPolynomialRing&lt;C&gt;.
+     * @param a algorithm, a = igb or egb, dgb if fac is univariate over a
+     *            field.
+     * @param pl pair selection strategy
+     * @return GB algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C>> GroebnerBaseAbstract<GenPolynomial<C>> getImplementation(
+                    GenPolynomialRing<C> fac, Algo a, PairList<GenPolynomial<C>> pl) {
+        GroebnerBaseAbstract<GenPolynomial<C>> bba;
+        switch (a) {
+        case igb:
+            bba = new GroebnerBasePseudoRecSeq<C>(fac, pl);
+            break;
+        case egb:
+            if (fac.nvar > 1 || !fac.coFac.isField()) {
+                throw new IllegalArgumentException("coefficients not univariate or not over a field" + fac);
+            }
+            bba = new EGroebnerBaseSeq<GenPolynomial<C>>(); // pl not suitable
+            break;
+        case dgb:
+            if (fac.nvar > 1 || !fac.coFac.isField()) {
+                throw new IllegalArgumentException("coefficients not univariate or not over a field" + fac);
+            }
+            bba = new DGroebnerBaseSeq<GenPolynomial<C>>(); // pl not suitable
+            break;
+        default:
+            throw new IllegalArgumentException("algorithm not available for GenPolynomial<C> " + a);
+        }
+        return bba;
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case regular rings.
+     * @param fac RegularRing.
+     * @return GB algorithm implementation.
+     */
+    public static <C extends RingElem<C>> GroebnerBaseAbstract<Product<C>> getImplementation(
+                    ProductRing<C> fac) {
+        GroebnerBaseAbstract<Product<C>> bba;
+        if (fac.onlyFields()) {
+            bba = new RGroebnerBaseSeq<Product<C>>();
+        } else {
+            bba = new RGroebnerBasePseudoSeq<Product<C>>(fac);
+        }
+        return bba;
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, other cases.
+     * @param fac RingFactory&lt;C&gt;.
+     * @return GB algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C>> // interface RingElem not sufficient 
+    GroebnerBaseAbstract<C> getImplementation(RingFactory<C> fac) {
+        return getImplementation(fac, new OrderedPairlist<C>());
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, other cases.
+     * @param fac RingFactory&lt;C&gt;.
+     * @param pl pair selection strategy
+     * @return GB algorithm implementation.
+     */
+    @SuppressWarnings("unchecked")
+    public static <C extends GcdRingElem<C>> // interface RingElem not sufficient 
+    GroebnerBaseAbstract<C> getImplementation(RingFactory<C> fac, PairList<C> pl) {
+        logger.debug("fac = " + fac.getClass().getName());
+        if (fac.isField()) {
+            return new GroebnerBaseSeq<C>(pl);
+        }
+        GroebnerBaseAbstract bba = null;
+        Object ofac = fac;
+        if (ofac instanceof GenPolynomialRing) {
+            PairList<GenPolynomial<C>> pli;
+            if (pl instanceof OrderedMinPairlist) {
+                pli = new OrderedMinPairlist<GenPolynomial<C>>();
+            } else if (pl instanceof OrderedSyzPairlist) {
+                pli = new OrderedSyzPairlist<GenPolynomial<C>>();
+            } else {
+                pli = new OrderedPairlist<GenPolynomial<C>>();
+            }
+            GenPolynomialRing<C> rofac = (GenPolynomialRing<C>) ofac;
+            GroebnerBaseAbstract<GenPolynomial<C>> bbr = new GroebnerBasePseudoRecSeq<C>(rofac, pli); // not pl
+            bba = (GroebnerBaseAbstract) bbr;
+        } else if (ofac instanceof ProductRing) {
+            ProductRing pfac = (ProductRing) ofac;
+            if (pfac.onlyFields()) {
+                bba = new RGroebnerBaseSeq<Product<C>>();
+            } else {
+                bba = new RGroebnerBasePseudoSeq<Product<C>>(pfac);
+            }
+        } else {
+            bba = new GroebnerBasePseudoSeq<C>(fac, pl);
+        }
+        logger.debug("bba = " + bba.getClass().getName());
+        return bba;
+    }
+
+
+    /**
+     * Determine suitable parallel/concurrent implementation of GB algorithms if
+     * possible.
+     * @param fac RingFactory&lt;C&gt;.
+     * @return GB proxy algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C>> // interface RingElem not sufficient 
+    GroebnerBaseAbstract<C> getProxy(RingFactory<C> fac) {
+        return getProxy(fac, new OrderedPairlist<C>());
+    }
+
+
+    /**
+     * Determine suitable parallel/concurrent implementation of GB algorithms if
+     * possible.
+     * @param fac RingFactory&lt;C&gt;.
+     * @param pl pair selection strategy
+     * @return GB proxy algorithm implementation.
+     */
+    @SuppressWarnings("unchecked")
+    public static <C extends GcdRingElem<C>> // interface RingElem not sufficient 
+    GroebnerBaseAbstract<C> getProxy(RingFactory<C> fac, PairList<C> pl) {
+        if (ComputerThreads.NO_THREADS) {
+            return GBFactory.<C> getImplementation(fac, pl);
+        }
+        logger.debug("fac = " + fac.getClass().getName());
+        int th = (ComputerThreads.N_CPUS > 2 ? ComputerThreads.N_CPUS - 1 : 2);
+        if (fac.isField()) {
+            GroebnerBaseAbstract<C> e1 = new GroebnerBaseSeq<C>(pl);
+            GroebnerBaseAbstract<C> e2 = new GroebnerBaseParallel<C>(th, pl);
+            return new GBProxy<C>(e1, e2);
+        } else if (fac.characteristic().signum() == 0) {
+            if (fac instanceof GenPolynomialRing) {
+                GenPolynomialRing pfac = (GenPolynomialRing) fac;
+                OrderedPairlist ppl = new OrderedPairlist<GenPolynomial<C>>();
+                GroebnerBaseAbstract e1 = new GroebnerBasePseudoRecSeq<C>(pfac, ppl);
+                GroebnerBaseAbstract e2 = new GroebnerBasePseudoRecParallel<C>(th, pfac, ppl);
+                return new GBProxy<C>(e1, e2);
+            }
+            GroebnerBaseAbstract<C> e1 = new GroebnerBasePseudoSeq<C>(fac, pl);
+            GroebnerBaseAbstract<C> e2 = new GroebnerBasePseudoParallel<C>(th, fac, pl);
+            return new GBProxy<C>(e1, e2);
+        }
+        return getImplementation(fac, pl);
+    }
+
+
+    /**
+     * Determine suitable parallel/concurrent implementation of GB algorithms if
+     * possible.
+     * @param fac RingFactory&lt;C&gt;.
+     * @return GB proxy algorithm implementation.
+     */
+    @SuppressWarnings("unchecked")
+    public static <C extends GcdRingElem<C>> // interface RingElem not sufficient 
+    GroebnerBaseAbstract<GenPolynomial<C>> getProxy(GenPolynomialRing<C> fac) {
+        if (ComputerThreads.NO_THREADS) {
+            //return GBFactory.<GenPolynomial<C>> getImplementation(fac);
+            return GBFactory.getImplementation(fac);
+        }
+        logger.debug("fac = " + fac.getClass().getName());
+        int th = (ComputerThreads.N_CPUS > 2 ? ComputerThreads.N_CPUS - 1 : 2);
+        OrderedPairlist<GenPolynomial<C>> ppl = new OrderedPairlist<GenPolynomial<C>>();
+        GroebnerBaseAbstract<GenPolynomial<C>> e1 = new GroebnerBasePseudoRecSeq<C>(fac, ppl);
+        GroebnerBaseAbstract<GenPolynomial<C>> e2 = new GroebnerBasePseudoRecParallel<C>(th, fac, ppl);
+        //return new GBProxy<GenPolynomial<C>>(e1, e2);
+        return new GBProxy(e1, e2);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/GroebnerBaseFGLM.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/GroebnerBaseFGLM.java
@@ -1,0 +1,440 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.GroebnerBaseAbstract;
+import edu.jas.gb.PairList;
+import edu.jas.gb.Reduction;
+import edu.jas.gb.ReductionSeq;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.poly.TermOrder;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Groebner Base sequential FGLM algorithm. Implements Groebner base computation
+ * via FGLM algorithm.
+ * @param <C> coefficient type
+ * @author Jan Suess
+ *
+ * @see edu.jas.application.GBAlgorithmBuilder
+ * @see edu.jas.gbufd.GBFactory
+ */
+public class GroebnerBaseFGLM<C extends GcdRingElem<C>> extends GroebnerBaseAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GroebnerBaseFGLM.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * The backing GB algorithm implementation.
+     */
+    private GroebnerBaseAbstract<C> sgb;
+
+
+    /**
+     * Constructor.
+     */
+    public GroebnerBaseFGLM() {
+        super();
+        sgb = null;
+    }
+
+
+    /**
+     * Constructor.
+     * @param red Reduction engine
+     */
+    public GroebnerBaseFGLM(Reduction<C> red) {
+        super(red);
+        sgb = null;
+    }
+
+
+    /**
+     * Constructor.
+     * @param red Reduction engine
+     * @param pl pair selection strategy
+     */
+    public GroebnerBaseFGLM(Reduction<C> red, PairList<C> pl) {
+        super(red, pl);
+        sgb = null;
+    }
+
+
+    /**
+     * Constructor.
+     * @param red Reduction engine
+     * @param pl pair selection strategy
+     * @param gb backing GB algorithm.
+     */
+    public GroebnerBaseFGLM(Reduction<C> red, PairList<C> pl, GroebnerBaseAbstract<C> gb) {
+        super(red, pl);
+        sgb = gb;
+    }
+
+
+    /**
+     * Constructor.
+     * @param gb backing GB algorithm.
+     */
+    public GroebnerBaseFGLM(GroebnerBaseAbstract<C> gb) {
+        super();
+        sgb = gb;
+    }
+
+
+    /**
+     * Get the String representation with GB engine.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        if (sgb == null) {
+            return "GroebnerBaseFGLM()";
+        }
+        return "GroebnerBaseFGLM( " + sgb.toString() + " )";
+    }
+
+
+    /**
+     * Groebner base using FGLM algorithm.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return GB(F) a inv lex term order Groebner base of F.
+     */
+    public List<GenPolynomial<C>> GB(int modv, List<GenPolynomial<C>> F) {
+        if (modv != 0) {
+            throw new UnsupportedOperationException("case modv != 0 not yet implemented");
+        }
+        if (F == null || F.size() == 0) {
+            return F;
+        }
+        List<GenPolynomial<C>> G = new ArrayList<GenPolynomial<C>>();
+        if (F.size() <= 1) {
+            GenPolynomial<C> p = F.get(0).monic();
+            G.add(p);
+            return G;
+        }
+        // convert to graded term order
+        List<GenPolynomial<C>> Fp = new ArrayList<GenPolynomial<C>>(F.size());
+        GenPolynomialRing<C> pfac = F.get(0).ring;
+        if (!pfac.coFac.isField()) {
+            throw new IllegalArgumentException("coefficients not from a field: " + pfac.coFac);
+        }
+        TermOrder tord = new TermOrder(TermOrder.IGRLEX);
+        GenPolynomialRing<C> gfac = new GenPolynomialRing<C>(pfac.coFac, pfac.nvar, tord, pfac.getVars());
+        for (GenPolynomial<C> p : F) {
+            GenPolynomial<C> g = gfac.copy(p); // change term order
+            Fp.add(g);
+        }
+        // compute graded term order Groebner base
+        if (sgb == null) {
+            sgb = GBFactory.<C> getImplementation(pfac.coFac, strategy);
+        }
+        List<GenPolynomial<C>> Gp = sgb.GB(modv, Fp);
+        logger.info("graded GB = " + Gp);
+        if (tord.equals(pfac.tord)) {
+            return Gp;
+        }
+        if (Gp.size() == 0) {
+            return Gp;
+        }
+        if (Gp.size() == 1) { // also dimension -1
+            GenPolynomial<C> p = pfac.copy(Gp.get(0)); // change term order
+            G.add(p);
+            return G;
+        }
+        // check dimension zero
+        int z = commonZeroTest(Gp);
+        if (z > 0) {
+            logger.error("use Groebner Walk algorithm");
+            throw new IllegalArgumentException("ideal(G) not zero dimensional, dim =  " + z);
+        }
+        // compute invlex Groebner base via FGLM
+        G = convGroebnerToLex(Gp);
+        return G;
+    }
+
+
+    /**
+     * Algorithm CONVGROEBNER: Converts Groebner bases w.r.t. total degree
+     * termorder into Groebner base w.r.t to inverse lexicographical term order
+     * @return Groebner base w.r.t to inverse lexicographical term order
+     */
+    public List<GenPolynomial<C>> convGroebnerToLex(List<GenPolynomial<C>> groebnerBasis) {
+        if (groebnerBasis == null || groebnerBasis.size() == 0) {
+            throw new IllegalArgumentException("G may not be null or empty");
+        }
+        //Polynomial ring of input Groebnerbasis G
+        GenPolynomialRing<C> ring = groebnerBasis.get(0).ring;
+        int numberOfVariables = ring.nvar; //Number of Variables of the given Polynomial Ring
+        String[] ArrayOfVariables = ring.getVars(); //Variables of given polynomial ring w.r.t. to input G
+        RingFactory<C> cfac = ring.coFac;
+
+        //Main Algorithm
+        //Initialization
+
+        TermOrder invlex = new TermOrder(TermOrder.INVLEX);
+        //Polynomial ring of newGB with invlex order
+        GenPolynomialRing<C> ufac = new GenPolynomialRing<C>(cfac, numberOfVariables, invlex,
+                        ArrayOfVariables);
+
+        //Local Lists
+        List<GenPolynomial<C>> newGB = new ArrayList<GenPolynomial<C>>(); //Instantiate the return list of polynomials
+        List<GenPolynomial<C>> H = new ArrayList<GenPolynomial<C>>(); //Instantiate a help list of polynomials
+        List<GenPolynomial<C>> redTerms = new ArrayList<GenPolynomial<C>>();//Instantiate the return list of reduced terms
+
+        //Local Polynomials
+        GenPolynomial<C> t = ring.ONE; //Create ONE polynom of original polynomial ring
+        GenPolynomial<C> h; //Create help polynomial
+        GenPolynomial<GenPolynomial<C>> hh; //h as polynomial in rfac
+        GenPolynomial<GenPolynomial<C>> p; //Create another help polynomial
+        redTerms.add(t); //Add ONE to list of reduced terms
+
+        //create new indeterminate Y1
+        int indeterminates = 1; //Number of indeterminates, starting with Y1
+        GenPolynomialRing<C> cpfac = createRingOfIndeterminates(ring, indeterminates);
+        GenPolynomialRing<GenPolynomial<C>> rfac = new GenPolynomialRing<GenPolynomial<C>>(cpfac, ring);
+        GenPolynomial<GenPolynomial<C>> q = rfac.getZERO().sum(cpfac.univariate(0));
+
+        //Main while loop
+        int z = -1;
+        t = lMinterm(H, t);
+        while (t != null) {
+            //System.out.println("t = " + t);
+            h = red.normalform(groebnerBasis, t);
+            //System.out.println("Zwischennormalform h = " + h.toString());
+            hh = PolyUtil.<C> toRecursive(rfac, h);
+            p = hh.sum(q);
+            List<GenPolynomial<C>> Cf = new ArrayList<GenPolynomial<C>>(p.getMap().values());
+            Cf = red.irreducibleSet(Cf);
+            //System.out.println("Cf = " + Cf);
+            //System.out.println("Current Polynomial ring in Y_n: " + rfac.toString());
+
+            z = commonZeroTest(Cf);
+            //System.out.println("z = " + z);
+            if (z != 0) { //z=1 OR z=-1 --> Infinite number of solutions OR No solution
+                indeterminates++; //then, increase number of indeterminates by one
+                redTerms.add(t); //add current t to list of reduced terms
+                cpfac = addIndeterminate(cpfac);
+                rfac = new GenPolynomialRing<GenPolynomial<C>>(cpfac, ring);
+                hh = PolyUtil.<C> toRecursive(rfac, h);
+                GenPolynomial<GenPolynomial<C>> Yt = rfac.getZERO().sum(cpfac.univariate(0));
+                GenPolynomial<GenPolynomial<C>> Yth = hh.multiply(Yt);
+                q = PolyUtil.<C> extendCoefficients(rfac, q, 0, 0L);
+                q = Yth.sum(q);
+            } else { // z=0 --> one solution
+                GenPolynomial<C> g = ufac.getZERO();
+                for (GenPolynomial<C> pc : Cf) {
+                    ExpVector e = pc.leadingExpVector();
+                    //System.out.println("e = " + e);
+                    if (e == null) {
+                        continue;
+                    }
+                    int[] v = e.dependencyOnVariables();
+                    if (v == null || v.length == 0) {
+                        continue;
+                    }
+                    int vi = v[0];
+                    vi = indeterminates - vi;
+                    C tc = pc.trailingBaseCoefficient();
+                    if (!tc.isZERO()) {
+                        tc = tc.negate();
+                        GenPolynomial<C> csRedterm = redTerms.get(vi - 1).multiply(tc);
+                        //System.out.println("csRedterm = " + csRedterm);
+                        g = g.sum(csRedterm);
+                    }
+                }
+                g = g.sum(t);
+                g = ufac.copy(g);
+                H.add(t);
+                if (!g.isZERO()) {
+                    newGB.add(g);
+                    logger.info("new element for GB = " + g.leadingExpVector());
+                }
+            }
+            t = lMinterm(H, t); // compute lMINTERM of current t (lexMinterm)
+        }
+        //logger.info("GB = " + newGB);
+        return newGB;
+    }
+
+
+    /**
+     * Algorithm lMinterm: MINTERM algorithm for inverse lexicographical term
+     * order.
+     * @param t Term
+     * @param G Groebner basis
+     * @return Term that specifies condition (D) or null (Condition (D) in
+     *         "A computational approach to commutative algebra", Becker,
+     *         Weispfenning, Kredel 1993, p. 427)
+     */
+    public GenPolynomial<C> lMinterm(List<GenPolynomial<C>> G, GenPolynomial<C> t) {
+        //not ok: if ( G == null || G.size() == 0 ) ...
+        GenPolynomialRing<C> ring = t.ring;
+        int numberOfVariables = ring.nvar;
+        GenPolynomial<C> u = new GenPolynomial<C>(ring, t.leadingBaseCoefficient(), t.leadingExpVector()); //HeadTerm of of input polynomial
+        ReductionSeq<C> redHelp = new ReductionSeq<C>(); // Create instance of ReductionSeq to use method isReducible
+        //not ok: if ( redHelp.isTopReducible(G,u) ) ...
+        for (int i = numberOfVariables - 1; i >= 0; i--) { // Walk through all variables, starting with least w.r.t to lex-order
+            GenPolynomial<C> x = ring.univariate(i); // Create Linear Polynomial X_i
+            u = u.multiply(x); // Multiply current u with x
+            if (!redHelp.isTopReducible(G, u)) { // Check if any term in HT(G) divides current u
+                return u;
+            }
+            GenPolynomial<C> s = ring.univariate(i, u.degree(numberOfVariables - (i + 1))); //if not, eliminate variable x_i
+            u = u.divide(s);
+        }
+        return null;
+    }
+
+
+    /**
+     * Compute the residues to given polynomial list.
+     * @return List of reduced terms
+     */
+    public List<GenPolynomial<C>> redTerms(List<GenPolynomial<C>> groebnerBasis) {
+        if (groebnerBasis == null || groebnerBasis.size() == 0) {
+            throw new IllegalArgumentException("groebnerBasis may not be null or empty");
+        }
+        GenPolynomialRing<C> ring = groebnerBasis.get(0).ring;
+        int numberOfVariables = ring.nvar; //Number of Variables of the given Polynomial Ring
+        long[] degrees = new long[numberOfVariables]; //Array for the degree-limits for the reduced terms
+
+        List<GenPolynomial<C>> terms = new ArrayList<GenPolynomial<C>>(); //Instantiate the return object
+        for (GenPolynomial<C> g : groebnerBasis) { //For each polynomial of G
+            if (g.isONE()) {
+                terms.clear();
+                return terms; //If 1 e G, return empty list terms
+            }
+            ExpVector e = g.leadingExpVector(); //Take the exponent of the leading monomial             
+            if (e.totalDeg() == e.maxDeg()) { //and check, whether a variable x_i is isolated
+                for (int i = 0; i < numberOfVariables; i++) {
+                    long exp = e.getVal(i);
+                    if (exp > 0) {
+                        degrees[i] = exp; //if true, add the degree of univariate x_i to array degrees
+                    }
+                }
+            }
+        }
+        long max = maxArray(degrees); //Find maximum in Array degrees
+        for (int i = 0; i < degrees.length; i++) { //Set all zero grades to maximum of array "degrees"
+            if (degrees[i] == 0) {
+                logger.info("dimension not zero, setting degree to " + max);
+                degrees[i] = max; //--> to "make" the ideal zero-dimensional
+            }
+        }
+        terms.add(ring.ONE); //Add the one-polynomial of the ring to the list of reduced terms
+        ReductionSeq<C> s = new ReductionSeq<C>(); //Create instance of ReductionSeq to use method isReducible
+
+        //Main Algorithm
+        for (int i = 0; i < numberOfVariables; i++) {
+            GenPolynomial<C> x = ring.univariate(i); //Create  Linear Polynomial X_i
+            List<GenPolynomial<C>> S = new ArrayList<GenPolynomial<C>>(terms); //Copy all entries of return list "terms" into list "S"
+            for (GenPolynomial<C> t : S) {
+                for (int l = 1; l <= degrees[i]; l++) {
+                    t = t.multiply(x); //Multiply current element t with Linear Polynomial X_i
+                    if (!s.isReducible(groebnerBasis, t)) { //Check, if t is irreducible mod groebnerbase
+                        terms.add(t); //Add t to return list terms
+                    }
+                }
+            }
+        }
+        return terms;
+    }
+
+
+    /**
+     * Internal method to create a polynomial ring in i indeterminates. Create
+     * new ring over coefficients of ring with i variables Y1,...,Yi
+     * (indeterminate)
+     * @return polynomial ring with variables Y1...Yi and coefficient of ring.
+     */
+    GenPolynomialRing<C> createRingOfIndeterminates(GenPolynomialRing<C> ring, int i) {
+        RingFactory<C> cfac = ring.coFac;
+        int indeterminates = i;
+        String[] stringIndeterminates = new String[indeterminates];
+        for (int j = 1; j <= indeterminates; j++) {
+            stringIndeterminates[j - 1] = ("Y" + j);
+        }
+        TermOrder invlex = new TermOrder(TermOrder.INVLEX);
+        GenPolynomialRing<C> cpfac = new GenPolynomialRing<C>(cfac, indeterminates, invlex,
+                        stringIndeterminates);
+        return cpfac;
+    }
+
+
+    /**
+     * Internal method to add new indeterminates. Add another variabe
+     * (indeterminate) Y_{i+1} to existing ring
+     * @return polynomial ring with variables Y1,..,Yi,Yi+1 and coefficients of
+     *         ring.
+     */
+    GenPolynomialRing<C> addIndeterminate(GenPolynomialRing<C> ring) {
+        String[] stringIndeterminates = new String[1];
+        int number = ring.nvar + 1;
+        stringIndeterminates[0] = ("Y" + number);
+        ring = ring.extend(stringIndeterminates);
+        return ring;
+    }
+
+
+    /**
+     * Maximum of an array.
+     * @return maximum of an array
+     */
+    long maxArray(long[] t) {
+        if (t.length == 0) {
+            return 0L;
+        }
+        long maximum = t[0];
+        for (int i = 1; i < t.length; i++) {
+            if (t[i] > maximum) {
+                maximum = t[i];
+            }
+        }
+        return maximum;
+    }
+
+
+    /**
+     * Cleanup and terminate ThreadPool.
+     */
+    @Override
+    public void terminate() {
+        if (sgb == null) {
+            return;
+        }
+        sgb.terminate();
+    }
+
+
+    /**
+     * Cancel ThreadPool.
+     */
+    @Override
+    public int cancel() {
+        if (sgb == null) {
+            return 0;
+        }
+        return sgb.cancel();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/GroebnerBaseFGLMExamples.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/GroebnerBaseFGLMExamples.java
@@ -1,0 +1,1058 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import edu.jas.arith.BigRational;
+import edu.jas.arith.ModInteger;
+import edu.jas.arith.ModIntegerRing;
+import edu.jas.gb.GroebnerBase;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialTokenizer;
+import edu.jas.poly.Monomial;
+import edu.jas.poly.OrderedPolynomialList;
+import edu.jas.poly.PolyUtil;
+import edu.jas.poly.PolynomialList;
+
+
+/**
+ * Groebner base FGLM examples.
+ * @author Jan Suess
+ */
+
+public class GroebnerBaseFGLMExamples {
+
+
+    /**
+     * main
+     */
+    public static void main(String[] args) {
+        //junit.textui.TestRunner.run(suite());
+        GroebnerBaseFGLMExamples ex = new GroebnerBaseFGLMExamples();
+        ex.testC5();
+        /*
+        ex.xtestFiveVarsOrder();
+        ex.xtestCAP();
+        ex.xtestAUX();
+        ex.xtestModC5();
+        ex.xtestC6();
+        ex.xtestIsaac();
+        ex.xtestNiermann();
+        ex.ytestWalkS7();
+        ex.ytestCassouMod1();
+        ex.ytestOmdi1();
+        ex.ytestLamm1();
+        ex.xtestEquilibrium();
+        ex.xtestTrinks2();
+        ex.xtestHairerRungeKutta_1();
+        */
+    }
+
+
+    /*
+     * Constructs a <CODE>GroebnerBaseFGLMExamples</CODE> object.
+     * @param name String.
+    public GroebnerBaseFGLMExamples(String name) {
+        super(name);
+    }
+     */
+
+
+    /*
+     * suite.
+    public static Test suite() {
+        TestSuite suite = new TestSuite(GroebnerBaseFGLMExamples.class);
+        return suite;
+    }
+     */
+
+
+    //field Q
+    String all = "Zahlbereich | Ordnung    | Elements G | Elements L | bitHeight G | bitHeight L | Deg G | Deg L | Time G | Time FGLM | Time L";
+
+
+    String grad = "Zahlbereich | Ordnung    | Elements G | bitHeight G | Deg G | Time G | vDim";
+
+
+    String lex = "Zahlbereich | Ordnung      | Elements L | bitHeight L | Deg L | Time L";
+
+
+    String fglm = "Zahlbereich | Ordnung      | Elements G | Elements L  | bitHeight G | bitHeight L |  Deg G | Deg L | Time G | Time FGLM";
+
+
+    //MOD 1831
+    String modAll = "Zahlbereich | Ordnung    | Elements G | Elements L | Deg G | Deg L | Time G | Time FGLM | Time L";
+
+
+    //String modGrad = "Zahlbereich | Ordnung      | Elements G | Deg G | Time G";
+
+
+    String modfglm = "Zahlbereich | Ordnung      | Elements G | Elements L | Deg G | Deg L | Time G | Time FGLM";
+
+
+    /*
+    @Override
+    protected void setUp() {
+        System.out.println("Setup");
+    }
+
+
+    @Override
+    protected void tearDown() {
+        System.out.println("Tear Down");
+    }
+    */
+
+    //Test with five variables and different variable orders
+    public void xtestFiveVarsOrder() {
+        String polynomials = "( "
+                        + " (v^8*x*y*z), ( w^3*x - 2*v), ( 4*x*y - 2 + y), ( 3*y^5 - 3 + z ), ( 8*y^2*z^2 + x * y^6 )"
+                        + ") ";
+        String[] order = new String[] { "v", "w", "x", "y", "z" };
+
+        //String order1 = shuffle(order);
+        String order2 = shuffle(order);
+        //String order3 = shuffle(order);
+        //String order4 = shuffle(order);
+        //String order5 = shuffle(order);
+        //String order6 = "(z,w,v,y,x)"; //langsam
+        //String order7 = "(v,z,w,y,x)"; //langsam
+        //String order8 = "(w,z,v,x,y)"; //langsam
+
+        /*
+          String erg1 = testGeneral(order1, polynomials);
+          String erg2 = testGeneral(order2, polynomials);
+          String erg3 = testGeneral(order3, polynomials);
+          String erg4 = testGeneral(order4, polynomials);
+          String erg5 = testGeneral(order5, polynomials);
+        */
+        String ergM13 = modAll(order2, polynomials, 13);
+        String ergM7 = modAll(order2, polynomials, 7);
+
+        /*
+          String ergOnlyL_1 = testOnlyLex(order1, polynomials);
+          String ergOnlyL_2 = testOnlyLex(order2, polynomials);
+          String ergOnlyL_3 = testOnlyLex(order3, polynomials);
+          String ergOnlyL_4 = testOnlyLex(order4, polynomials);
+          String ergOnlyL_5 = testOnlyLex(order5, polynomials);
+          String erg6 = testGeneral(order6, polynomials);
+          String erg7 = testGeneral(order7, polynomials);
+          String erg8 = testGeneral(order8, polynomials);
+        */
+        //langsam: (z,w,v,y,x), (v,z,w,y,x)
+        /*
+          System.out.println(categoryLex);
+          System.out.println(ergOnlyL_1);
+          System.out.println(ergOnlyL_2);
+          System.out.println(ergOnlyL_3);
+          System.out.println(ergOnlyL_4);
+          System.out.println(ergOnlyL_5);
+                
+          System.out.println(category);
+          System.out.println(erg6);
+          System.out.println(erg7);
+          System.out.println(erg8);
+                
+                
+          System.out.println(erg1);
+          System.out.println(erg2);
+          System.out.println(erg3);
+          System.out.println(erg4);
+          System.out.println(erg5);
+        */
+        System.out.println(all);
+        System.out.println("Mod 13");
+        System.out.println(ergM13);
+        System.out.println("Mod 7");
+        System.out.println(ergM7);
+    }
+
+
+    //===================================================================
+    //Examples taken from "Efficient Computation of Zero-Dimensional Gröbner Bases by Change of Ordering", 
+    // 1994, Faugere, Gianni, Lazard, Mora (FGLM)
+    //===================================================================       
+    public void xtestCAP() {
+        String polynomials = "( " + " (y^2*z + 2*x*y*t - 2*x - z),"
+                        + "(-x^3*z + 4*x*y^2*z + 4*x^2*y*t + 2*y^3*t + 4*x^2 - 10*y^2 + 4*x*z - 10*y*t + 2),"
+                        + "(2*y*z*t + x*t^2 - x - 2*z),"
+                        + "(-x*z^3 + 4*y*z^2*t + 4*x*z*t^2 + 2*y*t^3 + 4*x*z + 4*z^2 - 10*y*t -10*t^2 + 2)"
+                        + ") ";
+
+        String orderINV = "(x,y,z,t)";
+        String orderL = "(t,z,y,x)";
+
+        //Tests
+        String erg_deg = grad(orderINV, polynomials);
+        System.out.println(grad);
+        System.out.println(erg_deg);
+
+        String erg1 = all(orderINV, polynomials);
+        String erg2 = all(orderL, polynomials);
+        String ergMod1 = modAll(orderINV, polynomials, 1831);
+        String ergMod2 = modAll(orderL, polynomials, 1831);
+        System.out.println(all);
+        System.out.println(erg1);
+        System.out.println(erg2);
+        System.out.println("\n");
+        System.out.println(modAll);
+        System.out.println(ergMod1);
+        System.out.println(ergMod2);
+    }
+
+
+    public void xtestAUX() {
+        String polynomials = "( " + " (a^2*b*c + a*b^2*c + a*b*c^2 + a*b*c + a*b + a*c + b*c),"
+                        + "(a^2*b^2*c + a*b^2*c^2 + a^2*b*c + a*b*c + b*c + a + c ),"
+                        + "(a^2*b^2*c^2 + a^2*b^2*c + a*b^2*c + a*b*c + a*c + c + 1)" + ") ";
+
+        String orderINV = "(a,b,c)";
+        String orderL = "(c,b,a)";
+
+        //Tests
+        String erg_deg = grad(orderINV, polynomials);
+        System.out.println(grad);
+        System.out.println(erg_deg);
+
+        String erg1 = all(orderINV, polynomials);
+        String erg2 = all(orderL, polynomials);
+        String ergMod1 = modAll(orderINV, polynomials, 1831);
+        String ergMod2 = modAll(orderL, polynomials, 1831);
+        System.out.println(all);
+        System.out.println(erg1);
+        System.out.println(erg2);
+        System.out.println("\n");
+        System.out.println(modAll);
+        System.out.println(ergMod1);
+        System.out.println(ergMod2);
+    }
+
+
+    public void testC5() {
+        String polynomials = "( " + " (a + b + c + d + e)," + "(a*b + b*c + c*d + a*e + d*e),"
+                        + "(a*b*c + b*c*d + a*b*e + a*d*e + c*d*e),"
+                        + "(a*b*c*d + a*b*c*e + a*b*d*e + a*c*d*e + b*c*d*e)," + "(a*b*c*d*e -1)" + ") ";
+
+        String orderINV = "(a,b,c,d,e)";
+        String orderL = "(e,d,c,b,a)";
+
+        //Tests
+        String erg_deg = grad(orderINV, polynomials);
+        //System.out.println(grad);
+        //System.out.println(erg_deg);
+
+        String erg1 = all(orderINV, polynomials);
+        String erg2 = all(orderL, polynomials);
+        String ergMod1 = modAll(orderINV, polynomials, 1831);
+        String ergMod2 = modAll(orderL, polynomials, 1831);
+
+        System.out.println(grad);
+        System.out.println(erg_deg);
+        System.out.println("");
+        System.out.println(all);
+        System.out.println(erg1);
+        System.out.println(erg2);
+        System.out.println("\n");
+        System.out.println(modAll);
+        System.out.println(ergMod1);
+        System.out.println(ergMod2);
+    }
+
+
+    public void xtestModC5() {
+        String polynomials = "( " + " (a + b + c + d + e)," + "(a*b + b*c + c*d + a*e + d*e),"
+                        + "(a*b*c + b*c*d + a*b*e + a*d*e + c*d*e),"
+                        + "(b*c*d + a*b*c*e + a*b*d*e + a*c*d*e + b*c*d*e)," + "(a*b*c*d*e -1)" + ") ";
+
+        //String orderINV = "(a,b,c,d,e)";
+        String orderL = "(e,d,c,b,a)";
+
+        //Tests
+        String erg_deg = grad(orderL, polynomials);
+        System.out.println(grad);
+        System.out.println(erg_deg);
+
+        /*              
+          String ergOnlyFGLM_1 = fglm(orderINV, polynomials);
+          System.out.println(fglm);
+          System.out.println(ergOnlyFGLM_1);            
+                
+          //Tests MODULO
+                
+          String ergOnlyG_1 = modGrad(orderINV, polynomials, 1831);
+          System.out.println(modGrad);
+          System.out.println(ergOnlyG_1);
+        
+          String erg1 = modfglm(orderINV, polynomials, 1831);
+          System.out.println(modfglm);
+          System.out.println(erg1);
+        */
+    }
+
+
+    public void xtestC6() {
+        String polynomials = "( " + " (a + b + c + d + e + f)," + "(a*b + b*c + c*d + d*e + e*f + a*f),"
+                        + "(a*b*c + b*c*d + c*d*e + d*e*f + a*e*f + a*b*f),"
+                        + "(a*b*c*d + b*c*d*e + c*d*e*f + a*d*e*f + a*b*e*f + a*b*c*f),"
+                        + "(a*b*c*d*e + b*c*d*e*f + a*c*d*e*f + a*b*d*e*f + a*b*c*e*f + a*b*c*d*f),"
+                        + "(a*b*c*d*e*f - 1)" + ") ";
+
+        String orderINV = "(a,b,c,d,e,f)";
+        //String orderL = "(f,e,d,c,b,a)";
+
+        //Tests      
+        String erg2 = modAll(orderINV, polynomials, 1831);
+        System.out.println(modAll);
+        System.out.println(erg2);
+        /*                
+          String ergOnlyG_1 = modGrad(orderINV, polynomials, 1831);
+          System.out.println(modGrad);
+          System.out.println(ergOnlyG_1);
+
+          String erg1 = modfglm(orderINV, polynomials, 1831);
+          System.out.println(modfglm);
+          System.out.println(erg1);
+        */
+    }
+
+
+    //===================================================================
+    //Examples taken from "Der FGLM-Algorithmus: verallgemeinert und implementiert in SINGULAR", 1997, Wichmann
+    //===================================================================
+    public void xtestIsaac() {
+        String polynomials = "( "
+                        + " (8*w^2 + 5*w*x - 4*w*y + 2*w*z + 3*w + 5*x^2 + 2*x*y - 7*x*z - 7*x + 7*y^2 -8*y*z - 7*y + 7*z^2 - 8*z + 8),"
+                        + "(3*w^2 - 5*w*x - 3*w*y - 6*w*z + 9*w + 4*x^2 + 2*x*y - 2*x*z + 7*x + 9*y^2 + 6*y*z + 5*y + 7*z^2 + 7*z + 5),"
+                        + "(-2*w^2 + 9*w*x + 9*w*y - 7*w*z - 4*w + 8*x^2 + 9*x*y - 3*x*z + 8*x + 6*y^2 - 7*y*z + 4*y - 6*z^2 + 8*z + 2),"
+                        + "(7*w^2 + 5*w*x + 3*w*y - 5*w*z - 5*w + 2*x^2 + 9*x*y - 7*x*z + 4*x -4*y^2 - 5*y*z + 6*y - 4*z^2 - 9*z + 2)"
+                        + ") ";
+
+        //String orderINV = "(w,x,y,z)";
+        String orderL = "(z,y,x,w)";
+
+        //Tests
+        String erg_deg = grad(orderL, polynomials);
+        System.out.println(grad);
+        System.out.println(erg_deg);
+        /*              
+          String erg3 = all(orderINV, polynomials);
+          System.out.println(all);
+          System.out.println(erg3);
+                
+          String ergOnlyLex_1 = lex(orderINV, polynomials);
+          String ergOnlyLex_2 = lex(orderL, polynomials);
+          System.out.println(lex);
+          System.out.println(ergOnlyLex_1);
+          System.out.println(ergOnlyLex_2);
+                
+          String ergOnlyFGLM_1 = fglm(orderINV, polynomials);
+          String ergOnlyFGLM_2 = fglm(orderL, polynomials);
+          System.out.println(fglm);
+          System.out.println(ergOnlyFGLM_1);
+          System.out.println(ergOnlyFGLM_2);
+                        
+          String ergm1 = modAll(orderINV, polynomials, 2147464751);
+          String ergm2 = modAll(orderL, polynomials, 2147464751);
+          System.out.println(modAll);
+          System.out.println(ergm1);
+          System.out.println(ergm2);
+        */
+    }
+
+
+    public void xtestNiermann() {
+        String polynomials = "( " + " (x^2 + x*y^2*z - 2*x*y + y^4 + y^2 + z^2),"
+                        + "(-x^3*y^2 + x*y^2*z + x*y*z^3 - 2*x*y + y^4)," + "(-2*x^2*y + x*y^4 + y*z^4 - 3)"
+                        + ") ";
+
+        String orderINV = "(x,y,z)";
+        String orderL = "(z,y,x)";
+
+        //Tests
+        String erg_deg = grad(orderINV, polynomials);
+        System.out.println(grad);
+        System.out.println(erg_deg);
+        /*
+          String erg1 = fglm(orderINV, polynomials);
+          String erg2 = fglm(orderL, polynomials);
+          System.out.println(fglm);
+          System.out.println(erg1);
+          System.out.println(erg2);
+        */
+        String ergm1 = modfglm(orderINV, polynomials, 1831);
+        String ergm2 = modfglm(orderL, polynomials, 2147464751);
+        System.out.println(modfglm);
+        System.out.println(ergm1);
+        System.out.println(ergm2);
+    }
+
+
+    public void ytestWalkS7() {
+        String polynomials = "( " + " (2*g*b + 2*f*c + 2*e*d + a^2 + a),"
+                        + "(2*g*c + 2*f*d + e^2 + 2*b*a + b)," + "(2*g*d + 2*f*e + 2*c*a + c + b^2),"
+                        + "(2*g*e + f^2 + 2*d*a + d + 2*c*b)," + "(2*g*f + 2*e*a + e + 2*d*b + c^2),"
+                        + "(g^2 + 2*f*a + f + 2*e*b + 2*d*c)," + "(2*g*a + g + 2*f*b + 2*e*c + d^2)" + ") ";
+
+        //String orderINV = "(a,b,c,d,e,f,g)";
+        String orderL = "(g,f,e,d,c,b,a)";
+
+        //Tests
+        //String ergm1 = modAll(orderINV, polynomials, 2147464751);
+        //String ergm2 = modfglm(orderL, polynomials, 1831);
+        //System.out.println(modfglm);
+        //System.out.println(ergm1);
+        //System.out.println(ergm2);
+
+        String erg2 = fglm(orderL, polynomials);
+        System.out.println(fglm);
+        System.out.println(erg2);
+    }
+
+
+    public void ytestCassouMod1() {
+        String polynomials = "( "
+                        + " (15*a^4*b*c^2 + 6*a^4*b^3 + 21*a^4*b^2*c - 144*a^2*b - 8*a^2*b^2*d - 28*a^2*b*c*d - 648*a^2*c + 36*c^2*d + 9*a^4*c^3 - 120),"
+                        + "(30*b^3*a^4*c - 32*c*d^2*b - 720*c*a^2*b - 24*b^3*a^2*d - 432*b^2*a^2 + 576*d*b - 576*c*d + 16*b*a^2*c^2*d + 16*c^2*d^2 + 16*d^2*b^2 + 9*b^4*a^4 + 5184 + 39*c^2*a^4*b^2 + 18*c^3*a^4*b - 432*c^2*a^2 + 24*c^3*a^2*d - 16*b^2*a^2*c*d - 240*b),"
+                        + "(216*c*a^2*b - 162*c^2*a^2 - 81*b^2*a^2 + 5184 + 1008*d*b - 1008*c*d + 15*b^2*a^2*c*d - 15*b^3*a^2*d - 80*c*d^2*b + 40*c^2*d^2 + 40*d^2*b^2),"
+                        + "(261 + 4*c*a^2*b - 3*c^2*a^2 - 4*b^2*a^2 + 22*d*b - 22*c*d)" + ") ";
+
+        String orderINV = "(a,b,c,d)";
+        String orderL = "(d,c,b,a)";
+
+        //Tests
+        String ergm1 = modfglm(orderL, polynomials, 1831);
+        String ergm2 = modfglm(orderINV, polynomials, 1831);
+        System.out.println(modfglm);
+        System.out.println(ergm1);
+        System.out.println(ergm2);
+    }
+
+
+    public void ytestOmdi1() {
+        String polynomials = "( " + " (a + c + v + 2*x - 1)," + "(a*b + c*u + 2*v*w + 2*x*y + 2*x*z -2/3),"
+                        + "(a*b^2 + c*u^2 + 2*v*w^2 + 2*x*y^2 + 2*x*z^2 - 2/5),"
+                        + "(a*b^3 + c*u^3 + 2*v*w^3 + 2*x*y^3 + 2*x*z^3 - 2/7),"
+                        + "(a*b^4 + c*u^4 + 2*v*w^4 + 2*x*y^4 + 2*x*z^4 - 2/9)," + "(v*w^2 + 2*x*y*z - 1/9),"
+                        + "(v*w^4 + 2*x*y^2*z^2 - 1/25)," + "(v*w^3 + 2*x*y*z^2 + x*y^2*z - 1/15),"
+                        + "(v*w^4 + x*y*z^3 + x*y^3*z -1/21)" + ") ";
+
+        //String orderINV = "(a,b,c,u,v,w,x,y,z)";
+        String orderL = "(z,y,x,w,v,u,c,b,a)";
+
+        //Tests
+        String erg_deg = grad(orderL, polynomials);
+        System.out.println(grad);
+        System.out.println(erg_deg);
+        /*
+          String ergm1 = modfglm(orderL, polynomials, 1831);
+          String ergm2 = modfglm(orderINV, polynomials, 1831);
+          System.out.println(modfglm);
+          System.out.println(ergm1);
+          System.out.println(ergm2);
+        */
+    }
+
+
+    public void ytestLamm1() {
+        String polynomials = "( "
+                        + " (45*x^8 + 3*x^7 + 39*x^6 + 30*x^5 + 13*x^4 + 41*x^3 + 5*x^2 + 46*x + 7),"
+                        + "(49*x^7*y + 35*x*y^7 + 37*x*y^6 + 9*y^7 + 4*x^6 + 6*y^6 + 27*x^3*y^2 + 20*x*y^4 + 31*x^4 + 33*x^2*y + 24*x^2 + 49*y + 43)"
+                        + ") ";
+
+        String orderINV = "(x,y)";
+        String orderL = "(y,x)";
+
+        //Tests
+        String erg_deg = grad(orderINV, polynomials);
+        System.out.println(grad);
+        System.out.println(erg_deg);
+
+        String erg1 = all(orderINV, polynomials);
+        String erg2 = all(orderL, polynomials);
+        String ergMod1 = modAll(orderINV, polynomials, 1831);
+        String ergMod2 = modAll(orderL, polynomials, 1831);
+        System.out.println(all);
+        System.out.println(erg1);
+        System.out.println(erg2);
+        System.out.println("\n");
+        System.out.println(modAll);
+        System.out.println(ergMod1);
+        System.out.println(ergMod2);
+    }
+
+
+    //===================================================================
+    //Examples taken from "Some Examples for Solving Systems of Algebraic Equations by Calculating Gröbner Bases", 1984, Boege, Gebauer, Kredel
+    //===================================================================               
+    public void xtestEquilibrium() {
+        String polynomials = "( "
+                        + " (y^4 - 20/7*z^2),"
+                        + "(z^2*x^4 + 7/10*z*x^4 + 7/48*x^4 - 50/27*z^2 - 35/27*z - 49/216),"
+                        + "(x^5*y^3 + 7/5*z^4*y^3 + 609/1000 *z^3*y^3 + 49/1250*z^2*y^3 - 27391/800000*z*y^3 - 1029/160000*y^3 + 3/7*z^5*x*y^2 +"
+                        + "3/5*z^6*x*y^2 + 63/200*z^3*x*y^2 + 147/2000*z^2*x*y^2 + 4137/800000*z*x*y^2 - 7/20*z^4*x^2*y - 77/125*z^3*x^2*y"
+                        + "- 23863/60000*z^2*x^2*y - 1078/9375*z*x^2*y - 24353/1920000*x^2*y - 3/20*z^4*x^3 - 21/100*z^3*x^3"
+                        + "- 91/800*z^2*x^3 - 5887/200000*z*x^3 - 343/128000*x^3)" + ") ";
+
+        String order = "(x,y,z)";
+
+        //Tests
+        String ergOnlyG_1 = grad(order, polynomials);
+        System.out.println(grad);
+        System.out.println(ergOnlyG_1);
+    }
+
+
+    public void xtestTrinks2() {
+        String polynomials = "( " + " (45*p + 35*s - 165*b - 36)," + "(35*p + 40*z + 25*t - 27*s),"
+                        + "(15*w + 25*p*s + 30*z - 18*t - 165*b^2)," + "(-9*w + 15*p*t + 20*z*s),"
+                        + "(w*p + 2*z*t - 11*b^3)," + "(99*w - 11*s*b + 3*b^2),"
+                        + "(b^2 + 33/50*b + 2673/10000)" + ") ";
+
+        String order1 = "(b,s,t,z,p,w)";
+        String order2 = "(s,b,t,z,p,w)";
+        String order3 = "(s,t,b,z,p,w)";
+        String order4 = "(s,t,z,p,b,w)";
+        String order5 = "(s,t,z,p,w,b)";
+        String order6 = "(s,z,p,w,b,t)";
+        String order7 = "(p,w,b,t,s,z)";
+        String order8 = "(z,w,b,s,t,p)";
+        String order9 = "(t,z,p,w,b,s)";
+        String order10 = "(z,p,w,b,s,t)";
+        String order11 = "(p,w,b,s,t,z)";
+        String order12 = "(w,b,s,t,z,p)";
+
+        //Tests
+        String erg_1 = all(order1, polynomials);
+        String erg_2 = all(order2, polynomials);
+        String erg_3 = all(order3, polynomials);
+        String erg_4 = all(order4, polynomials);
+        String erg_5 = all(order5, polynomials);
+        String erg_6 = all(order6, polynomials);
+        String erg_7 = all(order7, polynomials);
+        String erg_8 = all(order8, polynomials);
+        String erg_9 = all(order9, polynomials);
+        String erg_10 = all(order10, polynomials);
+        String erg_11 = all(order11, polynomials);
+        String erg_12 = all(order12, polynomials);
+        System.out.println(all);
+        System.out.println(erg_1);
+        System.out.println(erg_2);
+        System.out.println(erg_3);
+        System.out.println(erg_4);
+        System.out.println(erg_5);
+        System.out.println(erg_6);
+        System.out.println(erg_7);
+        System.out.println(erg_8);
+        System.out.println(erg_9);
+        System.out.println(erg_10);
+        System.out.println(erg_11);
+        System.out.println(erg_12);
+    }
+
+
+    public void xtestHairerRungeKutta_1() {
+        String polynomials = "( " + " (a-f),(b-h-g),(e+d+c-1),(d*a+c*b-1/2),(d*a^2+c*b^2-1/3),(c*g*a-1/6)"
+                        + ") ";
+
+        String[] order = new String[] { "a", "b", "c", "d", "e", "f", "g", "h" };
+
+        String order1 = shuffle(order);
+        String order2 = shuffle(order);
+        String order3 = shuffle(order);
+        String order4 = shuffle(order);
+        String order5 = shuffle(order);
+
+        // langsam (e,d,h,c,g,a,f,b), (h,d,b,e,c,g,a,f) um die 120
+
+        // sehr langsam (e,h,d,c,g,b,a,f) um die 1000
+
+        // sehr schnell (g,b,f,h,c,d,a,e), (h,c,a,g,d,f,e,b) 1 millisec
+
+        String ergOnlyG_1 = grad(order1, polynomials);
+        System.out.println(grad);
+        System.out.println(ergOnlyG_1);
+
+        String ergOnlyL_1 = lex(order1, polynomials);
+        String ergOnlyL_2 = lex(order2, polynomials);
+        String ergOnlyL_3 = lex(order3, polynomials);
+        String ergOnlyL_4 = lex(order4, polynomials);
+        String ergOnlyL_5 = lex(order5, polynomials);
+
+        System.out.println(lex);
+        System.out.println(ergOnlyL_1);
+        System.out.println(ergOnlyL_2);
+        System.out.println(ergOnlyL_3);
+        System.out.println(ergOnlyL_4);
+        System.out.println(ergOnlyL_5);
+
+        //String ergGeneral = all(order, polynomials);
+        //System.out.println(all);
+        //System.out.println(ergGeneral);
+    }
+
+
+    //================================================================================================= 
+    //Internal methods
+    //=================================================================================================
+    @SuppressWarnings({ "unchecked", "cast" })
+    public String all(String order, String polynomials) {
+        GroebnerBaseFGLM<BigRational> IdealObjectFGLM;
+        BigRational coeff = new BigRational();
+        GroebnerBase<BigRational> gb = GBFactory.getImplementation(coeff);
+
+        String polynomials_Grad = order + " G " + polynomials;
+        String polynomials_Lex = order + " L " + polynomials;
+
+        Reader sourceG = new StringReader(polynomials_Grad);
+        GenPolynomialTokenizer parserG = new GenPolynomialTokenizer(sourceG);
+        PolynomialList<BigRational> G = null;
+        Reader sourceL = new StringReader(polynomials_Lex);
+        GenPolynomialTokenizer parserL = new GenPolynomialTokenizer(sourceL);
+        PolynomialList<BigRational> L = null;
+
+        try {
+            G = (PolynomialList<BigRational>) parserG.nextPolynomialSet();
+            L = (PolynomialList<BigRational>) parserL.nextPolynomialSet();
+        } catch (IOException e) {
+            e.printStackTrace();
+            return "fail";
+        }
+        System.out.println("Input " + G);
+        System.out.println("Input " + L);
+
+        //Computation of the Groebnerbase with Buchberger w.r.t INVLEX
+        long buchberger_Lex = System.currentTimeMillis();
+        List<GenPolynomial<BigRational>> GL = gb.GB(L.list);
+        buchberger_Lex = System.currentTimeMillis() - buchberger_Lex;
+
+        //Computation of the Groebnerbase with Buchberger w.r.t GRADLEX (Total degree + INVLEX)
+        long buchberger_Grad = System.currentTimeMillis();
+        List<GenPolynomial<BigRational>> GG = gb.GB(G.list);
+        buchberger_Grad = System.currentTimeMillis() - buchberger_Grad;
+
+        //PolynomialList<BigRational> GGG = new PolynomialList<BigRational>(G.ring, GG);
+        //PolynomialList<BigRational> GLL = new PolynomialList<BigRational>(L.ring, GL);
+
+        IdealObjectFGLM = new GroebnerBaseFGLM<BigRational>(); //GGG);
+        //IdealObjectLex = new GroebnerBaseSeq<BigRational>(GLL);
+
+        long tconv = System.currentTimeMillis();
+        List<GenPolynomial<BigRational>> resultFGLM = IdealObjectFGLM.convGroebnerToLex(GG);
+        tconv = System.currentTimeMillis() - tconv;
+
+        OrderedPolynomialList<BigRational> o1 = new OrderedPolynomialList<BigRational>(GG.get(0).ring, GG);
+        OrderedPolynomialList<BigRational> o2 = new OrderedPolynomialList<BigRational>(
+                        resultFGLM.get(0).ring, resultFGLM);
+        //List<GenPolynomial<BigRational>> resultBuchberger = GL;
+        OrderedPolynomialList<BigRational> o3 = new OrderedPolynomialList<BigRational>(GL.get(0).ring, GL);
+
+        int grad_numberOfElements = GG.size();
+        int lex_numberOfElements = resultFGLM.size();
+        long grad_maxPolyGrad = PolyUtil.<BigRational> totalDegreeLeadingTerm(GG); // IdealObjectFGLM.maxDegreeOfGB(); 
+        long lex_maxPolyGrad = PolyUtil.<BigRational> totalDegreeLeadingTerm(GL); // IdealObjectLex.maxDegreeOfGB();
+
+        int grad_height = bitHeight(GG);
+        int lex_height = bitHeight(resultFGLM);
+
+        System.out.println("Order of Variables: " + order);
+        System.out.println("Groebnerbases: ");
+        System.out.println("Groebnerbase Buchberger (IGRLEX) " + o1);
+        System.out.println("Groebnerbase FGML (INVLEX) computed from Buchberger (IGRLEX) " + o2);
+        System.out.println("Groebnerbase Buchberger (INVLEX) " + o3);
+
+        String erg = "BigRational |" + order + " |" + grad_numberOfElements + "          |"
+                        + lex_numberOfElements + "          |" + grad_height + "   |" + lex_height
+                        + "           |" + grad_maxPolyGrad + "      |" + lex_maxPolyGrad + "    |"
+                        + buchberger_Grad + "      |" + tconv + "       |" + buchberger_Lex;
+
+        //assertEquals(o2, o3);
+        if (!o2.equals(o3)) {
+            throw new RuntimeException("FGLM != GB: " + o2 + " != " + o3);
+        }
+        return erg;
+    }
+
+
+    @SuppressWarnings({ "unchecked", "cast" })
+    public String fglm(String order, String polynomials) {
+        GroebnerBaseFGLM<BigRational> IdealObjectGrad;
+        //GroebnerBaseAbstract<BigRational> IdealObjectLex;
+
+        BigRational coeff = new BigRational();
+        GroebnerBase<BigRational> gb = GBFactory.getImplementation(coeff);
+
+        String polynomials_Grad = order + " G " + polynomials;
+
+        Reader sourceG = new StringReader(polynomials_Grad);
+        GenPolynomialTokenizer parserG = new GenPolynomialTokenizer(sourceG);
+        PolynomialList<BigRational> G = null;
+
+        try {
+            G = (PolynomialList<BigRational>) parserG.nextPolynomialSet();
+        } catch (IOException e) {
+            e.printStackTrace();
+            return "fail";
+        }
+        System.out.println("Input " + G);
+
+        //Computation of the Groebnerbase with Buchberger w.r.t GRADLEX (Total degree + INVLEX)
+        long buchberger_Grad = System.currentTimeMillis();
+        List<GenPolynomial<BigRational>> GG = gb.GB(G.list);
+        buchberger_Grad = System.currentTimeMillis() - buchberger_Grad;
+
+        //PolynomialList<BigRational> GGG = new PolynomialList<BigRational>(G.ring, GG);
+
+        IdealObjectGrad = new GroebnerBaseFGLM<BigRational>(); //GGG);
+
+        long tconv = System.currentTimeMillis();
+        List<GenPolynomial<BigRational>> resultFGLM = IdealObjectGrad.convGroebnerToLex(GG);
+        tconv = System.currentTimeMillis() - tconv;
+
+        //PolynomialList<BigRational> LLL = new PolynomialList<BigRational>(G.ring, resultFGLM);
+        //IdealObjectLex  = new GroebnerBaseSeq<BigRational>(); //LLL);
+
+        OrderedPolynomialList<BigRational> o1 = new OrderedPolynomialList<BigRational>(GG.get(0).ring, GG);
+        OrderedPolynomialList<BigRational> o2 = new OrderedPolynomialList<BigRational>(
+                        resultFGLM.get(0).ring, resultFGLM);
+
+        int grad_numberOfElements = GG.size();
+        int lex_numberOfElements = resultFGLM.size();
+        long grad_maxPolyGrad = PolyUtil.<BigRational> totalDegreeLeadingTerm(GG); //IdealObjectGrad.maxDegreeOfGB();
+        long lex_maxPolyGrad = PolyUtil.<BigRational> totalDegreeLeadingTerm(resultFGLM); //IdealObjectLex.maxDegreeOfGB();
+
+        int grad_height = bitHeight(GG);
+        int lex_height = bitHeight(resultFGLM);
+
+        System.out.println("Order of Variables: " + order);
+        System.out.println("Groebnerbases: ");
+        System.out.println("Groebnerbase Buchberger (IGRLEX) " + o1);
+        System.out.println("Groebnerbase FGML (INVLEX) computed from Buchberger (IGRLEX) " + o2);
+
+        String erg = "BigRational |" + order + " |" + grad_numberOfElements + "         |"
+                        + lex_numberOfElements + "  |" + grad_height + "   |" + lex_height + "           |"
+                        + grad_maxPolyGrad + "      |" + lex_maxPolyGrad + "    |" + buchberger_Grad
+                        + "      |" + tconv;
+        return erg;
+    }
+
+
+    @SuppressWarnings({ "unchecked", "cast" })
+    public String grad(String order, String polynomials) {
+        BigRational coeff = new BigRational();
+        GroebnerBase<BigRational> gb = GBFactory.getImplementation(coeff);
+
+        String polynomials_Grad = order + " G " + polynomials;
+
+        Reader sourceG = new StringReader(polynomials_Grad);
+        GenPolynomialTokenizer parserG = new GenPolynomialTokenizer(sourceG);
+        PolynomialList<BigRational> G = null;
+
+        try {
+            G = (PolynomialList<BigRational>) parserG.nextPolynomialSet();
+        } catch (IOException e) {
+            e.printStackTrace();
+            return "fail";
+        }
+        System.out.println("Input " + G);
+
+        //Computation of the Groebnerbase with Buchberger w.r.t GRADLEX (Total degree + INVLEX)
+        long buchberger_Grad = System.currentTimeMillis();
+        List<GenPolynomial<BigRational>> GG = gb.GB(G.list);
+        buchberger_Grad = System.currentTimeMillis() - buchberger_Grad;
+
+        //PolynomialList<BigRational> GGG = new PolynomialList<BigRational>(G.ring, GG);
+        OrderedPolynomialList<BigRational> o1 = new OrderedPolynomialList<BigRational>(GG.get(0).ring, GG);
+
+        GroebnerBaseFGLM<BigRational> IdealObjectGrad;
+        IdealObjectGrad = new GroebnerBaseFGLM<BigRational>(); //GGG);
+        long grad_maxPolyGrad = PolyUtil.<BigRational> totalDegreeLeadingTerm(GG); //IdealObjectGrad.maxDegreeOfGB();
+        List<GenPolynomial<BigRational>> reducedTerms = IdealObjectGrad.redTerms(GG);
+        OrderedPolynomialList<BigRational> o4 = new OrderedPolynomialList<BigRational>(
+                        reducedTerms.get(0).ring, reducedTerms);
+        int grad_numberOfReducedElements = reducedTerms.size();
+        int grad_numberOfElements = GG.size();
+        int grad_height = bitHeight(GG);
+
+        System.out.println("Order of Variables: " + order);
+        System.out.println("Groebnerbases: ");
+        System.out.println("Groebnerbase Buchberger (IGRLEX) " + o1);
+        System.out.println("Reduced Terms" + o4);
+
+        String erg = "BigRational |" + order + " |" + grad_numberOfElements + "    |" + grad_height + "    |"
+                        + grad_maxPolyGrad + "    |" + buchberger_Grad + "    |"
+                        + grad_numberOfReducedElements;
+        return erg;
+    }
+
+
+    @SuppressWarnings({ "unchecked", "cast" })
+    public String lex(String order, String polynomials) {
+        //GroebnerBaseAbstract<BigRational> IdealObjectLex;
+        BigRational coeff = new BigRational();
+        GroebnerBase<BigRational> gb = GBFactory.getImplementation(coeff);
+
+        String polynomials_Lex = order + " L " + polynomials;
+
+        Reader sourceL = new StringReader(polynomials_Lex);
+        GenPolynomialTokenizer parserL = new GenPolynomialTokenizer(sourceL);
+        PolynomialList<BigRational> L = null;
+
+        try {
+            L = (PolynomialList<BigRational>) parserL.nextPolynomialSet();
+        } catch (IOException e) {
+            e.printStackTrace();
+            return "fail";
+        }
+        System.out.println("Input " + L);
+
+        //Computation of the Groebnerbase with Buchberger w.r.t INVLEX
+        long buchberger_Lex = System.currentTimeMillis();
+        List<GenPolynomial<BigRational>> GL = gb.GB(L.list);
+        buchberger_Lex = System.currentTimeMillis() - buchberger_Lex;
+
+        //PolynomialList<BigRational> GLL = new PolynomialList<BigRational>(L.ring, GL);
+        //IdealObjectLex = new GroebnerBaseAbstract<BigRational>(GLL);
+
+        OrderedPolynomialList<BigRational> o3 = new OrderedPolynomialList<BigRational>(GL.get(0).ring, GL);
+
+        int lex_numberOfElements = GL.size();
+        long lex_maxPolyGrad = PolyUtil.<BigRational> totalDegreeLeadingTerm(GL); //IdealObjectLex.maxDegreeOfGB();
+        int lexHeigth = bitHeight(GL);
+
+        System.out.println("Order of Variables: " + order);
+        System.out.println("Groebnerbase Buchberger (INVLEX) " + o3);
+
+        String erg = "BigRational" + order + "|" + lex_numberOfElements + "     |" + lexHeigth + "    |"
+                        + lex_maxPolyGrad + "    |" + buchberger_Lex;
+        return erg;
+    }
+
+
+    @SuppressWarnings({ "unchecked", "cast" })
+    public String modAll(String order, String polynomials, Integer m) {
+        GroebnerBaseFGLM<ModInteger> IdealObjectFGLM;
+        //GroebnerBaseAbstract<ModInteger> IdealObjectLex;
+        ModIntegerRing ring = new ModIntegerRing(m);
+        GroebnerBase<ModInteger> gb = GBFactory.getImplementation(ring);
+
+        String polynomials_Grad = "Mod " + ring.modul + " " + order + " G " + polynomials;
+        String polynomials_Lex = "Mod " + ring.modul + " " + order + " L " + polynomials;
+
+        Reader sourceG = new StringReader(polynomials_Grad);
+        GenPolynomialTokenizer parserG = new GenPolynomialTokenizer(sourceG);
+        PolynomialList<ModInteger> G = null;
+        Reader sourceL = new StringReader(polynomials_Lex);
+        GenPolynomialTokenizer parserL = new GenPolynomialTokenizer(sourceL);
+        PolynomialList<ModInteger> L = null;
+
+        try {
+            G = (PolynomialList<ModInteger>) parserG.nextPolynomialSet();
+            L = (PolynomialList<ModInteger>) parserL.nextPolynomialSet();
+        } catch (IOException e) {
+            e.printStackTrace();
+            return "fail";
+        }
+        System.out.println("G= " + G);
+        System.out.println("L= " + L);
+
+        //Computation of the Groebnerbase with Buchberger w.r.t INVLEX
+        long buchberger_Lex = System.currentTimeMillis();
+        List<GenPolynomial<ModInteger>> GL = gb.GB(L.list);
+        buchberger_Lex = System.currentTimeMillis() - buchberger_Lex;
+
+        //Computation of the Groebnerbase with Buchberger w.r.t GRADLEX (Total degree + INVLEX)
+        long buchberger_Grad = System.currentTimeMillis();
+        List<GenPolynomial<ModInteger>> GG = gb.GB(G.list);
+        buchberger_Grad = System.currentTimeMillis() - buchberger_Grad;
+
+        //PolynomialList<ModInteger> GGG = new PolynomialList<ModInteger>(G.ring, GG);
+        //PolynomialList<ModInteger> GLL = new PolynomialList<ModInteger>(L.ring, GL);
+
+        IdealObjectFGLM = new GroebnerBaseFGLM<ModInteger>(); //GGG);
+        //IdealObjectLex = new GroebnerBaseAbstract<ModInteger>(GLL);
+
+        long tconv = System.currentTimeMillis();
+        List<GenPolynomial<ModInteger>> resultFGLM = IdealObjectFGLM.convGroebnerToLex(GG);
+        tconv = System.currentTimeMillis() - tconv;
+
+        OrderedPolynomialList<ModInteger> o1 = new OrderedPolynomialList<ModInteger>(GG.get(0).ring, GG);
+        OrderedPolynomialList<ModInteger> o2 = new OrderedPolynomialList<ModInteger>(resultFGLM.get(0).ring,
+                        resultFGLM);
+        List<GenPolynomial<ModInteger>> resultBuchberger = GL;
+        OrderedPolynomialList<ModInteger> o3 = new OrderedPolynomialList<ModInteger>(
+                        resultBuchberger.get(0).ring, resultBuchberger);
+
+        int grad_numberOfElements = GG.size();
+        int lex_numberOfElements = resultFGLM.size();
+        long grad_maxPolyGrad = PolyUtil.<ModInteger> totalDegreeLeadingTerm(GG); //IdealObjectFGLM.maxDegreeOfGB();
+        long lex_maxPolyGrad = PolyUtil.<ModInteger> totalDegreeLeadingTerm(GL); //IdealObjectLex.maxDegreeOfGB();
+
+        System.out.println("Order of Variables: " + order);
+        System.out.println("Groebnerbases: ");
+        System.out.println("Groebnerbase Buchberger (IGRLEX) " + o1);
+        System.out.println("Groebnerbase FGML (INVLEX) computed from Buchberger (IGRLEX) " + o2);
+        System.out.println("Groebnerbase Buchberger (INVLEX) " + o3);
+
+        String erg = "Mod " + m + "    |" + order + " |" + grad_numberOfElements + "          |"
+                        + lex_numberOfElements + "          |" + grad_maxPolyGrad + "    |" + lex_maxPolyGrad
+                        + "    |" + buchberger_Grad + "     |" + tconv + "    |" + buchberger_Lex;
+
+        //assertEquals(o2, o3);
+        if (!o2.equals(o3)) {
+            throw new RuntimeException("FGLM != GB: " + o2 + " != " + o3);
+        }
+        return erg;
+    }
+
+
+    @SuppressWarnings({ "unchecked", "cast" })
+    public String modGrad(String order, String polynomials, Integer m) {
+        //GroebnerBaseFGLM<ModInteger> IdealObjectFGLM;
+        ModIntegerRing ring = new ModIntegerRing(m);
+        GroebnerBase<ModInteger> gb = GBFactory.getImplementation(ring);
+
+        String polynomials_Grad = "Mod " + ring.modul + " " + order + " G " + polynomials;
+
+        Reader sourceG = new StringReader(polynomials_Grad);
+        GenPolynomialTokenizer parserG = new GenPolynomialTokenizer(sourceG);
+        PolynomialList<ModInteger> G = null;
+
+        try {
+            G = (PolynomialList<ModInteger>) parserG.nextPolynomialSet();
+        } catch (IOException e) {
+            e.printStackTrace();
+            return "fail";
+        }
+        System.out.println("G= " + G);
+
+        //Computation of the Groebnerbase with Buchberger w.r.t GRADLEX (Total degree + INVLEX)
+        long buchberger_Grad = System.currentTimeMillis();
+        List<GenPolynomial<ModInteger>> GG = gb.GB(G.list);
+        buchberger_Grad = System.currentTimeMillis() - buchberger_Grad;
+
+        //PolynomialList<ModInteger> GGG = new PolynomialList<ModInteger>(G.ring, GG);
+        //IdealObjectFGLM = new GroebnerBaseFGLM<ModInteger>(); //GGG);
+
+        OrderedPolynomialList<ModInteger> o1 = new OrderedPolynomialList<ModInteger>(GG.get(0).ring, GG);
+
+        int grad_numberOfElements = GG.size();
+        long grad_maxPolyGrad = PolyUtil.<ModInteger> totalDegreeLeadingTerm(GG); //IdealObjectFGLM.maxDegreeOfGB();
+
+        System.out.println("Order of Variables: " + order);
+        System.out.println("Groebnerbases: ");
+        System.out.println("Groebnerbase Buchberger (IGRLEX) " + o1);
+
+        String erg = "Mod " + m + "    |" + order + " |" + grad_numberOfElements + "           |"
+                        + grad_maxPolyGrad + "    |" + buchberger_Grad;
+        return erg;
+    }
+
+
+    @SuppressWarnings({ "unchecked", "cast" })
+    public String modfglm(String order, String polynomials, Integer m) {
+        GroebnerBaseFGLM<ModInteger> IdealObjectFGLM;
+        //GroebnerBaseAbstract<ModInteger> IdealObjectLex;
+        ModIntegerRing ring = new ModIntegerRing(m);
+        GroebnerBase<ModInteger> gb = GBFactory.getImplementation(ring);
+
+        String polynomials_Grad = "Mod " + ring.modul + " " + order + " G " + polynomials;
+
+        Reader sourceG = new StringReader(polynomials_Grad);
+        GenPolynomialTokenizer parserG = new GenPolynomialTokenizer(sourceG);
+        PolynomialList<ModInteger> G = null;
+
+        try {
+            G = (PolynomialList<ModInteger>) parserG.nextPolynomialSet();
+        } catch (IOException e) {
+            e.printStackTrace();
+            return "fail";
+        }
+        System.out.println("G= " + G);
+
+        //Computation of the Groebnerbase with Buchberger w.r.t GRADLEX (Total degree + INVLEX)
+        long buchberger_Grad = System.currentTimeMillis();
+        List<GenPolynomial<ModInteger>> GG = gb.GB(G.list);
+        buchberger_Grad = System.currentTimeMillis() - buchberger_Grad;
+
+        //PolynomialList<ModInteger> GGG = new PolynomialList<ModInteger>(G.ring, GG);
+        IdealObjectFGLM = new GroebnerBaseFGLM<ModInteger>(); //GGG);
+
+        long tconv = System.currentTimeMillis();
+        List<GenPolynomial<ModInteger>> resultFGLM = IdealObjectFGLM.convGroebnerToLex(GG);
+        tconv = System.currentTimeMillis() - tconv;
+
+        //PolynomialList<ModInteger> LLL = new PolynomialList<ModInteger>(G.ring, resultFGLM);
+        //IdealObjectLex  = new GroebnerBaseAbstract<ModInteger>(LLL);
+
+        OrderedPolynomialList<ModInteger> o1 = new OrderedPolynomialList<ModInteger>(GG.get(0).ring, GG);
+        OrderedPolynomialList<ModInteger> o2 = new OrderedPolynomialList<ModInteger>(resultFGLM.get(0).ring,
+                        resultFGLM);
+
+        int grad_numberOfElements = GG.size();
+        int lex_numberOfElements = resultFGLM.size();
+        long grad_maxPolyGrad = PolyUtil.<ModInteger> totalDegreeLeadingTerm(GG); //IdealObjectFGLM.maxDegreeOfGB();
+        long lex_maxPolyGrad = PolyUtil.<ModInteger> totalDegreeLeadingTerm(resultFGLM); //IdealObjectLex.maxDegreeOfGB();
+
+        System.out.println("Order of Variables: " + order);
+        System.out.println("Groebnerbases: ");
+        System.out.println("Groebnerbase Buchberger (IGRLEX) " + o1);
+        System.out.println("Groebnerbase FGML (INVLEX) computed from Buchberger (IGRLEX) " + o2);
+
+        String erg = "Mod " + m + "    |" + order + " |" + grad_numberOfElements + "         |"
+                        + lex_numberOfElements + "           |" + grad_maxPolyGrad + "    |"
+                        + lex_maxPolyGrad + "    |" + buchberger_Grad + "     |" + tconv;
+        return erg;
+    }
+
+
+    /**
+     * Method shuffle returns a random permutation of a string of variables.
+     */
+    public String shuffle(String[] tempOrder) {
+        Collections.shuffle(Arrays.asList(tempOrder));
+        StringBuffer ret = new StringBuffer("(");
+        ret.append(ExpVector.varsToString(tempOrder));
+        ret.append(")");
+        return ret.toString();
+    }
+
+
+    /**
+     * Method bitHeight returns the bitlength of the greatest number occurring
+     * during the computation of a Groebner base.
+     */
+    public int bitHeight(List<GenPolynomial<BigRational>> list) {
+        BigInteger denom = BigInteger.ONE;
+        BigInteger num = BigInteger.ONE;
+        for (GenPolynomial<BigRational> g : list) {
+            for (Monomial<BigRational> m : g) {
+                BigRational bi = m.coefficient();
+                BigInteger i = bi.denominator().abs();
+                BigInteger j = bi.numerator().abs();
+                if (i.compareTo(denom) > 0)
+                    denom = i;
+                if (j.compareTo(num) > 0)
+                    num = j;
+            }
+        }
+        int erg;
+        if (denom.compareTo(num) > 0) {
+            erg = denom.bitLength();
+        } else {
+            erg = num.bitLength();
+        }
+        return erg;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/GroebnerBasePartial.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/GroebnerBasePartial.java
@@ -1,0 +1,592 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.GroebnerBaseAbstract;
+import edu.jas.gb.GroebnerBaseSeq;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.OptimizedPolynomialList;
+import edu.jas.poly.PolyUtil;
+import edu.jas.poly.TermOrder;
+import edu.jas.poly.TermOrderOptimization;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Partial Groebner Bases for subsets of variables. Let <code>pvars</code> be a
+ * subset of variables <code>vars</code> of the polynomial ring K[vars]. Methods
+ * compute Groebner bases with coefficients from K[vars \ pvars] in the
+ * polynomial ring K[vars \ pvars][pvars].
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class GroebnerBasePartial<C extends GcdRingElem<C>> extends GroebnerBaseAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GroebnerBasePartial.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Backing Groebner base engine.
+     */
+    protected GroebnerBaseAbstract<C> bb;
+
+
+    /**
+     * Backing recursive Groebner base engine.
+     */
+    protected GroebnerBaseAbstract<GenPolynomial<C>> rbb; // can be null
+
+
+    /**
+     * Constructor.
+     */
+    public GroebnerBasePartial() {
+        this(new GroebnerBaseSeq<C>(), null);
+    }
+
+
+    /**
+     * Constructor.
+     * @param rf coefficient ring factory.
+     */
+    public GroebnerBasePartial(RingFactory<GenPolynomial<C>> rf) {
+        this(new GroebnerBaseSeq<C>(), new GroebnerBasePseudoRecSeq<C>(rf));
+    }
+
+
+    /**
+     * Constructor.
+     * @param bb Groebner base engine
+     * @param rbb recursive Groebner base engine
+     */
+    public GroebnerBasePartial(GroebnerBaseAbstract<C> bb, GroebnerBaseAbstract<GenPolynomial<C>> rbb) {
+        super();
+        this.bb = bb;
+        this.rbb = rbb;
+        //if (rbb == null) {
+            //logger.warn("no recursive GB given");
+        //}
+    }
+
+
+    /**
+     * Groebner base using pairlist class.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return GB(F) a Groebner base of F.
+     */
+    public List<GenPolynomial<C>> GB(int modv, List<GenPolynomial<C>> F) {
+        return bb.GB(modv, F);
+    }
+
+
+    /**
+     * Groebner base test.
+     * @param F polynomial list.
+     * @return true, if F is a partial Groebner base, else false.
+     */
+    public boolean isGBrec(List<GenPolynomial<GenPolynomial<C>>> F) {
+        return isGBrec(0, F);
+    }
+
+
+    /**
+     * Groebner base test.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return true, if F is a partial Groebner base, else false.
+     */
+    public boolean isGBrec(int modv, List<GenPolynomial<GenPolynomial<C>>> F) {
+        if (F == null || F.isEmpty()) {
+            return true;
+        }
+        if (true) {
+            rbb = new GroebnerBasePseudoRecSeq<C>(F.get(0).ring.coFac);
+        }
+        return rbb.isGB(modv, F);
+    }
+
+
+    /**
+     * Partial permuation for specific variables. Computes a permutation perm
+     * for the variables vars, such that perm(vars) == pvars ... (vars \ pvars).
+     * Uses internal (reversed) variable sorting.
+     * @param vars names for all variables.
+     * @param pvars names for main variables, pvars subseteq vars.
+     * @return permutation for vars, such that perm(vars) == pvars ... (vars \
+     *         pvars).
+     */
+    public static List<Integer> partialPermutation(String[] vars, String[] pvars) {
+        return partialPermutation(vars, pvars, null);
+        //no: return getPermutation(vars,pvars);
+    }
+
+
+    /**
+     * Permutation of variables for elimination.
+     * @param aname variables for the full polynomial ring.
+     * @param ename variables for the elimination ring, subseteq aname.
+     * @return perm({vars \ ename},ename)
+     */
+    public static List<Integer> getPermutation(String[] aname, String[] ename) {
+        if (aname == null || ename == null) {
+            throw new IllegalArgumentException("aname or ename may not be null");
+        }
+        List<Integer> perm = new ArrayList<Integer>(aname.length);
+        // add ename permutation
+        for (int i = 0; i < ename.length; i++) {
+            int j = indexOf(ename[i], aname);
+            if (j < 0) {
+                throw new IllegalArgumentException("ename not contained in aname");
+            }
+            perm.add(j);
+        }
+        //System.out.println("perm_low = " + perm);
+        // add aname \ ename permutation
+        for (int i = 0; i < aname.length; i++) {
+            if (!perm.contains(i)) {
+                perm.add(i);
+            }
+        }
+        //System.out.println("perm_all = " + perm);
+        // reverse permutation indices
+        int n1 = aname.length - 1;
+        List<Integer> perm1 = new ArrayList<Integer>(aname.length);
+        for (Integer k : perm) {
+            perm1.add(n1 - k);
+        }
+        perm = perm1;
+        //System.out.println("perm_inv = " + perm1);
+        Collections.reverse(perm);
+        //System.out.println("perm_rev = " + perm);
+        return perm;
+    }
+
+
+    /**
+     * Index of s in A.
+     * @param s search string
+     * @param A string array
+     * @return i if s == A[i] for some i, else -1.
+     */
+    public static int indexOf(String s, String[] A) {
+        for (int i = 0; i < A.length; i++) {
+            if (s.equals(A[i])) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+
+    /**
+     * Partial permuation for specific variables. Computes a permutation perm
+     * for the variables vars, such that perm(vars) == pvars ... (vars \ pvars).
+     * Uses internal (reversed) variable sorting.
+     * @param vars names for all variables.
+     * @param pvars names for main variables, pvars subseteq vars.
+     * @param rvars names for remaining variables, rvars eq { vars \ pvars }.
+     * @return permutation for vars, such that perm(vars) == (pvars, {vars \
+     *         pvars}).
+     */
+    public static List<Integer> partialPermutation(String[] vars, String[] pvars, String[] rvars) {
+        if (vars == null || pvars == null) {
+            throw new IllegalArgumentException("no variable names found");
+        }
+        List<String> variables = new ArrayList<String>(vars.length);
+        List<String> pvariables = new ArrayList<String>(pvars.length);
+        for (int i = 0; i < vars.length; i++) {
+            variables.add(vars[i]);
+        }
+        for (int i = 0; i < pvars.length; i++) {
+            pvariables.add(pvars[i]);
+        }
+        if (rvars == null) {
+            rvars = remainingVars(vars, pvars);
+        }
+        List<String> rvariables = new ArrayList<String>(rvars.length);
+        for (int i = 0; i < rvars.length; i++) {
+            rvariables.add(rvars[i]);
+        }
+        if (rvars.length + pvars.length == vars.length) {
+            //System.out.println("pvariables  = " + pvariables);
+            return getPermutation(vars, rvars);
+        }
+        logger.info("not implemented for " + variables + " != " + pvariables + " cup " + rvariables);
+        throw new UnsupportedOperationException("not implemented");
+        /*
+        if (!variables.containsAll(pvariables) || !variables.containsAll(rvariables)) {
+            throw new IllegalArgumentException("partial variables not contained in all variables ");
+        }
+        Collections.reverse(variables);
+        Collections.reverse(pvariables);
+        Collections.reverse(rvariables);
+        System.out.println("variables  = " + variables);
+        System.out.println("pvariables = " + pvariables);
+        System.out.println("rvariables = " + rvariables);
+
+        List<Integer> perm = new ArrayList<Integer>();
+        List<Integer> pv = new ArrayList<Integer>();
+        for (String s : variables) {
+            int j = pvariables.indexOf(s);
+            if (j >= 0) {
+                perm.add(j);
+            }
+        }
+        int i = pvariables.size();
+        for (String s : variables) {
+            if (!pvariables.contains(s)) {
+                pv.add(i);
+            }
+            i++;
+        }
+
+        System.out.println("perm, 1 = " + perm);
+        //System.out.println("pv   = " + pv);
+        // sort perm according to pvars
+        int ps = perm.size(); // == pvars.length
+        for (int k = 0; k < ps; k++) {
+            for (int j = k + 1; j < ps; j++) {
+                int kk = variables.indexOf(pvariables.get(k));
+                int jj = variables.indexOf(pvariables.get(j));
+                if (kk > jj) { // swap
+                    int t = perm.get(k);
+                    System.out.println("swap " + t + " with " + perm.get(j));
+                    perm.set(k, perm.get(j));
+                    perm.set(j, t);
+                }
+            }
+        }
+        //System.out.println("perm = " + perm);
+        // sort pv according to rvars
+        int rs = pv.size(); // == rvars.length
+        for (int k = 0; k < rs; k++) {
+            for (int j = k + 1; j < rs; j++) {
+                int kk = variables.indexOf(rvariables.get(k));
+                int jj = variables.indexOf(rvariables.get(j));
+                if (kk > jj) { // swap
+                    int t = pv.get(k);
+                    //System.out.println("swap " + t + " with " + perm.get(j));
+                    pv.set(k, pv.get(j));
+                    pv.set(j, t);
+                }
+            }
+        }
+        //System.out.println("pv   = " + pv);
+        perm.addAll(pv);
+        System.out.println("perm, 2 = " + perm);
+        return perm;
+        */
+    }
+
+
+    /**
+     * Partial permuation for specific variables. Computes a permutation perm
+     * for the variables vars, such that perm(vars) == (evars, pvars, (vars \ {
+     * evars, pvars }). Uses internal (reversed) variable sorting.
+     * @param vars names for all variables.
+     * @param evars names for elimination variables, evars subseteq vars.
+     * @param pvars names for main variables, pvars subseteq vars.
+     * @param rvars names for remaining variables, rvars eq {vars \ { evars,
+     *            pvars } }.
+     * @return permutation for vars, such that perm(vars) == (evars,pvars, {vars
+     *         \ {evars,pvars}}.
+     */
+    public static List<Integer> partialPermutation(String[] vars, String[] evars, String[] pvars,
+                    String[] rvars) {
+        if (vars == null || evars == null || pvars == null) {
+            throw new IllegalArgumentException("not all variable names given");
+        }
+        String[] uvars;
+        if (rvars != null) {
+            uvars = new String[pvars.length + rvars.length];
+            for (int i = 0; i < pvars.length; i++) {
+                uvars[i] = pvars[i];
+            }
+            for (int i = 0; i < rvars.length; i++) {
+                uvars[pvars.length + i] = rvars[i];
+            }
+        } else {
+            uvars = pvars;
+        }
+        //System.out.println("uvars = " + Arrays.toString(uvars));
+        List<Integer> perm = partialPermutation(vars, evars, uvars);
+        return perm;
+    }
+
+
+    /**
+     * Remaining variables vars \ pvars. Uses internal (reversed) variable
+     * sorting, original order is preserved.
+     * @param vars names for all variables.
+     * @param pvars names for main variables, pvars subseteq vars.
+     * @return remaining vars = (vars \ pvars).
+     */
+    public static String[] remainingVars(String[] vars, String[] pvars) {
+        if (vars == null || pvars == null) {
+            throw new IllegalArgumentException("no variable names found");
+        }
+        List<String> variables = new ArrayList<String>(vars.length);
+        List<String> pvariables = new ArrayList<String>(pvars.length);
+        for (int i = 0; i < vars.length; i++) {
+            variables.add(vars[i]);
+        }
+        for (int i = 0; i < pvars.length; i++) {
+            pvariables.add(pvars[i]);
+        }
+        if (!variables.containsAll(pvariables)) {
+            throw new IllegalArgumentException("partial variables not contained in all variables ");
+        }
+        // variables.setMinus(pvariables)
+        List<String> rvariables = new ArrayList<String>(variables);
+        for (String s : pvariables) {
+            rvariables.remove(s);
+        }
+        int cl = vars.length - pvars.length;
+        String[] rvars = new String[cl];
+        int i = 0;
+        for (String s : rvariables) {
+            rvars[i++] = s;
+        }
+        return rvars;
+    }
+
+
+    /**
+     * Partial recursive Groebner base for specific variables. Computes Groebner
+     * base in K[vars \ pvars][pvars] with coefficients from K[vars \ pvars].
+     * @param F polynomial list.
+     * @param pvars names for main variables of partial Groebner base
+     *            computation.
+     * @return a container for a partial Groebner base of F wrt pvars.
+     */
+    public OptimizedPolynomialList<GenPolynomial<C>> partialGBrec(List<GenPolynomial<C>> F, String[] pvars) {
+        if (F == null || F.isEmpty()) {
+            throw new IllegalArgumentException("empty F not allowed");
+        }
+        GenPolynomialRing<C> fac = F.get(0).ring;
+        String[] vars = fac.getVars();
+        if (vars == null || pvars == null) {
+            throw new IllegalArgumentException("not all variable names found");
+        }
+        if (vars.length == pvars.length) {
+            throw new IllegalArgumentException("use non recursive partialGB algorithm");
+        }
+        // compute permutation (in reverse sorting)
+        List<Integer> perm = partialPermutation(vars, pvars);
+
+        GenPolynomialRing<C> pfac = fac.permutation(perm);
+        if (logger.isInfoEnabled()) {
+            logger.info("pfac = " + pfac);
+        }
+        List<GenPolynomial<C>> ppolys = TermOrderOptimization.<C> permutation(perm, pfac, F);
+        //System.out.println("ppolys = " + ppolys);
+
+        int cl = fac.nvar - pvars.length; // > 0
+        int pl = pvars.length;
+        String[] rvars = remainingVars(vars, pvars);
+        GenPolynomialRing<C> cfac = new GenPolynomialRing<C>(fac.coFac, cl, fac.tord, rvars);
+        //System.out.println("cfac = " + cfac);
+        GenPolynomialRing<GenPolynomial<C>> rfac = new GenPolynomialRing<GenPolynomial<C>>(cfac, pl,
+                        fac.tord, pvars);
+        if (logger.isInfoEnabled()) {
+            logger.info("rfac = " + rfac);
+        }
+        //System.out.println("rfac = " + rfac);
+
+        List<GenPolynomial<GenPolynomial<C>>> Fr = PolyUtil.<C> recursive(rfac, ppolys);
+        //System.out.println("\nFr = " + Fr);
+
+        if (true) {
+            rbb = new GroebnerBasePseudoRecSeq<C>(cfac);
+        }
+        List<GenPolynomial<GenPolynomial<C>>> Gr = rbb.GB(Fr);
+        //System.out.println("\nGr = " + Gr);
+        //perm = perm.subList(0,pl);
+        OptimizedPolynomialList<GenPolynomial<C>> pgb = new OptimizedPolynomialList<GenPolynomial<C>>(perm,
+                        rfac, Gr);
+        return pgb;
+    }
+
+
+    /**
+     * Partial Groebner base for specific variables. Computes Groebner base in
+     * K[vars \ pvars][pvars] with coefficients from K[vars \ pvars] but returns
+     * polynomials in K[vars \ pvars, pvars].
+     * @param F polynomial list.
+     * @param pvars names for main variables of partial Groebner base
+     *            computation.
+     * @return a container for a partial Groebner base of F wrt pvars.
+     */
+    public OptimizedPolynomialList<C> partialGB(List<GenPolynomial<C>> F, String[] pvars) {
+        if (F == null || F.isEmpty()) {
+            throw new IllegalArgumentException("empty F not allowed");
+        }
+        GenPolynomialRing<C> fac = F.get(0).ring;
+        String[] vars = fac.getVars();
+        // compute permutation (in reverse sorting)
+        //String[] xvars = remainingVars(vars, pvars);
+        //System.out.println("xvars = " + Arrays.toString(xvars));
+
+        List<Integer> perm = partialPermutation(vars, pvars);
+        //System.out.println("pGB, perm   = " + perm);
+        //System.out.println("pGB, perm,1 = " + getPermutation(vars, xvars));
+
+        GenPolynomialRing<C> pfac = fac.permutation(perm);
+        if (logger.isInfoEnabled()) {
+            logger.info("pfac = " + pfac);
+        }
+        List<GenPolynomial<C>> ppolys = TermOrderOptimization.<C> permutation(perm, pfac, F);
+        //System.out.println("ppolys = " + ppolys);
+
+        int cl = fac.nvar - pvars.length;
+        if (cl == 0) { // non recursive case
+            //GroebnerBaseSeq<C> bb = new GroebnerBaseSeq<C>();
+            List<GenPolynomial<C>> G = bb.GB(ppolys);
+            OptimizedPolynomialList<C> pgb = new OptimizedPolynomialList<C>(perm, pfac, G);
+            return pgb;
+        }
+        // recursive case
+        int pl = pvars.length;
+        String[] rvars = remainingVars(vars, pvars);
+        GenPolynomialRing<C> cfac = new GenPolynomialRing<C>(fac.coFac, cl, fac.tord, rvars);
+        //System.out.println("cfac = " + cfac);
+
+        GenPolynomialRing<GenPolynomial<C>> rfac = new GenPolynomialRing<GenPolynomial<C>>(cfac, pl,
+                        fac.tord, pvars);
+        if (logger.isInfoEnabled()) {
+            logger.info("rfac = " + rfac);
+        }
+        //System.out.println("rfac = " + rfac);
+
+        List<GenPolynomial<GenPolynomial<C>>> Fr = PolyUtil.<C> recursive(rfac, ppolys);
+        //System.out.println("\nFr = " + Fr);
+
+        if (true) {
+            rbb = new GroebnerBasePseudoRecSeq<C>(cfac);
+        }
+        List<GenPolynomial<GenPolynomial<C>>> Gr = rbb.GB(Fr);
+        //System.out.println("\nGr = " + Gr);
+
+        List<GenPolynomial<C>> G = PolyUtil.<C> distribute(pfac, Gr);
+        //System.out.println("\nG = " + G);
+
+        OptimizedPolynomialList<C> pgb = new OptimizedPolynomialList<C>(perm, pfac, G);
+        return pgb;
+    }
+
+
+    /**
+     * Partial Groebner base for specific variables. Computes Groebner base with
+     * coefficients from K[pvars] but returns polynomials in K[pvars, evars].
+     * @param F polynomial list.
+     * @param evars names for upper main variables of partial Groebner base
+     *            computation.
+     * @param pvars names for lower main variables of partial Groebner base
+     *            computation.
+     * @return a container for a partial Groebner base of F wrt (pvars,evars).
+     */
+    public OptimizedPolynomialList<C> elimPartialGB(List<GenPolynomial<C>> F, String[] evars, String[] pvars) {
+        if (F == null || F.isEmpty()) {
+            throw new IllegalArgumentException("empty F not allowed");
+        }
+        GenPolynomialRing<C> fac = F.get(0).ring;
+        String[] vars = fac.getVars();
+        // compute permutation (in reverse sorting)
+        //System.out.println("vars  = " + Arrays.toString(vars));
+        //System.out.println("evars = " + Arrays.toString(evars));
+        //System.out.println("pvars = " + Arrays.toString(pvars));
+        List<Integer> perm = partialPermutation(vars, evars, pvars);
+        //System.out.println("perm = " + perm);
+
+        GenPolynomialRing<C> pfac = fac.permutation(perm);
+        if (logger.isInfoEnabled()) {
+            logger.info("pfac = " + pfac);
+        }
+        List<GenPolynomial<C>> ppolys = TermOrderOptimization.<C> permutation(perm, pfac, F);
+        //System.out.println("ppolys = " + ppolys);
+
+        int cl = fac.nvar - evars.length - pvars.length;
+        if (cl == 0) { // non recursive case
+            TermOrder to = pfac.tord;
+            int ev = to.getEvord();
+            //ev = TermOrder.IGRLEX;
+            TermOrder split = new TermOrder(ev, ev, pfac.nvar, evars.length);
+            pfac = new GenPolynomialRing<C>(pfac.coFac, pfac.nvar, split, pfac.getVars());
+            if (logger.isInfoEnabled()) {
+                //logger.info("split = " + split);
+                logger.info("pfac = " + pfac);
+            }
+            List<GenPolynomial<C>> Fs = new ArrayList<GenPolynomial<C>>(ppolys.size());
+            for (GenPolynomial<C> p : ppolys) {
+                Fs.add(pfac.copy(p));
+            }
+            List<GenPolynomial<C>> G = bb.GB(Fs);
+            OptimizedPolynomialList<C> pgb = new OptimizedPolynomialList<C>(perm, pfac, G);
+            if (logger.isInfoEnabled()) {
+                logger.info("pgb = " + pgb);
+            }
+            return pgb;
+        }
+        logger.warn("not meaningful for elimination " + cl);
+        // recursive case
+        int pl = pvars.length + pvars.length;
+        String[] rvars = remainingVars(vars, evars);
+        rvars = remainingVars(rvars, pvars);
+        String[] uvars = new String[evars.length + pvars.length];
+        for (int i = 0; i < pvars.length; i++) {
+            uvars[i] = pvars[i];
+        }
+        for (int i = 0; i < evars.length; i++) {
+            uvars[pvars.length + i] = evars[i];
+        }
+
+        GenPolynomialRing<C> cfac = new GenPolynomialRing<C>(fac.coFac, cl, fac.tord, rvars);
+        //System.out.println("cfac = " + cfac);
+
+        TermOrder to = pfac.tord;
+        int ev = to.getEvord();
+        TermOrder split = new TermOrder(ev, ev, pl, evars.length);
+        //GenPolynomialRing<C> sfac = new GenPolynomialRing<C>(pfac.coFac, pfac.nvar, split, pfac.getVars());
+
+        GenPolynomialRing<GenPolynomial<C>> rfac = new GenPolynomialRing<GenPolynomial<C>>(cfac, pl, split,
+                        uvars);
+        //System.out.println("rfac = " + rfac);
+
+        List<GenPolynomial<GenPolynomial<C>>> Fr = PolyUtil.<C> recursive(rfac, ppolys);
+        if (logger.isInfoEnabled()) {
+            logger.info("rfac = " + rfac);
+            logger.info("Fr   = " + Fr);
+        }
+
+        if (true) {
+            rbb = new GroebnerBasePseudoRecSeq<C>(cfac);
+        }
+        List<GenPolynomial<GenPolynomial<C>>> Gr = rbb.GB(Fr);
+        //System.out.println("\nGr = " + Gr);
+
+        List<GenPolynomial<C>> G = PolyUtil.<C> distribute(pfac, Gr);
+        //System.out.println("\nG = " + G);
+
+        OptimizedPolynomialList<C> pgb = new OptimizedPolynomialList<C>(perm, pfac, G);
+        return pgb;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/GroebnerBasePseudoParallel.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/GroebnerBasePseudoParallel.java
@@ -1,0 +1,515 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.GroebnerBaseAbstract;
+import edu.jas.gb.OrderedPairlist;
+import edu.jas.gb.Pair;
+import edu.jas.gb.PairList;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.ufd.GCDFactory;
+import edu.jas.ufd.GreatestCommonDivisorAbstract;
+import edu.jas.util.Terminator;
+
+
+/**
+ * Groebner Base with pseudo reduction multi-threaded parallel algorithm.
+ * Implements coefficient fraction free Groebner bases.
+ * Coefficients can for example be integers or (commutative) univariate polynomials.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ * 
+ * @see edu.jas.application.GBAlgorithmBuilder
+ * @see edu.jas.gbufd.GBFactory
+ */
+
+public class GroebnerBasePseudoParallel<C extends GcdRingElem<C>> extends GroebnerBaseAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GroebnerBasePseudoParallel.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Number of threads to use.
+     */
+    protected final int threads;
+
+
+    /**
+     * Pool of threads to use.
+     */
+    protected transient final ExecutorService pool;
+
+
+    /**
+     * Greatest common divisor engine for coefficient content and primitive
+     * parts.
+     */
+    protected final GreatestCommonDivisorAbstract<C> engine;
+
+
+    /**
+     * Pseudo reduction engine.
+     */
+    protected final PseudoReduction<C> red;
+
+
+    /**
+     * Coefficient ring factory.
+     */
+    protected final RingFactory<C> cofac;
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param rf coefficient ring factory.
+     */
+    public GroebnerBasePseudoParallel(int threads, RingFactory<C> rf) {
+        this(threads, rf, new PseudoReductionPar<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param rf coefficient ring factory. <b>Note:</b> red must be an instance
+     *            of PseudoReductionPar.
+     * @param red pseudo reduction engine.
+     */
+    public GroebnerBasePseudoParallel(int threads, RingFactory<C> rf, PseudoReduction<C> red) {
+        this(threads, rf, red, Executors.newFixedThreadPool(threads));
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param rf coefficient ring factory. <b>Note:</b> red must be an instance
+     *            of PseudoReductionPar.
+     * @param red pseudo reduction engine.
+     * @param pool ExecutorService to use.
+     */
+    public GroebnerBasePseudoParallel(int threads, RingFactory<C> rf, PseudoReduction<C> red, ExecutorService pool) {
+        this(threads, rf, red, pool, new OrderedPairlist<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param rf coefficient ring factory. <b>Note:</b> red must be an instance
+     *            of PseudoReductionPar.
+     * @param pl pair selection strategy
+     */
+    public GroebnerBasePseudoParallel(int threads, RingFactory<C> rf, PairList<C> pl) {
+        this(threads, rf, new PseudoReductionPar<C>(), Executors.newFixedThreadPool(threads), pl);
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param rf coefficient ring factory. <b>Note:</b> red must be an instance
+     *            of PseudoReductionPar.
+     * @param red pseudo reduction engine.
+     * @param pool ExecutorService to use.
+     * @param pl pair selection strategy
+     */
+    public GroebnerBasePseudoParallel(int threads, RingFactory<C> rf, PseudoReduction<C> red,
+                    ExecutorService pool, PairList<C> pl) {
+        super(red, pl);
+        if (!(red instanceof PseudoReductionPar)) {
+            logger.warn("parallel GB should use parallel aware reduction");
+        }
+        this.red = red;
+        cofac = rf;
+        if (threads < 1) {
+            threads = 1;
+        }
+        this.threads = threads;
+        engine = GCDFactory.<C> getImplementation(rf);
+        //not used: engine = (GreatestCommonDivisorAbstract<C>)GCDFactory.<C>getProxy( rf );
+        this.pool = pool;
+    }
+
+
+    /**
+     * Cleanup and terminate ExecutorService.
+     */
+    @Override
+    public void terminate() {
+        if (pool == null) {
+            return;
+        }
+        pool.shutdown();
+        try {
+            while (!pool.isTerminated()) {
+                //logger.info("await");
+                boolean rest = pool.awaitTermination(1000L, TimeUnit.MILLISECONDS);
+            }
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        logger.info(pool.toString());
+    }
+
+
+    /**
+     * Cancel ExecutorService.
+     */
+    @Override
+    public int cancel() {
+        if (pool == null) {
+            return 0;
+        }
+        int s = pool.shutdownNow().size();
+        logger.info(pool.toString());
+        return s;
+    }
+
+
+    /**
+     * Groebner base using pairlist class.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return GB(F) a Groebner base of F.
+     */
+    public List<GenPolynomial<C>> GB(int modv, List<GenPolynomial<C>> F) {
+        List<GenPolynomial<C>> G = normalizeZerosOnes(F);
+        G = engine.basePrimitivePart(G);
+        if ( G.size() <= 1 ) {
+            return G;
+        }
+        GenPolynomialRing<C> ring = G.get(0).ring;
+        if ( ring.coFac.isField() ) { // remove ?
+            throw new IllegalArgumentException("coefficients from a field");
+        }
+        PairList<C> pairlist = strategy.create( modv, ring ); 
+        pairlist.put(G);
+        logger.info("start " + pairlist);
+
+        Terminator fin = new Terminator(threads);
+        PseudoReducer<C> R;
+        for (int i = 0; i < threads; i++) {
+            R = new PseudoReducer<C>(fin, G, pairlist, engine);
+            pool.execute(R);
+        }
+        fin.waitDone();
+        if (Thread.currentThread().isInterrupted()) {
+            throw new RuntimeException("interrupt before minimalGB");
+        }
+        logger.debug("#parallel list = " + G.size());
+        G = minimalGB(G);
+        logger.info("" + pairlist);
+        return G;
+    }
+
+
+    /**
+     * Minimal ordered Groebner basis.
+     * @param Gp a Groebner base.
+     * @return a reduced Groebner base of Gp.
+     */
+    @Override
+    public List<GenPolynomial<C>> minimalGB(List<GenPolynomial<C>> Gp) {
+        List<GenPolynomial<C>> G = normalizeZerosOnes(Gp);
+        if (G.size() <= 1) {
+            return G;
+        }
+        // remove top reducible polynomials
+        GenPolynomial<C> a;
+        List<GenPolynomial<C>> F;
+        F = new ArrayList<GenPolynomial<C>>(G.size());
+        while (G.size() > 0) {
+            a = G.remove(0);
+            if (red.isTopReducible(G, a) || red.isTopReducible(F, a)) {
+                // drop polynomial 
+                if (debug) {
+                    System.out.println("dropped " + a);
+                    List<GenPolynomial<C>> ff;
+                    ff = new ArrayList<GenPolynomial<C>>(G);
+                    ff.addAll(F);
+                    a = red.normalform(ff, a);
+                    if (!a.isZERO()) {
+                        System.out.println("error, nf(a) " + a);
+                    }
+                }
+            } else {
+                F.add(a);
+            }
+        }
+        G = F;
+        if (G.size() <= 1) {
+            return G;
+        }
+        Collections.reverse(G); // important for lex GB
+        // reduce remaining polynomials
+        @SuppressWarnings("unchecked")
+        PseudoMiReducer<C>[] mirs = (PseudoMiReducer<C>[]) new PseudoMiReducer[G.size()];
+        int i = 0;
+        F = new ArrayList<GenPolynomial<C>>(G.size());
+        while (G.size() > 0) {
+            a = G.remove(0);
+            List<GenPolynomial<C>> R = new ArrayList<GenPolynomial<C>>(G.size() + F.size());
+            R.addAll(G);
+            R.addAll(F);
+            // System.out.println("doing " + a.length());
+            mirs[i] = new PseudoMiReducer<C>(R, a, engine);
+            pool.execute(mirs[i]);
+            i++;
+            F.add(a);
+        }
+        G = F;
+        F = new ArrayList<GenPolynomial<C>>(G.size());
+        for (i = 0; i < mirs.length; i++) {
+            a = mirs[i].getNF();
+            F.add(a);
+        }
+        Collections.reverse(F); // undo reverse
+        return F;
+    }
+
+}
+
+
+/**
+ * Pseudo GB Reducing worker threads.
+ */
+class PseudoReducer<C extends GcdRingElem<C>> implements Runnable {
+
+
+    private final List<GenPolynomial<C>> G;
+
+
+    private final PairList<C> pairlist;
+
+
+    private final Terminator fin;
+
+
+    private final PseudoReductionPar<C> red;
+
+
+    private final GreatestCommonDivisorAbstract<C> engine;
+
+
+    private static final Logger logger = LogManager.getLogger(PseudoReducer.class);
+
+
+    PseudoReducer(Terminator fin, List<GenPolynomial<C>> G, PairList<C> L,
+                    GreatestCommonDivisorAbstract<C> engine) {
+        this.fin = fin;
+        this.G = G;
+        pairlist = L;
+        red = new PseudoReductionPar<C>();
+        this.engine = engine;
+        fin.initIdle(1);
+    }
+
+
+    /**
+     * to string
+     */
+    @Override
+    public String toString() {
+        return "PseudoReducer";
+    }
+
+
+    public void run() {
+        Pair<C> pair;
+        GenPolynomial<C> pi;
+        GenPolynomial<C> pj;
+        GenPolynomial<C> S;
+        GenPolynomial<C> H;
+        //boolean set = false;
+        int reduction = 0;
+        int sleeps = 0;
+        while (pairlist.hasNext() || fin.hasJobs()) {
+            while (!pairlist.hasNext()) {
+                // wait
+                //fin.beIdle(); set = true;
+                try {
+                    sleeps++;
+                    if (sleeps % 10 == 0) {
+                        logger.info(" reducer is sleeping");
+                    } else {
+                        logger.debug("r");
+                    }
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    break;
+                }
+                if (!fin.hasJobs()) {
+                    break;
+                }
+            }
+            if (!pairlist.hasNext() && !fin.hasJobs()) {
+                break;
+            }
+
+            fin.notIdle(); // before pairlist get
+            pair = pairlist.removeNext();
+            if (Thread.currentThread().isInterrupted()) {
+                fin.initIdle(1);
+                throw new RuntimeException("interrupt after removeNext");
+            }
+            if (pair == null) {
+                fin.initIdle(1);
+                continue;
+            }
+
+            pi = pair.pi;
+            pj = pair.pj;
+            if (logger.isDebugEnabled()) {
+                logger.debug("pi    = " + pi);
+                logger.debug("pj    = " + pj);
+            }
+
+            S = red.SPolynomial(pi, pj);
+            if (S.isZERO()) {
+                pair.setZero();
+                fin.initIdle(1);
+                continue;
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("ht(S) = " + S.leadingExpVector());
+            }
+
+            H = red.normalform(G, S); //mod
+            reduction++;
+            if (H.isZERO()) {
+                pair.setZero();
+                fin.initIdle(1);
+                continue;
+            }
+            if (logger.isDebugEnabled()) {
+                logger.info("ht(H) = " + H.leadingExpVector());
+            }
+
+            H = engine.basePrimitivePart(H); //H.monic();
+            H = H.abs();
+            // System.out.println("H   = " + H);
+            if (H.isONE()) {
+                // putOne not required
+                pairlist.put(H);
+                synchronized (G) {
+                    G.clear();
+                    G.add(H);
+                }
+                fin.allIdle();
+                return;
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("H = " + H);
+            }
+            synchronized (G) {
+                G.add(H);
+            }
+            pairlist.put(H);
+            fin.initIdle(1);
+        }
+        fin.allIdle();
+        logger.info("terminated, done " + reduction + " reductions");
+    }
+}
+
+
+/**
+ * Pseudo Reducing worker threads for minimal GB.
+ */
+class PseudoMiReducer<C extends GcdRingElem<C>> implements Runnable {
+
+
+    private final List<GenPolynomial<C>> G;
+
+
+    private GenPolynomial<C> H;
+
+
+    private final PseudoReductionPar<C> red;
+
+
+    private final Semaphore done = new Semaphore(0);
+
+
+    private final GreatestCommonDivisorAbstract<C> engine;
+
+
+    private static final Logger logger = LogManager.getLogger(PseudoMiReducer.class);
+
+
+    PseudoMiReducer(List<GenPolynomial<C>> G, GenPolynomial<C> p, GreatestCommonDivisorAbstract<C> engine) {
+        this.G = G;
+        this.engine = engine;
+        H = p;
+        red = new PseudoReductionPar<C>();
+    }
+
+
+    /**
+     * to string
+     */
+    @Override
+    public String toString() {
+        return "PseudoMiReducer";
+    }
+
+
+    /**
+     * getNF. Blocks until the normal form is computed.
+     * @return the computed normal form.
+     */
+    public GenPolynomial<C> getNF() {
+        try {
+            done.acquire(); //done.P();
+        } catch (InterruptedException e) {
+            throw new RuntimeException("interrupt in getNF");
+        }
+        return H;
+    }
+
+
+    public void run() {
+        if (logger.isDebugEnabled()) {
+            logger.debug("ht(H) = " + H.leadingExpVector());
+        }
+        try {
+            H = red.normalform(G, H); //mod
+            H = engine.basePrimitivePart(H); //H.monic();
+            H = H.abs();
+            done.release(); //done.V();
+        } catch (RuntimeException e) {
+            Thread.currentThread().interrupt();
+            //throw new RuntimeException("interrupt in getNF");
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug("ht(H) = " + H.leadingExpVector());
+        }
+        // H = H.monic();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/GroebnerBasePseudoRecParallel.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/GroebnerBasePseudoRecParallel.java
@@ -1,0 +1,594 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.GroebnerBaseAbstract;
+import edu.jas.gb.OrderedPairlist;
+import edu.jas.gb.Pair;
+import edu.jas.gb.PairList;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.ufd.GCDFactory;
+import edu.jas.ufd.GreatestCommonDivisorAbstract;
+import edu.jas.util.Terminator;
+
+
+/**
+ * Groebner Base with recursive pseudo reduction multi-threaded parallel
+ * algorithm. Implements coefficient fraction free Groebner bases.
+ * Coefficients can for example be (commutative) multivariate polynomials. 
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ * 
+ * @see edu.jas.application.GBAlgorithmBuilder
+ * @see edu.jas.gbufd.GBFactory
+ */
+
+public class GroebnerBasePseudoRecParallel<C extends GcdRingElem<C>> extends
+                GroebnerBaseAbstract<GenPolynomial<C>> {
+
+
+    private static final Logger logger = LogManager.getLogger(GroebnerBasePseudoRecParallel.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Number of threads to use.
+     */
+    protected final int threads;
+
+
+    /**
+     * Pool of threads to use.
+     */
+    protected transient final ExecutorService pool;
+
+
+    /**
+     * Greatest common divisor engine for coefficient content and primitive
+     * parts.
+     */
+    protected final GreatestCommonDivisorAbstract<C> engine;
+
+
+    /**
+     * Pseudo reduction engine.
+     */
+    protected final PseudoReduction<C> redRec;
+
+
+    /**
+     * Pseudo reduction engine.
+     */
+    protected final PseudoReduction<GenPolynomial<C>> red;
+
+
+    /**
+     * Coefficient ring factory.
+     */
+    protected final RingFactory<GenPolynomial<C>> cofac;
+
+
+    /**
+     * Base coefficient ring factory.
+     */
+    protected final RingFactory<C> baseCofac;
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param rf coefficient ring factory.
+     */
+    public GroebnerBasePseudoRecParallel(int threads, RingFactory<GenPolynomial<C>> rf) {
+        this(threads, rf, new PseudoReductionPar<GenPolynomial<C>>(), Executors.newFixedThreadPool(threads),
+                        new OrderedPairlist<GenPolynomial<C>>(new GenPolynomialRing<GenPolynomial<C>>(rf, 1))); // 1=hack
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param rf coefficient ring factory. <b>Note:</b> red must be an instance
+     *            of PseudoReductionPar.
+     * @param red pseudo reduction engine.
+     */
+    public GroebnerBasePseudoRecParallel(int threads, RingFactory<GenPolynomial<C>> rf,
+                    PseudoReduction<GenPolynomial<C>> red) {
+        this(threads, rf, red, Executors.newFixedThreadPool(threads));
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param rf coefficient ring factory. <b>Note:</b> red must be an instance
+     *            of PseudoReductionPar.
+     * @param red pseudo reduction engine.
+     * @param pool ExecutorService to use.
+     */
+    public GroebnerBasePseudoRecParallel(int threads, RingFactory<GenPolynomial<C>> rf,
+                    PseudoReduction<GenPolynomial<C>> red, ExecutorService pool) {
+        this(threads, rf, red, pool, new OrderedPairlist<GenPolynomial<C>>(
+                        new GenPolynomialRing<GenPolynomial<C>>(rf, 1))); // 1=hack
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param rf coefficient ring factory. <b>Note:</b> red must be an instance
+     *            of PseudoReductionPar.
+     * @param pl pair selection strategy
+     */
+    public GroebnerBasePseudoRecParallel(int threads, RingFactory<GenPolynomial<C>> rf,
+                    PairList<GenPolynomial<C>> pl) {
+        this(threads, rf, new PseudoReductionPar<GenPolynomial<C>>(), Executors.newFixedThreadPool(threads), pl);
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads number of threads to use.
+     * @param rf coefficient ring factory. <b>Note:</b> red must be an instance
+     *            of PseudoReductionPar.
+     * @param red pseudo reduction engine.
+     * @param pool ExecutorService to use.
+     * @param pl pair selection strategy
+     */
+    @SuppressWarnings("unchecked")
+    public GroebnerBasePseudoRecParallel(int threads, RingFactory<GenPolynomial<C>> rf,
+                    PseudoReduction<GenPolynomial<C>> red, ExecutorService pool, PairList<GenPolynomial<C>> pl) {
+        super(red, pl);
+        if (!(red instanceof PseudoReductionPar)) {
+            logger.warn("parallel GB should use parallel aware reduction");
+        }
+        this.red = red;
+        this.redRec = (PseudoReduction<C>) (PseudoReduction) red;
+        cofac = rf;
+        if (threads < 1) {
+            threads = 1;
+        }
+        this.threads = threads;
+        GenPolynomialRing<C> rp = (GenPolynomialRing<C>) cofac;
+        baseCofac = rp.coFac;
+        //engine = (GreatestCommonDivisorAbstract<C>)GCDFactory.<C>getImplementation( baseCofac );
+        //not used: 
+        engine = GCDFactory.<C> getProxy(baseCofac);
+        this.pool = pool;
+    }
+
+
+    /**
+     * Cleanup and terminate ExecutorService.
+     */
+    @Override
+    public void terminate() {
+        if (pool == null) {
+            return;
+        }
+        pool.shutdown();
+        try {
+            while (!pool.isTerminated()) {
+                //logger.info("await");
+                boolean rest = pool.awaitTermination(1000L, TimeUnit.MILLISECONDS);
+            }
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        logger.info(pool.toString());
+    }
+
+
+    /**
+     * Cancel ExecutorService.
+     */
+    @Override
+    public int cancel() {
+        if (pool == null) {
+            return 0;
+        }
+        int s = pool.shutdownNow().size();
+        logger.info(pool.toString());
+        return s;
+    }
+
+
+    /**
+     * Groebner base using pairlist class.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return GB(F) a Groebner base of F.
+     */
+    public List<GenPolynomial<GenPolynomial<C>>> GB(int modv, List<GenPolynomial<GenPolynomial<C>>> F) {
+        List<GenPolynomial<GenPolynomial<C>>> G = normalizeZerosOnes(F);
+        G = engine.recursivePrimitivePart(G);
+        if (G.size() <= 1) {
+            return G;
+        }
+        GenPolynomialRing<GenPolynomial<C>> ring = G.get(0).ring;
+        if (ring.coFac.isField()) { // remove ?
+            throw new IllegalArgumentException("coefficients from a field");
+        }
+        PairList<GenPolynomial<C>> pairlist = strategy.create(modv, ring);
+        pairlist.put(G);
+        logger.info("start " + pairlist);
+
+        Terminator fin = new Terminator(threads);
+        PseudoReducerRec<C> R;
+        for (int i = 0; i < threads; i++) {
+            R = new PseudoReducerRec<C>(fin, G, pairlist, engine);
+            pool.execute(R);
+        }
+        fin.waitDone();
+        if (Thread.currentThread().isInterrupted()) {
+            throw new RuntimeException("interrupt before minimalGB");
+        }
+        logger.debug("#parallel list = " + G.size());
+        G = minimalGB(G);
+        logger.info("" + pairlist);
+        return G;
+    }
+
+
+    /**
+     * Minimal ordered Groebner basis.
+     * @param Gp a Groebner base.
+     * @return a reduced Groebner base of Gp.
+     */
+    @Override
+    public List<GenPolynomial<GenPolynomial<C>>> minimalGB(List<GenPolynomial<GenPolynomial<C>>> Gp) {
+        List<GenPolynomial<GenPolynomial<C>>> G = normalizeZerosOnes(Gp);
+        if (G.size() <= 1) {
+            return G;
+        }
+        // remove top reducible polynomials
+        GenPolynomial<GenPolynomial<C>> a;
+        List<GenPolynomial<GenPolynomial<C>>> F;
+        F = new ArrayList<GenPolynomial<GenPolynomial<C>>>(G.size());
+        while (G.size() > 0) {
+            a = G.remove(0);
+            if (red.isTopReducible(G, a) || red.isTopReducible(F, a)) {
+                // drop polynomial 
+                if (debug) {
+                    System.out.println("dropped " + a);
+                    List<GenPolynomial<GenPolynomial<C>>> ff;
+                    ff = new ArrayList<GenPolynomial<GenPolynomial<C>>>(G);
+                    ff.addAll(F);
+                    //a = red.normalform(ff, a);
+                    a = redRec.normalformRecursive(ff, a);
+                    if (!a.isZERO()) {
+                        System.out.println("error, nf(a) " + a);
+                    }
+                }
+            } else {
+                F.add(a);
+            }
+        }
+        G = F;
+        if (G.size() <= 1) {
+            return G;
+        }
+        Collections.reverse(G); // important for lex GB
+        // reduce remaining polynomials
+        @SuppressWarnings("unchecked")
+        PseudoMiReducerRec<C>[] mirs = (PseudoMiReducerRec<C>[]) new PseudoMiReducerRec[G.size()];
+        int i = 0;
+        F = new ArrayList<GenPolynomial<GenPolynomial<C>>>(G.size());
+        while (G.size() > 0) {
+            a = G.remove(0);
+            List<GenPolynomial<GenPolynomial<C>>> R = new ArrayList<GenPolynomial<GenPolynomial<C>>>(G.size()
+                            + F.size());
+            R.addAll(G);
+            R.addAll(F);
+            // System.out.println("doing " + a.length());
+            mirs[i] = new PseudoMiReducerRec<C>(R, a, engine);
+            pool.execute(mirs[i]);
+            i++;
+            F.add(a);
+        }
+        G = F;
+        F = new ArrayList<GenPolynomial<GenPolynomial<C>>>(G.size());
+        for (i = 0; i < mirs.length; i++) {
+            a = mirs[i].getNF();
+            F.add(a);
+        }
+        Collections.reverse(F); // undo reverse
+        return F;
+    }
+
+
+    /**
+     * Groebner base simple test.
+     * @param modv module variable number.
+     * @param F recursive polynomial list.
+     * @return true, if F is a Groebner base, else false.
+     */
+    @Override
+    public boolean isGBsimple(int modv, List<GenPolynomial<GenPolynomial<C>>> F) {
+        if (F == null || F.isEmpty()) {
+            return true;
+        }
+        GenPolynomial<GenPolynomial<C>> pi, pj, s, h;
+        ExpVector ei, ej, eij;
+        for (int i = 0; i < F.size(); i++) {
+            pi = F.get(i);
+            ei = pi.leadingExpVector();
+            for (int j = i + 1; j < F.size(); j++) {
+                pj = F.get(j);
+                ej = pj.leadingExpVector();
+                if (!red.moduleCriterion(modv, ei, ej)) {
+                    continue;
+                }
+                eij = ei.lcm(ej);
+                if (!red.criterion4(ei, ej, eij)) {
+                    continue;
+                }
+                //if (!criterion3(i, j, eij, F)) {
+                //    continue;
+                //}
+                s = red.SPolynomial(pi, pj);
+                if (s.isZERO()) {
+                    continue;
+                }
+                //System.out.println("i, j = " + i + ", " + j); 
+                h = redRec.normalformRecursive(F, s);
+                if (!h.isZERO()) {
+                    logger.info("no GB: pi = " + pi + ", pj = " + pj);
+                    logger.info("s  = " + s + ", h = " + h);
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+}
+
+
+/**
+ * Pseudo GB Reducing worker threads.
+ */
+class PseudoReducerRec<C extends GcdRingElem<C>> implements Runnable {
+
+
+    private final List<GenPolynomial<GenPolynomial<C>>> G;
+
+
+    private final PairList<GenPolynomial<C>> pairlist;
+
+
+    private final Terminator fin;
+
+
+    private final PseudoReductionPar<GenPolynomial<C>> red;
+
+
+    private final PseudoReductionPar<C> redRec;
+
+
+    private final GreatestCommonDivisorAbstract<C> engine;
+
+
+    private static final Logger logger = LogManager.getLogger(PseudoReducerRec.class);
+
+
+    PseudoReducerRec(Terminator fin, List<GenPolynomial<GenPolynomial<C>>> G, PairList<GenPolynomial<C>> L,
+                    GreatestCommonDivisorAbstract<C> engine) {
+        this.fin = fin;
+        this.G = G;
+        pairlist = L;
+        red = new PseudoReductionPar<GenPolynomial<C>>();
+        redRec = new PseudoReductionPar<C>();
+        this.engine = engine;
+        fin.initIdle(1);
+    }
+
+
+    /**
+     * to string
+     */
+    @Override
+    public String toString() {
+        return "PseudoReducer";
+    }
+
+
+    public void run() {
+        Pair<GenPolynomial<C>> pair;
+        GenPolynomial<GenPolynomial<C>> pi, pj, S, H;
+        //boolean set = false;
+        int reduction = 0;
+        int sleeps = 0;
+        while (pairlist.hasNext() || fin.hasJobs()) {
+            while (!pairlist.hasNext()) {
+                // wait
+                //fin.beIdle(); set = true;
+                try {
+                    sleeps++;
+                    if (sleeps % 10 == 0) {
+                        logger.info(" reducer is sleeping");
+                    } else {
+                        logger.debug("r");
+                    }
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    break;
+                }
+                if (!fin.hasJobs()) {
+                    break;
+                }
+            }
+            if (!pairlist.hasNext() && !fin.hasJobs()) {
+                break;
+            }
+
+            fin.notIdle(); // before pairlist get
+            pair = pairlist.removeNext();
+            if (Thread.currentThread().isInterrupted()) {
+                fin.initIdle(1);
+                throw new RuntimeException("interrupt after removeNext");
+            }
+            if (pair == null) {
+                fin.initIdle(1);
+                continue;
+            }
+
+            pi = pair.pi;
+            pj = pair.pj;
+            if (logger.isDebugEnabled()) {
+                logger.debug("pi    = " + pi);
+                logger.debug("pj    = " + pj);
+            }
+
+            S = red.SPolynomial(pi, pj);
+            if (S.isZERO()) {
+                pair.setZero();
+                fin.initIdle(1);
+                continue;
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("ht(S) = " + S.leadingExpVector());
+            }
+
+            //H = red.normalform(G, S); //mod
+            H = redRec.normalformRecursive(G, S);
+            reduction++;
+            if (H.isZERO()) {
+                pair.setZero();
+                fin.initIdle(1);
+                continue;
+            }
+            if (logger.isDebugEnabled()) {
+                logger.info("ht(H) = " + H.leadingExpVector());
+            }
+
+            H = engine.recursivePrimitivePart(H); //H.monic();
+            H = H.abs();
+            // System.out.println("H   = " + H);
+            if (H.isONE()) {
+                // putOne not required
+                pairlist.put(H);
+                synchronized (G) {
+                    G.clear();
+                    G.add(H);
+                }
+                fin.allIdle();
+                return;
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("H = " + H);
+            }
+            synchronized (G) {
+                G.add(H);
+            }
+            pairlist.put(H);
+            fin.initIdle(1);
+        }
+        fin.allIdle();
+        logger.info("terminated, done " + reduction + " reductions");
+    }
+}
+
+
+/**
+ * Pseudo Reducing worker threads for minimal GB.
+ */
+class PseudoMiReducerRec<C extends GcdRingElem<C>> implements Runnable {
+
+
+    private final List<GenPolynomial<GenPolynomial<C>>> G;
+
+
+    private GenPolynomial<GenPolynomial<C>> H;
+
+
+    //private final PseudoReductionPar<GenPolynomial<C>> red;
+
+
+    private final PseudoReductionPar<C> redRec;
+
+
+    private final Semaphore done = new Semaphore(0);
+
+
+    private final GreatestCommonDivisorAbstract<C> engine;
+
+
+    private static final Logger logger = LogManager.getLogger(PseudoMiReducerRec.class);
+
+
+    PseudoMiReducerRec(List<GenPolynomial<GenPolynomial<C>>> G, GenPolynomial<GenPolynomial<C>> p,
+                    GreatestCommonDivisorAbstract<C> engine) {
+        this.G = G;
+        this.engine = engine;
+        H = p;
+        //red = new PseudoReductionPar<GenPolynomial<C>>();
+        redRec = new PseudoReductionPar<C>();
+    }
+
+
+    /**
+     * to string
+     */
+    @Override
+    public String toString() {
+        return "PseudoMiReducerRec";
+    }
+
+
+    /**
+     * getNF. Blocks until the normal form is computed.
+     * @return the computed normal form.
+     */
+    public GenPolynomial<GenPolynomial<C>> getNF() {
+        try {
+            done.acquire(); //done.P();
+        } catch (InterruptedException e) {
+            throw new RuntimeException("interrupt in getNF");
+        }
+        return H;
+    }
+
+
+    public void run() {
+        if (logger.isDebugEnabled()) {
+            logger.debug("ht(H) = " + H.leadingExpVector());
+        }
+        try {
+            //H = red.normalform(G, H); //mod
+            H = redRec.normalformRecursive(G, H);
+            H = engine.recursivePrimitivePart(H); //H.monic();
+            H = H.abs();
+            done.release(); //done.V();
+        } catch (RuntimeException e) {
+            Thread.currentThread().interrupt();
+            //throw new RuntimeException("interrupt in getNF");
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug("ht(H) = " + H.leadingExpVector());
+        }
+        // H = H.monic();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/GroebnerBasePseudoRecSeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/GroebnerBasePseudoRecSeq.java
@@ -1,0 +1,298 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.GroebnerBaseAbstract;
+import edu.jas.gb.OrderedPairlist;
+import edu.jas.gb.Pair;
+import edu.jas.gb.PairList;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.ufd.GCDFactory;
+import edu.jas.ufd.GreatestCommonDivisorAbstract;
+
+
+/**
+ * Groebner Base with pseudo reduction sequential algorithm for integral
+ * function coefficients. Implements polynomial fraction free coefficients
+ * Groebner bases. Coefficients can for example be 
+ * (commutative) multivariate polynomials.
+ * @param <C> base coefficient type
+ * @author Heinz Kredel
+ * 
+ * @see edu.jas.application.GBAlgorithmBuilder
+ * @see edu.jas.gbufd.GBFactory
+ */
+
+public class GroebnerBasePseudoRecSeq<C extends GcdRingElem<C>> extends
+                GroebnerBaseAbstract<GenPolynomial<C>> {
+
+
+    private static final Logger logger = LogManager.getLogger(GroebnerBasePseudoRecSeq.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Greatest common divisor engine for coefficient content and primitive
+     * parts.
+     */
+    protected final GreatestCommonDivisorAbstract<C> engine;
+
+
+    /**
+     * Pseudo reduction engine.
+     */
+    protected final PseudoReduction<C> redRec;
+
+
+    /**
+     * Pseudo reduction engine.
+     */
+    protected final PseudoReduction<GenPolynomial<C>> red;
+
+
+    /**
+     * Coefficient ring factory.
+     */
+    protected final RingFactory<GenPolynomial<C>> cofac;
+
+
+    /**
+     * Base coefficient ring factory.
+     */
+    protected final RingFactory<C> baseCofac;
+
+
+    /**
+     * Constructor.
+     * @param rf coefficient ring factory.
+     */
+    public GroebnerBasePseudoRecSeq(RingFactory<GenPolynomial<C>> rf) {
+        this(new PseudoReductionSeq<GenPolynomial<C>>(), rf, new OrderedPairlist<GenPolynomial<C>>(
+                        new GenPolynomialRing<GenPolynomial<C>>(rf, 1))); // 1=hack
+    }
+
+
+    /**
+     * Constructor.
+     * @param rf coefficient ring factory.
+     * @param pl pair selection strategy
+     */
+    public GroebnerBasePseudoRecSeq(RingFactory<GenPolynomial<C>> rf, PairList<GenPolynomial<C>> pl) {
+        this(new PseudoReductionSeq<GenPolynomial<C>>(), rf, pl);
+    }
+
+
+    /**
+     * Constructor.
+     * @param red pseudo reduction engine. <b>Note:</b> red must be an instance
+     *            of PseudoReductionSeq.
+     * @param rf coefficient ring factory.
+     * @param pl pair selection strategy
+     */
+    @SuppressWarnings("unchecked")
+    public GroebnerBasePseudoRecSeq(PseudoReduction<GenPolynomial<C>> red, RingFactory<GenPolynomial<C>> rf,
+                    PairList<GenPolynomial<C>> pl) {
+        super(red, pl);
+        this.red = red;
+        this.redRec = (PseudoReduction<C>) (PseudoReduction) red;
+        cofac = rf;
+        GenPolynomialRing<C> rp = (GenPolynomialRing<C>) cofac;
+        baseCofac = rp.coFac;
+        //engine = (GreatestCommonDivisorAbstract<C>)GCDFactory.<C>getImplementation( baseCofac );
+        //not used: 
+        engine = GCDFactory.<C> getProxy(baseCofac);
+    }
+
+
+    /**
+     * Groebner base using pairlist class.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return GB(F) a Groebner base of F.
+     */
+    //@Override
+    public List<GenPolynomial<GenPolynomial<C>>> GB(int modv, List<GenPolynomial<GenPolynomial<C>>> F) {
+        List<GenPolynomial<GenPolynomial<C>>> G = normalizeZerosOnes(F);
+        G = engine.recursivePrimitivePart(G);
+        if (G.size() <= 1) {
+            return G;
+        }
+        GenPolynomialRing<GenPolynomial<C>> ring = G.get(0).ring;
+        if (ring.coFac.isField()) { // remove ?
+            throw new IllegalArgumentException("coefficients from a field");
+        }
+        PairList<GenPolynomial<C>> pairlist = strategy.create(modv, ring);
+        pairlist.put(G);
+
+        Pair<GenPolynomial<C>> pair;
+        GenPolynomial<GenPolynomial<C>> pi, pj, S, H;
+        while (pairlist.hasNext()) {
+            pair = pairlist.removeNext();
+            if (pair == null)
+                continue;
+
+            pi = pair.pi;
+            pj = pair.pj;
+            if (debug) {
+                logger.debug("pi    = " + pi);
+                logger.debug("pj    = " + pj);
+            }
+
+            S = red.SPolynomial(pi, pj);
+            if (S.isZERO()) {
+                pair.setZero();
+                continue;
+            }
+            if (debug) {
+                logger.info("ht(S) = " + S.leadingExpVector());
+            }
+
+            H = redRec.normalformRecursive(G, S);
+            if (H.isZERO()) {
+                pair.setZero();
+                continue;
+            }
+            if (debug) {
+                logger.info("ht(H) = " + H.leadingExpVector());
+            }
+            H = engine.recursivePrimitivePart(H);
+            H = H.abs();
+            if (H.isConstant()) {
+                G.clear();
+                G.add(H);
+                return G; // since no threads are activated
+            }
+            if (debug) {
+                logger.debug("H = " + H);
+            }
+            if (H.length() > 0) {
+                //l++;
+                G.add(H);
+                pairlist.put(H);
+            }
+        }
+        logger.debug("#sequential list = " + G.size());
+        G = minimalGB(G);
+        logger.info("" + pairlist);
+        return G;
+    }
+
+
+    /**
+     * Minimal ordered Groebner basis.
+     * @param Gp a Groebner base.
+     * @return a reduced Groebner base of Gp.
+     */
+    @Override
+    public List<GenPolynomial<GenPolynomial<C>>> minimalGB(List<GenPolynomial<GenPolynomial<C>>> Gp) {
+        List<GenPolynomial<GenPolynomial<C>>> G = normalizeZerosOnes(Gp);
+        if (G.size() <= 1) {
+            return G;
+        }
+        // remove top reducible polynomials
+        GenPolynomial<GenPolynomial<C>> a;
+        List<GenPolynomial<GenPolynomial<C>>> F;
+        F = new ArrayList<GenPolynomial<GenPolynomial<C>>>(G.size());
+        while (G.size() > 0) {
+            a = G.remove(0);
+            if (red.isTopReducible(G, a) || red.isTopReducible(F, a)) {
+                // drop polynomial 
+                if (debug) {
+                    System.out.println("dropped " + a);
+                    List<GenPolynomial<GenPolynomial<C>>> ff;
+                    ff = new ArrayList<GenPolynomial<GenPolynomial<C>>>(G);
+                    ff.addAll(F);
+                    a = redRec.normalformRecursive(ff, a);
+                    if (!a.isZERO()) {
+                        System.out.println("error, nf(a) " + a);
+                    }
+                }
+            } else {
+                F.add(a);
+            }
+        }
+        G = F;
+        if (G.size() <= 1) {
+            return G;
+        }
+        Collections.reverse(G); // important for lex GB
+        // reduce remaining polynomials
+        int len = G.size();
+        int i = 0;
+        while (i < len) {
+            a = G.remove(0);
+            //System.out.println("doing " + a.length());
+            a = redRec.normalformRecursive(G, a);
+            a = engine.recursivePrimitivePart(a); //a.monic(); was not required
+            a = a.abs();
+            //a = redRec.normalformRecursive( F, a );
+            G.add(a); // adds as last
+            i++;
+        }
+        Collections.reverse(G); // undo reverse
+        return G;
+    }
+
+
+    /**
+     * Groebner base simple test.
+     * @param modv module variable number.
+     * @param F recursive polynomial list.
+     * @return true, if F is a Groebner base, else false.
+     */
+    @Override
+    public boolean isGBsimple(int modv, List<GenPolynomial<GenPolynomial<C>>> F) {
+        if (F == null || F.isEmpty()) {
+            return true;
+        }
+        GenPolynomial<GenPolynomial<C>> pi, pj, s, h;
+        ExpVector ei, ej, eij;
+        for (int i = 0; i < F.size(); i++) {
+            pi = F.get(i);
+            ei = pi.leadingExpVector();
+            for (int j = i + 1; j < F.size(); j++) {
+                pj = F.get(j);
+                ej = pj.leadingExpVector();
+                if (!red.moduleCriterion(modv, ei, ej)) {
+                    continue;
+                }
+                eij = ei.lcm(ej);
+                if (!red.criterion4(ei, ej, eij)) {
+                    continue;
+                }
+                //if (!criterion3(i, j, eij, F)) {
+                //    continue;
+                //}
+                s = red.SPolynomial(pi, pj);
+                if (s.isZERO()) {
+                    continue;
+                }
+                //System.out.println("i, j = " + i + ", " + j); 
+                h = redRec.normalformRecursive(F, s);
+                if (!h.isZERO()) {
+                    logger.info("no GB: pi = " + pi + ", pj = " + pj);
+                    logger.info("s  = " + s + ", h = " + h);
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/GroebnerBasePseudoSeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/GroebnerBasePseudoSeq.java
@@ -1,0 +1,229 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.GroebnerBaseAbstract;
+import edu.jas.gb.OrderedPairlist;
+import edu.jas.gb.Pair;
+import edu.jas.gb.PairList;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.ufd.GCDFactory;
+import edu.jas.ufd.GreatestCommonDivisorAbstract;
+
+
+/**
+ * Groebner Base with pseudo reduction sequential algorithm. Implements
+ * coefficient fraction free Groebner bases.
+ * Coefficients can for example be integers or (commutative) univariate polynomials.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ * 
+ * @see edu.jas.application.GBAlgorithmBuilder
+ * @see edu.jas.gbufd.GBFactory
+ */
+
+public class GroebnerBasePseudoSeq<C extends GcdRingElem<C>> extends GroebnerBaseAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GroebnerBasePseudoSeq.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Greatest common divisor engine for coefficient content and primitive
+     * parts.
+     */
+    protected final GreatestCommonDivisorAbstract<C> engine;
+
+
+    /**
+     * Pseudo reduction engine.
+     */
+    protected final PseudoReduction<C> red;
+
+
+    /**
+     * Coefficient ring factory.
+     */
+    protected final RingFactory<C> cofac;
+
+
+    /**
+     * Constructor.
+     * @param rf coefficient ring factory.
+     */
+    public GroebnerBasePseudoSeq(RingFactory<C> rf) {
+        this(new PseudoReductionSeq<C>(), rf, new OrderedPairlist<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param rf coefficient ring factory.
+     * @param pl pair selection strategy
+     */
+    public GroebnerBasePseudoSeq(RingFactory<C> rf, PairList<C> pl) {
+        this(new PseudoReductionSeq<C>(), rf, pl);
+    }
+
+
+    /**
+     * Constructor.
+     * @param red pseudo reduction engine. <b>Note:</b> red must be an instance
+     *            of PseudoReductionSeq.
+     * @param rf coefficient ring factory.
+     * @param pl pair selection strategy
+     */
+    public GroebnerBasePseudoSeq(PseudoReduction<C> red, RingFactory<C> rf, PairList<C> pl) {
+        super(red, pl);
+        this.red = red;
+        cofac = rf;
+        engine = GCDFactory.<C> getImplementation(rf);
+        //not used: engine = (GreatestCommonDivisorAbstract<C>)GCDFactory.<C>getProxy( rf );
+    }
+
+
+    /**
+     * Groebner base using pairlist class.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return GB(F) a Groebner base of F.
+     */
+    public List<GenPolynomial<C>> GB(int modv, List<GenPolynomial<C>> F) {
+        List<GenPolynomial<C>> G = normalizeZerosOnes(F);
+        G = engine.basePrimitivePart(G);
+        if (G.size() <= 1) {
+            return G;
+        }
+        GenPolynomialRing<C> ring = G.get(0).ring;
+        if (ring.coFac.isField()) { // remove ?
+            throw new IllegalArgumentException("coefficients from a field");
+        }
+        PairList<C> pairlist = strategy.create(modv, ring);
+        pairlist.put(G);
+
+        Pair<C> pair;
+        GenPolynomial<C> pi, pj, S, H;
+        while (pairlist.hasNext()) {
+            pair = pairlist.removeNext();
+            if (pair == null)
+                continue;
+
+            pi = pair.pi;
+            pj = pair.pj;
+            if (debug) {
+                logger.debug("pi    = " + pi);
+                logger.debug("pj    = " + pj);
+            }
+
+            S = red.SPolynomial(pi, pj);
+            if (S.isZERO()) {
+                pair.setZero();
+                continue;
+            }
+            if (debug) {
+                logger.debug("ht(S) = " + S.leadingExpVector());
+            }
+
+            H = red.normalform(G, S);
+            if (H.isZERO()) {
+                pair.setZero();
+                continue;
+            }
+            if (debug) {
+                logger.debug("ht(H) = " + H.leadingExpVector());
+            }
+            H = engine.basePrimitivePart(H);
+            H = H.abs();
+            if (H.isConstant()) {
+                G.clear();
+                G.add(H);
+                return G; // since no threads are activated
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("H = " + H);
+            }
+            if (H.length() > 0) {
+                //l++;
+                G.add(H);
+                pairlist.put(H);
+            }
+        }
+        logger.debug("#sequential list = " + G.size());
+        G = minimalGB(G);
+        logger.info("" + pairlist);
+        return G;
+    }
+
+
+    /**
+     * Minimal ordered Groebner basis.
+     * @param Gp a Groebner base.
+     * @return a reduced Groebner base of Gp.
+     */
+    @Override
+    public List<GenPolynomial<C>> minimalGB(List<GenPolynomial<C>> Gp) {
+        List<GenPolynomial<C>> G = normalizeZerosOnes(Gp);
+        if (G.size() <= 1) {
+            return G;
+        }
+        // remove top reducible polynomials
+        GenPolynomial<C> a;
+        List<GenPolynomial<C>> F;
+        F = new ArrayList<GenPolynomial<C>>(G.size());
+        while (G.size() > 0) {
+            a = G.remove(0);
+            if (red.isTopReducible(G, a) || red.isTopReducible(F, a)) {
+                // drop polynomial 
+                if (debug) {
+                    System.out.println("dropped " + a);
+                    List<GenPolynomial<C>> ff;
+                    ff = new ArrayList<GenPolynomial<C>>(G);
+                    ff.addAll(F);
+                    a = red.normalform(ff, a);
+                    if (!a.isZERO()) {
+                        System.out.println("error, nf(a) " + a);
+                    }
+                }
+            } else {
+                F.add(a);
+            }
+        }
+        G = F;
+        if (G.size() <= 1) {
+            return G;
+        }
+        Collections.reverse(G); // important for lex GB
+        // reduce remaining polynomials
+        int len = G.size();
+        int i = 0;
+        while (i < len) {
+            a = G.remove(0);
+            //System.out.println("doing " + a.length());
+            a = red.normalform(G, a);
+            a = engine.basePrimitivePart(a); //a.monic(); not possible
+            a = a.abs();
+            //a = red.normalform( F, a );
+            G.add(a); // adds as last
+            i++;
+        }
+        Collections.reverse(G); // undo reverse
+        return G;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/GroebnerBaseQuotient.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/GroebnerBaseQuotient.java
@@ -1,0 +1,214 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.GroebnerBaseAbstract;
+import edu.jas.gb.PairList;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.ufd.PolyUfdUtil;
+import edu.jas.ufd.Quotient;
+import edu.jas.ufd.QuotientRing;
+
+
+/**
+ * Groebner Base sequential algorithm for rational function coefficients,
+ * fraction free computation. Implements Groebner bases.
+ * @param <C> Quotient coefficient type
+ * @author Heinz Kredel
+ */
+
+public class GroebnerBaseQuotient<C extends GcdRingElem<C>> extends GroebnerBaseAbstract<Quotient<C>> {
+
+
+    private static final Logger logger = LogManager.getLogger(GroebnerBaseQuotient.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    public final GroebnerBaseAbstract<GenPolynomial<C>> bba;
+
+
+    /**
+     * Constructor.
+     * @param rf quotient coefficient ring factory.
+     */
+    public GroebnerBaseQuotient(QuotientRing<C> rf) {
+        this(new GroebnerBasePseudoRecSeq<C>(rf.ring));
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads the number of parallel threads.
+     * @param rf quotient coefficient ring factory.
+     */
+    public GroebnerBaseQuotient(int threads, QuotientRing<C> rf) {
+        this(new GroebnerBasePseudoRecParallel<C>(threads, rf.ring));
+    }
+
+
+    /**
+     * Constructor.
+     * @param rf quotient coefficient ring factory.
+     * @param pl pair selection strategy (for fraction parts).
+     */
+    public GroebnerBaseQuotient(QuotientRing<C> rf, PairList<GenPolynomial<C>> pl) {
+        this(new GroebnerBasePseudoRecSeq<C>(rf.ring, pl));
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads the number of parallel threads.
+     * @param rf quotient coefficient ring factory.
+     * @param pl pair selection strategy (for fraction parts).
+     */
+    public GroebnerBaseQuotient(int threads, QuotientRing<C> rf, PairList<GenPolynomial<C>> pl) {
+        this(new GroebnerBasePseudoRecParallel<C>(threads, rf.ring, pl));
+    }
+
+
+    /**
+     * Constructor.
+     * @param bba Groebner base algorithm for GenPolynomial coefficients.
+     */
+    public GroebnerBaseQuotient(GroebnerBaseAbstract<GenPolynomial<C>> bba) {
+        super();
+        this.bba = bba;
+    }
+
+
+    /**
+     * Get the String representation with GB engines.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName() + "(" + bba.toString() + ")";
+    }
+
+
+    /**
+     * Groebner base using fraction free computation.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return GB(F) a Groebner base of F.
+     */
+    @Override
+    public List<GenPolynomial<Quotient<C>>> GB(int modv, List<GenPolynomial<Quotient<C>>> F) {
+        List<GenPolynomial<Quotient<C>>> G = F;
+        if (F == null || F.isEmpty()) {
+            return G;
+        }
+        GenPolynomialRing<Quotient<C>> rring = F.get(0).ring;
+        QuotientRing<C> cf = (QuotientRing<C>) rring.coFac;
+        GenPolynomialRing<GenPolynomial<C>> iring = new GenPolynomialRing<GenPolynomial<C>>(cf.ring, rring);
+        List<GenPolynomial<GenPolynomial<C>>> Fi = PolyUfdUtil.<C> integralFromQuotientCoefficients(iring, F);
+        //System.out.println("Fi = " + Fi);
+        logger.info("#Fi = " + Fi.size());
+
+        List<GenPolynomial<GenPolynomial<C>>> Gi = bba.GB(modv, Fi);
+        //System.out.println("Gi = " + Gi);
+        logger.info("#Gi = " + Gi.size());
+
+        G = PolyUfdUtil.<C> quotientFromIntegralCoefficients(rring, Gi);
+        G = PolyUtil.<Quotient<C>> monic(G);
+        return G;
+    }
+
+
+    /**
+     * Minimal ordered Groebner basis.
+     * @param Gp a Groebner base.
+     * @return a reduced Groebner base of Gp.
+     */
+    @Override
+    public List<GenPolynomial<Quotient<C>>> minimalGB(List<GenPolynomial<Quotient<C>>> Gp) {
+        if (Gp == null || Gp.size() <= 1) {
+            return Gp;
+        }
+        // remove zero polynomials
+        List<GenPolynomial<Quotient<C>>> G = new ArrayList<GenPolynomial<Quotient<C>>>(Gp.size());
+        for (GenPolynomial<Quotient<C>> a : Gp) {
+            if (a != null && !a.isZERO()) { // always true in GB()
+                // already positive a = a.abs();
+                G.add(a);
+            }
+        }
+        if (G.size() <= 1) {
+            return G;
+        }
+        // remove top reducible polynomials
+        GenPolynomial<Quotient<C>> a;
+        List<GenPolynomial<Quotient<C>>> F;
+        F = new ArrayList<GenPolynomial<Quotient<C>>>(G.size());
+        while (G.size() > 0) {
+            a = G.remove(0);
+            if (red.isTopReducible(G, a) || red.isTopReducible(F, a)) {
+                // drop polynomial 
+                if (debug) {
+                    System.out.println("dropped " + a);
+                    List<GenPolynomial<Quotient<C>>> ff;
+                    ff = new ArrayList<GenPolynomial<Quotient<C>>>(G);
+                    ff.addAll(F);
+                    a = red.normalform(ff, a);
+                    if (!a.isZERO()) {
+                        System.out.println("error, nf(a) " + a);
+                    }
+                }
+            } else {
+                F.add(a);
+            }
+        }
+        G = F;
+        if (G.size() <= 1) {
+            return G;
+        }
+
+        // reduce remaining polynomials
+        GenPolynomialRing<Quotient<C>> rring = G.get(0).ring;
+        QuotientRing<C> cf = (QuotientRing<C>) rring.coFac;
+        GenPolynomialRing<GenPolynomial<C>> iring = new GenPolynomialRing<GenPolynomial<C>>(cf.ring, rring);
+        List<GenPolynomial<GenPolynomial<C>>> Fi = PolyUfdUtil.integralFromQuotientCoefficients(iring, F);
+        logger.info("#Fi = " + Fi.size());
+
+        List<GenPolynomial<GenPolynomial<C>>> Gi = bba.minimalGB(Fi);
+        logger.info("#Gi = " + Gi.size());
+
+        G = PolyUfdUtil.<C> quotientFromIntegralCoefficients(rring, Gi);
+        G = PolyUtil.<Quotient<C>> monic(G);
+        return G;
+    }
+
+
+    /**
+     * Cleanup and terminate ThreadPool.
+     */
+    @Override
+    public void terminate() {
+        bba.terminate();
+    }
+
+
+    /**
+     * Cancel ThreadPool.
+     */
+    @Override
+    public int cancel() {
+        return bba.cancel();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/GroebnerBaseRational.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/GroebnerBaseRational.java
@@ -1,0 +1,208 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.arith.BigInteger;
+import edu.jas.arith.BigRational;
+import edu.jas.gb.GroebnerBaseAbstract;
+import edu.jas.gb.PairList;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+
+
+/**
+ * Groebner Base sequential algorithm for rational coefficients, fraction free
+ * computation. Implements Groebner bases.
+ * @param <C> BigRational coefficient type
+ * @author Heinz Kredel
+ */
+
+public class GroebnerBaseRational<C extends BigRational> extends GroebnerBaseAbstract<BigRational> {
+
+
+    private static final Logger logger = LogManager.getLogger(GroebnerBaseRational.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    public final GroebnerBaseAbstract<BigInteger> bba;
+
+
+    /**
+     * Constructor.
+     */
+    public GroebnerBaseRational() {
+        this(new GroebnerBasePseudoSeq<BigInteger>(new BigInteger()));
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads the number of parallel threads.
+     */
+    public GroebnerBaseRational(int threads) {
+        this(new GroebnerBasePseudoParallel<BigInteger>(threads, new BigInteger()));
+    }
+
+
+    /**
+     * Constructor.
+     * @param pl pair selection strategy
+     */
+    public GroebnerBaseRational(PairList<BigInteger> pl) {
+        this(new GroebnerBasePseudoSeq<BigInteger>(new BigInteger(), pl));
+    }
+
+
+    /**
+     * Constructor.
+     * @param threads the number of parallel threads.
+     * @param pl pair selection strategy
+     */
+    public GroebnerBaseRational(int threads, PairList<BigInteger> pl) {
+        this(new GroebnerBasePseudoParallel<BigInteger>(threads, new BigInteger(), pl));
+    }
+
+
+    /**
+     * Constructor.
+     * @param bba Groebner base algorithm for BigInteger coefficients.
+     */
+    public GroebnerBaseRational(GroebnerBaseAbstract<BigInteger> bba) {
+        super();
+        this.bba = bba;
+    }
+
+
+    /**
+     * Get the String representation with GB engines.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName() + "(" + bba.toString() + ")";
+    }
+
+
+    /**
+     * Groebner base using fraction free computation.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return GB(F) a Groebner base of F.
+     */
+    @Override
+    public List<GenPolynomial<BigRational>> GB(int modv, List<GenPolynomial<BigRational>> F) {
+        List<GenPolynomial<BigRational>> G = F;
+        if (F == null || F.isEmpty()) {
+            return G;
+        }
+        GenPolynomialRing<BigRational> rring = F.get(0).ring;
+        BigInteger cf = new BigInteger();
+        GenPolynomialRing<BigInteger> iring = new GenPolynomialRing<BigInteger>(cf, rring);
+        List<GenPolynomial<BigInteger>> Fi = PolyUtil.integerFromRationalCoefficients(iring, F);
+        //System.out.println("Fi = " + Fi);
+        logger.info("#Fi = " + Fi.size());
+
+        List<GenPolynomial<BigInteger>> Gi = bba.GB(modv, Fi);
+        //System.out.println("Gi = " + Gi);
+        logger.info("#Gi = " + Gi.size());
+
+        G = PolyUtil.<BigRational> fromIntegerCoefficients(rring, Gi);
+        G = PolyUtil.<BigRational> monic(G);
+        return G;
+    }
+
+
+    /**
+     * Minimal ordered Groebner basis.
+     * @param Gp a Groebner base.
+     * @return a reduced Groebner base of Gp.
+     */
+    @Override
+    public List<GenPolynomial<BigRational>> minimalGB(List<GenPolynomial<BigRational>> Gp) {
+        if (Gp == null || Gp.size() <= 1) {
+            return Gp;
+        }
+        // remove zero polynomials
+        List<GenPolynomial<BigRational>> G = new ArrayList<GenPolynomial<BigRational>>(Gp.size());
+        for (GenPolynomial<BigRational> a : Gp) {
+            if (a != null && !a.isZERO()) { // always true in GB()
+                // already positive a = a.abs();
+                G.add(a);
+            }
+        }
+        if (G.size() <= 1) {
+            return G;
+        }
+        // remove top reducible polynomials
+        GenPolynomial<BigRational> a;
+        List<GenPolynomial<BigRational>> F;
+        F = new ArrayList<GenPolynomial<BigRational>>(G.size());
+        while (G.size() > 0) {
+            a = G.remove(0);
+            if (red.isTopReducible(G, a) || red.isTopReducible(F, a)) {
+                // drop polynomial 
+                if (debug) {
+                    System.out.println("dropped " + a);
+                    List<GenPolynomial<BigRational>> ff;
+                    ff = new ArrayList<GenPolynomial<BigRational>>(G);
+                    ff.addAll(F);
+                    a = red.normalform(ff, a);
+                    if (!a.isZERO()) {
+                        System.out.println("error, nf(a) " + a);
+                    }
+                }
+            } else {
+                F.add(a);
+            }
+        }
+        G = F;
+        if (G.size() <= 1) {
+            return G;
+        }
+
+        // reduce remaining polynomials
+        GenPolynomialRing<BigRational> rring = G.get(0).ring;
+        BigInteger cf = new BigInteger();
+        GenPolynomialRing<BigInteger> iring = new GenPolynomialRing<BigInteger>(cf, rring);
+        List<GenPolynomial<BigInteger>> Fi = PolyUtil.integerFromRationalCoefficients(iring, F);
+        logger.info("#Fi = " + Fi.size());
+
+        List<GenPolynomial<BigInteger>> Gi = bba.minimalGB(Fi);
+        logger.info("#Gi = " + Gi.size());
+
+        G = PolyUtil.<BigRational> fromIntegerCoefficients(rring, Gi);
+        G = PolyUtil.<BigRational> monic(G);
+        return G;
+    }
+
+
+    /**
+     * Cleanup and terminate ThreadPool.
+     */
+    @Override
+    public void terminate() {
+        bba.terminate();
+    }
+
+
+    /**
+     * Cancel ThreadPool.
+     */
+    @Override
+    public int cancel() {
+        return bba.cancel();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/GroebnerBaseWalk.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/GroebnerBaseWalk.java
@@ -1,0 +1,478 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.GroebnerBaseAbstract;
+import edu.jas.gb.ReductionAbstract;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.Monomial;
+import edu.jas.poly.PolyUtil;
+import edu.jas.poly.PolynomialList;
+import edu.jas.poly.TermOrder;
+import edu.jas.poly.TermOrderByName;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Groebner Base sequential Groebner Walk algorithm. Implements Groebner base
+ * computation via Groebner Walk algorithm. See "The generic Groebner walk" by
+ * Fukuda, Jensen, Lauritzen, Thomas, 2005.
+ *
+ * The start term order t1 can be set by a constructor. The target term order t2
+ * is taken from the input polynomials term order.
+ *
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ * 
+ * @see edu.jas.application.GBAlgorithmBuilder
+ * @see edu.jas.gbufd.GBFactory
+ */
+public class GroebnerBaseWalk<C extends GcdRingElem<C>> extends GroebnerBaseAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GroebnerBaseWalk.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * The backing GB algorithm implementation.
+     */
+    protected GroebnerBaseAbstract<C> sgb;
+
+
+    /**
+     * The start term order t1.
+     */
+    //protected TermOrder startTO = TermOrderByName.IGRLEX.blockOrder(2); 
+    protected TermOrder startTO = TermOrderByName.IGRLEX;
+
+
+    /**
+     * Print intermediate GB after this number of iterations.
+     */
+    int iterPrint = 100;
+
+
+    /**
+     * Constructor.
+     */
+    public GroebnerBaseWalk() {
+        super();
+        sgb = null;
+    }
+
+
+    /**
+     * Constructor.
+     * @param coFac coefficient ring of polynomial ring.
+     */
+    public GroebnerBaseWalk(RingFactory<C> coFac) {
+        this(GBFactory.<C> getImplementation(coFac));
+    }
+
+
+    /**
+     * Constructor.
+     * @param coFac coefficient ring of polynomial ring.
+     * @param t1 start term order.
+     */
+    public GroebnerBaseWalk(RingFactory<C> coFac, TermOrder t1) {
+        this(GBFactory.<C> getImplementation(coFac), t1);
+    }
+
+
+    /**
+     * Constructor.
+     * @param gb backing GB algorithm.
+     */
+    public GroebnerBaseWalk(GroebnerBaseAbstract<C> gb) {
+        super(gb.red, gb.strategy);
+        sgb = gb;
+    }
+
+
+    /**
+     * Constructor.
+     * @param gb backing GB algorithm.
+     * @param t1 start term order.
+     */
+    public GroebnerBaseWalk(GroebnerBaseAbstract<C> gb, TermOrder t1) {
+        this(gb);
+        startTO = t1;
+    }
+
+
+    /**
+     * Get the String representation with GB engine.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        if (sgb == null) {
+            return "GroebnerBaseWalk(" + startTO.toScript() + ")";
+        }
+        return "GroebnerBaseWalk( " + sgb.toString() + ", " + startTO.toScript() + " )";
+    }
+
+
+    /**
+     * Groebner base using Groebner Walk algorithm.
+     * @param modv module variable number.
+     * @param F polynomial list in target term order.
+     * @return GB(F) a INVLEX / target term order Groebner base of F.
+     */
+    public List<GenPolynomial<C>> GB(int modv, List<GenPolynomial<C>> F) {
+        List<GenPolynomial<C>> G = normalizeZerosOnes(F);
+        G = PolyUtil.<C> monic(G);
+        if (G == null || G.size() == 0) {
+            return G;
+        }
+        GenPolynomialRing<C> pfac = G.get(0).ring;
+        if (!pfac.coFac.isField()) {
+            throw new IllegalArgumentException("coefficients not from a field: " + pfac.coFac);
+        }
+        if (G.size() <= 1) {
+            GenPolynomial<C> p = pfac.copy(G.get(0)); // change term order
+            G.clear();
+            G.add(p);
+            return G;
+        }
+        // compute in graded / start term order
+        TermOrder grord = startTO; //new TermOrder(TermOrder.IGRLEX);
+        GenPolynomialRing<C> gfac = new GenPolynomialRing<C>(pfac, grord);
+        if (debug) {
+            logger.info("gfac = " + gfac.toScript());
+        }
+        List<GenPolynomial<C>> Fp = gfac.copy(F);
+        logger.info("Term order: graded = " + grord + ", target = " + pfac.tord);
+
+        // compute graded / start term order Groebner base
+        if (sgb == null) {
+            sgb = GBFactory.<C> getImplementation(pfac.coFac, strategy);
+        }
+        List<GenPolynomial<C>> Gp = sgb.GB(modv, Fp);
+        logger.info("graded / start GB = " + Gp);
+        if (grord.equals(pfac.tord)) {
+            return Gp;
+        }
+        if (Gp.size() == 1) { // also dimension -1
+            GenPolynomial<C> p = pfac.copy(Gp.get(0)); // change term order
+            G.clear();
+            G.add(p);
+            return G;
+        }
+        // info on FGLM
+        int z = commonZeroTest(Gp);
+        if (z == 0) {
+            logger.info("ideal zero dimensional, can use also FGLM algorithm");
+        }
+        // compute target term order Groebner base via Groebner Walk
+        G = walkGroebnerToTarget(modv, Gp, pfac);
+        return G;
+    }
+
+
+    /**
+     * Converts Groebner bases w.r.t. total degree / start term order to
+     * Groebner base w.r.t to inverse lexicographical / target term order.
+     * @param modv module variable number.
+     * @param Gl Groebner base with respect to graded / start term order.
+     * @param ufac target polynomial ring and term order.
+     * @return Groebner base w.r.t inverse lexicographical / target term order
+     */
+    public List<GenPolynomial<C>> walkGroebnerToTarget(int modv, List<GenPolynomial<C>> Gl,
+                    GenPolynomialRing<C> ufac) {
+        if (Gl == null || Gl.size() == 0) {
+            throw new IllegalArgumentException("G may not be null or empty");
+        }
+        //Polynomial ring of input Groebner basis Gl
+        GenPolynomialRing<C> ring = Gl.get(0).ring;
+        if (debug) {
+            logger.info("ring = " + ring.toScript());
+        }
+        //Polynomial ring of newGB with INVLEX / target term order
+        //TermOrder lexi = ufac.tord; //new TermOrder(TermOrder.INVLEX);
+        logger.info("G walk from ev1 = " + ring.tord.toScript() + " to ev2 = " + ufac.tord.toScript());
+        List<GenPolynomial<C>> Giter = Gl;
+        // determine initial marks
+        List<ExpVector> marks = new ArrayList<ExpVector>();
+        List<Monomial<C>> M = new ArrayList<Monomial<C>>();
+        for (GenPolynomial<C> p : Giter) {
+            marks.add(p.leadingExpVector());
+            M.add(new Monomial<C>(p.leadingMonomial()));
+        }
+        logger.info("marks = " + marks);
+        List<Monomial<C>> Mp = new ArrayList<Monomial<C>>(M);
+        // weight matrix for target term order
+        long[][] ufweight = TermOrderByName.weightForOrder(ufac.tord, ring.nvar);
+        //TermOrder word = TermOrder.reverseWeight(ufweight);
+        TermOrder word = new TermOrder(ufweight);
+        logger.info("weight order: " + word);
+        ufweight = word.getWeight(); // because of weightDeg usage
+
+        // loop throught term orders
+        ExpVector w = null;
+        int iter = 0; // count #loops
+        boolean done = false;
+        while (!done) {
+            iter++;
+            // determine V and w
+            PolynomialList<C> Pl = new PolynomialList<C>(ring, Giter);
+            SortedSet<ExpVector> delta = Pl.deltaExpVectors(marks);
+            //logger.info("delta(marks) = " + delta);
+            logger.info("w_old = " + w);
+            ExpVector v = facetNormal(ring.tord, ufac.tord, delta, ring.evzero, ufweight);
+            logger.info("minimal v = " + v);
+            if (v == null) {
+                done = true;
+                break; // finished
+            }
+            w = v;
+            // determine facet polynomials for w
+            List<GenPolynomial<C>> iG = new ArrayList<GenPolynomial<C>>();
+            int i = 0;
+            for (GenPolynomial<C> f : Giter) {
+                ExpVector h = marks.get(i++);
+                GenPolynomial<C> ing = f.leadingFacetPolynomial(h, w);
+                if (debug) {
+                    logger.info("ing_g = [" + ing + "], lt(ing) = "
+                                    + ing.ring.toScript(ing.leadingExpVector()) + ", f = "
+                                    + f.ring.toScript(f.leadingExpVector()));
+                }
+                iG.add(ing);
+            }
+            List<GenPolynomial<C>> inOmega = ufac.copy(iG);
+            if (debug) {
+                logger.info("inOmega = " + inOmega);
+                logger.info("inOmega.ring: " + inOmega.get(0).ring.toScript());
+            }
+
+            // INVLEX / target term order GB of inOmega
+            List<GenPolynomial<C>> inOG = sgb.GB(modv, inOmega);
+            if (debug) {
+                logger.info("GB(inOmega) = " + inOG);
+            }
+            // remark polynomials 
+            marks.clear();
+            M.clear();
+            for (GenPolynomial<C> p : inOG) {
+                marks.add(p.leadingExpVector());
+                M.add(new Monomial<C>(p.leadingMonomial()));
+            }
+            logger.info("new marks/M = " + marks);
+            // lift and reduce
+            List<GenPolynomial<C>> G = liftReductas(M, Mp, Giter, inOG);
+            if (debug || (iter % iterPrint == 0)) {
+                logger.info("lift(" + iter + ") inOG, new GB: " + G);
+            }
+            if (G.size() == 1) { // will not happen
+                GenPolynomial<C> p = ufac.copy(G.get(0)); // change term order
+                G.clear();
+                G.add(p);
+                return G;
+            }
+            // iterate
+            Giter = G;
+            Mp.clear();
+            Mp.addAll(M);
+        }
+        return Giter;
+    }
+
+
+    /**
+     * Determine new facet normal.
+     * @param t1 old term order.
+     * @param t2 new term order.
+     * @param delta exponent vectors deltas.
+     * @param zero exponent vector.
+     * @param t2weight weight representation of t2.
+     * @return new facet normal v or null if no new facet normal exists.
+     */
+    public ExpVector facetNormal(TermOrder t1, TermOrder t2, Set<ExpVector> delta, ExpVector zero,
+                    long[][] t2weight) {
+        TermOrder.EVComparator ev1 = t1.getAscendComparator();
+        TermOrder.EVComparator ev2 = t2.getAscendComparator();
+        ExpVector v = null;
+        long d = 0; // = Long.MIN_VALUE;
+        for (ExpVector e : delta) {
+            if (ev1.compare(zero, e) >= 0 || ev2.compare(zero, e) <= 0) { //ring.evzero
+                //logger.info("skip e = " + e);
+                continue;
+            }
+            int s = 0;
+            long d2 = 0;
+            ExpVector vt = null;
+            ExpVector et = null;
+            if (v == null) {
+                v = e;
+                logger.info("init v = " + v);
+                continue;
+            }
+            for (long[] tau : t2weight) {
+                //logger.info("current tau = " + Arrays.toString(tau));
+                //compare
+                d = v.weightDeg(tau);
+                d2 = e.weightDeg(tau);
+                vt = v.scalarMultiply(d2);
+                et = e.scalarMultiply(d);
+                s = ev1.compare(et, vt);
+                if (s == 0) {
+                    continue; // next tau
+                } else if (s > 0) { // <, (> by example)
+                    v = e;
+                    break;
+                } else {
+                    break;
+                }
+            }
+            //logger.info("step s  = " + s + ", d = " + d + ", d2 = " + d2 + ", e = " + e); 
+            //   + ", v = " + v + ", et = " + et + ", vt = " + vt);
+        }
+        return v;
+    }
+
+
+    /**
+     * Cleanup and terminate ThreadPool.
+     */
+    @Override
+    public void terminate() {
+        if (sgb == null) {
+            return;
+        }
+        sgb.terminate();
+    }
+
+
+    /**
+     * Cancel ThreadPool.
+     */
+    @Override
+    public int cancel() {
+        if (sgb == null) {
+            return 0;
+        }
+        return sgb.cancel();
+    }
+
+
+    /**
+     * Lift leading polynomials to full Groebner base with respect to term
+     * order.
+     * @param M new leading monomial list of polynomials as marks.
+     * @param Mp old leading monomial list of polynomials as marks.
+     * @param G Groebner base polynomials for lift.
+     * @param A polynomial list of leading omega polynomials to lift.
+     * @return lift(A) a Groebner base wrt M of ideal(G).
+     */
+    public List<GenPolynomial<C>> liftReductas(List<Monomial<C>> M, List<Monomial<C>> Mp,
+                    List<GenPolynomial<C>> G, List<GenPolynomial<C>> A) {
+        if (G == null || M == null || Mp == null || G.isEmpty()) {
+            throw new IllegalArgumentException("null or empty lists not allowed");
+        }
+        if (A == null || A.isEmpty()) {
+            return A;
+        }
+        if (G.size() != Mp.size() || A.size() != M.size()) {
+            throw new IllegalArgumentException("equal sized lists required");
+        }
+        GenPolynomial<C> pol = G.get(0);
+        if (pol == null) {
+            throw new IllegalArgumentException("null polynomial not allowed");
+        }
+        // remove mark monomials
+        List<GenPolynomial<C>> Gp = new ArrayList<GenPolynomial<C>>(G.size());
+        int i = 0;
+        int len = G.size();
+        for (i = 0; i < len; i++) {
+            Monomial<C> mon = Mp.get(i);
+            GenPolynomial<C> s = G.get(i).subtract(mon);
+            Gp.add(s);
+        }
+        if (debug) {
+            logger.info("lifter GB: Gp  = " + Gp + ", Mp = " + Mp);
+        }
+        // compute f^Gp for f in A
+        //GenPolynomialRing<C> oring = pol.ring;
+        logger.info("liftReductas: G = " + G.size() + ", Mp = " + Mp.size()); // + ", old = " + oring.toScript());
+        List<GenPolynomial<C>> Ap = A; //oring.copy(A);
+        //logger.info("to lift Ap = " + Ap);
+        ReductionAbstract<C> sred = (ReductionAbstract<C>) sgb.red; //new ReductionSeq<C>();
+        List<GenPolynomial<C>> red = new ArrayList<GenPolynomial<C>>();
+        GenPolynomialRing<C> tring = A.get(0).ring;
+        len = Ap.size();
+        for (i = 0; i < len; i++) {
+            GenPolynomial<C> a = Ap.get(i);
+            GenPolynomial<C> r = sred.normalformMarked(Mp, Gp, a);
+            red.add(r);
+        }
+        logger.info("liftReductas: red(A) = " + red.size());
+        // combine f - f^Gp in tring
+        if (debug) {
+            logger.info("tring = " + tring.toScript()); // + ", M = " + M);
+        }
+        List<GenPolynomial<C>> nb = new ArrayList<GenPolynomial<C>>(red.size());
+        for (i = 0; i < A.size(); i++) {
+            GenPolynomial<C> x = tring.copy(A.get(i)); // Ap? A!
+            GenPolynomial<C> r = tring.copy(red.get(i));
+            GenPolynomial<C> s = x.subtract(r);
+            Monomial<C> m = M.get(i);
+            s.doAddTo(m.coefficient().negate(), m.exponent()); // remove marked term
+            if (!s.coefficient(m.exponent()).isZERO()) {
+                System.out.println("L-M: x = " + x + ", r = " + r);
+                throw new IllegalArgumentException("mark not removed: " + s + ", m = " + m);
+            }
+            nb.add(s);
+        }
+        if (debug) {
+            logger.info("lifted-M, nb = " + nb.size());
+        }
+        // minimal GB with preserved marks
+        //Collections.reverse(nb); // important for lex GB
+        len = nb.size();
+        i = 0;
+        while (i < len) {
+            GenPolynomial<C> a = nb.remove(0);
+            Monomial<C> m = M.remove(0); // in step with element from nb
+            if (debug) {
+                logger.info("doing " + a + ", lt = " + tring.toScript(m.exponent()));
+            }
+            //a = sgb.red.normalform(nb, a);
+            a = sred.normalformMarked(M, nb, a);
+            if (debug) {
+                logger.info("done, a = " + a + ", lt = " + tring.toScript(a.leadingExpVector()));
+            }
+            nb.add(a); // adds as last
+            M.add(m);
+            i++;
+        }
+        // re-add mark after minimal
+        for (i = 0; i < len; i++) {
+            GenPolynomial<C> a = nb.get(i);
+            Monomial<C> m = M.get(i);
+            a.doAddTo(m.coefficient(), m.exponent()); // re-add marked term
+            nb.set(i, a);
+        }
+        logger.info("liftReductas: nb = " + nb.size() + ", M = " + M.size());
+        //Collections.reverse(nb); // undo reverse
+        return nb;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/MultiplicativeSet.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/MultiplicativeSet.java
@@ -1,0 +1,300 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Multiplicative set of polynomials. a, b in M implies a*b in M, 1 in M.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+public class MultiplicativeSet<C extends GcdRingElem<C>> implements Serializable {
+
+
+    private static final Logger logger = LogManager.getLogger(MultiplicativeSet.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Data structure.
+     */
+    public final List<GenPolynomial<C>> mset;
+
+
+    /**
+     * Polynomial ring factory.
+     */
+    public final GenPolynomialRing<C> ring;
+
+
+    /**
+     * MultiplicativeSet constructor. Constructs an empty multiplicative set.
+     * @param ring polynomial ring factory for coefficients.
+     */
+    public MultiplicativeSet(GenPolynomialRing<C> ring) {
+        this(ring, new ArrayList<GenPolynomial<C>>());
+        if (ring == null) {
+            throw new IllegalArgumentException("only for non null rings");
+        }
+    }
+
+
+    /**
+     * MultiplicativeSet constructor.
+     * @param ring polynomial ring factory for coefficients.
+     * @param ms a list of non-zero polynomials.
+     */
+    protected MultiplicativeSet(GenPolynomialRing<C> ring, List<GenPolynomial<C>> ms) {
+        if (ms == null || ring == null) {
+            throw new IllegalArgumentException("only for non null parts");
+        }
+        this.ring = ring;
+        mset = ms;
+    }
+
+
+    /**
+     * toString.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "MultiplicativeSet" + mset;
+    }
+
+
+    /**
+     * Equals.
+     * @param ob an Object.
+     * @return true if this is equal to o, else false.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object ob) {
+        MultiplicativeSet<C> c = null;
+        try {
+            c = (MultiplicativeSet<C>) ob;
+        } catch (ClassCastException e) {
+            return false;
+        }
+        if (c == null) {
+            return false;
+        }
+        if (!ring.equals(c.ring)) {
+            return false;
+        }
+        return mset.equals(c.mset);
+    }
+
+
+    /**
+     * Hash code for this condition.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = ring.hashCode();
+        h = h << 17;
+        h += mset.hashCode();
+        return h;
+    }
+
+
+    /**
+     * Is set.
+     * @return true if this is the empty set, else false.
+     */
+    public boolean isEmpty() {
+        return mset.size() == 0;
+    }
+
+
+    /**
+     * Test if a polynomial is contained in this multiplicative set.
+     * @param c polynomial searched in mset.
+     * @return true, if c = prod_{m in mset} m, else false
+     */
+    public boolean contains(GenPolynomial<C> c) {
+        if (c == null || c.isZERO()) {
+            return false;
+        }
+        if (c.isConstant()) {
+            return true;
+        }
+        if (mset.isEmpty()) {
+            return false;
+        }
+        GenPolynomial<C> d = c;
+        for (GenPolynomial<C> n : mset) {
+            // System.out.println("mset n = " + n);
+            if (n.isONE()) { // do not use 1
+                continue;
+            }
+            GenPolynomial<C> q, r;
+            do {
+                GenPolynomial<C>[] qr = d.quotientRemainder(n);
+                q = qr[0];
+                r = qr[1];
+                // System.out.println("q = " + q + ", r = " + r + ", d = " + d +
+                // ", n = " + n);
+                if (!r.isZERO()) {
+                    continue;
+                }
+                if (q.isConstant()) {
+                    return true;
+                }
+                d = q;
+            } while (r.isZERO() && !d.isConstant());
+        }
+        return d.isConstant(); // false
+    }
+
+
+    /**
+     * Test if a list of polynomials is contained in multiplicative set.
+     * @param L list of polynomials to be searched in mset.
+     * @return true, if all c in L are in mset, else false
+     */
+    public boolean contains(List<GenPolynomial<C>> L) {
+        if (L == null || L.size() == 0) {
+            return true;
+        }
+        for (GenPolynomial<C> c : L) {
+            if (!contains(c)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Add polynomial to mset.
+     * @param cc polynomial to be added to mset.
+     * @return new multiplicative set. <b>Note:</b> must be overridden in
+     *         sub-classes.
+     */
+    public MultiplicativeSet<C> add(GenPolynomial<C> cc) {
+        if (cc == null || cc.isZERO() || cc.isConstant()) {
+            return this;
+        }
+        if (ring.coFac.isField()) {
+            cc = cc.monic();
+        }
+        List<GenPolynomial<C>> list;
+        if (mset.size() == 0) {
+            list = new ArrayList<GenPolynomial<C>>(1);
+            list.add(cc);
+            return new MultiplicativeSet<C>(ring, list);
+        }
+        GenPolynomial<C> c = removeFactors(cc);
+        if (c.isConstant()) {
+            logger.info("skipped unit or constant = " + c);
+            return this;
+        }
+        if (ring.coFac.isField()) {
+            c = c.monic();
+        }
+        if (mset.size() == 0) {
+            logger.info("added to empty mset = " + c);
+        } else {
+            logger.info("added to mset = " + c);
+        }
+        list = new ArrayList<GenPolynomial<C>>(mset);
+        list.add(c);
+        return new MultiplicativeSet<C>(ring, list);
+    }
+
+
+    /**
+     * Replace polynomial list of mset.
+     * @param L polynomial list to replace mset.
+     * @return new multiplicative set. <b>Note:</b> must be overridden in
+     *         sub-classes.
+     */
+    public MultiplicativeSet<C> replace(List<GenPolynomial<C>> L) {
+        MultiplicativeSet<C> ms = new MultiplicativeSet<C>(ring);
+        if (L == null || L.size() == 0) {
+            return ms;
+        }
+        for (GenPolynomial<C> p : L) {
+            ms = ms.add(p);
+        }
+        return ms;
+    }
+
+
+    /**
+     * Remove factors by mset factors division.
+     * @param cc polynomial to be removed factors from mset.
+     * @return quotient polynomial.
+     */
+    public GenPolynomial<C> removeFactors(GenPolynomial<C> cc) {
+        if (cc == null || cc.isZERO() || cc.isConstant()) {
+            return cc;
+        }
+        if (mset.size() == 0) {
+            return cc;
+        }
+        GenPolynomial<C> c = cc;
+        for (GenPolynomial<C> n : mset) {
+            if (n.isConstant()) { // do not use 1, should not be in mset
+                continue;
+            }
+            GenPolynomial<C> q, r;
+            do {
+                GenPolynomial<C>[] qr = c.quotientRemainder(n);
+                q = qr[0];
+                r = qr[1];
+                if (!r.isZERO()) {
+                    continue;
+                }
+                if (q.isConstant()) {
+                    return q;
+                }
+                c = q;
+            } while (r.isZERO() && !c.isConstant());
+        }
+        return c;
+    }
+
+
+    /**
+     * Remove factors by mset factors division.
+     * @param L list of polynomial to be removed factors from mset.
+     * @return quotient polynomial list.
+     */
+    public List<GenPolynomial<C>> removeFactors(List<GenPolynomial<C>> L) {
+        if (L == null || L.size() == 0) {
+            return L;
+        }
+        if (mset.size() == 0) {
+            return L;
+        }
+        List<GenPolynomial<C>> M = new ArrayList<GenPolynomial<C>>(L.size());
+        for (GenPolynomial<C> p : L) {
+            p = removeFactors(p);
+            // nono, really: if ( !p.isConstant() ) {
+            M.add(p);
+        }
+        return M;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/MultiplicativeSetCoPrime.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/MultiplicativeSetCoPrime.java
@@ -1,0 +1,151 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.ufd.GCDFactory;
+import edu.jas.ufd.GreatestCommonDivisorAbstract;
+
+
+/**
+ * Multiplicative set of co-prime polynomials. a, b in M implies a*b in M, 1 in
+ * M.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+public class MultiplicativeSetCoPrime<C extends GcdRingElem<C>> extends MultiplicativeSet<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(MultiplicativeSetCoPrime.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Gcd computation engine.
+     */
+    protected final GreatestCommonDivisorAbstract<C> engine;
+
+
+    /**
+     * MultiplicativeSet constructor. Constructs an empty multiplicative set.
+     * @param ring polynomial ring factory for coefficients.
+     */
+    public MultiplicativeSetCoPrime(GenPolynomialRing<C> ring) {
+        super(ring);
+        engine = GCDFactory.getProxy(ring.coFac);
+    }
+
+
+    /**
+     * MultiplicativeSet constructor.
+     * @param ring polynomial ring factory for coefficients.
+     * @param ms a list of non-zero polynomials.
+     * @param eng gcd computation engine.
+     */
+    protected MultiplicativeSetCoPrime(GenPolynomialRing<C> ring, List<GenPolynomial<C>> ms,
+                    GreatestCommonDivisorAbstract<C> eng) {
+        super(ring, ms);
+        engine = eng;
+    }
+
+
+    /**
+     * toString.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "MultiplicativeSetCoPrime" + mset;
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object B) {
+        if (!(B instanceof MultiplicativeSetCoPrime)) {
+            return false;
+        }
+        return super.equals(B);
+    }
+
+
+    /**
+     * Hash code for this multiplicative set.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+
+    /**
+     * Add polynomial to mset.
+     * @param cc polynomial to be added to mset.
+     * @return new multiplicative set.
+     */
+    @Override
+    public MultiplicativeSetCoPrime<C> add(GenPolynomial<C> cc) {
+        if (cc == null || cc.isZERO() || cc.isConstant()) {
+            return this;
+        }
+        if (ring.coFac.isField()) {
+            cc = cc.monic();
+        }
+        List<GenPolynomial<C>> list;
+        if (mset.size() == 0) {
+            list = engine.coPrime(cc, mset);
+            if (ring.coFac.isField()) {
+                list = PolyUtil.<C> monic(list);
+            }
+            return new MultiplicativeSetCoPrime<C>(ring, list, engine);
+        }
+        GenPolynomial<C> c = removeFactors(cc);
+        if (c.isConstant()) {
+            logger.info("skipped unit or constant = " + c);
+            return this;
+        }
+        logger.info("added to co-prime mset = " + c);
+        list = engine.coPrime(c, mset);
+        if (ring.coFac.isField()) {
+            list = PolyUtil.<C> monic(list);
+        }
+        return new MultiplicativeSetCoPrime<C>(ring, list, engine);
+    }
+
+
+    /**
+     * Replace polynomial list of mset.
+     * @param L polynomial list to replace mset.
+     * @return new multiplicative set.
+     */
+    @Override
+    public MultiplicativeSetCoPrime<C> replace(List<GenPolynomial<C>> L) {
+        MultiplicativeSetCoPrime<C> ms = new MultiplicativeSetCoPrime<C>(ring);
+        if (L == null || L.size() == 0) {
+            return ms;
+        }
+        for (GenPolynomial<C> p : L) {
+            ms = ms.add(p);
+        }
+        return ms;
+    }
+
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/MultiplicativeSetFactors.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/MultiplicativeSetFactors.java
@@ -1,0 +1,152 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.ufd.FactorAbstract;
+import edu.jas.ufd.FactorFactory;
+
+
+/**
+ * Multiplicative set of irreducible polynomials. a, b in M implies a*b in M, 1
+ * in M.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+public class MultiplicativeSetFactors<C extends GcdRingElem<C>> extends MultiplicativeSet<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(MultiplicativeSetFactors.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Factors decomposition engine.
+     */
+    protected final FactorAbstract<C> engine;
+
+
+    /**
+     * MultiplicativeSet constructor. Constructs an empty multiplicative set.
+     * @param ring polynomial ring factory for coefficients.
+     */
+    public MultiplicativeSetFactors(GenPolynomialRing<C> ring) {
+        super(ring);
+        engine = FactorFactory.getImplementation(ring.coFac);
+    }
+
+
+    /**
+     * MultiplicativeSet constructor.
+     * @param ring polynomial ring factory for coefficients.
+     * @param ms a list of non-zero polynomials.
+     * @param eng factorization engine.
+     */
+    protected MultiplicativeSetFactors(GenPolynomialRing<C> ring, List<GenPolynomial<C>> ms,
+                    FactorAbstract<C> eng) {
+        super(ring, ms);
+        engine = eng;
+    }
+
+
+    /**
+     * toString.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "MultiplicativeSetFactors" + mset;
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object B) {
+        if (!(B instanceof MultiplicativeSetFactors)) {
+            return false;
+        }
+        return super.equals(B);
+    }
+
+
+    /**
+     * Hash code for this multiplicative set.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+
+    /**
+     * Add polynomial to mset.
+     * @param cc polynomial to be added to mset.
+     * @return new multiplicative set.
+     */
+    @Override
+    public MultiplicativeSetFactors<C> add(GenPolynomial<C> cc) {
+        if (cc == null || cc.isZERO() || cc.isConstant()) {
+            return this;
+        }
+        if (ring.coFac.isField()) {
+            cc = cc.monic();
+        }
+        GenPolynomial<C> c = removeFactors(cc);
+        if (c.isConstant()) {
+            logger.info("skipped unit or constant = " + c);
+            return this;
+        }
+        List<GenPolynomial<C>> list = engine.factorsRadical(c);
+        logger.info("factorsRadical = " + list);
+        if (ring.coFac.isField()) {
+            list = PolyUtil.<C> monic(list);
+        }
+        List<GenPolynomial<C>> ms = new ArrayList<GenPolynomial<C>>(mset);
+        for (GenPolynomial<C> p : list) {
+            if (!p.isConstant() && !p.isZERO()) {
+                if (!mset.contains(p)) {
+                    logger.info("added to irreducible mset = " + p);
+                    ms.add(p);
+                }
+            }
+        }
+        return new MultiplicativeSetFactors<C>(ring, ms, engine);
+    }
+
+
+    /**
+     * Replace polynomial list of mset.
+     * @param L polynomial list to replace mset.
+     * @return new multiplicative set.
+     */
+    @Override
+    public MultiplicativeSetFactors<C> replace(List<GenPolynomial<C>> L) {
+        MultiplicativeSetFactors<C> ms = new MultiplicativeSetFactors<C>(ring);
+        if (L == null || L.size() == 0) {
+            return ms;
+        }
+        for (GenPolynomial<C> p : L) {
+            ms = ms.add(p);
+        }
+        return ms;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/MultiplicativeSetSquarefree.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/MultiplicativeSetSquarefree.java
@@ -1,0 +1,150 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.ufd.SquarefreeAbstract;
+import edu.jas.ufd.SquarefreeFactory;
+
+
+/**
+ * Multiplicative set of squarefree and co-prime polynomials. a, b in M implies
+ * a*b in M, 1 in M.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+public class MultiplicativeSetSquarefree<C extends GcdRingElem<C>> extends MultiplicativeSet<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(MultiplicativeSetSquarefree.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Squarefree decomposition engine.
+     */
+    protected final SquarefreeAbstract<C> engine;
+
+
+    /**
+     * MultiplicativeSet constructor. Constructs an empty multiplicative set.
+     * @param ring polynomial ring factory for coefficients.
+     */
+    public MultiplicativeSetSquarefree(GenPolynomialRing<C> ring) {
+        super(ring);
+        engine = SquarefreeFactory.getImplementation(ring.coFac);
+    }
+
+
+    /**
+     * MultiplicativeSet constructor.
+     * @param ring polynomial ring factory for coefficients.
+     * @param ms a list of non-zero polynomials.
+     * @param eng squarefree factorization engine.
+     */
+    protected MultiplicativeSetSquarefree(GenPolynomialRing<C> ring, List<GenPolynomial<C>> ms,
+                    SquarefreeAbstract<C> eng) {
+        super(ring, ms);
+        engine = eng;
+    }
+
+
+    /**
+     * toString.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "MultiplicativeSetSquarefree" + mset;
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object B) {
+        if (!(B instanceof MultiplicativeSetSquarefree)) {
+            return false;
+        }
+        return super.equals(B);
+    }
+
+
+    /**
+     * Hash code for this multiplicative set.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+
+    /**
+     * Add polynomial to mset.
+     * @param cc polynomial to be added to mset.
+     * @return new multiplicative set.
+     */
+    @Override
+    public MultiplicativeSetSquarefree<C> add(GenPolynomial<C> cc) {
+        if (cc == null || cc.isZERO() || cc.isConstant()) {
+            return this;
+        }
+        if (ring.coFac.isField()) {
+            cc = cc.monic();
+        }
+        List<GenPolynomial<C>> list;
+        if (mset.size() == 0) {
+            list = engine.coPrimeSquarefree(cc, mset);
+            if (ring.coFac.isField()) {
+                list = PolyUtil.<C> monic(list);
+            }
+            return new MultiplicativeSetSquarefree<C>(ring, list, engine);
+        }
+        GenPolynomial<C> c = removeFactors(cc);
+        if (c.isConstant()) {
+            logger.info("skipped unit or constant = " + c);
+            return this;
+        }
+        logger.info("added to squarefree mset = " + c);
+        list = engine.coPrimeSquarefree(c, mset);
+        if (ring.coFac.isField()) {
+            list = PolyUtil.<C> monic(list);
+        }
+        return new MultiplicativeSetSquarefree<C>(ring, list, engine);
+    }
+
+
+    /**
+     * Replace polynomial list of mset.
+     * @param L polynomial list to replace mset.
+     * @return new multiplicative set.
+     */
+    @Override
+    public MultiplicativeSetSquarefree<C> replace(List<GenPolynomial<C>> L) {
+        MultiplicativeSetSquarefree<C> ms = new MultiplicativeSetSquarefree<C>(ring);
+        if (L == null || L.size() == 0) {
+            return ms;
+        }
+        for (GenPolynomial<C> p : L) {
+            ms = ms.add(p);
+        }
+        return ms;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/OrderedRPairlist.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/OrderedRPairlist.java
@@ -1,0 +1,162 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.Map;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.OrderedPairlist;
+import edu.jas.gb.Pair;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.structure.RegularRingElem;
+
+/**
+ * Pair list management for R-Groebner bases.
+ * Implemented using GenPolynomial, TreeMap and BitSet.
+ * @author Heinz Kredel
+ */
+
+public class OrderedRPairlist<C extends RegularRingElem<C> > 
+    extends OrderedPairlist<C> {
+
+    private static final Logger logger = LogManager.getLogger(OrderedRPairlist.class);
+
+    protected final RReduction<C> rreduction;
+
+
+    /**
+     * Constructor for OrderedRPairlist.
+     * @param r polynomial factory.
+     */
+    public OrderedRPairlist(GenPolynomialRing<C> r) {
+        this(0,r);
+    }
+
+
+    /**
+     * Constructor for OrderedRPairlist.
+     * @param m number of module variables.
+     * @param r polynomial factory.
+     */
+    public OrderedRPairlist(int m, GenPolynomialRing<C> r) {
+        super(m,r);
+        rreduction = new RReductionSeq<C>();
+    }
+
+
+    /**
+     * Remove the next required pair from the pairlist and reduction matrix.
+     * Appy the criterions 3 and 4 to see if the S-polynomial is required.
+     * @return the next pair if one exists, otherwise null.
+     */
+    @Override
+    public synchronized Pair<C> removeNext() { 
+        if ( oneInGB ) {
+            return null;
+        }
+        Iterator< Map.Entry<ExpVector,LinkedList<Pair<C>>> > ip 
+            = pairlist.entrySet().iterator();
+
+        Pair<C> pair = null;
+        boolean c = false;
+        int i, j;
+
+        if  ( ip.hasNext() )  {
+            Map.Entry<ExpVector,LinkedList<Pair<C>>> me = ip.next();
+            ExpVector g =  me.getKey();
+            LinkedList<Pair<C>> xl = me.getValue();
+            if ( logger.isInfoEnabled() ) {
+                logger.info("g  = " + g);
+            }
+            pair = null;
+            if ( xl.size() > 0 ) {
+                pair = xl.removeFirst();
+                // xl is also modified in pairlist 
+                i = pair.i; 
+                j = pair.j; 
+                // System.out.println("pair(" + j + "," +i+") ");
+                if ( useCriterion4 ) {
+                    c = rreduction.criterion4( pair.pi, pair.pj, g ); 
+                } else {
+                    c = true;
+                }
+                pair.setUseCriterion4(c);
+                //System.out.println("c4  = " + c);  
+                if ( c ) {
+                    c = criterion3( i, j, g );
+                    //System.out.println("c3  = " + c); 
+                    pair.setUseCriterion3(c);
+                }
+                red.get( j ).clear(i); // set(i,false) jdk1.4
+            }
+            if ( xl.size() == 0 ) {
+                ip.remove(); 
+                // = pairlist.remove( g );
+            }
+        }
+        remCount++; // count pairs
+        return pair; 
+    }
+
+
+    /**
+     * GB criterium 3.
+     * @return true if the S-polynomial(i,j) is required.
+     */
+    @Override
+    public boolean criterion3(int i, int j, ExpVector eij) {  
+        // assert i < j;
+        boolean s;
+        s = red.get( j ).get(i); 
+        if ( ! s ) { 
+            logger.warn("c3.s false for " + j + " " + i); 
+            return s;
+        }
+        s = true;
+        boolean m;
+        GenPolynomial<C> A;
+        ExpVector ek;
+        C ci = P.get(i).leadingBaseCoefficient();
+        C cj = P.get(j).leadingBaseCoefficient();
+        C c = ci.multiply(cj); // a guess
+        C ck;
+        for ( int k = 0; k < P.size(); k++ ) {
+            A = P.get( k );
+            ek = A.leadingExpVector();
+            m = eij.multipleOf(ek);
+            if ( m ) {
+                ck = A.leadingBaseCoefficient();
+                C r = c.multiply(ck); // a guess
+                m = r.isZERO();
+            }
+            if ( m ) {
+                if ( k < i ) {
+                    // System.out.println("k < i "+k+" "+i); 
+                    s =    red.get( i ).get(k) 
+                        || red.get( j ).get(k); 
+                }
+                if ( i < k && k < j ) {
+                    // System.out.println("i < k < j "+i+" "+k+" "+j); 
+                    s =    red.get( k ).get(i) 
+                        || red.get( j ).get(k); 
+                }
+                if ( j < k ) {
+                    //System.out.println("j < k "+j+" "+k); 
+                    s =    red.get( k ).get(i) 
+                        || red.get( k ).get(j); 
+                }
+                //System.out.println("s."+k+" = " + s); 
+                if ( ! s ) return s;
+            }
+        }
+        return true;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/PolyGBUtil.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/PolyGBUtil.java
@@ -1,0 +1,739 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.gb.GroebnerBaseAbstract;
+import edu.jas.gb.SolvableGroebnerBaseAbstract;
+import edu.jas.gb.SolvableReductionAbstract;
+import edu.jas.gb.SolvableReductionSeq;
+import edu.jas.gb.WordGroebnerBaseAbstract;
+import edu.jas.gb.WordGroebnerBaseSeq;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.GenSolvablePolynomialRing;
+import edu.jas.poly.GenWordPolynomial;
+import edu.jas.poly.GenWordPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Package gbufd utilities.
+ * @author Heinz Kredel
+ */
+
+public class PolyGBUtil {
+
+
+    private static final Logger logger = LogManager.getLogger(PolyGBUtil.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Test for resultant.
+     * @param A generic polynomial.
+     * @param B generic polynomial.
+     * @param r generic polynomial.
+     * @return true if res(A,B) isContained in ideal(A,B), else false.
+     */
+    public static <C extends GcdRingElem<C>> boolean isResultant(GenPolynomial<C> A, GenPolynomial<C> B,
+                    GenPolynomial<C> r) {
+        if (r == null || r.isZERO()) {
+            return true;
+        }
+        GroebnerBaseAbstract<C> bb = GBFactory.<C> getImplementation(r.ring.coFac);
+        List<GenPolynomial<C>> F = new ArrayList<GenPolynomial<C>>(2);
+        F.add(A);
+        F.add(B);
+        List<GenPolynomial<C>> G = bb.GB(F);
+        //System.out.println("G = " + G);
+        GenPolynomial<C> n = bb.red.normalform(G, r);
+        //System.out.println("n = " + n);
+        return n.isZERO();
+    }
+
+
+    /**
+     * Top pseudo reduction wrt the main variables.
+     * @param P generic polynomial.
+     * @param A list of generic polynomials sorted according to appearing main
+     *            variables.
+     * @return top pseudo remainder of P wrt. A for the appearing variables.
+     */
+    public static <C extends RingElem<C>> GenPolynomial<C> topPseudoRemainder(List<GenPolynomial<C>> A,
+                    GenPolynomial<C> P) {
+        if (A == null || A.isEmpty()) {
+            return P.monic();
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        //System.out.println("remainder, P = " + P);
+        GenPolynomialRing<C> pfac = A.get(0).ring;
+        if (pfac.nvar <= 1) { // recursion base 
+            GenPolynomial<C> R = PolyUtil.<C> baseSparsePseudoRemainder(P, A.get(0));
+            return R.monic();
+        }
+        // select polynomials according to the main variable
+        GenPolynomialRing<GenPolynomial<C>> rfac = pfac.recursive(1);
+        GenPolynomial<C> Q = A.get(0); // wrong, must eventually search polynomial
+        GenPolynomial<GenPolynomial<C>> qr = PolyUtil.<C> recursive(rfac, Q);
+        GenPolynomial<GenPolynomial<C>> pr = PolyUtil.<C> recursive(rfac, P);
+        GenPolynomial<GenPolynomial<C>> rr;
+        if (qr.isONE()) {
+            return P.ring.getZERO();
+        }
+        if (qr.degree(0) > 0) {
+            rr = PolyUtil.<C> recursiveSparsePseudoRemainder(pr, qr);
+            //System.out.println("remainder, pr = " + pr);
+            //System.out.println("remainder, qr = " + qr);
+            //System.out.println("remainder, rr = " + rr);
+        } else {
+            rr = pr;
+        }
+        if (rr.degree(0) > 0) {
+            GenPolynomial<C> R = PolyUtil.<C> distribute(pfac, rr);
+            return R.monic();
+            // not further reduced wrt. other variables = top-reduction only
+        }
+        List<GenPolynomial<C>> zeroDeg = zeroDegrees(A);
+        GenPolynomial<C> R = topPseudoRemainder(zeroDeg, rr.leadingBaseCoefficient());
+        R = R.extend(pfac, 0, 0L);
+        return R.monic();
+    }
+
+
+    /**
+     * Top coefficient pseudo remainder of the leading coefficient of P wrt A in
+     * the main variables.
+     * @param P generic polynomial in n+1 variables.
+     * @param A list of generic polynomials in n variables sorted according to
+     *            appearing main variables.
+     * @return pseudo remainder of the leading coefficient of P wrt A.
+     */
+    public static <C extends RingElem<C>> GenPolynomial<C> topCoefficientPseudoRemainder(
+                    List<GenPolynomial<C>> A, GenPolynomial<C> P) {
+        if (A == null || A.isEmpty()) {
+            return P.monic();
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        GenPolynomialRing<C> pfac = P.ring;
+        GenPolynomialRing<C> pfac1 = A.get(0).ring;
+        if (pfac1.nvar <= 1) { // recursion base 
+            GenPolynomial<C> a = A.get(0);
+            GenPolynomialRing<GenPolynomial<C>> rfac = pfac.recursive(pfac.nvar - 1);
+            GenPolynomial<GenPolynomial<C>> pr = PolyUtil.<C> recursive(rfac, P);
+            // ldcf(P,x_m) = q a + r 
+            GenPolynomial<GenPolynomial<C>> rr = PolyGBUtil.<C> coefficientPseudoRemainderBase(pr, a);
+            GenPolynomial<C> R = PolyUtil.<C> distribute(pfac, rr);
+            return R.monic();
+        }
+        // select polynomials according to the main variable
+        GenPolynomialRing<GenPolynomial<C>> rfac1 = pfac1.recursive(1);
+        int nv = pfac.nvar - pfac1.nvar;
+        GenPolynomialRing<GenPolynomial<C>> rfac = pfac.recursive(1 + nv);
+        GenPolynomialRing<GenPolynomial<GenPolynomial<C>>> rfac2 = rfac.recursive(nv);
+        if (debug) {
+            logger.info("rfac =" + rfac);
+        }
+        GenPolynomial<GenPolynomial<C>> pr = PolyUtil.<C> recursive(rfac, P);
+        GenPolynomial<GenPolynomial<GenPolynomial<C>>> pr2 = PolyUtil.<GenPolynomial<C>> recursive(rfac2, pr);
+        //System.out.println("recursion, pr2 = " + pr2);
+        GenPolynomial<C> Q = A.get(0);
+        GenPolynomial<GenPolynomial<C>> qr = PolyUtil.<C> recursive(rfac1, Q);
+        GenPolynomial<GenPolynomial<GenPolynomial<C>>> rr;
+        if (qr.isONE()) {
+            return P.ring.getZERO();
+        }
+        if (qr.degree(0) > 0) {
+            // pseudo remainder:  ldcf(P,x_m) = a q + r 
+            rr = PolyGBUtil.<C> coefficientPseudoRemainder(pr2, qr);
+            //System.out.println("recursion, qr  = " + qr);
+            //System.out.println("recursion, pr  = " + pr2);
+            //System.out.println("recursion, rr  = " + rr);
+        } else {
+            rr = pr2;
+        }
+        // reduction wrt. the other variables
+        List<GenPolynomial<C>> zeroDeg = zeroDegrees(A);
+        GenPolynomial<GenPolynomial<C>> Rr = PolyUtil.<GenPolynomial<C>> distribute(rfac, rr);
+        GenPolynomial<C> R = PolyUtil.<C> distribute(pfac, Rr);
+        R = topCoefficientPseudoRemainder(zeroDeg, R);
+        return R.monic();
+    }
+
+
+    /**
+     * Polynomial leading coefficient pseudo remainder.
+     * @param P generic polynomial in n+1 variables.
+     * @param A generic polynomial in n variables.
+     * @return pseudo remainder of the leading coefficient of P wrt A, with
+     *         ldcf(A)<sup>m'</sup> P = quotient * A + remainder.
+     */
+    public static <C extends RingElem<C>> GenPolynomial<GenPolynomial<GenPolynomial<C>>> coefficientPseudoRemainder(
+                    GenPolynomial<GenPolynomial<GenPolynomial<C>>> P, GenPolynomial<GenPolynomial<C>> A) {
+        if (A == null || A.isZERO()) { // findbugs
+            throw new ArithmeticException(P + " division by zero " + A);
+        }
+        if (A.isONE()) {
+            return P.ring.getZERO();
+        }
+        if (P.isZERO() || P.isONE()) {
+            return P;
+        }
+        GenPolynomialRing<GenPolynomial<GenPolynomial<C>>> pfac = P.ring;
+        GenPolynomialRing<GenPolynomial<C>> afac = A.ring; // == pfac.coFac
+        GenPolynomial<GenPolynomial<GenPolynomial<C>>> r = P;
+        GenPolynomial<GenPolynomial<C>> h;
+        GenPolynomial<GenPolynomial<GenPolynomial<C>>> hr;
+        GenPolynomial<GenPolynomial<C>> ldcf = P.leadingBaseCoefficient();
+        long m = ldcf.degree(0);
+        long n = A.degree(0);
+        GenPolynomial<C> c = A.leadingBaseCoefficient();
+        GenPolynomial<GenPolynomial<C>> cc = afac.getZERO().sum(c);
+        //System.out.println("cc = " + cc);
+        ExpVector e = A.leadingExpVector();
+        for (long i = m; i >= n; i--) {
+            if (r.isZERO()) {
+                return r;
+            }
+            GenPolynomial<GenPolynomial<C>> p = r.leadingBaseCoefficient();
+            ExpVector g = r.leadingExpVector();
+            long k = p.degree(0);
+            if (i == k) {
+                GenPolynomial<C> pl = p.leadingBaseCoefficient();
+                ExpVector f = p.leadingExpVector();
+                f = f.subtract(e);
+                r = r.multiply(cc); // coeff cc
+                h = A.multiply(pl, f); // coeff ac
+                hr = new GenPolynomial<GenPolynomial<GenPolynomial<C>>>(pfac, h, g);
+                r = r.subtract(hr);
+            } else {
+                r = r.multiply(cc);
+            }
+            //System.out.println("r = " + r);
+        }
+        if (r.degree(0) < P.degree(0)) { // recursion for degree
+            r = coefficientPseudoRemainder(r, A);
+        }
+        return r;
+    }
+
+
+    /**
+     * Polynomial leading coefficient pseudo remainder, base case.
+     * @param P generic polynomial in 1+1 variables.
+     * @param A generic polynomial in 1 variable.
+     * @return pseudo remainder of the leading coefficient of P wrt. A, with
+     *         ldcf(A)<sup>m'</sup> P = quotient * A + remainder.
+     */
+    public static <C extends RingElem<C>> GenPolynomial<GenPolynomial<C>> coefficientPseudoRemainderBase(
+                    GenPolynomial<GenPolynomial<C>> P, GenPolynomial<C> A) {
+        if (A == null || A.isZERO()) { // findbugs
+            throw new ArithmeticException(P + " division by zero " + A);
+        }
+        if (A.isONE()) {
+            return P.ring.getZERO();
+        }
+        if (P.isZERO() || P.isONE()) {
+            return P;
+        }
+        GenPolynomialRing<GenPolynomial<C>> pfac = P.ring;
+        GenPolynomialRing<C> afac = A.ring; // == pfac.coFac
+        GenPolynomial<GenPolynomial<C>> r = P;
+        GenPolynomial<C> h;
+        GenPolynomial<GenPolynomial<C>> hr;
+        GenPolynomial<C> ldcf = P.leadingBaseCoefficient();
+        long m = ldcf.degree(0);
+        long n = A.degree(0);
+        C c = A.leadingBaseCoefficient();
+        GenPolynomial<C> cc = afac.getZERO().sum(c);
+        //System.out.println("cc = " + cc);
+        ExpVector e = A.leadingExpVector();
+        for (long i = m; i >= n; i--) {
+            if (r.isZERO()) {
+                return r;
+            }
+            GenPolynomial<C> p = r.leadingBaseCoefficient();
+            ExpVector g = r.leadingExpVector();
+            long k = p.degree(0);
+            if (i == k) {
+                C pl = p.leadingBaseCoefficient();
+                ExpVector f = p.leadingExpVector();
+                f = f.subtract(e);
+                r = r.multiply(cc); // coeff cc
+                h = A.multiply(pl, f); // coeff ac
+                hr = new GenPolynomial<GenPolynomial<C>>(pfac, h, g);
+                r = r.subtract(hr);
+            } else {
+                r = r.multiply(cc);
+            }
+            //System.out.println("r = " + r);
+        }
+        if (r.degree(0) < P.degree(0)) { // recursion for degree
+            r = coefficientPseudoRemainderBase(r, A);
+        }
+        return r;
+    }
+
+
+    /**
+     * Extract polynomials with degree zero in the main variable.
+     * @param A list of generic polynomials in n variables.
+     * @return Z = [a_i] with deg(a_i,x_n) = 0 and in n-1 variables.
+     */
+    public static <C extends RingElem<C>> List<GenPolynomial<C>> zeroDegrees(List<GenPolynomial<C>> A) {
+        if (A == null || A.isEmpty()) {
+            return A;
+        }
+        GenPolynomialRing<C> pfac = A.get(0).ring;
+        GenPolynomialRing<GenPolynomial<C>> rfac = pfac.recursive(1);
+        List<GenPolynomial<C>> zeroDeg = new ArrayList<GenPolynomial<C>>(A.size());
+        for (int i = 0; i < A.size(); i++) {
+            GenPolynomial<C> q = A.get(i);
+            GenPolynomial<GenPolynomial<C>> fr = PolyUtil.<C> recursive(rfac, q);
+            if (fr.degree(0) == 0) {
+                zeroDeg.add(fr.leadingBaseCoefficient());
+            }
+        }
+        return zeroDeg;
+    }
+
+
+    /**
+     * Intersection. Generators for the intersection of ideals.
+     * @param pfac polynomial ring
+     * @param A list of polynomials
+     * @param B list of polynomials
+     * @return generators for (A \cap B)
+     */
+    public static <C extends GcdRingElem<C>> List<GenPolynomial<C>> intersect(GenPolynomialRing<C> pfac,
+                    List<GenPolynomial<C>> A, List<GenPolynomial<C>> B) {
+        if (A == null || A.isEmpty()) { // (0)
+            return B;
+        }
+        if (B == null || B.isEmpty()) { // (0)
+            return A;
+        }
+        int s = A.size() + B.size();
+        List<GenPolynomial<C>> c = new ArrayList<GenPolynomial<C>>(s);
+        GenPolynomialRing<C> tfac = pfac.extend(1);
+        // term order is also adjusted
+        for (GenPolynomial<C> p : A) {
+            p = p.extend(tfac, 0, 1L); // t*p
+            c.add(p);
+        }
+        for (GenPolynomial<C> p : B) {
+            GenPolynomial<C> q = p.extend(tfac, 0, 1L);
+            GenPolynomial<C> r = p.extend(tfac, 0, 0L);
+            p = r.subtract(q); // (1-t)*p
+            c.add(p);
+        }
+        GroebnerBaseAbstract<C> bb = GBFactory.<C> getImplementation(tfac.coFac);
+        logger.warn("intersect computing GB");
+        List<GenPolynomial<C>> G = bb.GB(c);
+        if (debug) {
+            logger.debug("intersect GB = " + G);
+        }
+        List<GenPolynomial<C>> I = PolyUtil.<C> intersect(pfac, G);
+        return I;
+    }
+
+
+    /**
+     * Intersection. Generators for the intersection of ideals.
+     * @param pfac solvable polynomial ring
+     * @param A list of polynomials
+     * @param B list of polynomials
+     * @return generators for (A \cap B)
+     */
+    public static <C extends GcdRingElem<C>> List<GenSolvablePolynomial<C>> intersect(
+                    GenSolvablePolynomialRing<C> pfac, List<GenSolvablePolynomial<C>> A,
+                    List<GenSolvablePolynomial<C>> B) {
+        if (A == null || A.isEmpty()) { // (0)
+            return B;
+        }
+        if (B == null || B.isEmpty()) { // (0)
+            return A;
+        }
+        int s = A.size() + B.size();
+        List<GenSolvablePolynomial<C>> c = new ArrayList<GenSolvablePolynomial<C>>(s);
+        GenSolvablePolynomialRing<C> tfac = pfac.extend(1);
+        // term order is also adjusted
+        for (GenSolvablePolynomial<C> p : A) {
+            p = (GenSolvablePolynomial<C>) p.extend(tfac, 0, 1L); // t*p
+            c.add(p);
+        }
+        for (GenSolvablePolynomial<C> p : B) {
+            GenSolvablePolynomial<C> q = (GenSolvablePolynomial<C>) p.extend(tfac, 0, 1L);
+            GenSolvablePolynomial<C> r = (GenSolvablePolynomial<C>) p.extend(tfac, 0, 0L);
+            p = (GenSolvablePolynomial<C>) r.subtract(q); // (1-t)*p
+            c.add(p);
+        }
+        SolvableGroebnerBaseAbstract<C> sbb = SGBFactory.<C> getImplementation(tfac.coFac);
+        //new SolvableGroebnerBaseSeq<C>();
+        logger.warn("intersect computing GB");
+        List<GenSolvablePolynomial<C>> g = sbb.leftGB(c);
+        //List<GenSolvablePolynomial<C>> g = sbb.twosidedGB(c);
+        if (debug) {
+            logger.debug("intersect GB = " + g);
+        }
+        List<GenSolvablePolynomial<C>> I = PolyUtil.<C> intersect(pfac, g);
+        return I;
+    }
+
+
+    /**
+     * Intersection. Generators for the intersection of word ideals.
+     * @param pfac word polynomial ring
+     * @param A list of word polynomials
+     * @param B list of word polynomials
+     * @return generators for (A \cap B) if it exists
+     */
+    public static <C extends GcdRingElem<C>> List<GenWordPolynomial<C>> intersect(
+                    GenWordPolynomialRing<C> pfac, List<GenWordPolynomial<C>> A,
+                    List<GenWordPolynomial<C>> B) {
+        if (A == null || A.isEmpty()) { // (0)
+            return B;
+        }
+        if (B == null || B.isEmpty()) { // (0)
+            return A;
+        }
+        int s = A.size() + B.size();
+        List<GenWordPolynomial<C>> L = new ArrayList<GenWordPolynomial<C>>(s);
+        GenWordPolynomialRing<C> tfac = pfac.extend(1);
+        List<GenWordPolynomial<C>> gens = tfac.univariateList();
+        //System.out.println("gens = " + gens);
+        GenWordPolynomial<C> t = gens.get(gens.size() - 1);
+        //System.out.println("t = " + t);
+        // make t commute with other variables
+        for (GenWordPolynomial<C> p : gens) {
+            if (t == p) {
+                continue;
+            }
+            GenWordPolynomial<C> c = t.multiply(p).subtract(p.multiply(t)); // t p - p t
+            L.add(c);
+        }
+        for (GenWordPolynomial<C> p : A) {
+            p = tfac.valueOf(p).multiply(t); // t p
+            L.add(p);
+        }
+        for (GenWordPolynomial<C> p : B) {
+            GenWordPolynomial<C> q = tfac.valueOf(p).multiply(t);
+            GenWordPolynomial<C> r = tfac.valueOf(p);
+            p = r.subtract(q); // (1-t) p
+            L.add(p);
+        }
+        //System.out.println("L = " + L);
+        WordGroebnerBaseAbstract<C> bb = new WordGroebnerBaseSeq<C>();
+        logger.warn("intersect computing GB");
+        List<GenWordPolynomial<C>> G = bb.GB(L);
+        //System.out.println("G = " + G);
+        if (debug) {
+            logger.debug("intersect GB = " + G);
+        }
+        List<GenWordPolynomial<C>> I = PolyUtil.<C> intersect(pfac, G);
+        return I;
+    }
+
+
+    /**
+     * Solvable quotient and remainder via reduction.
+     * @param n first solvable polynomial.
+     * @param d second solvable polynomial.
+     * @return [ n/d, n - (n/d)*d ]
+     */
+    @SuppressWarnings({"cast","unchecked"})
+    public static <C extends GcdRingElem<C>> GenSolvablePolynomial<C>[] quotientRemainder(
+                    GenSolvablePolynomial<C> n, GenSolvablePolynomial<C> d) {
+        GenSolvablePolynomial<C>[] res = (GenSolvablePolynomial<C>[]) new GenSolvablePolynomial[2];
+        if (d.isZERO()) {
+            throw new RuntimeException("division by zero: " + n + "/" + d);
+        }
+        if (n.isZERO()) {
+            res[0] = n;
+            res[1] = n;
+            return res;
+        }
+        GenSolvablePolynomialRing<C> r = n.ring;
+        if (d.isONE()) {
+            res[0] = n;
+            res[1] = r.getZERO();
+            return res;
+        }
+        // divide
+        List<GenSolvablePolynomial<C>> Q = new ArrayList<GenSolvablePolynomial<C>>(1);
+        Q.add(r.getZERO());
+        List<GenSolvablePolynomial<C>> D = new ArrayList<GenSolvablePolynomial<C>>(1);
+        D.add(d);
+        SolvableReductionAbstract<C> sred = new SolvableReductionSeq<C>();
+        res[1] = sred.rightNormalform(Q, D, n); // left
+        res[0] = Q.get(0);
+        return res;
+    }
+
+
+    /**
+     * Subring generators.
+     * @param A list of polynomials in n variables.
+     * @return a Groebner base of polynomials in m &gt; n variables generating
+     *         the subring of K[A].
+     */
+    public static <C extends GcdRingElem<C>> List<GenPolynomial<C>> subRing(List<GenPolynomial<C>> A) {
+        if (A == null || A.isEmpty()) {
+            return A;
+        }
+        GenPolynomialRing<C> pfac = A.get(0).ring;
+        logger.debug("pfac = " + pfac.toScript());
+        int n = pfac.nvar;
+        List<GenPolynomial<C>> Ap = new ArrayList<GenPolynomial<C>>();
+        for (GenPolynomial<C> a : A) {
+            if (a == null || a.isZERO() || a.isONE()) {
+                continue;
+            }
+            Ap.add(a);
+        }
+        int k = Ap.size();
+        if (k == 0) {
+            return Ap;
+        }
+        GenPolynomialRing<C> rfac = pfac.extendLower(k);
+        logger.debug("rfac = " + rfac.toScript());
+        assert rfac.nvar == n + k : "rfac.nvar == n+k";
+        List<GenPolynomial<C>> sr = new ArrayList<GenPolynomial<C>>();
+        int i = 0;
+        for (GenPolynomial<C> a : Ap) {
+            GenPolynomial<C> b = a.extendLower(rfac, 0, 0L);
+            b = b.subtract(pfac.getONE().extendLower(rfac, i++, 1L));
+            //System.out.println("a = " + a);
+            //System.out.println("b = " + b);
+            sr.add(b);
+        }
+        GroebnerBaseAbstract<C> bb = GBFactory.<C> getImplementation(pfac.coFac);
+        List<GenPolynomial<C>> srg = bb.GB(sr);
+        return srg;
+    }
+
+
+    /**
+     * Subring membership.
+     * @param A Groebner base of polynomials in m &gt; n variables generating
+     *            the subring of elements of K[A].
+     * @param g polynomial in n variables.
+     * @return true, if g \in K[A], else false.
+     */
+    public static <C extends GcdRingElem<C>> boolean subRingMember(List<GenPolynomial<C>> A,
+                    GenPolynomial<C> g) {
+        if (A == null || A.isEmpty()) {
+            return true;
+        }
+        GenPolynomialRing<C> pfac = A.get(0).ring;
+        GenPolynomial<C> m = g;
+        if (pfac.nvar != g.ring.nvar) {
+            m = m.extendLower(pfac, 0, 0L);
+        } else {
+            throw new IllegalArgumentException("g must be extended: " + pfac.nvar + " == " + g.ring.nvar
+                            + " did you mean method subRingAndMember()?");
+        }
+        //ReductionAbstract<C> red = new ReductionSeq<C>();
+        GroebnerBaseAbstract<C> bb = GBFactory.<C> getImplementation(pfac.coFac);
+        GenPolynomial<C> r = bb.red.normalform(A, m);
+        //System.out.println("r = " + r);
+        GenPolynomialRing<C> cfac = pfac.contract(g.ring.nvar);
+        logger.debug("cfac = " + cfac.toScript());
+        Map<ExpVector, GenPolynomial<C>> map = r.contract(cfac);
+        //System.out.println("map = " + map);
+        boolean t = map.size() == 1 && map.keySet().contains(g.ring.evzero);
+        if (!t) {
+            System.out.println("false: map = " + map);
+        }
+        return t;
+    }
+
+
+    /**
+     * Subring and membership test.
+     * @param A list of polynomials in n variables.
+     * @param g polynomial in n variables.
+     * @return true, if g \in K[A], else false.
+     */
+    public static <C extends GcdRingElem<C>> boolean subRingAndMember(List<GenPolynomial<C>> A,
+                    GenPolynomial<C> g) {
+        if (A == null || A.isEmpty()) {
+            return true;
+        }
+        List<GenPolynomial<C>> srg = PolyGBUtil.<C> subRing(A);
+        return PolyGBUtil.<C> subRingMember(srg, g);
+    }
+
+
+    /**
+     * Chinese remainder theorem.
+     * @param F = ( F_i ) list of list of polynomials in n variables.
+     * @param A = ( f_i ) list of polynomials in n variables.
+     * @return p \in \Cap_i (f_i + ideal(F_i)) if it exists, else null.
+     */
+    public static <C extends GcdRingElem<C>> GenPolynomial<C> chineseRemainderTheorem(
+                    List<List<GenPolynomial<C>>> F, List<GenPolynomial<C>> A) {
+        if (F == null || F.isEmpty() || A == null || A.isEmpty()) {
+            throw new IllegalArgumentException("F and A may not be empty or null");
+        }
+        int m = F.size();
+        if (m != A.size()) {
+            throw new IllegalArgumentException("size(F) and size(A) must be equal");
+        }
+        GenPolynomialRing<C> pfac = A.get(0).ring;
+        logger.debug("pfac = " + pfac.toScript());
+        GenPolynomialRing<C> rfac = pfac.extend(m);
+        logger.debug("rfac = " + rfac.toScript());
+        GenPolynomial<C> y = rfac.getONE();
+        GenPolynomial<C> f = rfac.getZERO();
+        int i = 0;
+        List<GenPolynomial<C>> Fp = new ArrayList<GenPolynomial<C>>(); //m**2?
+        //System.out.println("A = " + A);
+        for (List<GenPolynomial<C>> Fi : F) {
+            GenPolynomial<C> Yi = pfac.getONE().extend(rfac, i, 1L);
+            y = y.subtract(Yi);
+            List<GenPolynomial<C>> Fip = new ArrayList<GenPolynomial<C>>(Fi.size());
+            //System.out.println("Fi = " + Fi);
+            for (GenPolynomial<C> a : Fi) {
+                GenPolynomial<C> b = a.extend(rfac, i, 1L);
+                Fip.add(b);
+            }
+            //System.out.println("Fip = " + Fip);
+            Fp.addAll(Fip);
+            GenPolynomial<C> a = A.get(i);
+            //System.out.println("a = " + a);
+            f = f.sum(a.extend(rfac, i, 1L));
+            i++;
+        }
+        Fp.add(y);
+        //System.out.println("f = " + f);
+        //System.out.println("Fp = " + Fp);
+        GroebnerBaseAbstract<C> bb = GBFactory.<C> getImplementation(pfac.coFac);
+        List<GenPolynomial<C>> Fpp = bb.GB(Fp);
+        //System.out.println("Fpp = " + Fpp);
+        GenPolynomial<C> h = bb.red.normalform(Fpp, f);
+        //System.out.println("h = " + h);
+        ////PseudoReduction<C> pr = new PseudoReductionSeq<C>();
+        ////PseudoReductionEntry<C> fz = pr.normalformFactor(Fpp, f);
+        ////System.out.println("fz = " + fz);
+        List<GenPolynomial<C>> H = new ArrayList<GenPolynomial<C>>();
+        H.add(h);
+        H = PolyUtil.<C> intersect(pfac, H);
+        //System.out.println("H != (): " + (! H.isEmpty()));
+        if (H.isEmpty()) {
+            return null;
+        }
+        return H.get(0);
+    }
+
+
+    /**
+     * Is Chinese remainder.
+     * @param F = ( F_i ) list of list of polynomials in n variables.
+     * @param A = ( f_i ) list of polynomials in n variables.
+     * @param h polynomial in n variables.
+     * @return true if h \in \Cap_i (f_i + ideal(F_i)), else false.
+     */
+    public static <C extends GcdRingElem<C>> boolean isChineseRemainder(List<List<GenPolynomial<C>>> F,
+                    List<GenPolynomial<C>> A, GenPolynomial<C> h) {
+        if (h == null) {
+            return false;
+        }
+        if (F == null || F.isEmpty() || A == null || A.isEmpty()) {
+            return false;
+        }
+        if (F.size() != A.size()) {
+            return false;
+        }
+        GenPolynomialRing<C> pfac = h.ring;
+        if (!pfac.coFac.isField()) {
+            //System.out.println("pfac = " + pfac.toScript());
+            logger.error("only for field coefficients: " + pfac.toScript());
+            //throw new IllegalArgumentException("only for field coefficients: " + pfac.toScript());
+        }
+        GroebnerBaseAbstract<C> bb = GBFactory.<C> getImplementation(pfac.coFac);
+        int i = 0;
+        for (List<GenPolynomial<C>> Fi : F) {
+            List<GenPolynomial<C>> Fp = bb.GB(Fi);
+            //System.out.println("Fp = " + Fp);
+            GenPolynomial<C> a = A.get(i);
+            GenPolynomial<C> fi = bb.red.normalform(Fp, h.subtract(a));
+            if (!fi.isZERO()) {
+                //System.out.println("Fp = " + Fp + ", Fi = " + Fi);
+                //System.out.println("h  = " + h  + ", a  = " + a  + ", fi  = " + fi);
+                logger.info("h-a = " + h.subtract(a) + ", fi  = " + fi);
+                return false;
+            }
+            i++;
+        }
+        return true;
+    }
+
+
+    /**
+     * Chinese remainder theorem, interpolation.
+     * @param fac polynomial ring over K in n variables.
+     * @param E = ( E_i ), E_i = ( e_ij ) list of list of elements of K, the evaluation points.
+     * @param V = ( f_i ) list of elements of K, the evaluation values.
+     * @return p \in K[X1,...,Xn], with p(E_i) = f_i, if it exists, else null.
+     */
+    @SuppressWarnings({"cast","unchecked"})
+    public static <C extends GcdRingElem<C>> GenPolynomial<C> CRTInterpolation(
+                  GenPolynomialRing<C> fac, List<List<C>> E, List<C> V) {
+        if (E == null || E.isEmpty() || V == null || V.isEmpty()) {
+            throw new IllegalArgumentException("E and V may not be empty or null");
+        }
+        int m = E.size();
+        if (m != V.size()) {
+            throw new IllegalArgumentException("size(E) and size(V) must be equal");
+        }
+        //System.out.println("fac = " + fac.toScript());
+        List<List<GenPolynomial<C>>> F = new ArrayList<List<GenPolynomial<C>>>(E.size());
+        List<GenPolynomial<C>> A = new ArrayList<GenPolynomial<C>>(V.size());
+        List<GenPolynomial<C>> gen = (List<GenPolynomial<C>>) fac.univariateList();
+        //System.out.println("gen = " + gen);
+        int i = 0;
+        for (List<C> Ei : E) {
+            List<GenPolynomial<C>> Fi = new ArrayList<GenPolynomial<C>>();
+            int j = 0;
+            for (C eij : Ei) {
+                GenPolynomial<C> ep = gen.get(j);
+                ep = ep.subtract( fac.valueOf(eij) );
+                Fi.add(ep);
+                j++;
+            }
+            F.add(Fi);
+            String ai = " " + V.get(i); // (sic) .toString() not possible
+            //System.out.println("ai = " + ai);
+            GenPolynomial<C> ap = fac.valueOf(ai);
+            A.add(ap);
+            i++;
+        }
+        //System.out.println("F = " + F);
+        //System.out.println("A = " + A);
+        GenPolynomial<C> p = PolyGBUtil. <C>chineseRemainderTheorem(F,A);
+        //System.out.println("p = " + p);
+        //System.out.println("t = " + PolyGBUtil. <C>isChineseRemainder(F,A,p));
+        return p;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/PolyModUtil.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/PolyModUtil.java
@@ -1,0 +1,280 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.gb.SolvableGroebnerBaseAbstract;
+import edu.jas.gb.SolvableGroebnerBaseSeq;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.GenSolvablePolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Package gb and gbufd utilities.
+ * @author Heinz Kredel
+ */
+
+public class PolyModUtil {
+
+
+    private static final Logger logger = LogManager.getLogger(PolyModUtil.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Least common multiple via ideal intersection.
+     * @param r solvable polynomial ring.
+     * @param n first solvable polynomial.
+     * @param d second solvable polynomial.
+     * @return lcm(n,d)
+     */
+    public static <C extends GcdRingElem<C>> GenSolvablePolynomial<C> syzLcm(GenSolvablePolynomialRing<C> r,
+                    GenSolvablePolynomial<C> n, GenSolvablePolynomial<C> d) {
+        if (n.isZERO()) {
+            return n;
+        }
+        if (d.isZERO()) {
+            return d;
+        }
+        if (n.isONE()) {
+            return d;
+        }
+        if (d.isONE()) {
+            return n;
+        }
+        List<GenSolvablePolynomial<C>> A = new ArrayList<GenSolvablePolynomial<C>>(1);
+        A.add(n);
+        List<GenSolvablePolynomial<C>> B = new ArrayList<GenSolvablePolynomial<C>>(1);
+        B.add(d);
+        List<GenSolvablePolynomial<C>> c = PolyGBUtil.<C> intersect(r, A, B);
+        //if (c.size() != 1) {
+        // SolvableSyzygyAbstract<C> sz = new SolvableSyzygyAbstract<C>();
+        // GenSolvablePolynomial<C>[] oc = sz.leftOreCond(n,d);
+        // GenSolvablePolynomial<C> nc = oc[0].multiply(n);
+        // System.out.println("nc = " + nc);
+        // return nc;
+        //}
+        GenSolvablePolynomial<C> lcm = null;
+        for (GenSolvablePolynomial<C> p : c) {
+            if (p == null || p.isZERO()) {
+                continue;
+            }
+            //System.out.println("p = " + p);
+            if (lcm == null) {
+                lcm = p;
+                continue;
+            }
+            if (lcm.compareTo(p) > 0) {
+                lcm = p;
+            }
+        }
+        if (lcm == null) {
+            throw new RuntimeException("this cannot happen: lcm == null: " + c);
+        }
+        return lcm;
+    }
+
+
+    /**
+     * Greatest common divisor via least common multiple.
+     * @param r solvable polynomial ring.
+     * @param n first solvable polynomial.
+     * @param d second solvable polynomial.
+     * @return gcd(n,d)
+     */
+    public static <C extends GcdRingElem<C>> GenSolvablePolynomial<C> syzGcd(GenSolvablePolynomialRing<C> r,
+                    GenSolvablePolynomial<C> n, GenSolvablePolynomial<C> d) {
+        return syzLeftGcd(r, n, d);
+    }
+
+
+    /**
+     * Left greatest common divisor via least common multiple.
+     * @param r solvable polynomial ring.
+     * @param n first solvable polynomial.
+     * @param d second solvable polynomial.
+     * @return gcd(n,d)
+     */
+    public static <C extends GcdRingElem<C>> GenSolvablePolynomial<C> syzLeftGcd(
+                    GenSolvablePolynomialRing<C> r, GenSolvablePolynomial<C> n, GenSolvablePolynomial<C> d) {
+
+        if (n.isZERO()) {
+            return d;
+        }
+        if (d.isZERO()) {
+            return n;
+        }
+        if (n.isConstant()) {
+            return r.getONE();
+        }
+        if (d.isConstant()) {
+            return r.getONE();
+        }
+        if (n.totalDegree() > 3 || d.totalDegree() > 3) { // how avoid too long running GBs ?
+            //if (n.totalDegree() + d.totalDegree() > 6) { // how avoid too long running GBs ?
+            // && n.length() < 10 && d.length() < 10
+            logger.warn("skipping GB computation: degs = " + n.totalDegree() + ", " + d.totalDegree());
+            return r.getONE();
+        }
+        List<GenSolvablePolynomial<C>> A = new ArrayList<GenSolvablePolynomial<C>>(2);
+        A.add(n);
+        A.add(d);
+        SolvableGroebnerBaseAbstract<C> sbb = new SolvableGroebnerBaseSeq<C>();
+        logger.warn("left syzGcd computing GB: " + A);
+        List<GenSolvablePolynomial<C>> G = sbb.rightGB(A); //not: leftGB, not: sbb.twosidedGB(A);
+        if (debug) {
+            logger.info("G = " + G);
+        }
+        if (G.size() == 1) {
+            return G.get(0);
+        }
+        logger.warn("gcd not determined, set to 1: " + G); // + ", A = " + A);
+        return r.getONE();
+    }
+
+
+    /**
+     * Right greatest common divisor via least common multiple.
+     * @param r solvable polynomial ring.
+     * @param n first solvable polynomial.
+     * @param d second solvable polynomial.
+     * @return gcd(n,d)
+     */
+    public static <C extends GcdRingElem<C>> GenSolvablePolynomial<C> syzRightGcd(
+                    GenSolvablePolynomialRing<C> r, GenSolvablePolynomial<C> n, GenSolvablePolynomial<C> d) {
+
+        if (n.isZERO()) {
+            return d;
+        }
+        if (d.isZERO()) {
+            return n;
+        }
+        if (n.isConstant()) {
+            return r.getONE();
+        }
+        if (d.isConstant()) {
+            return r.getONE();
+        }
+        if (n.totalDegree() > 3 || d.totalDegree() > 3) { // how avoid too long running GBs ?
+            //if (n.totalDegree() + d.totalDegree() > 6) { // how avoid too long running GBs ?
+            // && n.length() < 10 && d.length() < 10
+            logger.warn("skipping GB computation: degs = " + n.totalDegree() + ", " + d.totalDegree());
+            return r.getONE();
+        }
+        List<GenSolvablePolynomial<C>> A = new ArrayList<GenSolvablePolynomial<C>>(2);
+        A.add(n);
+        A.add(d);
+        SolvableGroebnerBaseAbstract<C> sbb = new SolvableGroebnerBaseSeq<C>();
+        logger.warn("right syzGcd computing GB: " + A);
+        List<GenSolvablePolynomial<C>> G = sbb.leftGB(A); // not: sbb.twosidedGB(A);
+        if (debug) {
+            logger.info("G = " + G);
+        }
+        if (G.size() == 1) {
+            return G.get(0);
+        }
+        logger.warn("gcd not determined, set to 1: " + G); // + ", A = " + A);
+        return r.getONE();
+    }
+
+
+    /**
+     * Greatest common divisor and cofactors via least common multiple and
+     * reduction.
+     * @param r solvable polynomial ring.
+     * @param n first solvable polynomial.
+     * @param d second solvable polynomial.
+     * @return [ g=gcd(n,d), n/g, d/g ]
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    public static <C extends GcdRingElem<C>> GenSolvablePolynomial<C>[] syzGcdCofactors(
+                    GenSolvablePolynomialRing<C> r, GenSolvablePolynomial<C> n, GenSolvablePolynomial<C> d) {
+        GenSolvablePolynomial<C>[] res = (GenSolvablePolynomial<C>[]) new GenSolvablePolynomial[3];
+        res[0] = PolyModUtil.<C> syzGcd(r, n, d);
+        res[1] = n;
+        res[2] = d;
+        if (res[0].isONE()) {
+            return res;
+        }
+        GenSolvablePolynomial<C>[] nqr = PolyGBUtil.<C> quotientRemainder(n, res[0]);
+        if (!nqr[1].isZERO()) {
+            res[0] = r.getONE();
+            return res;
+        }
+        GenSolvablePolynomial<C>[] dqr = PolyGBUtil.<C> quotientRemainder(d, res[0]);
+        if (!dqr[1].isZERO()) {
+            res[0] = r.getONE();
+            return res;
+        }
+        res[1] = nqr[0];
+        res[2] = dqr[0];
+        return res;
+    }
+
+
+    /**
+     * Least common multiple. Just for fun, is not efficient.
+     * @param r polynomial ring.
+     * @param n first polynomial.
+     * @param d second polynomial.
+     * @return lcm(n,d)
+     */
+    public static <C extends GcdRingElem<C>> GenPolynomial<C> syzLcm(GenPolynomialRing<C> r,
+                    GenPolynomial<C> n, GenPolynomial<C> d) {
+        List<GenPolynomial<C>> A = new ArrayList<GenPolynomial<C>>(1);
+        A.add(n);
+        List<GenPolynomial<C>> B = new ArrayList<GenPolynomial<C>>(1);
+        B.add(d);
+        List<GenPolynomial<C>> c = PolyGBUtil.<C> intersect(r, A, B);
+        if (c.size() != 1) {
+            logger.warn("lcm not uniqe: " + c);
+            //throw new RuntimeException("lcm not uniqe: " + c);
+        }
+        GenPolynomial<C> lcm = c.get(0);
+        return lcm;
+    }
+
+
+    /**
+     * Greatest common divisor. Just for fun, is not efficient.
+     * @param r polynomial ring.
+     * @param n first polynomial.
+     * @param d second polynomial.
+     * @return gcd(n,d)
+     */
+    public static <C extends GcdRingElem<C>> GenPolynomial<C> syzGcd(GenPolynomialRing<C> r,
+                    GenPolynomial<C> n, GenPolynomial<C> d) {
+        if (n.isZERO()) {
+            return d;
+        }
+        if (d.isZERO()) {
+            return n;
+        }
+        if (n.isONE()) {
+            return n;
+        }
+        if (d.isONE()) {
+            return d;
+        }
+        GenPolynomial<C> p = n.multiply(d);
+        GenPolynomial<C> lcm = syzLcm(r, n, d);
+        GenPolynomial<C> gcd = PolyUtil.<C> basePseudoDivide(p, lcm);
+        return gcd;
+    }
+
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/PseudoReduction.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/PseudoReduction.java
@@ -1,0 +1,41 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.List;
+
+import edu.jas.gb.Reduction;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Polynomial pseudo reduction interface. Defines additionaly normalformFactor.
+ * @param <C> coefficient type.
+ * @author Heinz Kredel
+ */
+
+public interface PseudoReduction<C extends RingElem<C>> extends Reduction<C> {
+
+
+    /**
+     * Normalform with multiplication factor.
+     * @param Pp polynomial list.
+     * @param Ap polynomial.
+     * @return ( nf(Ap), mf ) with respect to Pp and mf as multiplication factor
+     *         for Ap.
+     */
+    public PseudoReductionEntry<C> normalformFactor(List<GenPolynomial<C>> Pp, GenPolynomial<C> Ap);
+
+    /**
+     * Normalform recursive.
+     * @param Ap recursive polynomial.
+     * @param Pp recursive polynomial list.
+     * @return nf(Ap) with respect to Pp.
+     */
+    public GenPolynomial<GenPolynomial<C>> normalformRecursive(List<GenPolynomial<GenPolynomial<C>>> Pp, GenPolynomial<GenPolynomial<C>> Ap);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/PseudoReductionEntry.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/PseudoReductionEntry.java
@@ -1,0 +1,38 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Polynomial reduction container. Used as container for the return value of
+ * normalformFactor.
+ * @author Heinz Kredel
+ */
+
+public class PseudoReductionEntry<C extends RingElem<C>> {
+
+
+    public final GenPolynomial<C> pol;
+
+
+    public final C multiplicator;
+
+
+    public PseudoReductionEntry(GenPolynomial<C> pol, C multiplicator) {
+        this.pol = pol;
+        this.multiplicator = multiplicator;
+    }
+
+
+    @Override
+    public String toString() {
+        return " " + multiplicator + " times " + pol;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/PseudoReductionPar.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/PseudoReductionPar.java
@@ -1,0 +1,327 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.ReductionAbstract;
+import edu.jas.poly.PolyUtil;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Polynomial pseudo reduction sequential use algorithm. Coefficients of
+ * polynomials must not be from a field, i.e. the fraction free reduction is
+ * implemented. Implements normalform.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class PseudoReductionPar<C extends RingElem<C>> extends ReductionAbstract<C> implements
+                PseudoReduction<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(PseudoReductionPar.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     */
+    public PseudoReductionPar() {
+    }
+
+
+    /**
+     * Normalform.
+     * @param Ap polynomial.
+     * @param Pp polynomial list.
+     * @return nf(Ap) with respect to Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public GenPolynomial<C> normalform(List<GenPolynomial<C>> Pp, GenPolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        GenPolynomial<C>[] P = new GenPolynomial[0];
+        List<GenPolynomial<C>> Ppp;
+        synchronized (Pp) {
+            Ppp = new ArrayList<GenPolynomial<C>>(Pp); // sic
+        }
+        P = Ppp.toArray(P);
+        int ll = Ppp.size();
+        GenPolynomial<C> Rz = Ap.ring.getZERO();
+        GenPolynomial<C> R = Rz.copy();
+
+        GenPolynomial<C> S = Ap.copy();
+        while (S.length() > 0) {
+            if (Pp.size() != ll) {
+                //System.out.println("Pp.size() = " + Pp.size() + ", ll = " + ll);
+                //long t = System.currentTimeMillis();
+                synchronized (Pp) {
+                    Ppp = new ArrayList<GenPolynomial<C>>(Pp); // sic
+                }
+                P = Ppp.toArray(P);
+                ll = Ppp.size();
+                //ll = P.length; // wrong
+                //t = System.currentTimeMillis()-t;
+                //logger.info("Pp.toArray(): size() = " + l + ", ll = " + ll);
+                S = Ap.copy(); // S.add(R)? // restart reduction ?
+                R = Rz.copy();
+            }
+            boolean mt = false;
+            Map.Entry<ExpVector, C> m = S.leadingMonomial();
+            ExpVector e = m.getKey();
+            C a = m.getValue();
+            ExpVector f = null;
+            int i;
+            for (i = 0; i < ll; i++) {
+                f = P[i].leadingExpVector();
+                mt = e.multipleOf(f);
+                if (mt)
+                    break;
+            }
+            if (!mt) {
+                //System.out.println("m = " + m);
+                //logger.debug("irred");
+                //R = R.sum(a, e);
+                //S = S.subtract(a, e);
+                R.doPutToMap(e, a);
+                S.doRemoveFromMap(e, a);
+                //System.out.println(" S = " + S);
+            } else {
+                e = e.subtract(f);
+                //logger.info("red div = " + e);
+                C c = P[i].leadingBaseCoefficient();
+                if (a.remainder(c).isZERO()) { //c.isUnit() ) {
+                    a = a.divide(c);
+                    S = S.subtractMultiple(a, e, P[i]);
+                } else {
+                    R = R.multiply(c);
+                    //S = S.multiply(c);
+                    S = S.scaleSubtractMultiple(c, a, e, P[i]);
+                }
+                //Q = p[i].multiply(a, e);
+                //S = S.subtract(Q);
+            }
+        }
+        return R;
+    }
+
+
+    /**
+     * Normalform.
+     * @param Pp polynomial list.
+     * @param Ap polynomial.
+     * @return ( nf(Ap), mf ) with respect to Pp and mf as multiplication factor
+     *         for Ap.
+     */
+    @SuppressWarnings("unchecked")
+    public PseudoReductionEntry<C> normalformFactor(List<GenPolynomial<C>> Pp, GenPolynomial<C> Ap) {
+        if (Ap == null) {
+            return null;
+        }
+        C mfac = Ap.ring.getONECoefficient();
+        PseudoReductionEntry<C> pf = new PseudoReductionEntry<C>(Ap, mfac);
+        if (Pp == null || Pp.isEmpty()) {
+            return pf;
+        }
+        if (Ap.isZERO()) {
+            return pf;
+        }
+        GenPolynomial<C>[] P = new GenPolynomial[0];
+        List<GenPolynomial<C>> Ppp;
+        synchronized (Pp) {
+            Ppp = new ArrayList<GenPolynomial<C>>(Pp); // sic
+        }
+        P = Ppp.toArray(P);
+        int l = Ppp.size();
+        boolean mt = false;
+        GenPolynomial<C> Rz = Ap.ring.getZERO();
+        GenPolynomial<C> R = Rz.copy();
+        //GenPolynomial<C> T = null;
+        //GenPolynomial<C> Q = null;
+        GenPolynomial<C> S = Ap.copy();
+        while (S.length() > 0) {
+            if (Pp.size() != l) {
+                //long t = System.currentTimeMillis();
+                synchronized (Pp) {
+                    Ppp = new ArrayList<GenPolynomial<C>>(Pp);
+                }
+                P = Ppp.toArray(P);
+                l = Ppp.size();
+                //t = System.currentTimeMillis()-t;
+                //logger.info("Pp.toArray() = " + t + " ms, size() = " + l);
+                S = Ap.copy(); // S.add(R)? // restart reduction ?
+                R = Rz.copy();
+            }
+            Map.Entry<ExpVector, C> m = S.leadingMonomial();
+            ExpVector e = m.getKey();
+            C a = m.getValue();
+            ExpVector f = null;
+            int i;
+            for (i = 0; i < l; i++) {
+                f = P[i].leadingExpVector();
+                mt = e.multipleOf(f);
+                if (mt)
+                    break;
+            }
+            if (!mt) {
+                //logger.debug("irred");
+                //R = R.sum(a, e);
+                //S = S.subtract(a, e);
+                R.doPutToMap(e, a);
+                S.doRemoveFromMap(e, a);
+                //System.out.println(" S = " + S);
+            } else {
+                e = e.subtract(f);
+                //logger.info("red div = " + e);
+                C c = P[i].leadingBaseCoefficient();
+                if (a.remainder(c).isZERO()) { //c.isUnit() ) {
+                    a = a.divide(c);
+                    S = S.subtractMultiple(a, e, P[i]);
+                } else {
+                    mfac = mfac.multiply(c);
+                    R = R.multiply(c);
+                    //S = S.multiply(c);
+                    S = S.scaleSubtractMultiple(c, a, e, P[i]);
+                }
+                //Q = p[i].multiply(a, e);
+                //S = S.subtract(Q);
+            }
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("multiplicative factor = " + mfac);
+        }
+        pf = new PseudoReductionEntry<C>(R, mfac);
+        return pf;
+    }
+
+
+    /**
+     * Normalform with recording. <b>Note:</b> Only meaningful if all divisions
+     * are exact. Compute first the multiplication factor <code>m</code> with
+     * <code>normalform(Pp,Ap,m)</code>, then call this method with
+     * <code>normalform(row,Pp,m*Ap)</code>.
+     * @param row recording matrix, is modified.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @return nf(Pp,Ap), the normal form of Ap wrt. Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public GenPolynomial<C> normalform(List<GenPolynomial<C>> row, List<GenPolynomial<C>> Pp,
+                    GenPolynomial<C> Ap) {
+        throw new RuntimeException("normalform with recording not implemented");
+    }
+
+
+    /**
+     * Normalform recursive.
+     * @param Ap recursive polynomial.
+     * @param Pp recursive polynomial list.
+     * @return nf(Ap) with respect to Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public GenPolynomial<GenPolynomial<C>> normalformRecursive(List<GenPolynomial<GenPolynomial<C>>> Pp, GenPolynomial<GenPolynomial<C>> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        GenPolynomial<GenPolynomial<C>>[] P = new GenPolynomial[0];
+        List<GenPolynomial<GenPolynomial<C>>> Ppp;
+        synchronized (Pp) {
+            Ppp = new ArrayList<GenPolynomial<GenPolynomial<C>>>(Pp); // sic
+        }
+        P = Ppp.toArray(P);
+        int ll = Ppp.size();
+        GenPolynomial<GenPolynomial<C>> Rz = Ap.ring.getZERO();
+        GenPolynomial<GenPolynomial<C>> R = Rz.copy();
+
+        GenPolynomial<GenPolynomial<C>> S = Ap.copy();
+        while (S.length() > 0) {
+            if (Pp.size() != ll) {
+                //System.out.println("Pp.size() = " + Pp.size() + ", ll = " + ll);
+                //long t = System.currentTimeMillis();
+                synchronized (Pp) {
+                    Ppp = new ArrayList<GenPolynomial<GenPolynomial<C>>>(Pp); // sic
+                }
+                P = Ppp.toArray(P);
+                ll = Ppp.size();
+                //ll = P.length; // wrong
+                //t = System.currentTimeMillis()-t;
+                //logger.info("Pp.toArray(): size() = " + l + ", ll = " + ll);
+                S = Ap.copy(); // S.add(R)? // restart reduction ?
+                R = Rz.copy();
+            }
+            boolean mt = false;
+            Map.Entry<ExpVector, GenPolynomial<C>> m = S.leadingMonomial();
+            ExpVector e = m.getKey();
+            GenPolynomial<C> a = m.getValue();
+            ExpVector f = null;
+            int i;
+            for (i = 0; i < ll; i++) {
+                f = P[i].leadingExpVector();
+                mt = e.multipleOf(f);
+                if (mt)
+                    break;
+            }
+            if (!mt) {
+                //System.out.println("m = " + m);
+                //logger.debug("irred");
+                //R = R.sum(a, e);
+                //S = S.subtract(a, e);
+                R.doPutToMap(e, a);
+                S.doRemoveFromMap(e, a);
+                //System.out.println(" S = " + S);
+            } else {
+                f = e.subtract(f);
+                if (debug) {
+                    logger.info("red div = " + e);
+                }
+                GenPolynomial<C> c = P[i].leadingBaseCoefficient();
+                //if (a.remainder(c).isZERO()) { //c.isUnit() ) {
+                if (PolyUtil.<C> baseSparsePseudoRemainder(a,c).isZERO()) { 
+                    if (debug) {
+                        logger.info("red c = " + c);
+                    }
+                    //a = a.divide(c);
+                    GenPolynomial<C> b = PolyUtil.<C> basePseudoDivide(a,c);
+                    GenPolynomial<GenPolynomial<C>> Sp = S.subtractMultiple(b, f, P[i]);
+                    if (e.equals(Sp.leadingExpVector())) { // TODO: avoid if possible
+                        //throw new RuntimeException("degree not descending");
+                        logger.info("degree not descending: S = " + S + ", Sp = " + Sp);
+                        R = R.multiply(c);
+                        //S = S.multiply(c);
+                        Sp = S.scaleSubtractMultiple(c, a, f, P[i]);
+                    }
+                    S = Sp; 
+                } else {
+                    R = R.multiply(c);
+                    //S = S.multiply(c);
+                    S = S.scaleSubtractMultiple(c, a, f, P[i]);
+                }
+                //Q = p[i].multiply(a, f);
+                //S = S.subtract(Q);
+            }
+        }
+        return R;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/PseudoReductionSeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/PseudoReductionSeq.java
@@ -1,0 +1,417 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.ReductionAbstract;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Polynomial pseudo reduction sequential use algorithm. Coefficients of
+ * polynomials must not be from a field, i.e. the fraction free reduction is
+ * implemented. Implements normalform.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class PseudoReductionSeq<C extends RingElem<C>> extends ReductionAbstract<C> implements
+                PseudoReduction<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(PseudoReductionSeq.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     */
+    public PseudoReductionSeq() {
+    }
+
+
+    /**
+     * Normalform.
+     * @param Ap polynomial.
+     * @param Pp polynomial list.
+     * @return nf(Ap) with respect to Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public GenPolynomial<C> normalform(List<GenPolynomial<C>> Pp, GenPolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        Map.Entry<ExpVector, C> m;
+        GenPolynomial<C>[] P = new GenPolynomial[0];
+        synchronized (Pp) {
+            P = Pp.toArray(P);
+        }
+        int l = P.length;
+        ExpVector[] htl = new ExpVector[l];
+        C[] lbc = (C[]) new RingElem[l];
+        GenPolynomial<C>[] p = new GenPolynomial[l];
+        int i;
+        int j = 0;
+        for (i = 0; i < l; i++) {
+            if (P[i] == null) {
+                continue;
+            }
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        ExpVector e, f;
+        C a, b;
+        boolean mt = false;
+        GenPolynomial<C> R = Ap.ring.getZERO().copy();
+
+        GenPolynomial<C> S = Ap.copy();
+        while (S.length() > 0) {
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt)
+                    break;
+            }
+            if (!mt) {
+                //logger.debug("irred");
+                //R = R.sum(a, e);
+                //S = S.subtract(a, e);
+                R.doPutToMap(e, a);
+                S.doRemoveFromMap(e, a);
+                //System.out.println(" S = " + S);
+            } else {
+                f = e.subtract(htl[i]);
+                //logger.info("red div = " + e);
+                @SuppressWarnings("unchecked")
+                C c = (C) lbc[i];
+                if (a.remainder(c).isZERO()) { //c.isUnit() ) {
+                    b = a.divide(c);
+                    GenPolynomial<C> Sp = S.subtractMultiple(b, f, p[i]);
+                    if (e.equals(Sp.leadingExpVector())) { // TODO: avoid if possible
+                        logger.info("degree not descending: S = " + S + ", Sp = " + Sp);
+                        R = R.multiply(c);
+                        //S = S.multiply(c);
+                        Sp = S.scaleSubtractMultiple(c, a, f, p[i]);
+                    }
+                    S = Sp;                    
+                } else {
+                    R = R.multiply(c);
+                    //S = S.multiply(c);
+                    S = S.scaleSubtractMultiple(c, a, f, p[i]);
+                }
+                //Q = p[i].multiply(a, e);
+                //S = S.subtract(Q);
+            }
+        }
+        return R;
+    }
+
+
+    /**
+     * Normalform recursive.
+     * @param Ap recursive polynomial.
+     * @param Pp recursive polynomial list.
+     * @return nf(Ap) with respect to Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public GenPolynomial<GenPolynomial<C>> normalformRecursive(List<GenPolynomial<GenPolynomial<C>>> Pp,
+                    GenPolynomial<GenPolynomial<C>> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        Map.Entry<ExpVector, GenPolynomial<C>> m;
+        GenPolynomial<GenPolynomial<C>>[] P = new GenPolynomial[0];
+        synchronized (Pp) {
+            P = Pp.toArray(P);
+        }
+        int l = P.length;
+        ExpVector[] htl = new ExpVector[l];
+        GenPolynomial<C>[] lbc = (GenPolynomial<C>[]) new GenPolynomial[l];
+        GenPolynomial<GenPolynomial<C>>[] p = new GenPolynomial[l];
+        int i;
+        int j = 0;
+        for (i = 0; i < l; i++) {
+            if (P[i] == null) {
+                continue;
+            }
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        ExpVector e, f;
+        GenPolynomial<C> a, b;
+        boolean mt = false;
+        GenPolynomial<GenPolynomial<C>> R = Ap.ring.getZERO().copy();
+
+        GenPolynomial<GenPolynomial<C>> S = Ap.copy();
+        while (S.length() > 0) {
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt)
+                    break;
+            }
+            if (!mt) {
+                //logger.debug("irred");
+                //R = R.sum(a, e);
+                //S = S.subtract(a, e);
+                R.doPutToMap(e, a);
+                S.doRemoveFromMap(e, a);
+                //System.out.println(" S = " + S);
+            } else {
+                f = e.subtract(htl[i]);
+                if (debug) {
+                    logger.info("red div = " + f);
+                    //logger.info("red a = " + a);
+                }
+                GenPolynomial<C> c = (GenPolynomial<C>) lbc[i];
+                //if (a.remainder(c).isZERO()) { //c.isUnit() ) {
+                if (PolyUtil.<C> baseSparsePseudoRemainder(a, c).isZERO()) { //c.isUnit() ) {
+                    if (debug) {
+                        logger.info("red c = " + c);
+                    }
+                    //a = a.divide(c);
+                    b = PolyUtil.<C> basePseudoDivide(a, c);
+                    GenPolynomial<GenPolynomial<C>> Sp = S.subtractMultiple(b, f, p[i]);
+                    if (e.equals(Sp.leadingExpVector())) { // TODO: avoid if possible
+                        //throw new RuntimeException("degree not descending");
+                        logger.info("degree not descending: S = " + S + ", Sp = " + Sp);
+                        R = R.multiply(c);
+                        //S = S.multiply(c);
+                        Sp = S.scaleSubtractMultiple(c, a, f, p[i]);
+                    }
+                    S = Sp;
+                } else {
+                    R = R.multiply(c);
+                    //S = S.multiply(c);
+                    S = S.scaleSubtractMultiple(c, a, f, p[i]);
+                }
+                //Q = p[i].multiply(a, e);
+                //S = S.subtract(Q);
+            }
+        }
+        return R;
+    }
+
+
+    /**
+     * Normalform with recording. <b>Note:</b> Only meaningful if all divisions
+     * are exact. Compute first the multiplication factor <code>m</code> with
+     * <code>normalform(Pp,Ap,m)</code>, then call this method with
+     * <code>normalform(row,Pp,m*Ap)</code>.
+     * @param row recording matrix, is modified.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @return nf(Pp,Ap), the normal form of Ap wrt. Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public GenPolynomial<C> normalform(List<GenPolynomial<C>> row, List<GenPolynomial<C>> Pp,
+                    GenPolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        GenPolynomial<C>[] P = new GenPolynomial[0];
+        synchronized (Pp) {
+            P = Pp.toArray(P);
+        }
+        int l = P.length;
+        ExpVector[] htl = new ExpVector[l];
+        Object[] lbc = new Object[l]; // want C 
+        GenPolynomial<C>[] p = new GenPolynomial[l];
+        Map.Entry<ExpVector, C> m;
+        int j = 0;
+        int i;
+        for (i = 0; i < l; i++) {
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        ExpVector e;
+        C a;
+        boolean mt = false;
+        GenPolynomial<C> zero = Ap.ring.getZERO();
+        GenPolynomial<C> R = Ap.ring.getZERO().copy();
+        GenPolynomial<C> fac = null;
+        GenPolynomial<C> S = Ap.copy();
+        while (S.length() > 0) {
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt)
+                    break;
+            }
+            if (!mt) {
+                //logger.debug("irred");
+                //R = R.sum(a, e);
+                //S = S.subtract(a, e);
+                R.doPutToMap(e, a);
+                S.doRemoveFromMap(e, a);
+                // System.out.println(" S = " + S);
+            } else {
+                e = e.subtract(htl[i]);
+                //logger.info("red div = " + e);
+                C c = (C) lbc[i];
+                if (a.remainder(c).isZERO()) { //c.isUnit() ) {
+                    a = a.divide(c);
+                    S = S.subtractMultiple(a, e, p[i]);
+                    //System.out.print("|");
+                } else {
+                    //System.out.print("*");
+                    R = R.multiply(c);
+                    //S = S.multiply(c);
+                    S = S.scaleSubtractMultiple(c, a, e, p[i]);
+                }
+                //Q = p[i].multiply(a, e);
+                //S = S.subtract(Q);
+                fac = row.get(i);
+                if (fac == null) {
+                    fac = zero.sum(a, e);
+                } else {
+                    fac = fac.sum(a, e);
+                }
+                row.set(i, fac);
+            }
+        }
+        return R;
+    }
+
+
+    /**
+     * Normalform.
+     * @param Pp polynomial list.
+     * @param Ap polynomial.
+     * @return ( nf(Ap), mf ) with respect to Pp and mf as multiplication factor
+     *         for Ap.
+     */
+    @SuppressWarnings("unchecked")
+    public PseudoReductionEntry<C> normalformFactor(List<GenPolynomial<C>> Pp, GenPolynomial<C> Ap) {
+        if (Ap == null) {
+            return null;
+        }
+        C mfac = Ap.ring.getONECoefficient();
+        PseudoReductionEntry<C> pf = new PseudoReductionEntry<C>(Ap, mfac);
+        if (Pp == null || Pp.isEmpty()) {
+            return pf;
+        }
+        if (Ap.isZERO()) {
+            return pf;
+        }
+        Map.Entry<ExpVector, C> m;
+        GenPolynomial<C>[] P = new GenPolynomial[0];
+        synchronized (Pp) {
+            P = Pp.toArray(P);
+        }
+        int l = P.length;
+        ExpVector[] htl = new ExpVector[l];
+        C[] lbc = (C[]) new RingElem[l]; // want C[] 
+        GenPolynomial<C>[] p = new GenPolynomial[l];
+        int i;
+        int j = 0;
+        for (i = 0; i < l; i++) {
+            if (P[i] == null) {
+                continue;
+            }
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        ExpVector e;
+        C a;
+        boolean mt = false;
+        GenPolynomial<C> R = Ap.ring.getZERO().copy();
+
+        GenPolynomial<C> S = Ap.copy();
+        while (S.length() > 0) {
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt)
+                    break;
+            }
+            if (!mt) {
+                //logger.debug("irred");
+                //R = R.sum(a, e);
+                //S = S.subtract(a, e);
+                R.doPutToMap(e, a);
+                S.doRemoveFromMap(e, a);
+                //System.out.println(" S = " + S);
+            } else {
+                e = e.subtract(htl[i]);
+                //logger.info("red div = " + e);
+                C c = lbc[i];
+                if (a.remainder(c).isZERO()) { //c.isUnit() ) {
+                    a = a.divide(c);
+                    S = S.subtractMultiple(a, e, p[i]);
+                } else {
+                    mfac = mfac.multiply(c);
+                    R = R.multiply(c);
+                    //S = S.multiply(c);
+                    S = S.scaleSubtractMultiple(c, a, e, p[i]);
+                }
+                //Q = p[i].multiply(a, e);
+                //S = S.subtract(Q);
+            }
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("multiplicative factor = " + mfac);
+        }
+        pf = new PseudoReductionEntry<C>(R, mfac);
+        return pf;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/RGroebnerBasePseudoSeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/RGroebnerBasePseudoSeq.java
@@ -1,0 +1,484 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.Pair;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.RegularRingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.ufd.GCDFactory;
+import edu.jas.ufd.GreatestCommonDivisorAbstract;
+
+
+/**
+ * Regular ring Groebner Base with pseudo reduction sequential algorithm.
+ * Implements R-Groebner bases and GB test.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class RGroebnerBasePseudoSeq<C extends RegularRingElem<C>> extends RGroebnerBaseSeq<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(RGroebnerBasePseudoSeq.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Greatest common divisor engine for coefficient content and primitive
+     * parts.
+     */
+    protected final GreatestCommonDivisorAbstract<C> engine;
+
+
+    /**
+     * Pseudo reduction engine.
+     */
+    protected final RPseudoReduction<C> red;
+
+
+    /**
+     * Coefficient ring factory.
+     */
+    protected final RingFactory<C> cofac;
+
+
+    /**
+     * Constructor.
+     * @param rf coefficient ring factory.
+     */
+    public RGroebnerBasePseudoSeq(RingFactory<C> rf) {
+        this(new RPseudoReductionSeq<C>(), rf);
+    }
+
+
+    /**
+     * Constructor.
+     * @param red R-pseudo-Reduction engine
+     * @param rf coefficient ring factory.
+     */
+    public RGroebnerBasePseudoSeq(RPseudoReduction<C> red, RingFactory<C> rf) {
+        super(red);
+        this.red = red;
+        cofac = rf;
+        engine = GCDFactory.<C> getImplementation(rf);
+        // not used: engine =
+        // (GreatestCommonDivisorAbstract<C>)GCDFactory.<C>getProxy( rf );
+    }
+
+
+    /**
+     * R-Groebner base using pairlist class.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return GB(F) a R-Groebner base of F.
+     */
+    @Override
+    public List<GenPolynomial<C>> GB(int modv, List<GenPolynomial<C>> F) {
+        if (F == null) {
+            return F;
+        }
+        /* boolean closure */
+        List<GenPolynomial<C>> bcF = red.reducedBooleanClosure(F);
+        logger.info("#bcF-#F = " + (bcF.size() - F.size()));
+        F = bcF;
+        /* normalize input */
+        List<GenPolynomial<C>> G = new ArrayList<GenPolynomial<C>>();
+        OrderedRPairlist<C> pairlist = null;
+        for (GenPolynomial<C> p : F) {
+            if (!p.isZERO()) {
+                p = engine.basePrimitivePart(p); // not monic, no field
+                p = p.abs();
+                if (p.isConstant() && p.leadingBaseCoefficient().isFull()) {
+                    G.clear();
+                    G.add(p);
+                    return G; // since boolean closed and no threads are activated
+                }
+                G.add(p); // G.add( 0, p ); //reverse list
+                if (pairlist == null) {
+                    pairlist = new OrderedRPairlist<C>(modv, p.ring);
+                }
+                // putOne not required
+                pairlist.put(p);
+            }
+        }
+        if (G.size() <= 1) {
+            return G; // since boolean closed and no threads are activated
+        }
+        /* loop on critical pairs */
+        Pair<C> pair;
+        GenPolynomial<C> pi;
+        GenPolynomial<C> pj;
+        GenPolynomial<C> S;
+        // GenPolynomial<C> D;
+        GenPolynomial<C> H;
+        List<GenPolynomial<C>> bcH;
+        while (pairlist.hasNext()) {
+            pair = pairlist.removeNext();
+            // System.out.println("pair = " + pair);
+            if (pair == null)
+                continue;
+
+            pi = pair.pi;
+            pj = pair.pj;
+            if (logger.isDebugEnabled()) {
+                logger.info("pi    = " + pi);
+                logger.info("pj    = " + pj);
+            }
+            if (!red.moduleCriterion(modv, pi, pj)) {
+                continue;
+            }
+
+            // S-polynomial -----------------------
+            // Criterion3(), Criterion4() not applicable
+            S = red.SPolynomial(pi, pj);
+            if (S.isZERO()) {
+                pair.setZero();
+                continue;
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("ht(S) = " + S.leadingExpVector());
+            }
+
+            H = red.normalform(G, S);
+            if (H.isZERO()) {
+                pair.setZero();
+                continue;
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("ht(H) = " + H.leadingExpVector());
+            }
+            H = engine.basePrimitivePart(H);
+            H = H.abs(); // not monic, no field
+            if (H.isConstant() && H.leadingBaseCoefficient().isFull()) {
+                // mostly useless
+                G.clear();
+                G.add(H);
+                return G; // not boolean closed ok, no threads are activated
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("H = " + H);
+            }
+            if (!H.isZERO()) {
+                // logger.info("Sred = " + H);
+                // len = G.size();
+                bcH = red.reducedBooleanClosure(G, H);
+                // logger.info("#bcH = " + bcH.size());
+                // G.addAll( bcH );
+                for (GenPolynomial<C> h : bcH) {
+                    h = engine.basePrimitivePart(h);
+                    h = h.abs(); // monic() not ok, since no field
+                    logger.info("bc(Sred) = " + h);
+                    G.add(h);
+                    pairlist.put(h);
+                }
+                if (debug) {
+                    if (!pair.getUseCriterion3() || !pair.getUseCriterion4()) {
+                        logger.info("H != 0 but: " + pair);
+                    }
+                }
+            }
+        }
+        logger.debug("#sequential list = " + G.size());
+        G = minimalGB(G);
+        // G = red.irreducibleSet(G); // not correct since not boolean closed
+        logger.info("" + pairlist);
+        return G;
+    }
+
+
+    /**
+     * Minimal ordered Groebner basis.
+     * @param Gp a Groebner base.
+     * @return a reduced Groebner base of Gp.
+     */
+    @Override
+    public List<GenPolynomial<C>> minimalGB(List<GenPolynomial<C>> Gp) {
+        if (Gp == null || Gp.size() <= 1) {
+            return Gp;
+        }
+        // remove zero polynomials
+        List<GenPolynomial<C>> G = new ArrayList<GenPolynomial<C>>(Gp.size());
+        for (GenPolynomial<C> a : Gp) {
+            if (a != null && !a.isZERO()) { // always true in GB()
+                a = a.abs(); // already positive in GB
+                G.add(a);
+            }
+        }
+        // remove top reducible polynomials
+        logger.info("minGB start with " + G.size());
+        GenPolynomial<C> a, b;
+        List<GenPolynomial<C>> F;
+        F = new ArrayList<GenPolynomial<C>>(G.size());
+        while (G.size() > 0) {
+            a = G.remove(0);
+            b = a;
+            if (red.isTopReducible(G, a) || red.isTopReducible(F, a)) {
+                // try to drop polynomial
+                List<GenPolynomial<C>> ff;
+                ff = new ArrayList<GenPolynomial<C>>(G);
+                ff.addAll(F);
+                a = red.normalform(ff, a);
+                if (a.isZERO()) {
+                    //if (false && !isGB(ff)) { // is really required, but why?
+                    //    logger.info("minGB not dropped " + b);
+                    //    F.add(b);
+                    //} else {
+                    if (debug) {
+                        logger.debug("minGB dropped " + b);
+                    }
+                    //}
+                } else { // happens
+                    logger.info("minGB not zero " + a);
+                    F.add(a);
+                }
+            } else { // not top reducible, keep polynomial
+                F.add(a);
+            }
+        }
+        G = F;
+        Collections.reverse(G); // important for lex GB
+        // reduce remaining polynomials
+        int len = G.size();
+        int el = 0;
+        while (el < len) {
+            el++;
+            a = G.remove(0);
+            b = a;
+            a = red.normalform(G, a);
+            a = engine.basePrimitivePart(a); // not a.monic() since no field
+            a = a.abs();
+            if (red.isBooleanClosed(a)) {
+                //List<GenPolynomial<C>> ff;
+                //ff = new ArrayList<GenPolynomial<C>>(G);
+                //ff.add(a);
+                //if (true || isGB(ff)) {
+                if (debug) {
+                    logger.debug("minGB reduced " + b + " to " + a);
+                }
+                G.add(a);
+                //} else {
+                //    logger.info("minGB not reduced " + b + " to " + a);
+                //    G.add(b);
+                //}
+                continue;
+            }
+            logger.info("minGB not boolean closed " + a);
+            G.add(b); // do not reduce
+        }
+        /* stratify: collect polynomials with equal leading terms */
+        ExpVector e, f;
+        F = new ArrayList<GenPolynomial<C>>(G.size());
+        List<GenPolynomial<C>> ff;
+        ff = new ArrayList<GenPolynomial<C>>(G);
+        for (int i = 0; i < ff.size(); i++) {
+            a = ff.get(i);
+            if (a == null || a.isZERO()) {
+                continue;
+            }
+            e = a.leadingExpVector();
+            for (int j = i + 1; j < ff.size(); j++) {
+                b = ff.get(j);
+                if (b == null || b.isZERO()) {
+                    continue;
+                }
+                f = b.leadingExpVector();
+                if (e.equals(f)) {
+                    // System.out.println("minGB e == f: " + a + ", " + b);
+                    a = a.sum(b);
+                    ff.set(j, null);
+                }
+            }
+            F.add(a);
+        }
+        //if (true || isGB(F)) {
+        G = F;
+        //} else {
+        //    logger.info("minGB not stratified " + F);
+        //}
+        logger.info("minGB end with #G = " + G.size());
+        return G;
+    }
+
+
+    /*
+     * Minimal ordered Groebner basis. 
+     * @param Gp a Groebner base. 
+     * @return a reduced Groebner base of Gp. 
+     */
+    List<GenPolynomial<C>> minimalGBtesting(List<GenPolynomial<C>> Gp) {
+        if (Gp == null || Gp.size() <= 1) {
+            return Gp;
+        }
+        // remove zero polynomials
+        List<GenPolynomial<C>> G = new ArrayList<GenPolynomial<C>>(Gp.size());
+        for (GenPolynomial<C> a : Gp) {
+            if (a != null && !a.isZERO()) { // always true in GB()
+                // already positive a = a.abs();
+                G.add(a);
+            }
+        }
+        //if (G.size() <= 1) {
+            // wg monic do not return G;
+        //}
+        // remove top reducible polynomials
+        GenPolynomial<C> a, b;
+        List<GenPolynomial<C>> F;
+        List<GenPolynomial<C>> bcH;
+        F = new ArrayList<GenPolynomial<C>>(G.size());
+        while (G.size() > 0) {
+            a = G.remove(0);
+            b = a;
+            if (red.isTopReducible(G, a) || red.isTopReducible(F, a)) {
+                // drop polynomial
+                if (logger.isInfoEnabled()) {
+                    List<GenPolynomial<C>> ff;
+                    ff = new ArrayList<GenPolynomial<C>>(G);
+                    ff.addAll(F);
+                    a = red.normalform(ff, a);
+                    if (!a.isZERO()) {
+                        System.out.println("minGB nf(a) != 0 " + a);
+                        bcH = red.reducedBooleanClosure(G, a);
+                        if (bcH.size() > 1) { // never happend so far
+                            System.out.println("minGB not bc: bcH size = " + bcH.size());
+                            F.add(b); // do not replace, stay with b
+                        } else {
+                            // System.out.println("minGB add bc(a): a = " + a + ",
+                            // bc(a) = " + bcH.get(0));
+                            F.add(b); // do not replace, stay with b
+                            // F.addAll( bcH );
+                        }
+                    } else {
+                        if (!isGB(ff)) {
+                            System.out.println("minGB not dropped " + b);
+                            F.add(b);
+                        } else {
+                            System.out.println("minGB dropped " + b);
+                        }
+                    }
+                }
+            } else { // not top reducible, keep polynomial
+                F.add(a);
+            }
+        }
+        G = F;
+        //if (G.size() <= 1) {
+            // wg monic return G;
+        //}
+        Collections.reverse(G); // important for lex GB
+        // reduce remaining polynomials
+        int len = G.size();
+        int el = 0;
+        // System.out.println("minGB reducing " + len);
+        while (el < len) {
+            el++;
+            a = G.remove(0);
+            b = a;
+            // System.out.println("minGB doing " + el + ", a = " + a);
+            a = red.normalform(G, a);
+            // use primitivePart
+            a = engine.basePrimitivePart(a); // not a.monic() since no field
+            // not bc:
+            if (red.isBooleanClosed(a)) {
+                List<GenPolynomial<C>> ff;
+                ff = new ArrayList<GenPolynomial<C>>(G);
+                ff.add(a);
+                if (isGB(ff)) {
+                    System.out.println("minGB reduced " + b + " to " + a);
+                    G.add(a);
+                } else {
+                    System.out.println("minGB not reduced " + b + " to " + a);
+                    G.add(b);
+                }
+                continue;
+            }
+            System.out.println("minGB not bc: a = " + a + "\n BC(a) = " + red.booleanClosure(a)
+                            + ", BR(a) = " + red.booleanRemainder(a));
+            bcH = red.reducedBooleanClosure(G, a);
+            if (bcH.size() > 1) {
+                System.out.println("minGB not bc: bcH size = " + bcH.size());
+                G.add(b); // do not reduce
+            } else {
+                // G.addAll( bcH );
+                G.add(b); // do not reduce
+                for (GenPolynomial<C> h : bcH) {
+                    // use primitivePart
+                    h = engine.basePrimitivePart(h);
+                    h = h.abs(); // monic() not ok, since no field
+                    // G.add( h );
+                }
+            }
+        }
+        // make abs if possible
+        F = new ArrayList<GenPolynomial<C>>(G.size());
+        for (GenPolynomial<C> p : G) {
+            a = p.abs();
+            F.add(a);
+        }
+        G = F;
+        //if (false) {
+        //    return G;
+        //}
+        // stratify: collect polynomials with equal leading terms
+        ExpVector e, f;
+        F = new ArrayList<GenPolynomial<C>>(G.size());
+        for (int i = 0; i < G.size(); i++) {
+            a = G.get(i);
+            if (a == null || a.isZERO()) {
+                continue;
+            }
+            e = a.leadingExpVector();
+            for (int j = i + 1; j < G.size(); j++) {
+                b = G.get(j);
+                if (b == null || b.isZERO()) {
+                    continue;
+                }
+                f = b.leadingExpVector();
+                if (e.equals(f)) {
+                    // System.out.println("minGB e == f: " + a + ", " + b);
+                    a = a.sum(b);
+                    G.set(j, null);
+                }
+            }
+            F.add(a);
+        }
+        G = F;
+
+        // info on boolean algebra element blocks
+        Map<C, List<GenPolynomial<C>>> bd = new TreeMap<C, List<GenPolynomial<C>>>();
+        for (GenPolynomial<C> p : G) {
+            C cf = p.leadingBaseCoefficient();
+            cf = cf.idempotent();
+            List<GenPolynomial<C>> block = bd.get(cf);
+            if (block == null) {
+                block = new ArrayList<GenPolynomial<C>>();
+            }
+            block.add(p);
+            bd.put(cf, block);
+        }
+        System.out.println("\nminGB bd:");
+        for (Map.Entry<C, List<GenPolynomial<C>>> me : bd.entrySet()) {
+            System.out.println("\nkey = " + me.getKey() + ":");
+            System.out.println("val = " + me.getValue());
+        }
+        System.out.println();
+        //
+        return G;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/RGroebnerBaseSeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/RGroebnerBaseSeq.java
@@ -1,0 +1,357 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.GroebnerBaseAbstract;
+import edu.jas.gb.Pair;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.RegularRingElem;
+
+
+/**
+ * Regular ring Groebner Base sequential algorithm. Implements R-Groebner bases
+ * and GB test.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class RGroebnerBaseSeq<C extends RegularRingElem<C>> extends GroebnerBaseAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(RGroebnerBaseSeq.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Reduction engine.
+     */
+    protected RReduction<C> rred; // shadow super.red ??
+
+
+    /**
+     * Constructor.
+     */
+    public RGroebnerBaseSeq() {
+        this(new RReductionSeq<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param rred R-Reduction engine
+     */
+    public RGroebnerBaseSeq(RReduction<C> rred) {
+        super(rred);
+        this.rred = rred;
+        assert super.red == this.rred;
+    }
+
+
+    /**
+     * R-Groebner base test.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return true, if F is a R-Groebner base, else false.
+     */
+    @Override
+    public boolean isGB(int modv, List<GenPolynomial<C>> F) {
+        if (F == null) {
+            return true;
+        }
+        if (!rred.isBooleanClosed(F)) {
+            if (debug) {
+                logger.debug("not boolean closed");
+            }
+            return false;
+        }
+        GenPolynomial<C> pi, pj, s;
+        for (int i = 0; i < F.size(); i++) {
+            pi = F.get(i);
+            for (int j = i + 1; j < F.size(); j++) {
+                pj = F.get(j);
+                if (!red.moduleCriterion(modv, pi, pj)) {
+                    continue;
+                }
+                // red.criterion4 not applicable
+                s = red.SPolynomial(pi, pj);
+                if (s.isZERO()) {
+                    continue;
+                }
+                s = red.normalform(F, s);
+                if (!s.isZERO()) {
+                    if (debug) {
+                        logger.debug("p" + i + " = " + pi);
+                        logger.debug("p" + j + " = " + pj);
+                        logger.debug("s-pol = " + red.SPolynomial(pi, pj));
+                        logger.debug("s-pol(" + i + "," + j + ") != 0: " + s);
+                    }
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * R-Groebner base using pairlist class.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return GB(F) a R-Groebner base of F.
+     */
+    public List<GenPolynomial<C>> GB(int modv, List<GenPolynomial<C>> F) {
+        /* boolean closure */
+        List<GenPolynomial<C>> bcF = rred.reducedBooleanClosure(F);
+        logger.info("#bcF-#F = " + (bcF.size() - F.size()));
+        F = bcF;
+        /* normalize input */
+        List<GenPolynomial<C>> G = new ArrayList<GenPolynomial<C>>();
+        OrderedRPairlist<C> pairlist = null;
+        for (GenPolynomial<C> p : F) {
+            if (!p.isZERO()) {
+                p = p.monic(); //p.abs(); // not monic, monic if boolean closed
+                if (p.isONE()) {
+                    G.clear();
+                    G.add(p);
+                    return G; // since boolean closed and no threads are activated
+                }
+                G.add(p); //G.add( 0, p ); //reverse list
+                if (pairlist == null) {
+                    pairlist = new OrderedRPairlist<C>(modv, p.ring);
+                }
+                // putOne not required
+                pairlist.put(p);
+            }
+        }
+        if (G.size() <= 1) {
+            return G; // since boolean closed and no threads are activated
+        }
+        /* loop on critical pairs */
+        Pair<C> pair;
+        GenPolynomial<C> pi;
+        GenPolynomial<C> pj;
+        GenPolynomial<C> S;
+        //GenPolynomial<C> D;
+        GenPolynomial<C> H;
+        List<GenPolynomial<C>> bcH;
+        //int len = G.size();
+        //System.out.println("len = " + len);
+        while (pairlist.hasNext()) {
+            pair = pairlist.removeNext();
+            //System.out.println("pair = " + pair);
+            if (pair == null)
+                continue;
+
+            pi = pair.pi;
+            pj = pair.pj;
+            if (logger.isDebugEnabled()) {
+                logger.debug("pi    = " + pi);
+                logger.debug("pj    = " + pj);
+            }
+            if (!red.moduleCriterion(modv, pi, pj)) {
+                continue;
+            }
+
+            // S-polynomial -----------------------
+            // Criterion3() Criterion4() not applicable
+            S = red.SPolynomial(pi, pj);
+            if (S.isZERO()) {
+                pair.setZero();
+                continue;
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("ht(S) = " + S.leadingExpVector());
+            }
+
+            H = red.normalform(G, S);
+            if (H.isZERO()) {
+                pair.setZero();
+                continue;
+            }
+            //H = H.monic(); // only for boolean closed H
+            if (logger.isDebugEnabled()) {
+                logger.debug("ht(H) = " + H.leadingExpVector());
+            }
+
+            if (H.isONE()) { // mostly useless
+                G.clear();
+                G.add(H);
+                return G; // not boolean closed ok, since no threads are activated
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("H = " + H);
+            }
+            if (!H.isZERO()) {
+                logger.info("Sred = " + H);
+                //len = G.size();
+                bcH = rred.reducedBooleanClosure(G, H);
+                logger.info("#bcH = " + bcH.size());
+                for (GenPolynomial<C> h : bcH) {
+                    h = h.monic(); // monic() ok, since boolean closed
+                    G.add(h);
+                    pairlist.put(h);
+                }
+                if (debug) {
+                    if (!pair.getUseCriterion3() || !pair.getUseCriterion4()) {
+                        logger.info("H != 0 but: " + pair);
+                    }
+                }
+            }
+        }
+        logger.debug("#sequential list = " + G.size());
+        G = minimalGB(G);
+        //G = red.irreducibleSet(G);
+        logger.info("" + pairlist);
+        return G;
+    }
+
+
+    /**
+     * Minimal ordered Groebner basis.
+     * @param Gp a Groebner base.
+     * @return a reduced Groebner base of Gp.
+     */
+    @Override
+    public List<GenPolynomial<C>> minimalGB(List<GenPolynomial<C>> Gp) {
+        if (Gp == null || Gp.size() <= 1) {
+            return Gp;
+        }
+        // remove zero polynomials
+        List<GenPolynomial<C>> G = new ArrayList<GenPolynomial<C>>(Gp.size());
+        for (GenPolynomial<C> a : Gp) {
+            if (a != null && !a.isZERO()) { // always true in GB()
+                // already positive a = a.abs();
+                G.add(a);
+            }
+        }
+        //if (G.size() <= 1) {
+            //wg monic do not return G;
+        //}
+        // remove top reducible polynomials
+        GenPolynomial<C> a, b;
+        List<GenPolynomial<C>> F;
+        List<GenPolynomial<C>> bcH;
+        F = new ArrayList<GenPolynomial<C>>(G.size());
+        while (G.size() > 0) {
+            a = G.remove(0);
+            b = a;
+            if (red.isTopReducible(G, a) || red.isTopReducible(F, a)) {
+                // drop polynomial 
+                if (logger.isInfoEnabled()) {
+                    List<GenPolynomial<C>> ff;
+                    ff = new ArrayList<GenPolynomial<C>>(G);
+                    ff.addAll(F);
+                    a = red.normalform(ff, a);
+                    if (!a.isZERO()) { // happens
+                        logger.info("minGB not zero " + a);
+                        bcH = rred.reducedBooleanClosure(G, a);
+                        if (bcH.size() > 1) { // never happend so far
+                            System.out.println("minGB not bc: bcH size = " + bcH.size());
+                            F.add(b); // do not replace, stay with b
+                        } else {
+                            //System.out.println("minGB add bc(a): a = " + a + ", bc(a) = " + bcH.get(0));
+                            F.addAll(bcH);
+                        }
+                    } else {
+                        //System.out.println("minGB dropped " + b);
+                    }
+                }
+            } else {
+                F.add(a);
+            }
+        }
+        G = F;
+        //if (G.size() <= 1) {
+            // wg monic return G;
+        //}
+        Collections.reverse(G); // important for lex GB
+        // reduce remaining polynomials
+        int len = G.size();
+        int el = 0;
+        while (el < len) {
+            a = G.remove(0);
+            b = a;
+            //System.out.println("doing " + a.length());
+            a = red.normalform(G, a);
+            bcH = rred.reducedBooleanClosure(G, a);
+            if (bcH.size() > 1) {
+                System.out.println("minGB not bc: bcH size = " + bcH.size());
+                G.add(b); // do not reduce
+            } else {
+                G.addAll(bcH);
+            }
+            el++;
+        }
+        // make monic if possible
+        F = new ArrayList<GenPolynomial<C>>(G.size());
+        for (GenPolynomial<C> p : G) {
+            a = p.monic().abs();
+            if (p.length() != a.length()) {
+                System.out.println("minGB not bc: #p != #a: a = " + a + ", p = " + p);
+                a = p; // dont make monic for now
+            }
+            F.add(a);
+        }
+        G = F;
+
+        /* stratify: collect polynomials with equal leading terms */
+        ExpVector e, f;
+        F = new ArrayList<GenPolynomial<C>>(G.size());
+        for (int i = 0; i < G.size(); i++) {
+            a = G.get(i);
+            if (a == null || a.isZERO()) {
+                continue;
+            }
+            e = a.leadingExpVector();
+            for (int j = i + 1; j < G.size(); j++) {
+                b = G.get(j);
+                if (b == null || b.isZERO()) {
+                    continue;
+                }
+                f = b.leadingExpVector();
+                if (e.equals(f)) {
+                    //System.out.println("minGB e == f: " + a + ", " + b);
+                    a = a.sum(b);
+                    G.set(j, null);
+                }
+            }
+            F.add(a);
+        }
+        G = F;
+
+        /* info on boolean algebra element blocks 
+        Map<C,List<GenPolynomial<C>>> bd = new TreeMap<C,List<GenPolynomial<C>>>();
+        for ( GenPolynomial<C> p : G ) { 
+            C cf = p.leadingBaseCoefficient();
+            cf = cf.idempotent();
+            List<GenPolynomial<C>> block = bd.get( cf );
+            if ( block == null ) {
+               block = new ArrayList<GenPolynomial<C>>();
+            }
+            block.add( p ); 
+            bd.put( cf, block );
+        }
+        System.out.println("\nminGB bd:");
+        for( C k: bd.keySet() ) {
+           System.out.println("\nkey = " + k + ":");
+           System.out.println("val = " + bd.get(k));
+        }
+        System.out.println();
+        */
+        return G;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/RPseudoReduction.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/RPseudoReduction.java
@@ -1,0 +1,21 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import edu.jas.structure.RegularRingElem;
+
+
+/**
+ * Polynomial R pseudo reduction interface. Combines RReduction and
+ * PseudoReduction.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public interface RPseudoReduction<C extends RegularRingElem<C>> extends RReduction<C>,
+        PseudoReduction<C> {
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/RPseudoReductionSeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/RPseudoReductionSeq.java
@@ -1,0 +1,381 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.RegularRingElem;
+
+
+/**
+ * Polynomial regular ring pseudo reduction sequential use algorithm. Implements
+ * fraction free normalform algorithm.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class RPseudoReductionSeq<C extends RegularRingElem<C>> extends RReductionSeq<C> implements
+                RPseudoReduction<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(RPseudoReductionSeq.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     */
+    public RPseudoReductionSeq() {
+    }
+
+
+    /**
+     * Normalform using r-reduction.
+     * @param Ap polynomial.
+     * @param Pp polynomial list.
+     * @return r-nf(Ap) with respect to Pp.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public GenPolynomial<C> normalform(List<GenPolynomial<C>> Pp, GenPolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        int l;
+        GenPolynomial<C>[] P;
+        synchronized (Pp) {
+            l = Pp.size();
+            P = (GenPolynomial<C>[]) new GenPolynomial[l];
+            //P = Pp.toArray();
+            for (int i = 0; i < Pp.size(); i++) {
+                P[i] = Pp.get(i);
+            }
+        }
+        //System.out.println("l = " + l);
+        Map.Entry<ExpVector, C> m;
+        ExpVector[] htl = new ExpVector[l];
+        C[] lbc = (C[]) new RegularRingElem[l]; // want <C>
+        GenPolynomial<C>[] p = (GenPolynomial<C>[]) new GenPolynomial[l];
+        int i;
+        int j = 0;
+        for (i = 0; i < l; i++) {
+            if (P[i] == null) {
+                continue;
+            }
+            p[i] = P[i].abs();
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        ExpVector e, f;
+        C a;
+        C r = null;
+        boolean mt = false;
+        GenPolynomial<C> R = Ap.ring.getZERO();
+        GenPolynomial<C> Q = null;
+        GenPolynomial<C> S = Ap;
+        while (S.length() > 0) {
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            //System.out.println("--a = " + a);
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt) {
+                    C c = lbc[i];
+                    //r = a.idempotent().multiply( c.idempotent() );
+                    r = a.idempotentAnd(c);
+                    mt = !r.isZERO(); // && mt
+                    if (mt) {
+                        f = e.subtract(htl[i]);
+                        if (a.remainder(c).isZERO()) { //c.isUnit() ) {
+                            a = a.divide(c);
+                            if (a.isZERO()) {
+                                throw new ArithmeticException("a.isZERO()");
+                            }
+                        } else {
+                            c = c.fillOne();
+                            S = S.multiply(c);
+                            R = R.multiply(c);
+                        }
+                        Q = p[i].multiply(a, f);
+                        S = S.subtract(Q);
+
+                        f = S.leadingExpVector();
+                        if (!e.equals(f)) {
+                            a = Ap.ring.coFac.getZERO();
+                            break;
+                        }
+                        a = S.leadingBaseCoefficient();
+                    }
+                }
+            }
+            if (!a.isZERO()) { //! mt ) { 
+                //logger.debug("irred");
+                R = R.sum(a, e);
+                S = S.reductum();
+            }
+        }
+        return R.abs(); // not monic if not boolean closed
+    }
+
+
+    /**
+     * Normalform using r-reduction.
+     * @param Pp polynomial list.
+     * @param Ap polynomial.
+     * @return ( nf(Ap), mf ) with respect to Pp and mf as multiplication factor
+     *         for Ap.
+     */
+    @SuppressWarnings("unchecked")
+    public PseudoReductionEntry<C> normalformFactor(List<GenPolynomial<C>> Pp, GenPolynomial<C> Ap) {
+        if (Ap == null) {
+            return null;
+        }
+        C mfac = Ap.ring.getONECoefficient();
+        PseudoReductionEntry<C> pf = new PseudoReductionEntry<C>(Ap, mfac);
+        if (Pp == null || Pp.isEmpty()) {
+            return pf;
+        }
+        if (Ap.isZERO()) {
+            return pf;
+        }
+        int l;
+        GenPolynomial<C>[] P;
+        synchronized (Pp) {
+            l = Pp.size();
+            P = (GenPolynomial<C>[]) new GenPolynomial[l];
+            //P = Pp.toArray();
+            for (int i = 0; i < Pp.size(); i++) {
+                P[i] = Pp.get(i);
+            }
+        }
+        //System.out.println("l = " + l);
+        Map.Entry<ExpVector, C> m;
+        ExpVector[] htl = new ExpVector[l];
+        C[] lbc = (C[]) new RegularRingElem[l]; // want <C>
+        GenPolynomial<C>[] p = (GenPolynomial<C>[]) new GenPolynomial[l];
+        int i;
+        int j = 0;
+        for (i = 0; i < l; i++) {
+            if (P[i] == null) {
+                continue;
+            }
+            p[i] = P[i].abs();
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        ExpVector e, f;
+        C a;
+        C r = null;
+        boolean mt = false;
+        GenPolynomial<C> R = Ap.ring.getZERO();
+        GenPolynomial<C> Q = null;
+        GenPolynomial<C> S = Ap;
+        while (S.length() > 0) {
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            //System.out.println("--a = " + a);
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt) {
+                    C c = lbc[i];
+                    //r = a.idempotent().multiply( c.idempotent() );
+                    r = a.idempotentAnd(c);
+                    mt = !r.isZERO(); // && mt
+                    if (mt) {
+                        f = e.subtract(htl[i]);
+                        if (a.remainder(c).isZERO()) { //c.isUnit() ) {
+                            a = a.divide(c);
+                            if (a.isZERO()) {
+                                throw new ArithmeticException("a.isZERO()");
+                            }
+                        } else {
+                            c = c.fillOne();
+                            S = S.multiply(c);
+                            R = R.multiply(c);
+                            mfac = mfac.multiply(c);
+                        }
+                        Q = p[i].multiply(a, f);
+                        S = S.subtract(Q);
+
+                        f = S.leadingExpVector();
+                        if (!e.equals(f)) {
+                            a = Ap.ring.coFac.getZERO();
+                            break;
+                        }
+                        a = S.leadingBaseCoefficient();
+                    }
+                }
+            }
+            if (!a.isZERO()) { //! mt ) { 
+                //logger.debug("irred");
+                R = R.sum(a, e);
+                S = S.reductum();
+            }
+        }
+        pf = new PseudoReductionEntry<C>(R, mfac); //.abs(); // not monic if not boolean closed
+        return pf;
+    }
+
+
+    /**
+     * Normalform with recording. <b>Note:</b> Only meaningfull if all divisions
+     * are exact. Compute first the multiplication factor <code>m</code> with
+     * <code>normalform(Pp,Ap,m)</code>, then call this method with
+     * <code>normalform(row,Pp,m*Ap)</code>.
+     * @param row recording matrix, is modified.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @return nf(Pp,Ap), the normal form of Ap wrt. Pp.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public GenPolynomial<C> normalform(List<GenPolynomial<C>> row, List<GenPolynomial<C>> Pp,
+                    GenPolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        int l;
+        GenPolynomial<C>[] P;
+        synchronized (Pp) {
+            l = Pp.size();
+            P = (GenPolynomial<C>[]) new GenPolynomial[l];
+            //P = Pp.toArray();
+            for (int i = 0; i < Pp.size(); i++) {
+                P[i] = Pp.get(i);
+            }
+        }
+        //System.out.println("l = " + l);
+        Map.Entry<ExpVector, C> m;
+        ExpVector[] htl = new ExpVector[l];
+        C[] lbc = (C[]) new RegularRingElem[l]; // want <C>
+        GenPolynomial<C>[] p = (GenPolynomial<C>[]) new GenPolynomial[l];
+        int i;
+        int j = 0;
+        for (i = 0; i < l; i++) {
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        ExpVector e, f;
+        C a, b;
+        C r = null;
+        boolean mt = false;
+        GenPolynomial<C> fac = null;
+        GenPolynomial<C> zero = Ap.ring.getZERO();
+        GenPolynomial<C> R = Ap.ring.getZERO();
+        GenPolynomial<C> Q = null;
+        GenPolynomial<C> S = Ap;
+        while (S.length() > 0) {
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt) {
+                    C c = lbc[i];
+                    //r = a.idempotent().multiply( c.idempotent() );
+                    r = a.idempotentAnd(c);
+                    //System.out.println("r = " + r);
+                    mt = !r.isZERO(); // && mt
+                    if (mt) {
+                        b = a.remainder(c);
+                        if (b.isZERO()) {
+                            a = a.divide(c);
+                            if (a.isZERO()) {
+                                throw new ArithmeticException("a.isZERO()");
+                            }
+                        } else {
+                            c = c.fillOne();
+                            S = S.multiply(c);
+                            R = R.multiply(c);
+                        }
+                        f = e.subtract(htl[i]);
+                        if (debug) {
+                            logger.info("red div = " + f);
+                        }
+                        Q = p[i].multiply(a, f);
+                        S = S.subtract(Q); // not ok with reductum
+
+                        fac = row.get(i);
+                        if (fac == null) {
+                            fac = zero.sum(a, f);
+                        } else {
+                            fac = fac.sum(a, f);
+                        }
+                        row.set(i, fac);
+
+                        f = S.leadingExpVector();
+                        if (!e.equals(f)) {
+                            a = Ap.ring.coFac.getZERO();
+                            break;
+                        }
+                        a = S.leadingBaseCoefficient();
+                    }
+                }
+            }
+            if (!a.isZERO()) { //! mt ) { 
+                //logger.debug("irred");
+                R = R.sum(a, e);
+                S = S.reductum();
+            }
+        }
+        return R; //.abs(); // not monic if not boolean closed
+    }
+
+
+    /**
+     * Normalform recursive.
+     * @param Ap recursive polynomial.
+     * @param Pp recursive polynomial list.
+     * @return nf(Ap) with respect to Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public GenPolynomial<GenPolynomial<C>> normalformRecursive(List<GenPolynomial<GenPolynomial<C>>> Pp,
+                    GenPolynomial<GenPolynomial<C>> Ap) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+
+    /*
+     * -------- boolean closure stuff -----------------------------------------
+     * -------- is all in superclass
+     */
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/RReduction.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/RReduction.java
@@ -1,0 +1,86 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.List;
+
+import edu.jas.structure.RegularRingElem;
+
+import edu.jas.gb.Reduction;
+import edu.jas.poly.GenPolynomial;
+
+
+/**
+ * Polynomial R Reduction interface. Defines additionally boolean closure
+ * methods.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public interface RReduction<C extends RegularRingElem<C>> extends Reduction<C> {
+
+
+    /**
+     * Is strong top reducible. Condition is idempotent(a) == idempotent(b), for
+     * a=ldcf(A) and b=ldcf(B) and lt(B) | lt(A) for some B in F.
+     * @param A polynomial.
+     * @param P polynomial list.
+     * @return true if A is string top reducible with respect to P.
+     */
+    public boolean isStrongTopReducible(List<GenPolynomial<C>> P, GenPolynomial<C> A);
+
+
+    /**
+     * Is boolean closed, test if A == idempotent(ldcf(A)) A.
+     * @param A polynomial.
+     * @return true if A is boolean closed, else false.
+     */
+    public boolean isBooleanClosed(GenPolynomial<C> A);
+
+
+    /**
+     * Is boolean closed, test if all A in F are boolean closed.
+     * @param F polynomial list.
+     * @return true if F is boolean closed, else false.
+     */
+    public boolean isBooleanClosed(List<GenPolynomial<C>> F);
+
+
+    /**
+     * Boolean closure, compute idempotent(ldcf(A)) A.
+     * @param A polynomial.
+     * @return bc(A).
+     */
+    public GenPolynomial<C> booleanClosure(GenPolynomial<C> A);
+
+
+    /**
+     * Boolean remainder, compute idemComplement(ldcf(A)) A.
+     * @param A polynomial.
+     * @return br(A) = A - bc(A).
+     */
+    public GenPolynomial<C> booleanRemainder(GenPolynomial<C> A);
+
+
+    /**
+     * Reduced boolean closure, compute BC(A) for all A in F.
+     * @param F polynomial list.
+     * @return red(bc(F)) = bc(red(F)).
+     */
+    public List<GenPolynomial<C>> reducedBooleanClosure(List<GenPolynomial<C>> F);
+
+
+    /**
+     * Reduced boolean closure, compute BC(A) modulo F.
+     * @param A polynomial.
+     * @param F polynomial list.
+     * @return red(bc(A)).
+     */
+    public List<GenPolynomial<C>> reducedBooleanClosure(List<GenPolynomial<C>> F,
+            GenPolynomial<C> A);
+
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/RReductionSeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/RReductionSeq.java
@@ -1,0 +1,717 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.ReductionAbstract;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.structure.RegularRingElem;
+
+
+/**
+ * Polynomial Regular ring Reduction sequential use algorithm. Implements
+ * normalform and boolean closure stuff.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class RReductionSeq<C extends RegularRingElem<C>> extends ReductionAbstract<C> implements
+                RReduction<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(RReductionSeq.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     */
+    public RReductionSeq() {
+    }
+
+
+    /**
+     * Is top reducible. Condition is a b != 0, for a=ldcf(A) and b=ldcf(B) and
+     * lt(B) | lt(A) for some B in F.
+     * @param A polynomial.
+     * @param P polynomial list.
+     * @return true if A is top reducible with respect to P.
+     */
+    @Override
+    public boolean isTopReducible(List<GenPolynomial<C>> P, GenPolynomial<C> A) {
+        if (P == null || P.isEmpty()) {
+            return false;
+        }
+        if (A == null || A.isZERO()) {
+            return false;
+        }
+        boolean mt = false;
+        ExpVector e = A.leadingExpVector();
+        C a = A.leadingBaseCoefficient();
+        a = a.idempotent();
+        for (GenPolynomial<C> p : P) {
+            mt = e.multipleOf(p.leadingExpVector());
+            if (mt) {
+                C b = p.leadingBaseCoefficient();
+                //C r = a.multiply( b );
+                //C r = a.multiply( b.idempotent() );
+                C r = a.idempotentAnd(b);
+                mt = !r.isZERO();
+                if (mt) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+
+    /**
+     * Is strong top reducible. Condition is idempotent(a) == idempotent(b), for
+     * a=ldcf(A) and b=ldcf(B) and lt(B) | lt(A) for some B in F.
+     * @param A polynomial.
+     * @param P polynomial list.
+     * @return true if A is string top reducible with respect to P.
+     */
+    public boolean isStrongTopReducible(List<GenPolynomial<C>> P, GenPolynomial<C> A) {
+        if (P == null || P.isEmpty()) {
+            return false;
+        }
+        if (A == null || A.isZERO()) {
+            return false;
+        }
+        boolean mt = false;
+        ExpVector e = A.leadingExpVector();
+        C a = A.leadingBaseCoefficient();
+        a = a.idempotent();
+        for (GenPolynomial<C> p : P) {
+            mt = e.multipleOf(p.leadingExpVector());
+            if (mt) {
+                C b = p.leadingBaseCoefficient();
+                mt = a.equals(b.idempotent());
+                if (mt) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+
+    /**
+     * Is in Normalform.
+     * @param Ap polynomial.
+     * @param Pp polynomial list.
+     * @return true if Ap is in normalform with respect to Pp.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean isNormalform(List<GenPolynomial<C>> Pp, GenPolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return true;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return true;
+        }
+        int l;
+        GenPolynomial<C>[] P;
+        synchronized (Pp) {
+            l = Pp.size();
+            P = new GenPolynomial[l];
+            //P = Pp.toArray();
+            for (int i = 0; i < Pp.size(); i++) {
+                P[i] = Pp.get(i);
+            }
+        }
+        ExpVector[] htl = new ExpVector[l];
+        C[] lbc = (C[]) new RegularRingElem[l]; // want <C>
+        GenPolynomial<C>[] p = new GenPolynomial[l];
+        Map.Entry<ExpVector, C> m;
+        int i;
+        int j = 0;
+        for (i = 0; i < l; i++) {
+            if (P[i] == null) {
+                continue;
+            }
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        boolean mt = false;
+        Map<ExpVector, C> Am = Ap.getMap();
+        for (Map.Entry<ExpVector, C> me : Am.entrySet()) {
+            ExpVector e = me.getKey();
+            C a = me.getValue();
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt) {
+                    //C r = a.multiply( lbc[i] );
+                    //C r = a.idempotent().multiply( lbc[i].idempotent() );
+                    C r = a.idempotentAnd(lbc[i]);
+                    mt = !r.isZERO();
+                    if (mt) {
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Normalform using r-reduction.
+     * @param Ap polynomial.
+     * @param Pp polynomial list.
+     * @return r-nf(Ap) with respect to Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public GenPolynomial<C> normalform(List<GenPolynomial<C>> Pp, GenPolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        int l;
+        GenPolynomial<C>[] P;
+        synchronized (Pp) {
+            l = Pp.size();
+            P = (GenPolynomial<C>[]) new GenPolynomial[l];
+            //P = Pp.toArray();
+            for (int i = 0; i < Pp.size(); i++) {
+                P[i] = Pp.get(i);
+            }
+        }
+        //System.out.println("l = " + l);
+        Map.Entry<ExpVector, C> m;
+        ExpVector[] htl = new ExpVector[l];
+        C[] lbc = (C[]) new RegularRingElem[l]; // want <C>
+        GenPolynomial<C>[] p = (GenPolynomial<C>[]) new GenPolynomial[l];
+        int i;
+        int j = 0;
+        for (i = 0; i < l; i++) {
+            if (P[i] == null) {
+                continue;
+            }
+            p[i] = P[i].abs();
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        ExpVector e, f;
+        C a, b;
+        C r = null;
+        boolean mt = false;
+        GenPolynomial<C> R = Ap.ring.getZERO();
+        GenPolynomial<C> Q = null;
+        GenPolynomial<C> S = Ap;
+        while (S.length() > 0) {
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            if (debug) {
+                if (a.isZERO()) {
+                    throw new RuntimeException("a.isZERO(): S = " + S);
+                }
+            }
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt) {
+                    //r = a.multiply( lbc[i] );
+                    //r = a.idempotent().multiply( lbc[i].idempotent() );
+                    r = a.idempotentAnd(lbc[i]);
+                    mt = !r.isZERO(); // && mt
+                    if (mt) {
+                        b = a.divide(lbc[i]);
+                        if (b.isZERO()) { // strange case in regular rings
+                            System.out.println("b == zero: r = " + r);
+                            continue;
+                        }
+                        f = e.subtract(htl[i]);
+                        //logger.info("red div = " + f);
+                        Q = p[i].multiply(b, f);
+                        S = S.subtract(Q); // not ok with reductum
+                        f = S.leadingExpVector();
+                        if (!e.equals(f)) {
+                            a = Ap.ring.coFac.getZERO();
+                            break;
+                        }
+                        a = S.leadingBaseCoefficient();
+                    }
+                }
+            }
+            if (!a.isZERO()) { //! mt ) { 
+                //logger.debug("irred");
+                R = R.sum(a, e);
+                S = S.reductum();
+            }
+        }
+        return R; //.abs(); // not monic if not boolean closed
+    }
+
+
+    /**
+     * GB criterium 4. Use only for commutative polynomial rings. <b>Note:</b>
+     * Experimental version for r-Groebner bases.
+     * @param A polynomial.
+     * @param B polynomial.
+     * @param e = lcm(ht(A),ht(B))
+     * @return true if the S-polynomial(i,j) is required, else false.
+     */
+    @Override
+    public boolean criterion4(GenPolynomial<C> A, GenPolynomial<C> B, ExpVector e) {
+        if (logger.isInfoEnabled()) {
+            if (!A.ring.equals(B.ring)) {
+                logger.error("rings equal");
+            }
+            if (A instanceof GenSolvablePolynomial || B instanceof GenSolvablePolynomial) {
+                logger.error("GBCriterion4 not applicabable to SolvablePolynomials");
+                return true;
+            }
+        }
+        ExpVector ei = A.leadingExpVector();
+        ExpVector ej = B.leadingExpVector();
+        ExpVector g = ei.sum(ej);
+        // boolean t =  g == e ;
+        ExpVector h = g.subtract(e);
+        int s = h.signum();
+        if (s == 0) { // disjoint ht
+            C a = A.leadingBaseCoefficient();
+            C b = B.leadingBaseCoefficient();
+            C d = a.multiply(b);
+            if (d.isZERO()) { // a guess
+                //System.out.println("d1 = " + d + ", a = " + a + ", b = " + b);
+                return false; // can skip pair
+            }
+        }
+        return true; //! ( s == 0 );
+    }
+
+
+    /**
+     * GB criterium 4. Use only for commutative polynomial rings. <b>Note:</b>
+     * Experimental version for r-Groebner bases.
+     * @param A polynomial.
+     * @param B polynomial.
+     * @return true if the S-polynomial(i,j) is required, else false.
+     */
+    @Override
+    public boolean criterion4(GenPolynomial<C> A, GenPolynomial<C> B) {
+        if (logger.isInfoEnabled()) {
+            if (A instanceof GenSolvablePolynomial || B instanceof GenSolvablePolynomial) {
+                logger.error("GBCriterion4 not applicabable to SolvablePolynomials");
+                return true;
+            }
+        }
+        ExpVector ei = A.leadingExpVector();
+        ExpVector ej = B.leadingExpVector();
+        ExpVector g = ei.sum(ej);
+        ExpVector e = ei.lcm(ej);
+        //        boolean t =  g == e ;
+        ExpVector h = g.subtract(e);
+        int s = h.signum();
+        if (s == 0) { // disjoint ht
+            C a = A.leadingBaseCoefficient();
+            C b = B.leadingBaseCoefficient();
+            C d = a.multiply(b);
+            if (d.isZERO()) { // a guess
+                return false; // can skip pair
+            }
+        }
+        return true; //! ( s == 0 );
+    }
+
+
+    /**
+     * Normalform with recording.
+     * @param row recording matrix, is modified.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @return Ap - row*Pp = nf(Pp,Ap) , the normal form of Ap wrt. Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public GenPolynomial<C> normalform(List<GenPolynomial<C>> row, List<GenPolynomial<C>> Pp,
+                    GenPolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        int l;
+        GenPolynomial<C>[] P;
+        synchronized (Pp) {
+            l = Pp.size();
+            P = (GenPolynomial<C>[]) new GenPolynomial[l];
+            //P = Pp.toArray();
+            for (int i = 0; i < Pp.size(); i++) {
+                P[i] = Pp.get(i);
+            }
+        }
+        //System.out.println("l = " + l);
+        Map.Entry<ExpVector, C> m;
+        ExpVector[] htl = new ExpVector[l];
+        C[] lbc = (C[]) new RegularRingElem[l]; // want <C>
+        GenPolynomial<C>[] p = (GenPolynomial<C>[]) new GenPolynomial[l];
+        int i;
+        int j = 0;
+        for (i = 0; i < l; i++) {
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        ExpVector e, f;
+        C a;
+        C r = null;
+        boolean mt = false;
+        GenPolynomial<C> fac = null;
+        GenPolynomial<C> zero = Ap.ring.getZERO();
+        GenPolynomial<C> R = Ap.ring.getZERO();
+        GenPolynomial<C> Q = null;
+        GenPolynomial<C> S = Ap;
+        while (S.length() > 0) {
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt) {
+                    //r = a.idempotent().multiply( lbc[i].idempotent() );
+                    //r = a.multiply( lbc[i] );
+                    r = a.idempotentAnd(lbc[i]);
+                    //System.out.println("r = " + r);
+                    mt = !r.isZERO(); // && mt
+                    if (mt) {
+                        a = a.divide(lbc[i]);
+                        if (a.isZERO()) { // strange case in regular rings
+                            System.out.println("b == zero: r = " + r);
+                            continue;
+                        }
+                        f = e.subtract(htl[i]);
+                        //logger.info("red div = " + f);
+                        Q = p[i].multiply(a, f);
+                        S = S.subtract(Q); // not ok with reductum
+
+                        fac = row.get(i);
+                        if (fac == null) {
+                            fac = zero.sum(a, f);
+                        } else {
+                            fac = fac.sum(a, f);
+                        }
+                        row.set(i, fac);
+
+                        f = S.leadingExpVector();
+                        if (!e.equals(f)) {
+                            a = Ap.ring.coFac.getZERO();
+                            break;
+                        }
+                        a = S.leadingBaseCoefficient();
+                    }
+                }
+            }
+            if (!a.isZERO()) { //! mt ) { 
+                //logger.debug("irred");
+                R = R.sum(a, e);
+                S = S.reductum();
+            }
+        }
+        return R; //.abs(); not for recording 
+    }
+
+
+    /**
+     * Irreducible set. May not be boolean closed.
+     * @param Pp polynomial list.
+     * @return a list P of polynomials which are in normalform wrt. P.
+     */
+    @Override
+    public List<GenPolynomial<C>> irreducibleSet(List<GenPolynomial<C>> Pp) {
+        ArrayList<GenPolynomial<C>> P = new ArrayList<GenPolynomial<C>>();
+        if (Pp == null) {
+            return null;
+        }
+        for (GenPolynomial<C> a : Pp) {
+            if (!a.isZERO()) {
+                P.add(a);
+            }
+        }
+        int l = P.size();
+        if (l <= 1)
+            return P;
+
+        int irr = 0;
+        ExpVector e;
+        ExpVector f;
+        GenPolynomial<C> a;
+        logger.debug("irr = ");
+        while (irr != l) {
+            //a = P.get(0);
+            a = P.remove(0);
+            e = a.leadingExpVector();
+            a = normalform(P, a);
+            // no not make monic because of boolean closure
+            logger.debug(String.valueOf(irr));
+            if (a.isZERO()) {
+                l--;
+                if (l <= 1) {
+                    return P;
+                }
+            } else {
+                f = a.leadingExpVector();
+                if (e.equals(f)) {
+                    // lbcf(a) eventually shorter
+                    // correct since longer coeffs can reduce shorter coeffs
+                    irr++;
+                } else {
+                    irr = 0;
+                }
+                P.add(a);
+            }
+        }
+        //System.out.println();
+        return P;
+    }
+
+
+    /*
+     * -------- boolean closure stuff -----------------------------------------
+     */
+
+    /**
+     * Is boolean closed, test if A == idempotent(ldcf(A)) A.
+     * @param A polynomial.
+     * @return true if A is boolean closed, else false.
+     */
+    public boolean isBooleanClosed(GenPolynomial<C> A) {
+        if (A == null || A.isZERO()) {
+            return true;
+        }
+        C a = A.leadingBaseCoefficient();
+        C i = a.idempotent();
+        GenPolynomial<C> B = A.multiply(i);
+        // better run idemAnd on coefficients
+        if (A.equals(B)) {
+            return true;
+        }
+        return false;
+    }
+
+
+    /**
+     * Is boolean closed, test if all A in F are boolean closed.
+     * @param F polynomial list.
+     * @return true if F is boolean closed, else false.
+     */
+    public boolean isBooleanClosed(List<GenPolynomial<C>> F) {
+        if (F == null || F.size() == 0) {
+            return true;
+        }
+        for (GenPolynomial<C> a : F) {
+            if (a == null || a.isZERO()) {
+                continue;
+            }
+            //System.out.println("a = " + a);
+            if (!isBooleanClosed(a)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Is reduced boolean closed, test if all A in F are boolean closed or br(A)
+     * reduces to zero.
+     * @param F polynomial list.
+     * @return true if F is boolean closed, else false.
+     */
+    public boolean isReducedBooleanClosed(List<GenPolynomial<C>> F) {
+        if (F == null || F.size() == 0) {
+            return true;
+        }
+        GenPolynomial<C> b;
+        GenPolynomial<C> r;
+        for (GenPolynomial<C> a : F) {
+            //System.out.println("a = " + a);
+            if (a == null) {
+                continue;
+            }
+            while (!a.isZERO()) {
+                if (!isBooleanClosed(a)) {
+                    b = booleanClosure(a);
+                    b = normalform(F, b);
+                    if (!b.isZERO()) { //F.contains(r)
+                        return false;
+                    }
+                }
+                r = booleanRemainder(a);
+                r = normalform(F, r);
+                if (!r.isZERO()) { //F.contains(r)
+                    return false;
+                }
+                //System.out.println("r = " + r);
+                a = r;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Boolean closure, compute idempotent(ldcf(A)) A.
+     * @param A polynomial.
+     * @return bc(A).
+     */
+    public GenPolynomial<C> booleanClosure(GenPolynomial<C> A) {
+        if (A == null || A.isZERO()) {
+            return A;
+        }
+        C a = A.leadingBaseCoefficient();
+        C i = a.idempotent();
+        GenPolynomial<C> B = A.multiply(i);
+        return B;
+    }
+
+
+    /**
+     * Boolean remainder, compute idemComplement(ldcf(A)) A.
+     * @param A polynomial.
+     * @return br(A).
+     */
+    public GenPolynomial<C> booleanRemainder(GenPolynomial<C> A) {
+        if (A == null || A.isZERO()) {
+            return A;
+        }
+        C a = A.leadingBaseCoefficient();
+        C i = a.idemComplement();
+        GenPolynomial<C> B = A.multiply(i);
+        return B;
+    }
+
+
+    /**
+     * Boolean closure, compute BC(A) for all A in F.
+     * @param F polynomial list.
+     * @return bc(F).
+     */
+    public List<GenPolynomial<C>> booleanClosure(List<GenPolynomial<C>> F) {
+        if (F == null || F.size() == 0) {
+            return F;
+        }
+        List<GenPolynomial<C>> B = new ArrayList<GenPolynomial<C>>(F.size());
+        for (GenPolynomial<C> a : F) {
+            if (a == null) {
+                continue;
+            }
+            while (!a.isZERO()) {
+                GenPolynomial<C> b = booleanClosure(a);
+                B.add(b);
+                a = booleanRemainder(a);
+            }
+        }
+        return B;
+    }
+
+
+    /**
+     * Reduced boolean closure, compute BC(A) for all A in F.
+     * @param F polynomial list.
+     * @return red(bc(F)) = bc(red(F)).
+     */
+    public List<GenPolynomial<C>> reducedBooleanClosure(List<GenPolynomial<C>> F) {
+        if (F == null || F.size() == 0) {
+            return F;
+        }
+        List<GenPolynomial<C>> B = new ArrayList<GenPolynomial<C>>(F);
+        GenPolynomial<C> a;
+        GenPolynomial<C> b;
+        GenPolynomial<C> c;
+        int len = B.size();
+        for (int i = 0; i < len; i++) { // not B.size(), it changes
+            a = B.remove(0);
+            if (a == null) {
+                continue;
+            }
+            while (!a.isZERO()) {
+                //System.out.println("a = " + a);
+                b = booleanClosure(a);
+                //System.out.println("b = " + b);
+                b = booleanClosure(normalform(B, b));
+                if (b.isZERO()) {
+                    break;
+                }
+                B.add(b); // adds as last
+                c = a.subtract(b); // = BR(a mod B)
+                //System.out.println("c = " + c);
+                c = normalform(B, c);
+                a = c;
+            }
+        }
+        return B;
+    }
+
+
+    /**
+     * Reduced boolean closure, compute BC(A) modulo F.
+     * @param A polynomial.
+     * @param F polynomial list.
+     * @return red(bc(A)).
+     */
+    public List<GenPolynomial<C>> reducedBooleanClosure(List<GenPolynomial<C>> F, GenPolynomial<C> A) {
+        List<GenPolynomial<C>> B = new ArrayList<GenPolynomial<C>>();
+        if (A == null || A.isZERO()) {
+            return B;
+        }
+        GenPolynomial<C> a = A;
+        GenPolynomial<C> b;
+        GenPolynomial<C> c;
+        while (!a.isZERO()) {
+            //System.out.println("a = " + a);
+            b = booleanClosure(a);
+            //System.out.println("b = " + b);
+            b = booleanClosure(normalform(F, b));
+            if (b.isZERO()) {
+                break;
+            }
+            B.add(b); // adds as last
+            c = a.subtract(b); // = BR(a mod F) 
+            //System.out.println("c = " + c);
+            c = normalform(F, c);
+            //System.out.println("c = " + c);
+            a = c;
+        }
+        return B;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/SGBFactory.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/SGBFactory.java
@@ -1,0 +1,592 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.arith.BigInteger;
+import edu.jas.arith.BigRational;
+import edu.jas.arith.ModInteger;
+import edu.jas.arith.ModIntegerRing;
+import edu.jas.arith.ModLong;
+import edu.jas.arith.ModLongRing;
+import edu.jas.gb.OrderedMinPairlist;
+import edu.jas.gb.OrderedPairlist;
+import edu.jas.gb.OrderedSyzPairlist;
+import edu.jas.gb.PairList;
+import edu.jas.gb.SGBProxy;
+import edu.jas.gb.SolvableGroebnerBaseAbstract;
+import edu.jas.gb.SolvableGroebnerBaseParallel;
+import edu.jas.gb.SolvableGroebnerBaseSeq;
+import edu.jas.gb.SolvableReductionSeq;
+import edu.jas.kern.ComputerThreads;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.QuotPairFactory;
+import edu.jas.structure.RingFactory;
+import edu.jas.structure.ValueFactory;
+import edu.jas.ufd.Quotient;
+import edu.jas.ufd.QuotientRing;
+
+
+// import edu.jas.application.SolvableResidueRing; // package cycle
+
+
+/**
+ * Solvable Groebner bases algorithms factory. Select appropriate Solvable
+ * Groebner bases engine based on the coefficient types.
+ * <p>
+ * <b>Usage:</b> To create objects that implement the
+ * <code>SolvableGroebnerBase</code> interface use the <code>SGBFactory</code>.
+ * It will select an appropriate implementation based on the types of polynomial
+ * coefficients C. The method to obtain an implementation is
+ * <code>getImplementation()</code>. It returns an object of a class which
+ * implements the <code>SolvableGroebnerBase</code> interface, more precisely an
+ * object of abstract class <code>SolvableGroebnerBaseAbstract</code>.
+ * 
+ * <pre>
+ * SolvableGroebnerBase&lt;CT&gt; engine;
+ * engine = SGBFactory.&lt;CT&gt; getImplementation(cofac);
+ * c = engine.GB(A);
+ * </pre>
+ * <p>
+ * For example, if the coefficient type is BigInteger, the usage looks like
+ * 
+ * <pre>
+ * BigInteger cofac = new BigInteger();
+ * SolvableGroebnerBase&lt;BigInteger&gt; engine;
+ * engine = SGBFactory.getImplementation(cofac);
+ * c = engine.GB(A);
+ * </pre>
+ * 
+ * @author Heinz Kredel
+ *
+ * @see edu.jas.gb.GroebnerBase
+ * @see edu.jas.gb.SolvableGroebnerBase
+ * @see edu.jas.application.GBAlgorithmBuilder
+ */
+
+public class SGBFactory {
+
+
+    private static final Logger logger = LogManager.getLogger(SGBFactory.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Protected factory constructor.
+     */
+    protected SGBFactory() {
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, no factory case.
+     * @return GB algorithm implementation for field coefficients.
+     */
+    public static <C extends GcdRingElem<C>> SolvableGroebnerBaseAbstract<C> getImplementation() {
+        logger.warn("no coefficent factory given, assuming field coeffcients");
+        SolvableGroebnerBaseAbstract<C> bba = new SolvableGroebnerBaseSeq<C>();
+        return bba;
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case ModLong.
+     * @param fac ModLongRing.
+     * @return GB algorithm implementation.
+     */
+    public static SolvableGroebnerBaseAbstract<ModLong> getImplementation(ModLongRing fac) {
+        return getImplementation(fac, new OrderedPairlist<ModLong>());
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case ModLong.
+     * @param fac ModLongRing.
+     * @param pl pair selection strategy
+     * @return GB algorithm implementation.
+     */
+    public static SolvableGroebnerBaseAbstract<ModLong> getImplementation(ModLongRing fac,
+                    PairList<ModLong> pl) {
+        SolvableGroebnerBaseAbstract<ModLong> bba;
+        if (fac.isField()) {
+            bba = new SolvableGroebnerBaseSeq<ModLong>(pl);
+        } else {
+            bba = new SolvableGroebnerBasePseudoSeq<ModLong>(fac, pl);
+        }
+        return bba;
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case ModInteger.
+     * @param fac ModIntegerRing.
+     * @return GB algorithm implementation.
+     */
+    public static SolvableGroebnerBaseAbstract<ModInteger> getImplementation(ModIntegerRing fac) {
+        return getImplementation(fac, new OrderedPairlist<ModInteger>());
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case ModInteger.
+     * @param fac ModIntegerRing.
+     * @param pl pair selection strategy
+     * @return GB algorithm implementation.
+     */
+    public static SolvableGroebnerBaseAbstract<ModInteger> getImplementation(ModIntegerRing fac,
+                    PairList<ModInteger> pl) {
+        SolvableGroebnerBaseAbstract<ModInteger> bba;
+        if (fac.isField()) {
+            bba = new SolvableGroebnerBaseSeq<ModInteger>(pl);
+        } else {
+            bba = new SolvableGroebnerBasePseudoSeq<ModInteger>(fac, pl);
+        }
+        return bba;
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case BigInteger.
+     * @param fac BigInteger.
+     * @return GB algorithm implementation.
+     */
+    public static SolvableGroebnerBaseAbstract<BigInteger> getImplementation(BigInteger fac) {
+        return getImplementation(fac, GBFactory.Algo.igb);
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case BigInteger.
+     * @param fac BigInteger.
+     * @param a algorithm, a = igb, egb, dgb.
+     * @return GB algorithm implementation.
+     */
+    public static SolvableGroebnerBaseAbstract<BigInteger> getImplementation(BigInteger fac,
+                    GBFactory.Algo a) {
+        return getImplementation(fac, a, new OrderedPairlist<BigInteger>());
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case BigInteger.
+     * @param fac BigInteger.
+     * @param pl pair selection strategy
+     * @return GB algorithm implementation.
+     */
+    public static SolvableGroebnerBaseAbstract<BigInteger> getImplementation(BigInteger fac,
+                    PairList<BigInteger> pl) {
+        return getImplementation(fac, GBFactory.Algo.igb, pl);
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case BigInteger.
+     * @param fac BigInteger.
+     * @param a algorithm, a = igb, egb, dgb.
+     * @param pl pair selection strategy
+     * @return GB algorithm implementation.
+     */
+    public static SolvableGroebnerBaseAbstract<BigInteger> getImplementation(BigInteger fac, GBFactory.Algo a,
+                    PairList<BigInteger> pl) {
+        SolvableGroebnerBaseAbstract<BigInteger> bba;
+        switch (a) {
+        case igb:
+            bba = new SolvableGroebnerBasePseudoSeq<BigInteger>(fac, pl);
+            break;
+        case egb:
+            throw new UnsupportedOperationException("egb algorithm not available for BigInteger " + a);
+        case dgb:
+            throw new UnsupportedOperationException("dgb algorithm not available for BigInteger " + a);
+        default:
+            throw new IllegalArgumentException("algorithm not available for BigInteger " + a);
+        }
+        return bba;
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case BigRational.
+     * @param fac BigRational.
+     * @return GB algorithm implementation.
+     */
+    public static SolvableGroebnerBaseAbstract<BigRational> getImplementation(BigRational fac) {
+        return getImplementation(fac, GBFactory.Algo.qgb);
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case BigRational.
+     * @param fac BigRational.
+     * @param a algorithm, a = qgb, ffgb.
+     * @return GB algorithm implementation.
+     */
+    public static SolvableGroebnerBaseAbstract<BigRational> getImplementation(BigRational fac,
+                    GBFactory.Algo a) {
+        return getImplementation(fac, a, new OrderedPairlist<BigRational>());
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case BigRational.
+     * @param fac BigRational.
+     * @param pl pair selection strategy
+     * @return GB algorithm implementation.
+     */
+    public static SolvableGroebnerBaseAbstract<BigRational> getImplementation(BigRational fac,
+                    PairList<BigRational> pl) {
+        return getImplementation(fac, GBFactory.Algo.qgb, pl);
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case BigRational.
+     * @param fac BigRational.
+     * @param a algorithm, a = qgb, ffgb.
+     * @param pl pair selection strategy
+     * @return GB algorithm implementation.
+     */
+    public static SolvableGroebnerBaseAbstract<BigRational> getImplementation(BigRational fac,
+                    GBFactory.Algo a, PairList<BigRational> pl) {
+        SolvableGroebnerBaseAbstract<BigRational> bba;
+        switch (a) {
+        case qgb:
+            bba = new SolvableGroebnerBaseSeq<BigRational>(pl);
+            break;
+        case ffgb:
+            throw new UnsupportedOperationException("ffgb algorithm not available for BigRational " + a);
+            //PairList<BigInteger> pli;
+            //if (pl instanceof OrderedMinPairlist) {
+            //    pli = new OrderedMinPairlist<BigInteger>();
+            //} else if (pl instanceof OrderedSyzPairlist) {
+            //    pli = new OrderedSyzPairlist<BigInteger>();
+            //} else {
+            //    pli = new OrderedPairlist<BigInteger>();
+            //}
+            //bba = new SolvableGroebnerBaseRational<BigRational>(pli); // pl not possible
+            //break;
+        default:
+            throw new IllegalArgumentException(
+                            "algorithm not available for " + fac.toScriptFactory() + ", Algo = " + a);
+        }
+        return bba;
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case Quotient
+     * coefficients.
+     * @param fac QuotientRing.
+     * @return GB algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C>> SolvableGroebnerBaseAbstract<Quotient<C>> getImplementation(
+                    QuotientRing<C> fac) {
+        return getImplementation(fac, GBFactory.Algo.qgb);
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case Quotient
+     * coefficients.
+     * @param fac QuotientRing.
+     * @param a algorithm, a = qgb, ffgb.
+     * @return GB algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C>> SolvableGroebnerBaseAbstract<Quotient<C>> getImplementation(
+                    QuotientRing<C> fac, GBFactory.Algo a) {
+        return getImplementation(fac, a, new OrderedPairlist<Quotient<C>>());
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case Quotient
+     * coefficients.
+     * @param fac QuotientRing.
+     * @param pl pair selection strategy
+     * @return GB algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C>> SolvableGroebnerBaseAbstract<Quotient<C>> getImplementation(
+                    QuotientRing<C> fac, PairList<Quotient<C>> pl) {
+        return getImplementation(fac, GBFactory.Algo.qgb, pl);
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case Quotient
+     * coefficients.
+     * @param fac QuotientRing.
+     * @param a algorithm, a = qgb, ffgb.
+     * @param pl pair selection strategy
+     * @return GB algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C>> SolvableGroebnerBaseAbstract<Quotient<C>> getImplementation(
+                    QuotientRing<C> fac, GBFactory.Algo a, PairList<Quotient<C>> pl) {
+        SolvableGroebnerBaseAbstract<Quotient<C>> bba;
+        if (logger.isInfoEnabled()) {
+            logger.info("QuotientRing, fac = " + fac);
+        }
+        switch (a) {
+        case qgb:
+            bba = new SolvableGroebnerBaseSeq<Quotient<C>>(new SolvableReductionSeq<Quotient<C>>(), pl);
+            break;
+        case ffgb:
+            throw new UnsupportedOperationException("ffgb algorithm not available for " + a);
+            //PairList<GenPolynomial<C>> pli;
+            //if (pl instanceof OrderedMinPairlist) {
+            //    pli = new OrderedMinPairlist<GenPolynomial<C>>();
+            //} else if (pl instanceof OrderedSyzPairlist) {
+            //    pli = new OrderedSyzPairlist<GenPolynomial<C>>();
+            //} else {
+            //    pli = new OrderedPairlist<GenPolynomial<C>>();
+            //}
+            //bba = new SolvableGroebnerBaseQuotient<C>(fac, pli); // pl not possible
+            //break;
+        default:
+            throw new IllegalArgumentException("algorithm not available for Quotient " + a);
+        }
+        return bba;
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case (recursive)
+     * polynomial.
+     * @param fac GenPolynomialRing&lt;C&gt;.
+     * @return GB algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C>> SolvableGroebnerBaseAbstract<GenPolynomial<C>> getImplementation(
+                    GenPolynomialRing<C> fac) {
+        return getImplementation(fac, GBFactory.Algo.igb);
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case (recursive)
+     * polynomial.
+     * @param fac GenPolynomialRing&lt;C&gt;.
+     * @param a algorithm, a = igb or egb, dgb if fac is univariate over a
+     *            field.
+     * @return GB algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C>> SolvableGroebnerBaseAbstract<GenPolynomial<C>> getImplementation(
+                    GenPolynomialRing<C> fac, GBFactory.Algo a) {
+        return getImplementation(fac, a, new OrderedPairlist<GenPolynomial<C>>());
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case (recursive)
+     * polynomial.
+     * @param fac GenPolynomialRing&lt;C&gt;.
+     * @param pl pair selection strategy
+     * @return GB algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C>> SolvableGroebnerBaseAbstract<GenPolynomial<C>> getImplementation(
+                    GenPolynomialRing<C> fac, PairList<GenPolynomial<C>> pl) {
+        return getImplementation(fac, GBFactory.Algo.igb, pl);
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, case (recursive)
+     * polynomial.
+     * @param fac GenPolynomialRing&lt;C&gt;.
+     * @param a algorithm, a = igb or egb, dgb if fac is univariate over a
+     *            field.
+     * @param pl pair selection strategy
+     * @return GB algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C>> SolvableGroebnerBaseAbstract<GenPolynomial<C>> getImplementation(
+                    GenPolynomialRing<C> fac, GBFactory.Algo a, PairList<GenPolynomial<C>> pl) {
+        SolvableGroebnerBaseAbstract<GenPolynomial<C>> bba;
+        switch (a) {
+        case igb:
+            bba = new SolvableGroebnerBasePseudoRecSeq<C>(fac, pl);
+            break;
+        case egb:
+            throw new UnsupportedOperationException("egb algorithm not available for " + a);
+            //if (fac.nvar > 1 || !fac.coFac.isField()) {
+            //    throw new IllegalArgumentException("coefficients not univariate or not over a field" + fac);
+            //}
+            //bba = new ESolvableGroebnerBaseSeq<GenPolynomial<C>>(); // pl not suitable
+            //break;
+        case dgb:
+            throw new UnsupportedOperationException("dgb algorithm not available for " + a);
+            //if (fac.nvar > 1 || !fac.coFac.isField()) {
+            //    throw new IllegalArgumentException("coefficients not univariate or not over a field" + fac);
+            //}
+            //bba = new DSolvableGroebnerBaseSeq<GenPolynomial<C>>(); // pl not suitable
+            //break;
+        default:
+            throw new IllegalArgumentException("algorithm not available for GenPolynomial<C> " + a);
+        }
+        return bba;
+    }
+
+
+    /*
+     * Determine suitable implementation of GB algorithms, case regular rings.
+     * @param fac RegularRing.
+     * @return GB algorithm implementation.
+    public static <C extends RingElem<C>> SolvableGroebnerBaseAbstract<Product<C>> getImplementation(
+                    ProductRing<C> fac) {
+        SolvableGroebnerBaseAbstract<Product<C>> bba;
+        if (fac.onlyFields()) {
+            bba = new RSolvableGroebnerBaseSeq<Product<C>>();
+        } else {
+            bba = new RSolvableGroebnerBasePseudoSeq<Product<C>>(fac);
+        }
+        return bba;
+    }
+     */
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, other cases.
+     * @param fac RingFactory&lt;C&gt;.
+     * @return GB algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C>> // interface RingElem not sufficient 
+    SolvableGroebnerBaseAbstract<C> getImplementation(RingFactory<C> fac) {
+        return getImplementation(fac, new OrderedPairlist<C>());
+    }
+
+
+    /**
+     * Determine suitable implementation of GB algorithms, other cases.
+     * @param fac RingFactory&lt;C&gt;.
+     * @param pl pair selection strategy
+     * @return GB algorithm implementation.
+     */
+    @SuppressWarnings({ "cast", "unchecked" })
+    public static <C extends GcdRingElem<C>> // interface RingElem not sufficient 
+    SolvableGroebnerBaseAbstract<C> getImplementation(RingFactory<C> fac, PairList<C> pl) {
+        if (debug) {
+            logger.debug("fac = " + fac.getClass().getName()); // + ", fac = " + fac.toScript());
+        }
+        if (fac.isField()) {
+            return new SolvableGroebnerBaseSeq<C>(pl);
+        }
+        if (fac instanceof ValueFactory) {
+            return new SolvableGroebnerBasePseudoSeq<C>(fac, pl);
+        }
+        if (fac instanceof QuotPairFactory) {
+            return new SolvableGroebnerBaseSeq<C>(pl);
+        }
+        SolvableGroebnerBaseAbstract bba = null;
+        Object ofac = fac;
+        if (ofac instanceof GenPolynomialRing) {
+            PairList<GenPolynomial<C>> pli;
+            if (pl instanceof OrderedMinPairlist) {
+                pli = new OrderedMinPairlist<GenPolynomial<C>>();
+            } else if (pl instanceof OrderedSyzPairlist) {
+                pli = new OrderedSyzPairlist<GenPolynomial<C>>();
+            } else {
+                pli = new OrderedPairlist<GenPolynomial<C>>();
+            }
+            GenPolynomialRing<C> rofac = (GenPolynomialRing<C>) ofac;
+            SolvableGroebnerBaseAbstract<GenPolynomial<C>> bbr = new SolvableGroebnerBasePseudoRecSeq<C>(
+                            rofac, pli); // not pl
+            bba = (SolvableGroebnerBaseAbstract) bbr;
+            //} else if (ofac instanceof ProductRing) {
+            //    ProductRing pfac = (ProductRing) ofac;
+            //    if (pfac.onlyFields()) {
+            //        bba = new RSolvableGroebnerBaseSeq<Product<C>>();
+            //    } else {
+            //        bba = new RSolvableGroebnerBasePseudoSeq<Product<C>>(pfac);
+            //    }
+        } else {
+            bba = new SolvableGroebnerBasePseudoSeq<C>(fac, pl);
+        }
+        logger.info("bba = " + bba.getClass().getName());
+        return bba;
+    }
+
+
+    /**
+     * Determine suitable parallel/concurrent implementation of GB algorithms if
+     * possible.
+     * @param fac RingFactory&lt;C&gt;.
+     * @return GB proxy algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C>> // interface RingElem not sufficient 
+    SolvableGroebnerBaseAbstract<C> getProxy(RingFactory<C> fac) {
+        return getProxy(fac, new OrderedPairlist<C>());
+    }
+
+
+    /**
+     * Determine suitable parallel/concurrent implementation of GB algorithms if
+     * possible.
+     * @param fac RingFactory&lt;C&gt;.
+     * @param pl pair selection strategy
+     * @return GB proxy algorithm implementation.
+     */
+    @SuppressWarnings({ "unchecked" })
+    public static <C extends GcdRingElem<C>> // interface RingElem not sufficient 
+    SolvableGroebnerBaseAbstract<C> getProxy(RingFactory<C> fac, PairList<C> pl) {
+        if (ComputerThreads.NO_THREADS) {
+            return SGBFactory.<C> getImplementation(fac, pl);
+        }
+        if (debug) {
+            logger.debug("proxy fac = " + fac.getClass().getName());
+        }
+        int th = (ComputerThreads.N_CPUS > 2 ? ComputerThreads.N_CPUS - 1 : 2);
+        if (fac.isField()) {
+            SolvableGroebnerBaseAbstract<C> e1 = new SolvableGroebnerBaseSeq<C>(pl);
+            SolvableGroebnerBaseAbstract<C> e2 = new SolvableGroebnerBaseParallel<C>(th, pl);
+            return new SGBProxy<C>(e1, e2);
+        } else if (fac.characteristic().signum() == 0) {
+            if (fac instanceof GenPolynomialRing) {
+                GenPolynomialRing pfac = (GenPolynomialRing) fac;
+                OrderedPairlist ppl = new OrderedPairlist<GenPolynomial<C>>();
+                SolvableGroebnerBaseAbstract e1 = new SolvableGroebnerBasePseudoRecSeq<C>(pfac, ppl);
+                logger.warn("no parallel version available, returning sequential version");
+                return e1;
+                //SolvableGroebnerBaseAbstract e2 = new SolvableGroebnerBasePseudoRecParallel<C>(th, pfac, ppl);
+                //return new SGBProxy<C>(e1, e2);
+            }
+            SolvableGroebnerBaseAbstract<C> e1 = new SolvableGroebnerBasePseudoSeq<C>(fac, pl);
+            logger.warn("no parallel version available, returning sequential version");
+            return e1;
+            //SolvableGroebnerBaseAbstract<C> e2 = new SolvableGroebnerBasePseudoParallel<C>(th, fac, pl);
+            //return new SGBProxy<C>(e1, e2);
+        }
+        return getImplementation(fac, pl);
+    }
+
+
+    /**
+     * Determine suitable parallel/concurrent implementation of GB algorithms if
+     * possible.
+     * @param fac RingFactory&lt;C&gt;.
+     * @return GB proxy algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C>> // interface RingElem not sufficient 
+    SolvableGroebnerBaseAbstract<GenPolynomial<C>> getProxy(GenPolynomialRing<C> fac) {
+        if (ComputerThreads.NO_THREADS) {
+            //return SGBFactory.<GenPolynomial<C>> getImplementation(fac);
+            return SGBFactory.getImplementation(fac);
+        }
+        if (debug) {
+            logger.debug("fac = " + fac.getClass().getName());
+        }
+        //int th = (ComputerThreads.N_CPUS > 2 ? ComputerThreads.N_CPUS - 1 : 2);
+        OrderedPairlist<GenPolynomial<C>> ppl = new OrderedPairlist<GenPolynomial<C>>();
+        SolvableGroebnerBaseAbstract<GenPolynomial<C>> e1 = new SolvableGroebnerBasePseudoRecSeq<C>(fac, ppl);
+        logger.warn("no parallel version available, returning sequential version");
+        return e1;
+        //SolvableGroebnerBaseAbstract<GenPolynomial<C>> e2 = new SolvableGroebnerBasePseudoRecParallel<C>(th, fac, ppl);
+        //return new SGBProxy<GenPolynomial<C>>(e1, e2);
+        //return new SGBProxy(e1, e2);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/SolvableGroebnerBasePseudoRecSeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/SolvableGroebnerBasePseudoRecSeq.java
@@ -1,0 +1,525 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.OrderedPairlist;
+import edu.jas.gb.Pair;
+import edu.jas.gb.PairList;
+import edu.jas.gb.SolvableExtendedGB;
+import edu.jas.gb.SolvableGroebnerBaseAbstract;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.GenSolvablePolynomialRing;
+import edu.jas.poly.QLRSolvablePolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.poly.PolynomialList;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.ufd.GCDFactory;
+import edu.jas.ufd.GreatestCommonDivisorAbstract;
+import edu.jas.ufd.GreatestCommonDivisorFake;
+
+
+/**
+ * Solvable Groebner Base with pseudo reduction sequential algorithm. Implements
+ * coefficient fraction free Groebner bases. Coefficients can for example be
+ * (commutative) multivariate polynomials.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ * 
+ * @see edu.jas.application.GBAlgorithmBuilder
+ * @see edu.jas.gbufd.GBFactory
+ */
+
+public class SolvableGroebnerBasePseudoRecSeq<C extends GcdRingElem<C>> extends
+                SolvableGroebnerBaseAbstract<GenPolynomial<C>> {
+
+
+    private static final Logger logger = LogManager.getLogger(SolvableGroebnerBasePseudoRecSeq.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Greatest common divisor engine for coefficient content and primitive
+     * parts.
+     */
+    protected final GreatestCommonDivisorAbstract<C> engine;
+
+
+    /**
+     * Pseudo reduction engine.
+     */
+    protected final SolvablePseudoReduction<C> sredRec;
+
+
+    /**
+     * Pseudo reduction engine.
+     */
+    protected final SolvablePseudoReduction<GenPolynomial<C>> sred;
+
+
+    /**
+     * Coefficient ring factory.
+     */
+    //protected final RingFactory<C> cofac;
+    protected final GenPolynomialRing<C> cofac;
+
+
+    /**
+     * Constructor.
+     * @param rf coefficient ring factory.
+     */
+    public SolvableGroebnerBasePseudoRecSeq(RingFactory<GenPolynomial<C>> rf) {
+        this(rf, new SolvablePseudoReductionSeq<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param rf coefficient ring factory.
+     * @param pl pair selection strategy
+     */
+    public SolvableGroebnerBasePseudoRecSeq(RingFactory<GenPolynomial<C>> rf, PairList<GenPolynomial<C>> pl) {
+        this(rf, new SolvablePseudoReductionSeq<C>(), pl);
+    }
+
+
+    /**
+     * Constructor.
+     * @param rf coefficient ring factory.
+     * @param red pseudo reduction engine. <b>Note:</b> red must be an instance
+     *            of PseudoReductionSeq.
+     */
+    public SolvableGroebnerBasePseudoRecSeq(RingFactory<GenPolynomial<C>> rf, SolvablePseudoReduction<C> red) {
+        this(rf, red, new OrderedPairlist<GenPolynomial<C>>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param rf coefficient ring factory.
+     * @param red pseudo reduction engine. <b>Note:</b> red must be an instance
+     *            of PseudoReductionSeq.
+     * @param pl pair selection strategy
+     */
+    @SuppressWarnings({ "cast", "unchecked" })
+    public SolvableGroebnerBasePseudoRecSeq(RingFactory<GenPolynomial<C>> rf, SolvablePseudoReduction<C> red,
+                    PairList<GenPolynomial<C>> pl) {
+        super((SolvablePseudoReduction<GenPolynomial<C>>) (SolvablePseudoReduction) red, pl);
+        this.sred = (SolvablePseudoReduction<GenPolynomial<C>>) (SolvablePseudoReduction) red;
+        sredRec = red;
+        //this.red = sred;
+        cofac = (GenPolynomialRing<C>) rf;
+        if (!cofac.isCommutative()) {
+            logger.warn("right reduction not correct for " + cofac.toScript());
+            engine = new GreatestCommonDivisorFake<C>();
+            // TODO check that also coeffTable is empty for recursive solvable poly ring
+        } else {
+            //engine = GCDFactory.<C> getImplementation(cofac.coFac);
+            engine = GCDFactory.<C> getProxy(cofac.coFac);
+        }
+    }
+
+
+    /**
+     * Left Groebner base using pairlist class.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return GB(F) a Groebner base of F.
+     */
+    @Override
+    public List<GenSolvablePolynomial<GenPolynomial<C>>> leftGB(int modv,
+                    List<GenSolvablePolynomial<GenPolynomial<C>>> F) {
+        List<GenSolvablePolynomial<GenPolynomial<C>>> G = normalizeZerosOnes(F);
+        G = PolynomialList.<GenPolynomial<C>> castToSolvableList(PolyUtil.<C> monicRec(engine
+                        .recursivePrimitivePart(PolynomialList.<GenPolynomial<C>> castToList(G))));
+        if (G.size() <= 1) {
+            return G;
+        }
+        GenSolvablePolynomialRing<GenPolynomial<C>> ring = G.get(0).ring;
+        if (ring.coFac.isField()) { // remove ? 
+            throw new IllegalArgumentException("coefficients from a field");
+        }
+        PairList<GenPolynomial<C>> pairlist = strategy.create(modv, ring);
+        pairlist.put(PolynomialList.<GenPolynomial<C>> castToList(G));
+        logger.info("leftGB start " + pairlist);
+
+        Pair<GenPolynomial<C>> pair;
+        GenSolvablePolynomial<GenPolynomial<C>> pi, pj, S, H;
+        while (pairlist.hasNext()) {
+            pair = pairlist.removeNext();
+            if (pair == null)
+                continue;
+
+            pi = (GenSolvablePolynomial<GenPolynomial<C>>) pair.pi;
+            pj = (GenSolvablePolynomial<GenPolynomial<C>>) pair.pj;
+            if (debug) {
+                logger.debug("pi    = " + pi);
+                logger.debug("pj    = " + pj);
+            }
+
+            S = sred.leftSPolynomial(pi, pj);
+            if (S.isZERO()) {
+                pair.setZero();
+                continue;
+            }
+            if (debug) {
+                logger.info("ht(S) = " + S.leadingExpVector());
+            }
+
+            H = sredRec.leftNormalformRecursive(G, S);
+            if (H.isZERO()) {
+                pair.setZero();
+                continue;
+            }
+            if (debug) {
+                logger.info("ht(H) = " + H.leadingExpVector() + ", #(H) = " + H.length());
+            }
+            H = (GenSolvablePolynomial<GenPolynomial<C>>) engine.recursivePrimitivePart(H);
+            H = PolyUtil.<C> monic(H);
+            if (H.isConstant()) {
+                G.clear();
+                G.add(H);
+                return G; // since no threads are activated
+            }
+            if (debug) {
+                logger.info("lc(pp(H)) = " + H.leadingBaseCoefficient().toScript());
+            }
+            if (H.length() > 0) {
+                G.add(H);
+                pairlist.put(H);
+            }
+        }
+        logger.debug("#sequential list = " + G.size());
+        G = leftMinimalGB(G);
+        logger.info("leftGB end  " + pairlist);
+        return G;
+    }
+
+
+    /**
+     * Minimal ordered Solvable Groebner basis.
+     * @param Gp a Solvable Groebner base.
+     * @return a reduced Solvable Groebner base of Gp.
+     */
+    @Override
+    public List<GenSolvablePolynomial<GenPolynomial<C>>> leftMinimalGB(
+                    List<GenSolvablePolynomial<GenPolynomial<C>>> Gp) {
+        List<GenSolvablePolynomial<GenPolynomial<C>>> G = normalizeZerosOnes(Gp);
+        if (G.size() <= 1) {
+            return G;
+        }
+        // remove top reducible polynomials
+        GenSolvablePolynomial<GenPolynomial<C>> a;
+        List<GenSolvablePolynomial<GenPolynomial<C>>> F = new ArrayList<GenSolvablePolynomial<GenPolynomial<C>>>(
+                        G.size());
+        while (G.size() > 0) {
+            a = G.remove(0);
+            if (sred.isTopReducible(G, a) || sred.isTopReducible(F, a)) {
+                // drop polynomial 
+                if (debug) {
+                    System.out.println("dropped " + a);
+                    List<GenSolvablePolynomial<GenPolynomial<C>>> ff;
+                    ff = new ArrayList<GenSolvablePolynomial<GenPolynomial<C>>>(G);
+                    ff.addAll(F);
+                    a = sredRec.leftNormalformRecursive(ff, a);
+                    if (!a.isZERO()) {
+                        System.out.println("error, nf(a) " + a);
+                    }
+                }
+            } else {
+                F.add(a);
+            }
+        }
+        G = F;
+        if (G.size() <= 1) {
+            return G;
+        }
+        Collections.reverse(G); // important for lex GB
+        // reduce remaining polynomials
+        int len = G.size();
+        int i = 0;
+        while (i < len) {
+            a = G.remove(0);
+            //System.out.println("doing " + a.length());
+            a = sredRec.leftNormalformRecursive(G, a);
+            a = (GenSolvablePolynomial<GenPolynomial<C>>) engine.recursivePrimitivePart(a); //a.monic(); not possible
+            a = PolyUtil.<C> monic(a);
+            G.add(a); // adds as last
+            i++;
+        }
+        return G;
+    }
+
+
+    /**
+     * Twosided Solvable Groebner base using pairlist class.
+     * @param modv number of module variables.
+     * @param Fp solvable polynomial list.
+     * @return tsGB(Fp) a twosided Groebner base of Fp.
+     */
+    @Override
+    public List<GenSolvablePolynomial<GenPolynomial<C>>> twosidedGB(int modv,
+                    List<GenSolvablePolynomial<GenPolynomial<C>>> Fp) {
+        List<GenSolvablePolynomial<GenPolynomial<C>>> G = normalizeZerosOnes(Fp);
+        G = PolynomialList.<GenPolynomial<C>> castToSolvableList(PolyUtil.<C> monicRec(engine
+                        .recursivePrimitivePart(PolynomialList.<GenPolynomial<C>> castToList(G))));
+        if (G.size() < 1) { // two-sided!
+            return G;
+        }
+        //System.out.println("G = " + G);
+        GenSolvablePolynomialRing<GenPolynomial<C>> ring = G.get(0).ring; // assert != null
+        if (ring.coFac.isField()) { // remove ?
+            throw new IllegalArgumentException("coefficients from a field");
+        }
+        // add also coefficient generators
+        List<GenSolvablePolynomial<GenPolynomial<C>>> X;
+        X = PolynomialList.castToSolvableList(ring.generators(modv)); 
+        logger.info("right multipliers = " + X);
+        List<GenSolvablePolynomial<GenPolynomial<C>>> F = new ArrayList<GenSolvablePolynomial<GenPolynomial<C>>>(
+                        G.size() * (1 + X.size()));
+        F.addAll(G);
+        GenSolvablePolynomial<GenPolynomial<C>> p, x, q;
+        for (int i = 0; i < F.size(); i++) { // F changes
+            p = F.get(i);
+            for (int j = 0; j < X.size(); j++) {
+                x = X.get(j);
+                if (x.isONE()) {
+                    continue;
+                }
+                q = p.multiply(x);
+                q = sredRec.leftNormalformRecursive(F, q);
+                if (!q.isZERO()) {
+                    q = (GenSolvablePolynomial<GenPolynomial<C>>) engine.recursivePrimitivePart(q);
+                    q = PolyUtil.<C> monic(q);
+                    F.add(q);
+                }
+            }
+        }
+        G = F;
+        //System.out.println("G generated = " + G);
+        PairList<GenPolynomial<C>> pairlist = strategy.create(modv, ring);
+        pairlist.put(PolynomialList.<GenPolynomial<C>> castToList(G));
+        logger.info("twosidedGB start " + pairlist);
+
+        Pair<GenPolynomial<C>> pair;
+        GenSolvablePolynomial<GenPolynomial<C>> pi, pj, S, H;
+        while (pairlist.hasNext()) {
+            pair = pairlist.removeNext();
+            if (pair == null) {
+                continue;
+            }
+
+            pi = (GenSolvablePolynomial<GenPolynomial<C>>) pair.pi;
+            pj = (GenSolvablePolynomial<GenPolynomial<C>>) pair.pj;
+            if (debug) {
+                logger.debug("pi    = " + pi);
+                logger.debug("pj    = " + pj);
+            }
+
+            S = sred.leftSPolynomial(pi, pj);
+            if (S.isZERO()) {
+                pair.setZero();
+                continue;
+            }
+            if (debug) {
+                logger.info("ht(S) = " + S.leadingExpVector());
+            }
+
+            H = sredRec.leftNormalformRecursive(G, S);
+            if (H.isZERO()) {
+                pair.setZero();
+                continue;
+            }
+            if (debug) {
+                logger.info("ht(H) = " + H.leadingExpVector());
+            }
+
+            H = (GenSolvablePolynomial<GenPolynomial<C>>) engine.recursivePrimitivePart(H);
+            H = PolyUtil.<C> monic(H);
+            if (H.isONE()) {
+                G.clear();
+                G.add(H);
+                return G; // since no threads are activated
+            }
+            if (debug) {
+                logger.info("lc(pp(H)) = " + H.leadingBaseCoefficient());
+            }
+            if (H.length() > 0) {
+                G.add(H);
+                pairlist.put(H);
+                for (int j = 0; j < X.size(); j++) {
+                    x = X.get(j);
+                    if (x.isONE()) {
+                        continue;
+                    }
+                    p = H.multiply(x);
+                    p = sredRec.leftNormalformRecursive(G, p);
+                    if (!p.isZERO()) {
+                        p = (GenSolvablePolynomial<GenPolynomial<C>>) engine.recursivePrimitivePart(p);
+                        p = PolyUtil.<C> monic(p);
+                        if (p.isONE()) {
+                            G.clear();
+                            G.add(p);
+                            return G; // since no threads are activated
+                        }
+                        G.add(p);
+                        pairlist.put(p);
+                    }
+                }
+            }
+        }
+        logger.debug("#sequential list = " + G.size());
+        G = leftMinimalGB(G);
+        logger.info("twosidedGB end  " + pairlist);
+        return G;
+    }
+
+
+    /**
+     * Left Groebner base test.
+     * @param modv number of module variables.
+     * @param F solvable polynomial list.
+     * @return true, if F is a left Groebner base, else false.
+     */
+    @Override
+    public boolean isLeftGBsimple(int modv, List<GenSolvablePolynomial<GenPolynomial<C>>> F) {
+        //System.out.println("F to left check = " + F);
+        GenSolvablePolynomial<GenPolynomial<C>> pi, pj, s, h;
+        for (int i = 0; i < F.size(); i++) {
+            pi = F.get(i);
+            for (int j = i + 1; j < F.size(); j++) {
+                pj = F.get(j);
+                if (!red.moduleCriterion(modv, pi, pj)) {
+                    continue;
+                }
+                // if ( ! red.criterion4( pi, pj ) ) { continue; }
+                s = sred.leftSPolynomial(pi, pj);
+                if (s.isZERO()) {
+                    continue;
+                }
+                h = sredRec.leftNormalformRecursive(F, s);
+                if (!h.isZERO()) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Left Groebner base idempotence test.
+     * @param modv module variable number.
+     * @param F solvable polynomial list.
+     * @return true, if F is equal to GB(F), else false.
+     */
+    @Override
+    public boolean isLeftGBidem(int modv, List<GenSolvablePolynomial<GenPolynomial<C>>> F) {
+        if (F == null || F.isEmpty()) {
+            return true;
+        }
+        GenSolvablePolynomialRing<GenPolynomial<C>> pring = F.get(0).ring;
+        List<GenSolvablePolynomial<GenPolynomial<C>>> G = leftGB(modv, F);
+        PolynomialList<GenPolynomial<C>> Fp = new PolynomialList<GenPolynomial<C>>(pring, F);
+        PolynomialList<GenPolynomial<C>> Gp = new PolynomialList<GenPolynomial<C>>(pring, G);
+        return Fp.compareTo(Gp) == 0;
+    }
+
+
+    /**
+     * Twosided Groebner base test.
+     * @param modv number of module variables.
+     * @param Fp solvable polynomial list.
+     * @return true, if Fp is a two-sided Groebner base, else false.
+     */
+    @Override
+    public boolean isTwosidedGB(int modv, List<GenSolvablePolynomial<GenPolynomial<C>>> Fp) {
+        //System.out.println("F to twosided check = " + Fp);
+        if (Fp == null || Fp.size() == 0) { // 0 not 1
+            return true;
+        }
+        GenSolvablePolynomialRing<GenPolynomial<C>> ring = Fp.get(0).ring; // assert != null
+        //List<GenSolvablePolynomial<C>> X = generateUnivar( modv, Fp );
+        List<GenSolvablePolynomial<GenPolynomial<C>>> X, Y;
+        X = PolynomialList.castToSolvableList(ring.generators()); // modv used below
+        Y = new ArrayList<GenSolvablePolynomial<GenPolynomial<C>>>();
+        for (GenSolvablePolynomial<GenPolynomial<C>> x : X) {
+             if (x.isConstant()) {
+                 Y.add(x);
+             }
+        }
+        X = Y;
+        X.addAll(ring.univariateList(modv));
+        logger.info("right multipliers = " + X);
+        List<GenSolvablePolynomial<GenPolynomial<C>>> F = new ArrayList<GenSolvablePolynomial<GenPolynomial<C>>>(
+                        Fp.size() * (1 + X.size()));
+        F.addAll(Fp);
+        GenSolvablePolynomial<GenPolynomial<C>> p, x, pi, pj, s, h;
+        for (int i = 0; i < Fp.size(); i++) {
+            p = Fp.get(i);
+            for (int j = 0; j < X.size(); j++) {
+                x = X.get(j);
+                if (x.isONE()) {
+                    continue;
+                }
+                p = p.multiply(x);
+                p = sredRec.leftNormalformRecursive(F, p);
+                if (!p.isZERO()) {
+                    return false;
+                    //F.add(p);
+                }
+            }
+        }
+        //System.out.println("F to check = " + F);
+        for (int i = 0; i < F.size(); i++) {
+            pi = F.get(i);
+            for (int j = i + 1; j < F.size(); j++) {
+                pj = F.get(j);
+                if (!red.moduleCriterion(modv, pi, pj)) {
+                    continue;
+                }
+                // if ( ! red.criterion4( pi, pj ) ) { continue; }
+                s = sred.leftSPolynomial(pi, pj);
+                if (s.isZERO()) {
+                    continue;
+                }
+                h = sredRec.leftNormalformRecursive(F, s);
+                if (!h.isZERO()) {
+                    logger.info("is not TwosidedGB: " + h);
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Solvable Extended Groebner base using critical pair class.
+     * @param modv module variable number.
+     * @param F solvable polynomial list.
+     * @return a container for an extended left Groebner base of F. <b>Note:
+     *         </b> not implemented;
+     */
+    //@SuppressWarnings("unchecked")
+    @Override
+    public SolvableExtendedGB<GenPolynomial<C>> extLeftGB(int modv,
+                    List<GenSolvablePolynomial<GenPolynomial<C>>> F) {
+        throw new UnsupportedOperationException(); // TODO
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/SolvableGroebnerBasePseudoSeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/SolvableGroebnerBasePseudoSeq.java
@@ -1,0 +1,371 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.OrderedPairlist;
+import edu.jas.gb.Pair;
+import edu.jas.gb.PairList;
+import edu.jas.gb.SolvableExtendedGB;
+import edu.jas.gb.SolvableGroebnerBaseAbstract;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.GenSolvablePolynomialRing;
+// import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolynomialList;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.ufd.GCDFactory;
+import edu.jas.ufd.GreatestCommonDivisorAbstract;
+import edu.jas.ufd.GreatestCommonDivisorFake;
+
+
+/**
+ * Solvable Groebner Base with pseudo reduction sequential algorithm. Implements
+ * coefficient fraction free Groebner bases. Coefficients can for example be
+ * integers or (commutative) univariate polynomials.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ * 
+ * @see edu.jas.application.GBAlgorithmBuilder
+ * @see edu.jas.gbufd.GBFactory
+ */
+
+public class SolvableGroebnerBasePseudoSeq<C extends GcdRingElem<C>> extends SolvableGroebnerBaseAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(SolvableGroebnerBasePseudoSeq.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Greatest common divisor engine for coefficient content and primitive
+     * parts.
+     */
+    protected final GreatestCommonDivisorAbstract<C> engine;
+
+
+    /**
+     * Pseudo reduction engine.
+     */
+    protected final SolvablePseudoReduction<C> sred;
+
+
+    /**
+     * Coefficient ring factory.
+     */
+    protected final RingFactory<C> cofac;
+
+
+    /**
+     * Constructor.
+     * @param rf coefficient ring factory.
+     */
+    public SolvableGroebnerBasePseudoSeq(RingFactory<C> rf) {
+        this(new SolvablePseudoReductionSeq<C>(), rf, new OrderedPairlist<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param rf coefficient ring factory.
+     * @param pl pair selection strategy
+     */
+    public SolvableGroebnerBasePseudoSeq(RingFactory<C> rf, PairList<C> pl) {
+        this(new SolvablePseudoReductionSeq<C>(), rf, pl);
+    }
+
+
+    /**
+     * Constructor.
+     * @param red pseudo reduction engine. <b>Note:</b> red must be an instance
+     *            of PseudoReductionSeq.
+     * @param rf coefficient ring factory.
+     * @param pl pair selection strategy
+     */
+    public SolvableGroebnerBasePseudoSeq(SolvablePseudoReduction<C> red, RingFactory<C> rf, PairList<C> pl) {
+        super(red, pl);
+        this.sred = red;
+        cofac = rf;
+        if (!cofac.isCommutative()) {
+            logger.warn("right reduction not correct for " + cofac.toScript());
+            engine = new GreatestCommonDivisorFake<C>(); // only for Ore conditions
+            // TODO check that also coeffTable is empty for recursive solvable poly ring
+            //System.out.println("stack trace = "); 
+            //Exception e = new RuntimeException("get stack trace");
+            //e.printStackTrace();
+        } else {
+            //engine = GCDFactory.<C> getImplementation(rf);
+            engine = GCDFactory.<C> getProxy(rf);
+        }
+    }
+
+
+    /**
+     * Left Groebner base using pairlist class.
+     * @param modv module variable number.
+     * @param F polynomial list.
+     * @return GB(F) a Groebner base of F.
+     */
+    @Override
+    public List<GenSolvablePolynomial<C>> leftGB(int modv, List<GenSolvablePolynomial<C>> F) {
+        List<GenSolvablePolynomial<C>> G = normalizeZerosOnes(F);
+        G = PolynomialList.<C> castToSolvableList(engine.basePrimitivePart(PolynomialList.<C> castToList(G)));
+        if (G.size() <= 1) {
+            return G;
+        }
+        GenSolvablePolynomialRing<C> ring = G.get(0).ring;
+        if (ring.coFac.isField()) { // remove ?
+            throw new IllegalArgumentException("coefficients from a field");
+        }
+        PairList<C> pairlist = strategy.create(modv, ring);
+        pairlist.put(PolynomialList.<C> castToList(G));
+
+        Pair<C> pair;
+        GenSolvablePolynomial<C> pi, pj, S, H;
+        while (pairlist.hasNext()) {
+            pair = pairlist.removeNext();
+            if (pair == null)
+                continue;
+
+            pi = (GenSolvablePolynomial<C>) pair.pi;
+            pj = (GenSolvablePolynomial<C>) pair.pj;
+            if (debug) {
+                logger.debug("pi    = " + pi);
+                logger.debug("pj    = " + pj);
+            }
+
+            S = sred.leftSPolynomial(pi, pj);
+            if (S.isZERO()) {
+                pair.setZero();
+                continue;
+            }
+            if (debug) {
+                logger.debug("ht(S) = " + S.leadingExpVector());
+            }
+
+            H = sred.leftNormalform(G, S);
+            if (H.isZERO()) {
+                pair.setZero();
+                continue;
+            }
+            if (debug) {
+                logger.debug("ht(H) = " + H.leadingExpVector());
+            }
+            H = (GenSolvablePolynomial<C>) engine.basePrimitivePart(H);
+            H = (GenSolvablePolynomial<C>) H.abs();
+            if (H.isConstant()) {
+                G.clear();
+                G.add(H);
+                return G; // since no threads are activated
+            }
+            if (logger.isDebugEnabled()) {
+                logger.debug("H = " + H);
+            }
+            if (H.length() > 0) {
+                G.add(H);
+                pairlist.put(H);
+            }
+        }
+        logger.debug("#sequential list = " + G.size());
+        G = leftMinimalGB(G);
+        logger.info("" + pairlist);
+        return G;
+    }
+
+
+    /**
+     * Minimal ordered Solvable Groebner basis.
+     * @param Gp a Solvable Groebner base.
+     * @return a reduced Solvable Groebner base of Gp.
+     */
+    @Override
+    public List<GenSolvablePolynomial<C>> leftMinimalGB(List<GenSolvablePolynomial<C>> Gp) {
+        List<GenSolvablePolynomial<C>> G = normalizeZerosOnes(Gp);
+        if (G.size() <= 1) {
+            return G;
+        }
+        // remove top reducible polynomials
+        GenSolvablePolynomial<C> a;
+        List<GenSolvablePolynomial<C>> F = new ArrayList<GenSolvablePolynomial<C>>(G.size());
+        while (G.size() > 0) {
+            a = G.remove(0);
+            if (sred.isTopReducible(G, a) || sred.isTopReducible(F, a)) {
+                // drop polynomial 
+                if (debug) {
+                    System.out.println("dropped " + a);
+                    List<GenSolvablePolynomial<C>> ff;
+                    ff = new ArrayList<GenSolvablePolynomial<C>>(G);
+                    ff.addAll(F);
+                    a = sred.leftNormalform(ff, a);
+                    if (!a.isZERO()) {
+                        System.out.println("error, nf(a) " + a);
+                    }
+                }
+            } else {
+                F.add(a);
+            }
+        }
+        G = F;
+        if (G.size() <= 1) {
+            return G;
+        }
+        Collections.reverse(G); // important for lex GB
+        // reduce remaining polynomials
+        int len = G.size();
+        int i = 0;
+        while (i < len) {
+            a = G.remove(0);
+            //System.out.println("doing " + a.length());
+            a = sred.leftNormalform(G, a);
+            a = (GenSolvablePolynomial<C>) engine.basePrimitivePart(a); //a.monic(); not possible
+            a = (GenSolvablePolynomial<C>) a.abs();
+            //a = sred.normalform( F, a );
+            G.add(a); // adds as last
+            i++;
+        }
+        return G;
+    }
+
+
+    /**
+     * Twosided Solvable Groebner base using pairlist class.
+     * @param modv number of module variables.
+     * @param Fp solvable polynomial list.
+     * @return tsGB(Fp) a twosided Groebner base of Fp.
+     */
+    @Override
+    public List<GenSolvablePolynomial<C>> twosidedGB(int modv, List<GenSolvablePolynomial<C>> Fp) {
+        List<GenSolvablePolynomial<C>> G = normalizeZerosOnes(Fp);
+        G = PolynomialList.<C> castToSolvableList(engine.basePrimitivePart(PolynomialList.<C> castToList(G)));
+        if (G.size() < 1) { // two-sided!
+            return G;
+        }
+        //System.out.println("G = " + G);
+        GenSolvablePolynomialRing<C> ring = G.get(0).ring; // assert != null
+        if (ring.coFac.isField()) { // remove ?
+            throw new IllegalArgumentException("coefficients from a field");
+        }
+        // add also coefficient generators
+        List<GenSolvablePolynomial<C>> X;
+        X = PolynomialList.castToSolvableList(ring.generators(modv)); 
+        logger.info("right multipliers = " + X);
+        List<GenSolvablePolynomial<C>> F = new ArrayList<GenSolvablePolynomial<C>>(G.size() * (1 + X.size()));
+        F.addAll(G);
+        logger.info("right multipy: F = " + F);
+        GenSolvablePolynomial<C> p, x, q;
+        for (int i = 0; i < F.size(); i++) { // F changes
+            p = F.get(i);
+            for (int j = 0; j < X.size(); j++) {
+                x = X.get(j);
+                q = p.multiply(x);
+                logger.info("right multipy: p = " + p + ", x = " + x + ", q = " + q);
+                q = sred.leftNormalform(F, q);
+                if (!q.isZERO()) {
+                    q = (GenSolvablePolynomial<C>) engine.basePrimitivePart(q);
+                    q = (GenSolvablePolynomial<C>) q.abs();
+                    logger.info("right multipy: red(q) = " + q);
+                    F.add(q);
+                }
+            }
+        }
+        G = F;
+        //System.out.println("G generated = " + G);
+        PairList<C> pairlist = strategy.create(modv, ring);
+        pairlist.put(PolynomialList.<C> castToList(G));
+
+        Pair<C> pair;
+        GenSolvablePolynomial<C> pi, pj, S, H;
+        while (pairlist.hasNext()) {
+            pair = pairlist.removeNext();
+            if (pair == null) {
+                continue;
+            }
+
+            pi = (GenSolvablePolynomial<C>) pair.pi;
+            pj = (GenSolvablePolynomial<C>) pair.pj;
+            if (debug) {
+                logger.debug("pi    = " + pi);
+                logger.debug("pj    = " + pj);
+            }
+
+            S = sred.leftSPolynomial(pi, pj);
+            if (S.isZERO()) {
+                pair.setZero();
+                continue;
+            }
+            if (debug) {
+                logger.debug("ht(S) = " + S.leadingExpVector());
+            }
+
+            H = sred.leftNormalform(G, S);
+            if (H.isZERO()) {
+                pair.setZero();
+                continue;
+            }
+            if (debug) {
+                logger.debug("ht(H) = " + H.leadingExpVector());
+            }
+
+            H = (GenSolvablePolynomial<C>) engine.basePrimitivePart(H);
+            H = (GenSolvablePolynomial<C>) H.abs();
+            if (H.isONE()) {
+                G.clear();
+                G.add(H);
+                return G; // since no threads are activated
+            }
+            if (debug) {
+                logger.debug("H = " + H);
+            }
+            if (H.length() > 0) {
+                G.add(H);
+                pairlist.put(H);
+                for (int j = 0; j < X.size(); j++) {
+                    x = X.get(j);
+                    p = H.multiply(x);
+                    p = sred.leftNormalform(G, p);
+                    if (!p.isZERO()) {
+                        p = (GenSolvablePolynomial<C>) engine.basePrimitivePart(p);
+                        p = (GenSolvablePolynomial<C>) p.abs();
+                        if (p.isONE()) {
+                            G.clear();
+                            G.add(p);
+                            return G; // since no threads are activated
+                        }
+                        G.add(p);
+                        pairlist.put(p);
+                    }
+                }
+            }
+        }
+        logger.debug("#sequential list = " + G.size());
+        G = leftMinimalGB(G);
+        logger.info("" + pairlist);
+        return G;
+    }
+
+
+    /**
+     * Solvable Extended Groebner base using critical pair class.
+     * @param modv module variable number.
+     * @param F solvable polynomial list.
+     * @return a container for an extended left Groebner base of F. <b>Note:
+     *         </b> not implemented;
+     */
+    //@SuppressWarnings("unchecked")
+    @Override
+    public SolvableExtendedGB<C> extLeftGB(int modv, List<GenSolvablePolynomial<C>> F) {
+        throw new UnsupportedOperationException(); // TODO
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/SolvablePseudoReduction.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/SolvablePseudoReduction.java
@@ -1,0 +1,66 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.List;
+
+import edu.jas.gb.SolvableReduction;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Polynomial pseudo reduction interface. Defines additionally normalformFactor
+ * and normalformRecursive.
+ * @param <C> coefficient type.
+ * @author Heinz Kredel
+ */
+
+public interface SolvablePseudoReduction<C extends RingElem<C>> extends SolvableReduction<C> {
+
+
+    /**
+     * Left normalform with multiplication factor.
+     * @param Pp polynomial list.
+     * @param Ap polynomial.
+     * @return ( nf(Ap), mf ) with respect to Pp and mf as multiplication factor
+     *         for Ap.
+     */
+    public PseudoReductionEntry<C> leftNormalformFactor(List<GenSolvablePolynomial<C>> Pp,
+                    GenSolvablePolynomial<C> Ap);
+
+
+    /*
+     * Right normalform with multiplication factor.
+     * @param Pp polynomial list.
+     * @param Ap polynomial.
+     * @return ( nf(Ap), mf ) with respect to Pp and mf as multiplication factor
+     *         for Ap.
+    public PseudoReductionEntry<C> rightNormalformFactor(List<GenSolvablePolynomial<C>> Pp, GenSolvablePolynomial<C> Ap);
+     */
+
+
+    /**
+     * Left normalform recursive.
+     * @param Ap recursive polynomial.
+     * @param Pp recursive polynomial list.
+     * @return nf(Ap) with respect to Pp.
+     */
+    public GenSolvablePolynomial<GenPolynomial<C>> leftNormalformRecursive(
+                    List<GenSolvablePolynomial<GenPolynomial<C>>> Pp,
+                    GenSolvablePolynomial<GenPolynomial<C>> Ap);
+
+
+    /*
+     * Right normalform recursive.
+     * @param Ap recursive polynomial.
+     * @param Pp recursive polynomial list.
+     * @return nf(Ap) with respect to Pp.
+    public GenSolvablePolynomial<GenPolynomial<C>> rightNormalformRecursive(List<GenSolvablePolynomial<GenPolynomial<C>>> Pp, GenSolvablePolynomial<GenPolynomial<C>> Ap);
+     */
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/SolvablePseudoReductionSeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/SolvablePseudoReductionSeq.java
@@ -1,0 +1,599 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.SolvableReductionAbstract;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.GenSolvablePolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Polynomial pseudo reduction sequential use algorithm. Coefficients of
+ * polynomials must not be from a field, i.e. the fraction free reduction is
+ * implemented. Implements normalform.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class SolvablePseudoReductionSeq<C extends GcdRingElem<C>> extends SolvableReductionAbstract<C>
+                implements SolvablePseudoReduction<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(SolvablePseudoReductionSeq.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     */
+    public SolvablePseudoReductionSeq() {
+    }
+
+
+    /**
+     * Left normalform.
+     * @param Ap polynomial.
+     * @param Pp polynomial list.
+     * @return nf(Ap) with respect to Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public GenSolvablePolynomial<C> leftNormalform(List<GenSolvablePolynomial<C>> Pp,
+                    GenSolvablePolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        Map.Entry<ExpVector, C> m;
+        GenSolvablePolynomial<C>[] P = new GenSolvablePolynomial[0];
+        synchronized (Pp) {
+            P = Pp.toArray(P);
+        }
+        int l = P.length;
+        ExpVector[] htl = new ExpVector[l];
+        //C[] lbc = (C[]) new GcdRingElem[l];
+        GenSolvablePolynomial<C>[] p = new GenSolvablePolynomial[l];
+        int i;
+        int j = 0;
+        for (i = 0; i < l; i++) {
+            if (P[i] == null) {
+                continue;
+            }
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                //lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        ExpVector e;
+        C a;
+        boolean mt = false;
+        GenSolvablePolynomial<C> R = Ap.ring.getZERO().copy();
+        GenSolvablePolynomial<C> Q = null;
+        GenSolvablePolynomial<C> S = Ap.copy();
+        while (S.length() > 0) {
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt)
+                    break;
+            }
+            if (!mt) {
+                //logger.debug("irred");
+                //R = R.sum(a, e);
+                //S = S.subtract(a, e);
+                R.doPutToMap(e, a);
+                S.doRemoveFromMap(e, a);
+                //System.out.println(" S = " + S);
+            } else {
+                e = e.subtract(htl[i]);
+                //logger.info("red div = " + e);
+                Q = p[i].multiplyLeft(e);
+                C c = Q.leadingBaseCoefficient();
+                ExpVector g = S.leadingExpVector();
+                C ap = a;
+                if (a.remainder(c).isZERO()) { // && !c.isConstant()) {
+                    a = a.divide(c);
+                    S = S.subtractMultiple(a, Q);
+                } else {
+                    R = R.multiplyLeft(c);
+                    S = S.scaleSubtractMultiple(c, a, Q);
+                }
+                ExpVector h = S.leadingExpVector();
+                if (g.equals(h)) { // Ore condition not fulfilled
+                    logger.info("g==h: g = " + g + ", c = " + c);
+                    throw new RuntimeException("g.equals(h): a = " + a + ", ap = " + ap + ", c = " + c);
+                }
+            }
+        }
+        return R;
+    }
+
+
+    /**
+     * Left normalform recursive.
+     * @param Ap recursive polynomial.
+     * @param Pp recursive polynomial list.
+     * @return nf(Ap) with respect to Pp.
+     */
+    @SuppressWarnings({ "unchecked" })
+    public GenSolvablePolynomial<GenPolynomial<C>> leftNormalformRecursive(
+                    List<GenSolvablePolynomial<GenPolynomial<C>>> Pp,
+                    GenSolvablePolynomial<GenPolynomial<C>> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        Map.Entry<ExpVector, GenPolynomial<C>> m;
+        GenSolvablePolynomial<GenPolynomial<C>>[] P = new GenSolvablePolynomial[0];
+        synchronized (Pp) {
+            P = Pp.toArray(P);
+        }
+        int l = P.length;
+        ExpVector[] htl = new ExpVector[l];
+        //GenPolynomial<C>[] lbc = (GenPolynomial<C>[]) new GenPolynomial[l];
+        GenSolvablePolynomial<GenPolynomial<C>>[] p = new GenSolvablePolynomial[l];
+        int i;
+        int j = 0;
+        for (i = 0; i < l; i++) {
+            if (P[i] == null) {
+                continue;
+            }
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                //lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        ExpVector e, f;
+        GenPolynomial<C> a, b;
+        boolean mt = false;
+        GenSolvablePolynomialRing<GenPolynomial<C>> ring = Ap.ring;
+        final boolean commCoeff = ring.coFac.isCommutative();
+        final SolvableSyzygyAbstract<C> ssy;
+        if (commCoeff) {
+            ssy = null;
+        } else {
+            ssy = new SolvableSyzygySeq<C>(((GenPolynomialRing<C>) ring.coFac).coFac);
+        }
+        GenSolvablePolynomial<GenPolynomial<C>> R = Ap.ring.getZERO().copy();
+        GenSolvablePolynomial<GenPolynomial<C>> Q = null;
+        GenSolvablePolynomial<GenPolynomial<C>> S = Ap.copy();
+        //GenSolvablePolynomial<GenPolynomial<C>> Sp = null;
+        while (S.length() > 0) {
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt)
+                    break;
+            }
+            if (!mt) {
+                //logger.debug("irred");
+                //R = R.sum(a, e);
+                //S = S.subtract(a, e);
+                R.doPutToMap(e, a);
+                S.doRemoveFromMap(e, a);
+                //System.out.println(" S = " + S);
+            } else {
+                f = e.subtract(htl[i]);
+                if (debug) {
+                    logger.info("red div = " + f);
+                    //logger.info("red a = " + a);
+                }
+                Q = p[i].multiplyLeft(f);
+                //if (a.remainder(c).isZERO()) { //c.isUnit() ) {
+                ExpVector g = S.leadingExpVector();
+                GenPolynomial<C> ap = a;
+                if (commCoeff) {
+                    GenPolynomial<C> c = Q.leadingBaseCoefficient();
+                    if (!c.isConstant() && PolyUtil.<C> baseSparsePseudoRemainder(a, c).isZERO()) {
+                        //a = a.divide(c);
+                        b = PolyUtil.<C> basePseudoDivide(a, c);
+                        if (a.equals(b.multiply(c))) {
+                            S = S.subtractMultiple(b, Q);
+                        } else {
+                            R = R.multiplyLeft(c);
+                            S = S.scaleSubtractMultiple(c, a, Q);
+                        }
+                    } else {
+                        R = R.multiplyLeft(c);
+                        S = S.scaleSubtractMultiple(c, a, Q);
+                    }
+                } else { // use Ore condition
+                    GenSolvablePolynomial<C> cs = (GenSolvablePolynomial<C>) Q.leadingBaseCoefficient();
+                    GenSolvablePolynomial<C> as = (GenSolvablePolynomial<C>) a;
+                    GenPolynomial<C>[] ore = ssy.leftOreCond(cs, as);
+                    //System.out.println("cs = " + cs + ", as = " + as);
+                    //System.out.println("ore[0] = " + ore[0] + "\nore[1] = " + ore[1]);
+                    R = R.multiplyLeft(ore[1]);
+                    S = S.scaleSubtractMultiple(ore[1], ore[0], Q);
+                }
+                ExpVector h = S.leadingExpVector();
+                if (g.equals(h)) { // ! Ore cond
+                    logger.info("g==h: g = " + g);
+                    throw new RuntimeException("g.equals(h): a = " + a + ", ap = " + ap);
+                }
+            }
+        }
+        //System.out.println("Ap = " + Ap + ", R = " + R);
+        return R;
+    }
+
+
+    /**
+     * Left normalform with recording. <b>Note:</b> Only meaningful if all
+     * divisions are exact. Compute first the multiplication factor
+     * <code>m</code> with <code>normalform(Pp,Ap,m)</code>, then call this
+     * method with <code>normalform(row,Pp,m*Ap)</code>.
+     * @param row recording matrix, is modified.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @return nf(Pp,Ap), the normal form of Ap wrt. Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public GenSolvablePolynomial<C> leftNormalform(List<GenSolvablePolynomial<C>> row,
+                    List<GenSolvablePolynomial<C>> Pp, GenSolvablePolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        GenSolvablePolynomial<C>[] P = new GenSolvablePolynomial[0];
+        synchronized (Pp) {
+            P = Pp.toArray(P);
+        }
+        int l = P.length;
+        ExpVector[] htl = new ExpVector[l];
+        //C[] lbc = (C[]) new GcdRingElem[l];
+        GenSolvablePolynomial<C>[] p = new GenSolvablePolynomial[l];
+        Map.Entry<ExpVector, C> m;
+        int j = 0;
+        int i;
+        for (i = 0; i < l; i++) {
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                //lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        ExpVector e;
+        C a;
+        boolean mt = false;
+        GenSolvablePolynomial<C> zero = Ap.ring.getZERO();
+        GenSolvablePolynomial<C> R = Ap.ring.getZERO().copy();
+        GenSolvablePolynomial<C> Q = null;
+        GenSolvablePolynomial<C> fac = null;
+        GenSolvablePolynomial<C> S = Ap.copy();
+        while (S.length() > 0) {
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt)
+                    break;
+            }
+            if (!mt) {
+                //logger.debug("irred");
+                //R = R.sum(a, e);
+                //S = S.subtract(a, e);
+                R.doPutToMap(e, a);
+                S.doRemoveFromMap(e, a);
+                // System.out.println(" S = " + S);
+                //throw new RuntimeException("Syzygy no GB");
+            } else {
+                e = e.subtract(htl[i]);
+                //logger.info("red div = " + e);
+                Q = p[i].multiplyLeft(e);
+                C c = Q.leadingBaseCoefficient();
+                ExpVector g = S.leadingExpVector();
+                C ap = a;
+                if (a.remainder(c).isZERO()) { //c.isUnit() ) {
+                    a = a.divide(c);
+                    S = S.subtractMultiple(a, Q);
+                    //System.out.print("|");
+                } else {
+                    //System.out.print("*");
+                    R = R.multiplyLeft(c);
+                    S = S.scaleSubtractMultiple(c, a, Q);
+                }
+                ExpVector h = S.leadingExpVector();
+                if (g.equals(h)) { // Ore condition not fulfilled
+                    System.out.println("g = " + g + ", h = " + h);
+                    System.out.println("c*ap = " + c.multiply(ap) + ", ap*c = " + ap.multiply(c));
+                    throw new RuntimeException("g.equals(h): a = " + a + ", ap = " + ap + ", c = " + c);
+                }
+                //Q = p[i].multiply(a, e);
+                //S = S.subtract(Q);
+                fac = row.get(i);
+                if (fac == null) {
+                    fac = (GenSolvablePolynomial<C>) zero.sum(a, e);
+                } else { // doAddTo ??
+                    fac = (GenSolvablePolynomial<C>) fac.sum(a, e);
+                }
+                row.set(i, fac);
+            }
+        }
+        return R;
+    }
+
+
+    /**
+     * Left normalform with factor.
+     * @param Pp polynomial list.
+     * @param Ap polynomial.
+     * @return ( nf(Ap), mf ) with respect to Pp and mf as multiplication factor
+     *         for Ap.
+     */
+    @SuppressWarnings("unchecked")
+    public PseudoReductionEntry<C> leftNormalformFactor(List<GenSolvablePolynomial<C>> Pp,
+                    GenSolvablePolynomial<C> Ap) {
+        if (Ap == null) {
+            return null;
+        }
+        C mfac = Ap.ring.getONECoefficient();
+        PseudoReductionEntry<C> pf = new PseudoReductionEntry<C>(Ap, mfac);
+        if (Pp == null || Pp.isEmpty()) {
+            return pf;
+        }
+        if (Ap.isZERO()) {
+            return pf;
+        }
+        Map.Entry<ExpVector, C> m;
+        GenSolvablePolynomial<C>[] P = new GenSolvablePolynomial[0];
+        synchronized (Pp) {
+            P = Pp.toArray(P);
+        }
+        int l = P.length;
+        ExpVector[] htl = new ExpVector[l];
+        //C[] lbc = (C[]) new GcdRingElem[l]; 
+        GenSolvablePolynomial<C>[] p = new GenSolvablePolynomial[l];
+        int i;
+        int j = 0;
+        for (i = 0; i < l; i++) {
+            if (P[i] == null) {
+                continue;
+            }
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                //lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        ExpVector e;
+        C a;
+        boolean mt = false;
+        GenSolvablePolynomial<C> R = Ap.ring.getZERO().copy();
+        GenSolvablePolynomial<C> Q = null;
+        GenSolvablePolynomial<C> S = Ap.copy();
+        while (S.length() > 0) {
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt)
+                    break;
+            }
+            if (!mt) {
+                //logger.debug("irred");
+                //R = R.sum(a, e);
+                //S = S.subtract(a, e);
+                R.doPutToMap(e, a);
+                S.doRemoveFromMap(e, a);
+                //System.out.println(" S = " + S);
+            } else {
+                e = e.subtract(htl[i]);
+                //logger.info("red div = " + e);
+                Q = p[i].multiplyLeft(e);
+                C c = Q.leadingBaseCoefficient();
+                ExpVector g = S.leadingExpVector();
+                C ap = a;
+                if (a.remainder(c).isZERO()) {
+                    a = a.divide(c);
+                    S = S.subtractMultiple(a, Q);
+                } else {
+                    mfac = c.multiply(mfac); // left
+                    R = R.multiplyLeft(c);
+                    S = S.scaleSubtractMultiple(c, a, Q);
+                }
+                ExpVector h = S.leadingExpVector();
+                if (g.equals(h)) { // Ore condition not fulfilled
+                    logger.info("g==h: g = " + g + ", c = " + c);
+                    throw new RuntimeException("g==h: a = " + a + ", ap = " + ap);
+                }
+            }
+        }
+        if (logger.isDebugEnabled()) {
+            logger.info("multiplicative factor = " + mfac);
+        }
+        pf = new PseudoReductionEntry<C>(R, mfac);
+        return pf;
+    }
+
+
+    /**
+     * Right normalform.
+     * @param Ap polynomial.
+     * @param Pp polynomial list.
+     * @return nf(Ap) with respect to Pp. 
+     */
+    @SuppressWarnings({ "unchecked" })
+    public GenSolvablePolynomial<C> rightNormalform(List<GenSolvablePolynomial<C>> Pp,
+                    GenSolvablePolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        Map.Entry<ExpVector, C> m;
+        GenSolvablePolynomial<C>[] P = new GenSolvablePolynomial[0];
+        synchronized (Pp) {
+            P = Pp.toArray(P);
+        }
+        int l = P.length;
+        ExpVector[] htl = new ExpVector[l];
+        //C[] lbc = (C[]) new GcdRingElem[l];
+        GenSolvablePolynomial<C>[] p = new GenSolvablePolynomial[l];
+        int i;
+        int j = 0;
+        for (i = 0; i < l; i++) {
+            if (P[i] == null) {
+                continue;
+            }
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                //lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        ExpVector e;
+        C a;
+        boolean mt = false;
+        GenSolvablePolynomial<C> R = Ap.ring.getZERO().copy();
+        GenSolvablePolynomial<C> Q = null;
+        GenSolvablePolynomial<C> S = Ap.copy();
+        while (S.length() > 0) {
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt)
+                    break;
+            }
+            if (!mt) {
+                //logger.debug("irred");
+                //R = R.sum(a, e);
+                //S = S.subtract(a, e);
+                R.doPutToMap(e, a);
+                S.doRemoveFromMap(e, a);
+                //System.out.println(" S = " + S);
+            } else {
+                e = e.subtract(htl[i]);
+                //logger.info("red div = " + e);
+                // need pi * a * e, but only pi * e * a or a * pi * e available
+                Q = p[i].multiply(e);
+                assert Q.multiply(a).equals(Q.multiplyLeft(a));
+                C c = Q.leadingBaseCoefficient();
+                ExpVector g = S.leadingExpVector();
+                C ap = a;
+                if (a.remainder(c).isZERO()) {
+                    a = a.divide(c); // left?
+                    //S = S.subtractMultiple(Q,a);
+                    S = (GenSolvablePolynomial<C>) S.subtract(Q.multiply(a));
+                } else {
+                    R = R.multiply(c);
+                    S = S.multiply(c);
+                    //S = S.scaleSubtractMultiple(c, Q, a);
+                    S = (GenSolvablePolynomial<C>) S.subtract(Q.multiply(a));
+                }
+                ExpVector h = S.leadingExpVector();
+                if (g.equals(h)) { // Ore condition not fulfilled
+                    logger.info("g==h: g = " + g + ", c = " + c);
+                    throw new RuntimeException("g.equals(h): a = " + a + ", ap = " + ap);
+                }
+            }
+        }
+        //System.out.println("R = " + R);
+        return R;
+    }
+
+
+    /**
+     * Right normalform recursive.
+     * @param Ap recursive polynomial.
+     * @param Pp recursive polynomial list.
+     * @return nf(Ap) with respect to Pp. <b>Note: </b> not implemented;
+     */
+    public GenSolvablePolynomial<GenPolynomial<C>> rightNormalformRecursive(
+                    List<GenSolvablePolynomial<GenPolynomial<C>>> Pp,
+                    GenSolvablePolynomial<GenPolynomial<C>> Ap) {
+        if (Pp == null || Ap == null) {
+            throw new IllegalArgumentException("Pp or Ap == null not supported");
+        }
+        throw new UnsupportedOperationException(); // TODO
+    }
+
+
+    /**
+     * Left normalform with recording. <b>Note:</b> Only meaningful if all
+     * divisions are exact. Compute first the multiplication factor
+     * <code>m</code> with <code>normalform(Pp,Ap,m)</code>, then call this
+     * method with <code>normalform(row,Pp,m*Ap)</code>.
+     * @param row recording matrix, is modified.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @return nf(Pp,Ap), the normal form of Ap wrt. Pp. <b>Note: </b> not
+     *         implemented;
+     */
+    public GenSolvablePolynomial<C> rightNormalform(List<GenSolvablePolynomial<C>> row,
+                    List<GenSolvablePolynomial<C>> Pp, GenSolvablePolynomial<C> Ap) {
+        if (row == null || Pp == null || Ap == null) {
+            throw new IllegalArgumentException("row, Pp or Ap == null not supported");
+        }
+        throw new UnsupportedOperationException(); // TODO
+    }
+
+
+    /**
+     * Right normalform with multiplication factor.
+     * @param Pp polynomial list.
+     * @param Ap polynomial.
+     * @return ( nf(Ap), mf ) with respect to Pp and mf as multiplication factor
+     *         for Ap. <b>Note: </b> not implemented;
+     */
+    public PseudoReductionEntry<C> rightNormalformFactor(List<GenSolvablePolynomial<C>> Pp,
+                    GenSolvablePolynomial<C> Ap) {
+        if (Pp == null || Ap == null) {
+            throw new IllegalArgumentException("Pp or Ap == null not supported");
+        }
+        throw new UnsupportedOperationException(); // TODO
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/SolvableSyzygy.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/SolvableSyzygy.java
@@ -1,0 +1,206 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.io.Serializable;
+import java.util.List;
+
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.ModuleList;
+import edu.jas.poly.PolynomialList;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Syzygy interface for solvable polynomials. Defines syzygy computations and
+ * tests.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public interface SolvableSyzygy<C extends RingElem<C>> extends Serializable {
+
+
+    /**
+     * Left syzygy for left Groebner base.
+     * @param F a Groebner base.
+     * @return leftSyz(F), a basis for the left module of syzygies for F.
+     */
+    public List<List<GenSolvablePolynomial<C>>> leftZeroRelations(List<GenSolvablePolynomial<C>> F);
+
+
+    /**
+     * Left syzygy for left Groebner base.
+     * @param modv number of module variables.
+     * @param F a Groebner base.
+     * @return leftSyz(F), a basis for the left module of syzygies for F.
+     */
+    public List<List<GenSolvablePolynomial<C>>> leftZeroRelations(int modv, List<GenSolvablePolynomial<C>> F);
+
+
+    /**
+     * Left syzygy for left module Groebner base.
+     * @param M a Groebner base.
+     * @return leftSyz(M), a basis for the left module of syzygies for M.
+     */
+    public ModuleList<C> leftZeroRelations(ModuleList<C> M);
+
+
+    /**
+     * Test if left syzygy.
+     * @param Z list of sysygies.
+     * @param F a polynomial list.
+     * @return true, if Z is a list of left syzygies for F, else false.
+     */
+    public boolean isLeftZeroRelation(List<List<GenSolvablePolynomial<C>>> Z, List<GenSolvablePolynomial<C>> F);
+
+
+    /**
+     * Test if right syzygy.
+     * @param Z list of sysygies.
+     * @param F a polynomial list.
+     * @return true, if Z is a list of right syzygies for F, else false.
+     */
+    public boolean isRightZeroRelation(List<List<GenSolvablePolynomial<C>>> Z,
+                    List<GenSolvablePolynomial<C>> F);
+
+
+    /**
+     * Test if left sysygy of modules
+     * @param Z list of sysygies.
+     * @param F a module list.
+     * @return true, if Z is a list of left syzygies for F, else false.
+     */
+    public boolean isLeftZeroRelation(ModuleList<C> Z, ModuleList<C> F);
+
+
+    /**
+     * Test if right sysygy of modules
+     * @param Z list of sysygies.
+     * @param F a module list.
+     * @return true, if Z is a list of right syzygies for F, else false.
+     */
+    public boolean isRightZeroRelation(ModuleList<C> Z, ModuleList<C> F);
+
+
+    /**
+     * Resolution of a module. Only with direct GBs.
+     * @param M a module list of a Groebner basis.
+     * @return a resolution of M.
+     */
+    public List<SolvResPart<C>> resolution(ModuleList<C> M);
+
+
+    /**
+     * Resolution of a polynomial list. Only with direct GBs.
+     * @param F a polynomial list of a Groebner basis.
+     * @return a resolution of F.
+     */
+    public List/*<SolvResPart<C>|SolvResPolPart<C>>*/resolution(PolynomialList<C> F);
+
+
+    /**
+     * Resolution of a module.
+     * @param M a module list of an arbitrary basis.
+     * @return a resolution of M.
+     */
+    public List<SolvResPart<C>> resolutionArbitrary(ModuleList<C> M);
+
+
+    /**
+     * Resolution of a polynomial list.
+     * @param F a polynomial list of an arbitrary basis.
+     * @return a resolution of F.
+     */
+    public List/*<SolvResPart<C>|SolvResPolPart<C>>*/resolutionArbitrary(PolynomialList<C> F);
+
+
+    /**
+     * Left syzygy module from arbitrary base.
+     * @param F a solvable polynomial list.
+     * @return syz(F), a basis for the module of left syzygies for F.
+     */
+    public List<List<GenSolvablePolynomial<C>>> leftZeroRelationsArbitrary(List<GenSolvablePolynomial<C>> F);
+
+
+    /**
+     * Left syzygy module from arbitrary base.
+     * @param modv number of module variables.
+     * @param F a solvable polynomial list.
+     * @return syz(F), a basis for the module of left syzygies for F.
+     */
+    public List<List<GenSolvablePolynomial<C>>> leftZeroRelationsArbitrary(int modv,
+                    List<GenSolvablePolynomial<C>> F);
+
+
+    /**
+     * Left syzygy for arbitrary left module base.
+     * @param M an arbitrary base.
+     * @return leftSyz(M), a basis for the left module of syzygies for M.
+     */
+    public ModuleList<C> leftZeroRelationsArbitrary(ModuleList<C> M);
+
+
+    /**
+     * Right syzygy module from arbitrary base.
+     * @param F a solvable polynomial list.
+     * @return syz(F), a basis for the module of right syzygies for F.
+     */
+    public List<List<GenSolvablePolynomial<C>>> rightZeroRelationsArbitrary(List<GenSolvablePolynomial<C>> F);
+
+
+    /**
+     * Right syzygy module from arbitrary base.
+     * @param modv number of module variables.
+     * @param F a solvable polynomial list.
+     * @return syz(F), a basis for the module of right syzygies for F.
+     */
+    public List<List<GenSolvablePolynomial<C>>> rightZeroRelationsArbitrary(int modv,
+                    List<GenSolvablePolynomial<C>> F);
+
+
+    /**
+     * Test left Ore condition.
+     * @param a solvable polynomial
+     * @param b solvable polynomial
+     * @param oc = [p,q] two solvable polynomials
+     * @return true if p*a = q*b, else false
+     */
+    public boolean isLeftOreCond(GenSolvablePolynomial<C> a, GenSolvablePolynomial<C> b,
+                    GenSolvablePolynomial<C>[] oc);
+
+
+    /**
+     * Test right Ore condition.
+     * @param a solvable polynomial
+     * @param b solvable polynomial
+     * @param oc = [p,q] two solvable polynomials
+     * @return true if a*p = b*q, else false
+     */
+    public boolean isRightOreCond(GenSolvablePolynomial<C> a, GenSolvablePolynomial<C> b,
+                    GenSolvablePolynomial<C>[] oc);
+
+
+    /**
+     * Left Ore condition. Generators for the left Ore condition of two solvable
+     * polynomials.
+     * @param a solvable polynomial
+     * @param b solvable polynomial
+     * @return [p,q] with p*a = q*b
+     */
+    public GenSolvablePolynomial<C>[] leftOreCond(GenSolvablePolynomial<C> a, GenSolvablePolynomial<C> b);
+
+
+    /**
+     * Right Ore condition. Generators for the right Ore condition of two
+     * solvable polynomials.
+     * @param a solvable polynomial
+     * @param b solvable polynomial
+     * @return [p,q] with a*p = b*q
+     */
+    public GenSolvablePolynomial<C>[] rightOreCond(GenSolvablePolynomial<C> a, GenSolvablePolynomial<C> b);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/SolvableSyzygyAbstract.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/SolvableSyzygyAbstract.java
@@ -1,0 +1,789 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.Reduction;
+import edu.jas.gb.ReductionSeq;
+import edu.jas.gb.SolvableReduction;
+import edu.jas.gb.SolvableReductionSeq;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.GenSolvablePolynomialRing;
+import edu.jas.poly.ModuleList;
+import edu.jas.poly.PolynomialList;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingElem;
+import edu.jas.vector.BasicLinAlg;
+
+
+/**
+ * Syzygy abstract class for solvable polynomials. Implements Syzygy
+ * computations and tests.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public abstract class SolvableSyzygyAbstract<C extends GcdRingElem<C>> implements SolvableSyzygy<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(SolvableSyzygyAbstract.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Solvable reduction engine.
+     */
+    public final SolvableReduction<C> sred;
+
+
+    /**
+     * Reduction engine.
+     */
+    protected Reduction<C> red;
+
+
+    /**
+     * Linear algebra engine.
+     */
+    protected BasicLinAlg<GenPolynomial<C>> blas;
+
+
+    /**
+     * Constructor.
+     */
+    public SolvableSyzygyAbstract() {
+        red = new ReductionSeq<C>();
+        sred = new SolvableReductionSeq<C>();
+        blas = new BasicLinAlg<GenPolynomial<C>>();
+    }
+
+
+    /**
+     * Left syzygy for left Groebner base.
+     * @param F a Groebner base.
+     * @return leftSyz(F), a basis for the left module of syzygies for F.
+     */
+    public List<List<GenSolvablePolynomial<C>>> leftZeroRelations(List<GenSolvablePolynomial<C>> F) {
+        return leftZeroRelations(0, F);
+    }
+
+
+    /**
+     * Left syzygy for left Groebner base.
+     * @param modv number of module variables.
+     * @param F a Groebner base.
+     * @return leftSyz(F), a basis for the left module of syzygies for F.
+     */
+    public List<List<GenSolvablePolynomial<C>>> leftZeroRelations(int modv, List<GenSolvablePolynomial<C>> F) {
+        List<List<GenSolvablePolynomial<C>>> Z = new ArrayList<List<GenSolvablePolynomial<C>>>();
+        ArrayList<GenSolvablePolynomial<C>> S = new ArrayList<GenSolvablePolynomial<C>>(F.size());
+        for (int i = 0; i < F.size(); i++) {
+            S.add(null);
+        }
+        GenSolvablePolynomial<C> pi, pj, s, h, zero;
+        zero = null;
+        for (int i = 0; i < F.size(); i++) {
+            pi = F.get(i);
+            if (zero == null) {
+                zero = pi.ring.getZERO();
+            }
+            for (int j = i + 1; j < F.size(); j++) {
+                pj = F.get(j);
+                //logger.info("p"+i+", p"+j+" = " + pi + ", " +pj);
+
+                if (!red.moduleCriterion(modv, pi, pj)) {
+                    continue;
+                }
+                // if ( ! red.criterion4( pi, pj ) ) continue;
+                List<GenSolvablePolynomial<C>> row = new ArrayList<GenSolvablePolynomial<C>>(S);
+                s = sred.leftSPolynomial(row, i, pi, j, pj);
+                //logger.info("row = " + row);
+                if (s.isZERO()) {
+                    Z.add(row);
+                    continue;
+                }
+
+                h = sred.leftNormalform(row, F, s);
+                if (!h.isZERO()) {
+                    throw new ArithmeticException("Syzygy no leftGB");
+                }
+                if (logger.isDebugEnabled()) {
+                    logger.info("row = " + row);
+                }
+                Z.add(row);
+            }
+        }
+        // set null to zero
+        for (List<GenSolvablePolynomial<C>> vr : Z) {
+            for (int j = 0; j < vr.size(); j++) {
+                if (vr.get(j) == null) {
+                    vr.set(j, zero);
+                }
+            }
+        }
+        return Z;
+    }
+
+
+    /**
+     * Left syzygy for left module Groebner base.
+     * @param M a Groebner base.
+     * @return leftSyz(M), a basis for the left module of syzygies for M.
+     */
+    @SuppressWarnings("unchecked")
+    public ModuleList<C> leftZeroRelations(ModuleList<C> M) {
+        ModuleList<C> N = null;
+        if (M == null || M.list == null) {
+            return N;
+        }
+        if (M.rows == 0 || M.cols == 0) {
+            return N;
+        }
+        GenSolvablePolynomial<C> zero = (GenSolvablePolynomial<C>) M.ring.getZERO();
+        //logger.info("zero = " + zero);
+
+        //ModuleList<C> Np = null;
+        PolynomialList<C> F = M.getPolynomialList();
+        int modv = M.cols; // > 0  
+        logger.info("modv = " + modv);
+        List<List<GenSolvablePolynomial<C>>> G = leftZeroRelations(modv, F.castToSolvableList());
+        //if (G == null) {
+        //    return N;
+        //}
+        List<List<GenSolvablePolynomial<C>>> Z = new ArrayList<List<GenSolvablePolynomial<C>>>();
+        for (int i = 0; i < G.size(); i++) {
+            List<GenSolvablePolynomial<C>> Gi = G.get(i);
+            List<GenSolvablePolynomial<C>> Zi = new ArrayList<GenSolvablePolynomial<C>>();
+            //System.out.println("\nG("+i+") = " + G.get(i));
+            for (int j = 0; j < Gi.size(); j++) {
+                //System.out.println("\nG("+i+","+j+") = " + Gi.get(j));
+                GenSolvablePolynomial<C> p = Gi.get(j);
+                if (p != null) {
+                    Map<ExpVector, GenPolynomial<C>> r = p.contract(M.ring);
+                    //System.out.println("map("+i+","+j+") = " + r + ", size = " + r.size() );
+                    if (r.size() == 0) {
+                        Zi.add(zero);
+                    } else if (r.size() == 1) {
+                        GenSolvablePolynomial<C> vi = (GenSolvablePolynomial<C>) (r.values().toArray())[0];
+                        Zi.add(vi);
+                    } else { // will not happen
+                        throw new RuntimeException("Map.size() > 1 = " + r.size());
+                    }
+                }
+            }
+            //System.out.println("\nZ("+i+") = " + Zi);
+            Z.add(Zi);
+        }
+        N = new ModuleList<C>((GenSolvablePolynomialRing<C>) M.ring, Z);
+        //System.out.println("\n\nN = " + N);
+        return N;
+    }
+
+
+    /**
+     * Right syzygy module from Groebner base.
+     * @param F a solvable polynomial list, a Groebner base.
+     * @return syz(F), a basis for the module of right syzygies for F.
+     */
+    public List<List<GenSolvablePolynomial<C>>> rightZeroRelations(List<GenSolvablePolynomial<C>> F) {
+        return rightZeroRelations(0, F);
+    }
+
+
+    /**
+     * Right syzygy module from Groebner base.
+     * @param modv number of module variables.
+     * @param F a solvable polynomial list, a Groebner base.
+     * @return syz(F), a basis for the module of right syzygies for F.
+     */
+    @SuppressWarnings("unchecked")
+    public List<List<GenSolvablePolynomial<C>>> rightZeroRelations(int modv, List<GenSolvablePolynomial<C>> F) {
+        GenSolvablePolynomialRing<C> ring = null;
+        for (GenSolvablePolynomial<C> p : F) {
+            if (p != null) {
+                ring = p.ring;
+                break;
+            }
+        }
+        List<List<GenSolvablePolynomial<C>>> Z;
+        if (ring == null) { // all null
+            Z = new ArrayList<List<GenSolvablePolynomial<C>>>(1);
+            Z.add(F);
+            return Z;
+        }
+        //System.out.println("ring to reverse = " + ring.toScript());
+        GenSolvablePolynomialRing<C> rring = ring.reverse(true);
+        GenSolvablePolynomial<C> q;
+        List<GenSolvablePolynomial<C>> rF;
+        rF = new ArrayList<GenSolvablePolynomial<C>>(F.size());
+        for (GenSolvablePolynomial<C> p : F) {
+            if (p != null) {
+                q = (GenSolvablePolynomial<C>) p.reverse(rring);
+                rF.add(q);
+            }
+        }
+        if (debug) {
+            PolynomialList<C> pl = new PolynomialList<C>(rring, rF);
+            logger.info("reversed problem = " + pl.toScript());
+        }
+        List<List<GenSolvablePolynomial<C>>> rZ = leftZeroRelations(modv, rF);
+        if (debug) {
+            boolean isit = isLeftZeroRelation(rZ, rF);
+            logger.debug("isLeftZeroRelation = " + isit);
+        }
+        GenSolvablePolynomialRing<C> oring = rring.reverse(true);
+        if (debug) {
+            logger.debug("ring == oring: " + ring.equals(oring));
+        }
+        ring = oring;
+        Z = new ArrayList<List<GenSolvablePolynomial<C>>>(rZ.size());
+        for (List<GenSolvablePolynomial<C>> z : rZ) {
+            if (z == null) {
+                continue;
+            }
+            List<GenSolvablePolynomial<C>> s;
+            s = new ArrayList<GenSolvablePolynomial<C>>(z.size());
+            for (GenSolvablePolynomial<C> p : z) {
+                if (p != null) {
+                    q = (GenSolvablePolynomial<C>) p.reverse(ring);
+                    s.add(q);
+                }
+            }
+            Z.add(s);
+        }
+        return Z;
+    }
+
+
+    /**
+     * Right syzygy for right module Groebner base.
+     * @param M a Groebner base.
+     * @return rightSyz(M), a basis for the right module of syzygies for M.
+     */
+    @SuppressWarnings("unchecked")
+    public ModuleList<C> rightZeroRelations(ModuleList<C> M) {
+        ModuleList<C> N = null;
+        if (M == null || M.list == null) {
+            return N;
+        }
+        if (M.rows == 0 || M.cols == 0) {
+            return N;
+        }
+        GenSolvablePolynomial<C> zero = (GenSolvablePolynomial<C>) M.ring.getZERO();
+        //logger.info("zero = " + zero);
+
+        //ModuleList<C> Np = null;
+        PolynomialList<C> F = M.getPolynomialList();
+        int modv = M.cols; // > 0  
+        logger.info("modv = " + modv);
+        List<List<GenSolvablePolynomial<C>>> G = rightZeroRelations(modv, F.castToSolvableList());
+        //if (G == null) {
+        //    return N;
+        //}
+        List<List<GenSolvablePolynomial<C>>> Z = new ArrayList<List<GenSolvablePolynomial<C>>>();
+        for (int i = 0; i < G.size(); i++) {
+            List<GenSolvablePolynomial<C>> Gi = G.get(i);
+            List<GenSolvablePolynomial<C>> Zi = new ArrayList<GenSolvablePolynomial<C>>();
+            //System.out.println("\nG("+i+") = " + G.get(i));
+            for (int j = 0; j < Gi.size(); j++) {
+                //System.out.println("\nG("+i+","+j+") = " + Gi.get(j));
+                GenSolvablePolynomial<C> p = Gi.get(j);
+                if (p != null) {
+                    Map<ExpVector, GenPolynomial<C>> r = p.contract(M.ring);
+                    //System.out.println("map("+i+","+j+") = " + r + ", size = " + r.size() );
+                    if (r.size() == 0) {
+                        Zi.add(zero);
+                    } else if (r.size() == 1) {
+                        GenSolvablePolynomial<C> vi = (GenSolvablePolynomial<C>) (r.values().toArray())[0];
+                        Zi.add(vi);
+                    } else { // will not happen
+                        throw new RuntimeException("Map.size() > 1 = " + r.size());
+                    }
+                }
+            }
+            //System.out.println("\nZ("+i+") = " + Zi);
+            Z.add(Zi);
+        }
+        N = new ModuleList<C>((GenSolvablePolynomialRing<C>) M.ring, Z);
+        //System.out.println("\n\nN = " + N);
+        return N;
+    }
+
+
+    /**
+     * Test if left syzygy.
+     * @param Z list of sysygies.
+     * @param F a polynomial list.
+     * @return true, if Z is a list of left syzygies for F, else false.
+     */
+    public boolean isLeftZeroRelation(List<List<GenSolvablePolynomial<C>>> Z, List<GenSolvablePolynomial<C>> F) {
+        List<GenPolynomial<C>> Fp = PolynomialList.<C> castToList(F);
+        for (List<GenSolvablePolynomial<C>> row : Z) {
+            // p has wrong type:
+            GenPolynomial<C> p = blas.scalarProduct(PolynomialList.<C> castToList(row), Fp);
+            if (p == null) {
+                continue;
+            }
+            if (!p.isZERO()) {
+                logger.info("is not ZeroRelation = " + p);
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Test if right syzygy.
+     * @param Z list of sysygies.
+     * @param F a polynomial list.
+     * @return true, if Z is a list of right syzygies for F, else false.
+     */
+    public boolean isRightZeroRelation(List<List<GenSolvablePolynomial<C>>> Z,
+                    List<GenSolvablePolynomial<C>> F) {
+        List<GenPolynomial<C>> Fp = PolynomialList.<C> castToList(F);
+        for (List<GenSolvablePolynomial<C>> row : Z) {
+            List<GenPolynomial<C>> yrow = PolynomialList.<C> castToList(row);
+            // p has wrong type:
+            GenPolynomial<C> p = blas.scalarProduct(Fp, yrow); // param order
+            if (p == null) {
+                continue;
+            }
+            if (!p.isZERO()) {
+                logger.info("is not ZeroRelation = " + p);
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Test if left sysygy of modules
+     * @param Z list of sysygies.
+     * @param F a module list.
+     * @return true, if Z is a list of left syzygies for F, else false.
+     */
+    public boolean isLeftZeroRelation(ModuleList<C> Z, ModuleList<C> F) {
+        if (Z == null || Z.list == null) {
+            return true;
+        }
+        for (List<GenPolynomial<C>> row : Z.list) {
+            List<GenPolynomial<C>> zr = blas.leftScalarProduct(row, F.list);
+            if (!blas.isZero(zr)) {
+                logger.info("is not ZeroRelation (" + zr.size() + ") = " + zr);
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Test if right sysygy of modules
+     * @param Z list of sysygies.
+     * @param F a module list.
+     * @return true, if Z is a list of right syzygies for F, else false.
+     */
+    public boolean isRightZeroRelation(ModuleList<C> Z, ModuleList<C> F) {
+        if (Z == null || Z.list == null) {
+            return true;
+        }
+        for (List<GenPolynomial<C>> row : Z.list) {
+            List<GenPolynomial<C>> zr = blas.rightScalarProduct(row, F.list);
+            //List<GenPolynomial<C>> zr = blas.scalarProduct(row,F.list);
+            if (!blas.isZero(zr)) {
+                logger.info("is not ZeroRelation (" + zr.size() + ") = " + zr);
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Left syzygy module from arbitrary base.
+     * @param F a solvable polynomial list.
+     * @return syz(F), a basis for the module of left syzygies for F.
+     */
+    public List<List<GenSolvablePolynomial<C>>> leftZeroRelationsArbitrary(List<GenSolvablePolynomial<C>> F) {
+        return leftZeroRelationsArbitrary(0, F);
+    }
+
+
+    /**
+     * Left syzygy for arbitrary left module base.
+     * @param M an arbitrary base.
+     * @return leftSyz(M), a basis for the left module of syzygies for M.
+     */
+    @SuppressWarnings("unchecked")
+    public ModuleList<C> leftZeroRelationsArbitrary(ModuleList<C> M) {
+        ModuleList<C> N = null;
+        if (M == null || M.list == null) {
+            return N;
+        }
+        if (M.rows == 0 || M.cols == 0) {
+            return N;
+        }
+        GenSolvablePolynomial<C> zero = (GenSolvablePolynomial<C>) M.ring.getZERO();
+        //logger.info("zero = " + zero);
+
+        //ModuleList<C> Np = null;
+        PolynomialList<C> F = M.getPolynomialList();
+        int modv = M.cols; // > 0  
+        logger.info("modv = " + modv);
+        List<List<GenSolvablePolynomial<C>>> G = leftZeroRelationsArbitrary(modv, F.castToSolvableList());
+        if (G == null) {
+            return N;
+        }
+        List<List<GenSolvablePolynomial<C>>> Z = new ArrayList<List<GenSolvablePolynomial<C>>>();
+        for (int i = 0; i < G.size(); i++) {
+            List<GenSolvablePolynomial<C>> Gi = G.get(i);
+            List<GenSolvablePolynomial<C>> Zi = new ArrayList<GenSolvablePolynomial<C>>();
+            //System.out.println("\nG("+i+") = " + G.get(i));
+            for (int j = 0; j < Gi.size(); j++) {
+                //System.out.println("\nG("+i+","+j+") = " + Gi.get(j));
+                GenSolvablePolynomial<C> p = Gi.get(j);
+                if (p != null) {
+                    Map<ExpVector, GenPolynomial<C>> r = p.contract(M.ring);
+                    //System.out.println("map("+i+","+j+") = " + r + ", size = " + r.size() );
+                    if (r.size() == 0) {
+                        Zi.add(zero);
+                    } else if (r.size() == 1) {
+                        GenSolvablePolynomial<C> vi = (GenSolvablePolynomial<C>) (r.values().toArray())[0];
+                        Zi.add(vi);
+                    } else { // will not happen
+                        throw new RuntimeException("Map.size() > 1 = " + r.size());
+                    }
+                }
+            }
+            //System.out.println("\nZ("+i+") = " + Zi);
+            Z.add(Zi);
+        }
+        N = new ModuleList<C>((GenSolvablePolynomialRing<C>) M.ring, Z);
+        //System.out.println("\n\nN = " + N);
+        return N;
+    }
+
+
+    /**
+     * Right syzygy module from arbitrary base.
+     * @param F a solvable polynomial list.
+     * @return syz(F), a basis for the module of right syzygies for F.
+     */
+    public List<List<GenSolvablePolynomial<C>>> rightZeroRelationsArbitrary(List<GenSolvablePolynomial<C>> F) {
+        return rightZeroRelationsArbitrary(0, F);
+    }
+
+
+    /**
+     * Right syzygy module from arbitrary base.
+     * @param modv number of module variables.
+     * @param F a solvable polynomial list.
+     * @return syz(F), a basis for the module of right syzygies for F.
+     */
+    @SuppressWarnings("unchecked")
+    public List<List<GenSolvablePolynomial<C>>> rightZeroRelationsArbitrary(int modv,
+                    List<GenSolvablePolynomial<C>> F) {
+        GenSolvablePolynomialRing<C> ring = null;
+        for (GenSolvablePolynomial<C> p : F) {
+            if (p != null) {
+                ring = p.ring;
+                break;
+            }
+        }
+        List<List<GenSolvablePolynomial<C>>> Z;
+        if (ring == null) { // all null
+            Z = new ArrayList<List<GenSolvablePolynomial<C>>>(1);
+            Z.add(F);
+            return Z;
+        }
+        GenSolvablePolynomialRing<C> rring = ring.reverse(true);
+        GenSolvablePolynomial<C> q;
+        List<GenSolvablePolynomial<C>> rF;
+        rF = new ArrayList<GenSolvablePolynomial<C>>(F.size());
+        for (GenSolvablePolynomial<C> p : F) {
+            if (p != null) {
+                q = (GenSolvablePolynomial<C>) p.reverse(rring);
+                rF.add(q);
+            }
+        }
+        if (debug) {
+            PolynomialList<C> pl = new PolynomialList<C>(rring, rF);
+            logger.info("reversed problem = " + pl.toScript());
+        }
+        List<List<GenSolvablePolynomial<C>>> rZ = leftZeroRelationsArbitrary(modv, rF);
+        if (debug) {
+            ModuleList<C> pl = new ModuleList<C>(rring, rZ);
+            logger.info("reversed syzygies = " + pl.toScript());
+            boolean isit = isLeftZeroRelation(rZ, rF);
+            logger.info("isLeftZeroRelation = " + isit);
+        }
+        GenSolvablePolynomialRing<C> oring = rring.reverse(true);
+        if (debug) {
+            logger.info("ring == oring: " + ring.equals(oring));
+        }
+        ring = oring;
+        Z = new ArrayList<List<GenSolvablePolynomial<C>>>(rZ.size());
+        for (List<GenSolvablePolynomial<C>> z : rZ) {
+            if (z == null) {
+                continue;
+            }
+            List<GenSolvablePolynomial<C>> s;
+            s = new ArrayList<GenSolvablePolynomial<C>>(z.size());
+            for (GenSolvablePolynomial<C> p : z) {
+                if (p != null) {
+                    q = (GenSolvablePolynomial<C>) p.reverse(ring);
+                    s.add(q);
+                    //System.out.println("p = " + p + "\nreverse(p) = " + q);
+                }
+            }
+            Z.add(s);
+        }
+        return Z;
+    }
+
+
+    /**
+     * Right syzygy for arbitrary base.
+     * @param M an arbitray base.
+     * @return rightSyz(M), a basis for the right module of syzygies for M.
+     */
+    @SuppressWarnings("unchecked")
+    public ModuleList<C> rightZeroRelationsArbitrary(ModuleList<C> M) {
+        ModuleList<C> N = null;
+        if (M == null || M.list == null) {
+            return N;
+        }
+        if (M.rows == 0 || M.cols == 0) {
+            return N;
+        }
+        GenSolvablePolynomial<C> zero = (GenSolvablePolynomial<C>) M.ring.getZERO();
+        //logger.info("zero = " + zero);
+
+        //ModuleList<C> Np = null;
+        PolynomialList<C> F = M.getPolynomialList();
+        int modv = M.cols; // > 0  
+        logger.info("modv = " + modv);
+        List<List<GenSolvablePolynomial<C>>> G = rightZeroRelationsArbitrary(modv, F.castToSolvableList());
+        //if (G == null) {
+        //    return N;
+        //}
+        List<List<GenSolvablePolynomial<C>>> Z = new ArrayList<List<GenSolvablePolynomial<C>>>();
+        for (int i = 0; i < G.size(); i++) {
+            List<GenSolvablePolynomial<C>> Gi = G.get(i);
+            List<GenSolvablePolynomial<C>> Zi = new ArrayList<GenSolvablePolynomial<C>>();
+            //System.out.println("G("+i+") = " + Gi);
+            for (int j = 0; j < Gi.size(); j++) {
+                GenSolvablePolynomial<C> p = Gi.get(j);
+                //System.out.println("G("+i+","+j+") = " + p);
+                if (p != null) {
+                    Map<ExpVector, GenPolynomial<C>> r = p.contract(M.ring);
+                    //System.out.println("map("+i+","+j+") = " + r + ", size = " + r.size() );
+                    if (r.size() == 0) {
+                        Zi.add(zero);
+                    } else if (r.size() == 1) {
+                        GenSolvablePolynomial<C> vi = (GenSolvablePolynomial<C>) (r.values().toArray())[0];
+                        Zi.add(vi);
+                    } else { // will not happen
+                        logger.error("p = " + p + ", r = " + r);
+                        throw new RuntimeException("Map.size() > 1 = " + r.size());
+                    }
+                }
+            }
+            //System.out.println("\nZ("+i+") = " + Zi);
+            Z.add(Zi);
+        }
+        N = new ModuleList<C>((GenSolvablePolynomialRing<C>) M.ring, Z);
+        //System.out.println("\n\nN = " + N);
+        return N;
+    }
+
+
+    /**
+     * Test left Ore condition.
+     * @param a solvable polynomial
+     * @param b solvable polynomial
+     * @param oc = [p,q] two solvable polynomials
+     * @return true if p*a = q*b, else false
+     */
+    public boolean isLeftOreCond(GenSolvablePolynomial<C> a, GenSolvablePolynomial<C> b,
+                    GenSolvablePolynomial<C>[] oc) {
+        GenSolvablePolynomial<C> c = oc[0].multiply(a);
+        GenSolvablePolynomial<C> d = oc[1].multiply(b);
+        return c.equals(d);
+    }
+
+
+    /**
+     * Test right Ore condition.
+     * @param a solvable polynomial
+     * @param b solvable polynomial
+     * @param oc = [p,q] two solvable polynomials
+     * @return true if a*p = b*q, else false
+     */
+    public boolean isRightOreCond(GenSolvablePolynomial<C> a, GenSolvablePolynomial<C> b,
+                    GenSolvablePolynomial<C>[] oc) {
+        GenSolvablePolynomial<C> c = a.multiply(oc[0]);
+        GenSolvablePolynomial<C> d = b.multiply(oc[1]);
+        return c.equals(d);
+    }
+
+
+    /**
+     * Left simplifier. Method of Apel &amp; Lassner (1987).
+     * @param a solvable polynomial
+     * @param b solvable polynomial
+     * @return [p,q] with a/b = p/q and q is minimal and monic
+     */
+    public abstract GenSolvablePolynomial<C>[] leftSimplifier(GenSolvablePolynomial<C> a,
+                    GenSolvablePolynomial<C> b);
+
+
+    /**
+     * Comparison like SolvableLocal or SolvableQuotient.
+     * @param num SolvablePolynomial.
+     * @param den SolvablePolynomial.
+     * @param n SolvablePolynomial.
+     * @param d SolvablePolynomial.
+     * @return sign((num/den)-(n/d)).
+     */
+    public int compare(GenSolvablePolynomial<C> num, GenSolvablePolynomial<C> den,
+                    GenSolvablePolynomial<C> n, GenSolvablePolynomial<C> d) {
+        if (n == null || n.isZERO()) {
+            return num.signum();
+        }
+        if (num.isZERO()) {
+            return -n.signum();
+        }
+        // assume sign(den,b.den) > 0
+        int s1 = num.signum();
+        int s2 = n.signum();
+        int t = (s1 - s2) / 2;
+        if (t != 0) {
+            System.out.println("compareTo: t = " + t);
+            //return t;
+        }
+        if (den.compareTo(d) == 0) {
+            return num.compareTo(n);
+        }
+        GenSolvablePolynomial<C> r, s;
+        // if (den.isONE()) { }
+        // if (b.den.isONE()) { }
+        GenSolvablePolynomial<C>[] oc = leftOreCond(den, d);
+        if (debug) {
+            System.out.println("oc[0] den =<>= oc[1] d: (" + oc[0] + ") (" + den + ") = (" + oc[1] + ") ("
+                            + d + ")");
+        }
+        //System.out.println("oc[0] = " + oc[0]);
+        //System.out.println("oc[1] = " + oc[1]);
+        r = oc[0].multiply(num);
+        s = oc[1].multiply(n);
+        logger.info("compare: r = " + r + ", s = " + s);
+        return r.compareTo(s);
+    }
+
+}
+
+
+/**
+ * Container for module resolution components.
+ * @param <C> coefficient type
+ */
+class SolvResPart<C extends RingElem<C>> implements Serializable {
+
+
+    public final ModuleList<C> module;
+
+
+    public final ModuleList<C> GB;
+
+
+    public final ModuleList<C> syzygy;
+
+
+    /**
+     * SolvResPart.
+     * @param m a module list.
+     * @param g a module list GB.
+     * @param z a syzygy module list.
+     */
+    public SolvResPart(ModuleList<C> m, ModuleList<C> g, ModuleList<C> z) {
+        module = m;
+        GB = g;
+        syzygy = z;
+    }
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString() {
+        StringBuffer s = new StringBuffer("SolvResPart(\n");
+        s.append("module = " + module);
+        s.append("\n GB = " + GB);
+        s.append("\n syzygy = " + syzygy);
+        s.append(")");
+        return s.toString();
+    }
+}
+
+
+/**
+ * Container for polynomial resolution components.
+ * @param <C> coefficient type
+ */
+class SolvResPolPart<C extends RingElem<C>> implements Serializable {
+
+
+    public final PolynomialList<C> ideal;
+
+
+    public final PolynomialList<C> GB;
+
+
+    public final ModuleList<C> syzygy;
+
+
+    /**
+     * SolvResPolPart.
+     * @param m a polynomial list.
+     * @param g a polynomial list GB.
+     * @param z a syzygy module list.
+     */
+    public SolvResPolPart(PolynomialList<C> m, PolynomialList<C> g, ModuleList<C> z) {
+        ideal = m;
+        GB = g;
+        syzygy = z;
+    }
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString() {
+        StringBuffer s = new StringBuffer("SolvResPolPart(\n");
+        s.append("ideal = " + ideal);
+        s.append("\n GB = " + GB);
+        s.append("\n syzygy = " + syzygy);
+        s.append(")");
+        return s.toString();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/SolvableSyzygySeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/SolvableSyzygySeq.java
@@ -1,0 +1,583 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.SolvableExtendedGB;
+import edu.jas.gb.SolvableGroebnerBase;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenSolvablePolynomial;
+import edu.jas.poly.GenSolvablePolynomialRing;
+import edu.jas.poly.ModuleList;
+import edu.jas.poly.PolynomialList;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Syzygy sequential class for solvable polynomials. Implements Syzygy
+ * computations and tests with Groebner bases.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class SolvableSyzygySeq<C extends GcdRingElem<C>> extends SolvableSyzygyAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(SolvableSyzygySeq.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    private static boolean assertEnabled = false;
+
+
+    static {
+        assert assertEnabled = true; // official hack to check assertions enabled
+    }
+
+
+    /**
+     * Groebner basis engine.
+     */
+    protected SolvableGroebnerBase<C> sbb;
+
+
+    /*
+     * Module Groebner basis engine.
+    //protected ModSolvableGroebnerBase<C> msbb;
+     */
+
+
+    /**
+     * Constructor.
+     * @param cf coefficient ring.
+     */
+    public SolvableSyzygySeq(RingFactory<C> cf) {
+        sbb = SGBFactory.getImplementation(cf);
+        //msbb = new ModSolvableGroebnerBaseSeq<C>(cf);
+    }
+
+
+    /**
+     * Resolution of a module. Only with direct GBs.
+     * @param M a module list of a Groebner basis.
+     * @return a resolution of M.
+     */
+    public List<SolvResPart<C>> resolution(ModuleList<C> M) {
+        List<SolvResPart<C>> R = new ArrayList<SolvResPart<C>>();
+        ModuleList<C> MM = M;
+        ModuleList<C> GM;
+        ModuleList<C> Z;
+        while (true) {
+            GM = sbb.leftGB(MM);
+            Z = leftZeroRelations(GM);
+            R.add(new SolvResPart<C>(MM, GM, Z));
+            if (Z == null || Z.list == null || Z.list.size() == 0) {
+                break;
+            }
+            MM = Z;
+        }
+        return R;
+    }
+
+
+    /**
+     * Resolution of a polynomial list. Only with direct GBs.
+     * @param F a polynomial list of a Groebner basis.
+     * @return a resolution of F.
+     */
+    @SuppressWarnings("unchecked")
+    public List/*<SolvResPart<C>|SolvResPolPart<C>>*/resolution(PolynomialList<C> F) {
+        List<List<GenSolvablePolynomial<C>>> Z;
+        ModuleList<C> Zm;
+        List<GenSolvablePolynomial<C>> G;
+        PolynomialList<C> Gl;
+
+        G = sbb.leftGB(F.castToSolvableList());
+        Z = leftZeroRelations(G);
+        Gl = new PolynomialList<C>((GenSolvablePolynomialRing<C>) F.ring, G);
+        Zm = new ModuleList<C>((GenSolvablePolynomialRing<C>) F.ring, Z);
+
+        List R = resolution(Zm);
+        R.add(0, new SolvResPolPart<C>(F, Gl, Zm));
+        return R;
+    }
+
+
+    /**
+     * Resolution of a module.
+     * @param M a module list of an arbitrary basis.
+     * @return a resolution of M.
+     */
+    public List<SolvResPart<C>> resolutionArbitrary(ModuleList<C> M) {
+        List<SolvResPart<C>> R = new ArrayList<SolvResPart<C>>();
+        ModuleList<C> MM = M;
+        ModuleList<C> GM = null;
+        ModuleList<C> Z;
+        while (true) {
+            //GM = sbb.leftGB(MM);
+            Z = leftZeroRelationsArbitrary(MM);
+            R.add(new SolvResPart<C>(MM, GM, Z));
+            if (Z == null || Z.list == null || Z.list.size() == 0) {
+                break;
+            }
+            MM = Z;
+        }
+        return R;
+    }
+
+
+    /**
+     * Resolution of a polynomial list.
+     * @param F a polynomial list of an arbitrary basis.
+     * @return a resolution of F.
+     */
+    @SuppressWarnings("unchecked")
+    public List/*<SolvResPart<C>|SolvResPolPart<C>>*/resolutionArbitrary(PolynomialList<C> F) {
+        List<List<GenSolvablePolynomial<C>>> Z;
+        ModuleList<C> Zm;
+        PolynomialList<C> Gl = null;
+        //List<GenSolvablePolynomial<C>> G = sbb.leftGB( F.castToSolvableList() );
+        //Gl = new PolynomialList<C>((GenSolvablePolynomialRing<C>)F.ring, G);
+        Z = leftZeroRelationsArbitrary(F.castToSolvableList());
+        Zm = new ModuleList<C>((GenSolvablePolynomialRing<C>) F.ring, Z);
+
+        List R = resolutionArbitrary(Zm);
+        R.add(0, new SolvResPolPart<C>(F, Gl, Zm));
+        return R;
+    }
+
+
+    /**
+     * Left syzygy module from arbitrary base.
+     * @param modv number of module variables.
+     * @param F a solvable polynomial list.
+     * @return syz(F), a basis for the module of left syzygies for F.
+     */
+    @SuppressWarnings("unchecked")
+    public List<List<GenSolvablePolynomial<C>>> leftZeroRelationsArbitrary(int modv,
+                    List<GenSolvablePolynomial<C>> F) {
+        if (F == null) {
+            return null; //leftZeroRelations( modv, F );
+        }
+        if (F.size() <= 1) {
+            return leftZeroRelations(modv, F);
+        }
+        final int lenf = F.size();
+        SolvableExtendedGB<C> exgb = sbb.extLeftGB(modv, F);
+        if (debug) {
+            logger.info("exgb = " + exgb);
+        }
+        if (assertEnabled) {
+            logger.info("check1 exgb start");
+            if (!sbb.isLeftReductionMatrix(exgb)) {
+                logger.error("is reduction matrix ? false");
+            }
+            logger.info("check1 exgb end");
+        }
+        List<GenSolvablePolynomial<C>> G = exgb.G;
+        List<List<GenSolvablePolynomial<C>>> G2F = exgb.G2F;
+        List<List<GenSolvablePolynomial<C>>> F2G = exgb.F2G;
+
+        List<List<GenSolvablePolynomial<C>>> sg = leftZeroRelations(modv, G);
+        GenSolvablePolynomialRing<C> ring = G.get(0).ring;
+        ModuleList<C> S = new ModuleList<C>(ring, sg);
+        if (debug) {
+            logger.info("syz = " + S);
+        }
+        if (assertEnabled) {
+            logger.info("check2 left syz start");
+            if (!isLeftZeroRelation(sg, G)) {
+                logger.error("is syzygy ? false");
+            }
+            logger.info("check2 left syz end");
+        }
+
+        List<List<GenSolvablePolynomial<C>>> sf;
+        sf = new ArrayList<List<GenSolvablePolynomial<C>>>(sg.size());
+        //List<GenPolynomial<C>> row;
+
+        for (List<GenSolvablePolynomial<C>> r : sg) {
+            Iterator<GenSolvablePolynomial<C>> it = r.iterator();
+            Iterator<List<GenSolvablePolynomial<C>>> jt = G2F.iterator();
+
+            List<GenSolvablePolynomial<C>> rf;
+            rf = new ArrayList<GenSolvablePolynomial<C>>(lenf);
+            for (int m = 0; m < lenf; m++) {
+                rf.add(ring.getZERO());
+            }
+            while (it.hasNext() && jt.hasNext()) {
+                GenSolvablePolynomial<C> si = it.next();
+                List<GenSolvablePolynomial<C>> ai = jt.next();
+                //System.out.println("si = " + si);
+                //System.out.println("ai = " + ai);
+                if (si == null || ai == null) {
+                    continue;
+                }
+                // pi has wrong type:
+                List<GenPolynomial<C>> pi = blas.scalarProduct(si, PolynomialList.<C> castToList(ai));
+                //System.out.println("pi = " + pi);
+                rf = PolynomialList.<C> castToSolvableList(blas.vectorAdd(PolynomialList.<C> castToList(rf),
+                                pi));
+            }
+            if (it.hasNext() || jt.hasNext()) {
+                logger.error("leftZeroRelationsArbitrary wrong sizes");
+            }
+            //System.out.println("\nrf = " + rf + "\n");
+            sf.add(rf);
+        }
+        if (assertEnabled) {
+            logger.info("check3 left syz start");
+            if (!isLeftZeroRelation(sf, F)) {
+                logger.error("is partial syz sf ? false");
+            }
+            logger.info("check3 left syz end");
+        }
+
+        List<List<GenSolvablePolynomial<C>>> M;
+        M = new ArrayList<List<GenSolvablePolynomial<C>>>(lenf);
+        for (List<GenSolvablePolynomial<C>> r : F2G) {
+            Iterator<GenSolvablePolynomial<C>> it = r.iterator();
+            Iterator<List<GenSolvablePolynomial<C>>> jt = G2F.iterator();
+
+            List<GenSolvablePolynomial<C>> rf;
+            rf = new ArrayList<GenSolvablePolynomial<C>>(lenf);
+            for (int m = 0; m < lenf; m++) {
+                rf.add(ring.getZERO());
+            }
+            while (it.hasNext() && jt.hasNext()) {
+                GenSolvablePolynomial<C> si = it.next();
+                List<GenSolvablePolynomial<C>> ai = jt.next();
+                //System.out.println("si = " + si);
+                //System.out.println("ai = " + ai);
+                if (si == null || ai == null) {
+                    continue;
+                }
+                //pi has wrong type, should be: List<GenSolvablePolynomial<C>>
+                List<GenPolynomial<C>> pi = blas.scalarProduct(si, PolynomialList.<C> castToList(ai));
+                //System.out.println("pi = " + pi);
+                rf = PolynomialList.<C> castToSolvableList(blas.vectorAdd(PolynomialList.<C> castToList(rf),
+                                pi));
+            }
+            if (it.hasNext() || jt.hasNext()) {
+                logger.error("zeroRelationsArbitrary wrong sizes");
+            }
+            //System.out.println("\nMg Mf = " + rf + "\n");
+            M.add(rf);
+        }
+        //ModuleList<C> ML = new ModuleList<C>( ring, M );
+        //System.out.println("syz ML = " + ML);
+        // debug only:
+        //List<GenSolvablePolynomial<C>> F2 = new ArrayList<GenSolvablePolynomial<C>>( F.size() );
+        /* not true in general
+        List<GenPolynomial<C>> Fp = PolynomialList.<C>castToList(F);
+        for ( List<GenSolvablePolynomial<C>> rr: M ) {
+            GenSolvablePolynomial<C> rrg = PolynomialList.<C>castToSolvableList(blas.scalarProduct(Fp,PolynomialList.<C>castToList(rr)));
+            F2.add( rrg );
+        }
+        PolynomialList<C> pF = new PolynomialList<C>( ring, F );
+        PolynomialList<C> pF2 = new PolynomialList<C>( ring, F2 );
+        if ( ! pF.equals( pF2 ) ) {
+           logger.error("is FAB = F ? false");
+           //System.out.println("pF  = " + pF.list.size());
+           //System.out.println("pF2 = " + pF2.list.size());
+        }
+        */
+        int sflen = sf.size();
+        List<List<GenSolvablePolynomial<C>>> M2;
+        M2 = new ArrayList<List<GenSolvablePolynomial<C>>>(lenf);
+        int i = 0;
+        for (List<GenSolvablePolynomial<C>> ri : M) {
+            List<GenSolvablePolynomial<C>> r2i;
+            r2i = new ArrayList<GenSolvablePolynomial<C>>(ri.size());
+            int j = 0;
+            for (GenSolvablePolynomial<C> rij : ri) {
+                GenSolvablePolynomial<C> p = null;
+                if (i == j) {
+                    p = (GenSolvablePolynomial<C>) ring.getONE().subtract(rij);
+                } else {
+                    if (rij != null) {
+                        p = (GenSolvablePolynomial<C>) rij.negate();
+                    }
+                }
+                r2i.add(p);
+                j++;
+            }
+            M2.add(r2i);
+            if (!blas.isZero(PolynomialList.<C> castToList(r2i))) {
+                sf.add(r2i);
+            }
+            i++;
+        }
+        ModuleList<C> M2L = new ModuleList<C>(ring, M2);
+        if (debug) {
+            logger.debug("syz M2L = " + M2L);
+        }
+
+        if (debug) {
+            ModuleList<C> SF = new ModuleList<C>(ring, sf);
+            logger.debug("syz sf = " + SF);
+            logger.debug("#syz " + sflen + ", " + sf.size());
+        }
+        if (assertEnabled) {
+            logger.info("check4 left syz start");
+            if (!isLeftZeroRelation(sf, F)) {
+                logger.error("is syz sf ? false");
+            }
+            logger.info("check4 left syz end");
+        }
+        return sf;
+    }
+
+
+    /**
+     * Left Ore condition. Generators for the left Ore condition of two solvable
+     * polynomials.
+     * @param a solvable polynomial
+     * @param b solvable polynomial
+     * @return [p,q] with p*a = q*b
+     */
+    @SuppressWarnings({ "cast", "unchecked" })
+    public GenSolvablePolynomial<C>[] leftOreCond(GenSolvablePolynomial<C> a, GenSolvablePolynomial<C> b) {
+        if (a == null || a.isZERO() || b == null || b.isZERO()) {
+            throw new IllegalArgumentException("a and b must be non zero");
+        }
+        GenSolvablePolynomialRing<C> pfac = a.ring;
+        GenSolvablePolynomial<C>[] oc = (GenSolvablePolynomial<C>[]) new GenSolvablePolynomial[2];
+        if (a.equals(b)) {
+            oc[0] = pfac.getONE();
+            oc[1] = pfac.getONE();
+            return oc;
+        }
+        if (a.isConstant()) {
+            if (pfac.coFac.isCommutative()) { // ??
+                oc[0] = b;
+                oc[1] = a;
+                return oc;
+            }
+            oc[1] = pfac.getONE();
+            C c = a.leadingBaseCoefficient().inverse();
+            oc[0] = b.multiply(c);
+            return oc;
+        }
+        if (b.isConstant()) {
+            if (pfac.coFac.isCommutative()) { // ??
+                oc[0] = b;
+                oc[1] = a;
+                return oc;
+            }
+            oc[0] = pfac.getONE();
+            C c = b.leadingBaseCoefficient().inverse();
+            oc[1] = a.multiply(c);
+            return oc;
+        }
+        logger.info("computing left Ore condition: " + a + ", " + b);
+        List<GenSolvablePolynomial<C>> F = new ArrayList<GenSolvablePolynomial<C>>(2);
+        F.add(a);
+        F.add(b);
+        List<List<GenSolvablePolynomial<C>>> Gz = leftZeroRelationsArbitrary(F);
+        /*
+        if (Gz.size() < 0) { // always false
+            //System.out.println("Gz = " + Gz);
+            ModuleList<C> M = new ModuleList<C>(pfac, Gz);
+            ModuleList<C> GM = sbb.leftGB(M);
+            //System.out.println("GM = " + GM);
+            Gz = GM.castToSolvableList();
+        }
+        */
+        List<GenSolvablePolynomial<C>> G1 = null;
+        GenSolvablePolynomial<C> g1 = null;
+        for (List<GenSolvablePolynomial<C>> Gi : Gz) {
+            //System.out.println("Gi = " + Gi);
+            if (Gi.get(0).isZERO()) {
+                continue;
+            }
+            if (G1 == null) {
+                G1 = Gi;
+            }
+            if (g1 == null) {
+                g1 = G1.get(0);
+            } else if (g1.compareTo(Gi.get(0)) > 0) { //g1.degree() > Gi.get(0).degree() 
+                G1 = Gi;
+                g1 = G1.get(0);
+            }
+        }
+        oc[0] = g1; //G1.get(0);
+        oc[1] = (GenSolvablePolynomial<C>) G1.get(1).negate();
+        //logger.info("Ore multiple: " + oc[0].multiply(a) + ", " + Arrays.toString(oc));
+        return oc;
+    }
+
+
+    /**
+     * Right Ore condition. Generators for the right Ore condition of two
+     * solvable polynomials.
+     * @param a solvable polynomial
+     * @param b solvable polynomial
+     * @return [p,q] with a*p = b*q
+     */
+    @SuppressWarnings({ "cast", "unchecked" })
+    public GenSolvablePolynomial<C>[] rightOreCond(GenSolvablePolynomial<C> a, GenSolvablePolynomial<C> b) {
+        if (a == null || a.isZERO() || b == null || b.isZERO()) {
+            throw new IllegalArgumentException("a and b must be non zero");
+        }
+        GenSolvablePolynomialRing<C> pfac = a.ring;
+        GenSolvablePolynomial<C>[] oc = (GenSolvablePolynomial<C>[]) new GenSolvablePolynomial[2];
+        if (a.equals(b)) {
+            oc[0] = pfac.getONE();
+            oc[1] = pfac.getONE();
+            return oc;
+        }
+        if (a.isConstant()) {
+            if (pfac.coFac.isCommutative()) { // ??
+                oc[0] = b;
+                oc[1] = a;
+                return oc;
+            }
+            oc[1] = pfac.getONE();
+            C c = a.leadingBaseCoefficient().inverse();
+            oc[0] = b.multiply(c);
+            return oc;
+        }
+        if (b.isConstant()) {
+            if (pfac.coFac.isCommutative()) { // ??
+                oc[0] = b;
+                oc[1] = a;
+                return oc;
+            }
+            oc[0] = pfac.getONE();
+            C c = b.leadingBaseCoefficient().inverse();
+            oc[1] = a.multiply(c);
+            return oc;
+        }
+        logger.info("computing right Ore condition: " + a + ", " + b);
+        List<GenSolvablePolynomial<C>> F = new ArrayList<GenSolvablePolynomial<C>>(2);
+        F.add(a);
+        F.add(b);
+        List<List<GenSolvablePolynomial<C>>> Gz = rightZeroRelationsArbitrary(F);
+        List<GenSolvablePolynomial<C>> G1 = null;
+        GenSolvablePolynomial<C> g1 = null;
+        for (List<GenSolvablePolynomial<C>> Gi : Gz) {
+            if (Gi.get(0).isZERO()) {
+                continue;
+            }
+            if (G1 == null) {
+                G1 = Gi;
+            }
+            if (g1 == null) {
+                g1 = G1.get(0);
+            } else if (g1.compareTo(Gi.get(0)) > 0) {
+                G1 = Gi;
+                g1 = G1.get(0);
+            }
+        }
+        oc[0] = G1.get(0);
+        oc[1] = (GenSolvablePolynomial<C>) G1.get(1).negate();
+        //logger.info("Ore multiple: " + a.multiply(oc[0]) + ", " + Arrays.toString(oc));
+        return oc;
+    }
+
+
+    /**
+     * Left simplifier. Method of Apel &amp; Lassner (1987).
+     * @param a solvable polynomial
+     * @param b solvable polynomial
+     * @return [p,q] with a/b = p/q and q is minimal and monic
+     */
+    @Override
+    @SuppressWarnings({ "unchecked" })
+    public GenSolvablePolynomial<C>[] leftSimplifier(GenSolvablePolynomial<C> a, GenSolvablePolynomial<C> b) {
+        if (a == null || a.isZERO() || b == null || b.isZERO()) {
+            throw new IllegalArgumentException("a and b must be non zero");
+        }
+        GenSolvablePolynomial<C>[] oc = null;
+        if (a.isConstant() || b.isConstant()) {
+            oc = new GenSolvablePolynomial[] { a, b };
+            return oc;
+        }
+        if (a.totalDegree() > 3 || b.totalDegree() > 3) { // how avoid too long running GBs ?
+            //if (a.totalDegree() + b.totalDegree() > 6) { 
+            // && a.length() < 10 && b.length() < 10
+            logger.info("skipping simplifier GB computation: degs = " + a.totalDegree() + ", " + b.totalDegree());
+            oc = new GenSolvablePolynomial[] { a, b };
+            return oc;
+        }
+        //GenSolvablePolynomialRing<C> pfac = a.ring;
+        oc = rightOreCond(a, b);
+        logger.info("oc = " + Arrays.toString(oc)); // + ", a = " + a + ", b = " + b);
+        List<GenSolvablePolynomial<C>> F = new ArrayList<GenSolvablePolynomial<C>>(oc.length);
+        // opposite order and undo negation
+        F.add((GenSolvablePolynomial<C>) oc[1].negate());
+        F.add(oc[0]);
+        //logger.info("F = " + F);
+        List<List<GenSolvablePolynomial<C>>> Gz = leftZeroRelationsArbitrary(F);
+        //logger.info("Gz: " + Gz);
+        List<GenSolvablePolynomial<C>> G1 = new ArrayList<GenSolvablePolynomial<C>>(Gz.size());
+        List<GenSolvablePolynomial<C>> G2 = new ArrayList<GenSolvablePolynomial<C>>(Gz.size());
+        for (List<GenSolvablePolynomial<C>> ll : Gz) {
+            if (!ll.get(0).isZERO()) { // && !ll.get(1).isZERO()
+                G1.add(ll.get(0)); // denominators
+                G2.add(ll.get(1)); // numerators
+            }
+        }
+        logger.info("G1(den): " + G1 + ", G2(num): " + G2);
+        SolvableExtendedGB<C> exgb = sbb.extLeftGB(G1);
+        logger.info("exgb.F: " + exgb.F + ", exgb.G: " + exgb.G);
+        List<GenSolvablePolynomial<C>> G = exgb.G;
+        int m = 0;
+        GenSolvablePolynomial<C> min = null;
+        for (int i = 0; i < G.size(); i++) {
+            if (min == null) {
+                min = G.get(i);
+                m = i;
+            } else if (min.compareTo(G.get(i)) > 0) {
+                min = G.get(i);
+                m = i;
+            }
+        }
+        //wrong: blas.scalarProduct(G2,exgb.G2F.get(m));
+        GenSolvablePolynomial<C> min2 = (GenSolvablePolynomial<C>) blas.scalarProduct(
+                        PolynomialList.<C> castToList(exgb.G2F.get(m)), PolynomialList.<C> castToList(G2));
+        logger.info("min(den): " + min + ", min(num): " + min2 + ", m = " + m + ", " + exgb.G2F.get(m));
+        // opposite order
+        GenSolvablePolynomial<C> n = min2; // nominator
+        GenSolvablePolynomial<C> d = min; // denominator
+        // normalize
+        if (d.signum() < 0) {
+            n = (GenSolvablePolynomial<C>) n.negate();
+            d = (GenSolvablePolynomial<C>) d.negate();
+        }
+        C lc = d.leadingBaseCoefficient();
+        if (!lc.isONE() && lc.isUnit()) {
+            lc = lc.inverse();
+            n = n.multiplyLeft(lc);
+            d = d.multiplyLeft(lc);
+        }
+        if (debug) {
+            int t = compare(a, b, n, d);
+            if (t != 0) {
+                oc[0] = a; // nominator
+                oc[1] = b; // denominator
+                throw new RuntimeException("simp wrong, giving up: t = " + t);
+                //logger.error("simp wrong, giving up: t = " + t);
+                //return oc;
+            }
+        }
+        oc[0] = n; // nominator
+        oc[1] = d; // denominator
+        return oc;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/Syzygy.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/Syzygy.java
@@ -1,0 +1,138 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.io.Serializable;
+import java.util.List;
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.ModuleList;
+import edu.jas.poly.PolynomialList;
+import edu.jas.structure.RingElem;
+import edu.jas.vector.GenVector;
+
+
+/**
+ * Syzygy interface. Defines Syzygy computations and tests.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public interface Syzygy<C extends RingElem<C>> extends Serializable {
+
+
+    /**
+     * Syzygy module from Groebner base. F must be a Groebner base.
+     * @param F a Groebner base.
+     * @return syz(F), a basis for the module of syzygies for F.
+     */
+    public List<List<GenPolynomial<C>>> zeroRelations(List<GenPolynomial<C>> F);
+
+
+    /**
+     * Syzygy module from Groebner base. F must be a Groebner base.
+     * @param modv number of module variables.
+     * @param F a Groebner base.
+     * @return syz(F), a basis for the module of syzygies for F.
+     */
+    public List<List<GenPolynomial<C>>> zeroRelations(int modv, List<GenPolynomial<C>> F);
+
+
+    /**
+     * Syzygy module from Groebner base. v must be a Groebner base.
+     * @param modv number of module variables.
+     * @param v a Groebner base.
+     * @return syz(v), a basis for the module of syzygies for v.
+     */
+    public List<List<GenPolynomial<C>>> zeroRelations(int modv, GenVector<GenPolynomial<C>> v);
+
+
+    /**
+     * Syzygy module from module Groebner base. M must be a module Groebner
+     * base.
+     * @param M a module Groebner base.
+     * @return syz(M), a basis for the module of syzygies for M.
+     */
+    public ModuleList<C> zeroRelations(ModuleList<C> M);
+
+
+    /**
+     * Test if sysygy.
+     * @param Z list of sysygies.
+     * @param F a polynomial list.
+     * @return true, if Z is a list of syzygies for F, else false.
+     */
+    public boolean isZeroRelation(List<List<GenPolynomial<C>>> Z, List<GenPolynomial<C>> F);
+
+
+    /**
+     * Test if sysygy of modules.
+     * @param Z list of sysygies.
+     * @param F a module list.
+     * @return true, if Z is a list of syzygies for F, else false.
+     */
+    public boolean isZeroRelation(ModuleList<C> Z, ModuleList<C> F);
+
+
+    /**
+     * Resolution of a module. Only with direct GBs.
+     * @param M a module list of a Groebner basis.
+     * @return a resolution of M.
+     */
+    public List<ResPart<C>> resolution(ModuleList<C> M);
+
+
+    /**
+     * Resolution of a polynomial list. Only with direct GBs.
+     * @param F a polynomial list of a Groebner basis.
+     * @return a resolution of F.
+     */
+    public List // <ResPart<C>|ResPolPart<C>>
+    resolution(PolynomialList<C> F);
+
+
+    /**
+     * Resolution of a polynomial list.
+     * @param F a polynomial list of an arbitrary basis.
+     * @return a resolution of F.
+     */
+    public List // <ResPart<C>|ResPolPart<C>>
+    resolutionArbitrary(PolynomialList<C> F);
+
+
+    /**
+     * Resolution of a module.
+     * @param M a module list of an arbitrary basis.
+     * @return a resolution of M.
+     */
+    public List<ResPart<C>> resolutionArbitrary(ModuleList<C> M);
+
+
+    /**
+     * Syzygy module from arbitrary base.
+     * @param F a polynomial list.
+     * @return syz(F), a basis for the module of syzygies for F.
+     */
+    public List<List<GenPolynomial<C>>> zeroRelationsArbitrary(List<GenPolynomial<C>> F);
+
+
+    /**
+     * Syzygy module from arbitrary base.
+     * @param modv number of module variables.
+     * @param F a polynomial list.
+     * @return syz(F), a basis for the module of syzygies for F.
+     */
+    public List<List<GenPolynomial<C>>> zeroRelationsArbitrary(int modv, List<GenPolynomial<C>> F);
+
+
+    /**
+     * Syzygy module from arbitrary module base.
+     * @param M an arbitrary module base.
+     * @return syz(M), a basis for the module of syzygies for M.
+     */
+    public ModuleList<C> zeroRelationsArbitrary(ModuleList<C> M);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/SyzygyAbstract.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/SyzygyAbstract.java
@@ -1,0 +1,402 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.Reduction;
+import edu.jas.gb.ReductionSeq;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.ModuleList;
+import edu.jas.poly.PolynomialList;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingElem;
+import edu.jas.vector.BasicLinAlg;
+import edu.jas.vector.GenVector;
+import edu.jas.vector.GenVectorModul;
+
+
+/**
+ * SyzygyAbstract class. Implements Syzygy computations and tests.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public abstract class SyzygyAbstract<C extends GcdRingElem<C>> implements Syzygy<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(SyzygyAbstract.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Reduction engine.
+     */
+    protected Reduction<C> red;
+
+
+    /**
+     * Linear algebra engine.
+     */
+    protected BasicLinAlg<GenPolynomial<C>> blas;
+
+
+    /**
+     * Constructor.
+     */
+    public SyzygyAbstract() {
+        red = new ReductionSeq<C>();
+        blas = new BasicLinAlg<GenPolynomial<C>>();
+    }
+
+
+    /**
+     * Syzygy module from Groebner base. F must be a Groebner base.
+     * @param F a Groebner base.
+     * @return syz(F), a basis for the module of syzygies for F.
+     */
+    public List<List<GenPolynomial<C>>> zeroRelations(List<GenPolynomial<C>> F) {
+        return zeroRelations(0, F);
+    }
+
+
+    /**
+     * Syzygy module from Groebner base. F must be a Groebner base.
+     * @param modv number of module variables.
+     * @param F a Groebner base.
+     * @return syz(F), a basis for the module of syzygies for F.
+     */
+    public List<List<GenPolynomial<C>>> zeroRelations(int modv, List<GenPolynomial<C>> F) {
+        List<List<GenPolynomial<C>>> Z = new ArrayList<List<GenPolynomial<C>>>();
+        if (F == null) {
+            return Z;
+        }
+        GenVectorModul<GenPolynomial<C>> mfac = null;
+        int i = 0;
+        while (mfac == null && i < F.size()) {
+            GenPolynomial<C> p = F.get(i);
+            if (p != null) {
+                mfac = new GenVectorModul<GenPolynomial<C>>(p.ring, F.size());
+            }
+        }
+        if (mfac == null) {
+            return Z;
+        }
+        GenVector<GenPolynomial<C>> v = mfac.fromList(F);
+        //System.out.println("F = " + F + " v = " + v);
+        return zeroRelations(modv, v);
+    }
+
+
+    /**
+     * Syzygy module from Groebner base. v must be a Groebner base.
+     * @param modv number of module variables.
+     * @param v a Groebner base.
+     * @return syz(v), a basis for the module of syzygies for v.
+     */
+    public List<List<GenPolynomial<C>>> zeroRelations(int modv, GenVector<GenPolynomial<C>> v) {
+        List<List<GenPolynomial<C>>> Z = new ArrayList<List<GenPolynomial<C>>>();
+        GenVectorModul<GenPolynomial<C>> mfac = v.modul;
+        List<GenPolynomial<C>> F = v.val;
+        GenVector<GenPolynomial<C>> S = mfac.getZERO();
+        GenPolynomial<C> pi, pj, s, h;
+        //zero = mfac.coFac.getZERO();
+        for (int i = 0; i < F.size(); i++) {
+            pi = F.get(i);
+            for (int j = i + 1; j < F.size(); j++) {
+                pj = F.get(j);
+                //logger.info("p"+i+", p"+j+" = " + pi + ", " +pj);
+
+                if (!red.moduleCriterion(modv, pi, pj)) {
+                    continue;
+                }
+                // if ( ! red.criterion4( pi, pj ) ) { continue; }
+                List<GenPolynomial<C>> row = S.copy().val;
+
+                s = red.SPolynomial(row, i, pi, j, pj);
+                if (s.isZERO()) {
+                    Z.add(row);
+                    continue;
+                }
+
+                h = red.normalform(row, F, s);
+                if (!h.isZERO()) {
+                    throw new RuntimeException("Syzygy no GB");
+                }
+                if (debug) {
+                    logger.info("row = " + row.size());
+                }
+                Z.add(row);
+            }
+        }
+        return Z;
+    }
+
+
+    /**
+     * Syzygy module from module Groebner base. M must be a module Groebner
+     * base.
+     * @param M a module Groebner base.
+     * @return syz(M), a basis for the module of syzygies for M.
+     */
+    public ModuleList<C> zeroRelations(ModuleList<C> M) {
+        ModuleList<C> N = M;
+        if (M == null || M.list == null) {
+            return N;
+        }
+        if (M.rows == 0 || M.cols == 0) {
+            return N;
+        }
+        GenPolynomial<C> zero = M.ring.getZERO();
+        //System.out.println("zero = " + zero);
+
+        //ModuleList<C> Np = null;
+        PolynomialList<C> F = M.getPolynomialList();
+        int modv = M.cols; // > 0  
+        //System.out.println("modv = " + modv);
+        List<List<GenPolynomial<C>>> G = zeroRelations(modv, F.list);
+        List<List<GenPolynomial<C>>> Z = new ArrayList<List<GenPolynomial<C>>>();
+        for (int i = 0; i < G.size(); i++) {
+            //F = new PolynomialList(F.ring,(List)G.get(i));
+            List<GenPolynomial<C>> Gi = G.get(i);
+            List<GenPolynomial<C>> Zi = new ArrayList<GenPolynomial<C>>();
+            // System.out.println("\nG("+i+") = " + G.get(i));
+            for (int j = 0; j < Gi.size(); j++) {
+                //System.out.println("\nG("+i+","+j+") = " + Gi.get(j));
+                GenPolynomial<C> p = Gi.get(j);
+                if (p != null) {
+                    Map<ExpVector, GenPolynomial<C>> r = p.contract(M.ring);
+                    int s = 0;
+                    for (GenPolynomial<C> vi : r.values()) {
+                        Zi.add(vi);
+                        s++;
+                    }
+                    if (s == 0) {
+                        Zi.add(zero);
+                    } else if (s > 1) { // will not happen
+                        System.out.println("p = " + p);
+                        System.out.println("map(" + i + "," + j + ") = " + r + ", size = " + r.size());
+                        throw new RuntimeException("Map.size() > 1 = " + r.size());
+                    }
+                }
+            }
+            //System.out.println("\nZ("+i+") = " + Zi);
+            Z.add(Zi);
+        }
+        N = new ModuleList<C>(M.ring, Z);
+        //System.out.println("\n\nN = " + N);
+        return N;
+    }
+
+
+    /**
+     * Test if sysygy.
+     * @param Z list of sysygies.
+     * @param F a polynomial list.
+     * @return true, if Z is a list of syzygies for F, else false.
+     */
+
+    public boolean isZeroRelation(List<List<GenPolynomial<C>>> Z, List<GenPolynomial<C>> F) {
+        for (List<GenPolynomial<C>> row : Z) {
+            GenPolynomial<C> p = blas.scalarProduct(row, F);
+            if (p == null) {
+                continue;
+            }
+            if (!p.isZERO()) {
+                logger.info("is not ZeroRelation = " + p.toString(p.ring.getVars()));
+                logger.info("row = " + row);
+                //logger.info("F = " + F);
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Test if sysygy of modules.
+     * @param Z list of sysygies.
+     * @param F a module list.
+     * @return true, if Z is a list of syzygies for F, else false.
+     */
+
+    public boolean isZeroRelation(ModuleList<C> Z, ModuleList<C> F) {
+        if (Z == null || Z.list == null) {
+            return true;
+        }
+        for (List<GenPolynomial<C>> row : Z.list) {
+            List<GenPolynomial<C>> zr = blas.leftScalarProduct(row, F.list);
+            if (!blas.isZero(zr)) {
+                logger.info("is not ZeroRelation (" + zr.size() + ") = " + zr);
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Syzygy module from arbitrary base.
+     * @param F a polynomial list.
+     * @return syz(F), a basis for the module of syzygies for F.
+     */
+    public List<List<GenPolynomial<C>>> zeroRelationsArbitrary(List<GenPolynomial<C>> F) {
+        return zeroRelationsArbitrary(0, F);
+    }
+
+
+    /**
+     * Syzygy module from arbitrary module base.
+     * @param M an arbitrary module base.
+     * @return syz(M), a basis for the module of syzygies for M.
+     */
+    public ModuleList<C> zeroRelationsArbitrary(ModuleList<C> M) {
+        ModuleList<C> N = M;
+        if (M == null || M.list == null) {
+            return N;
+        }
+        if (M.rows == 0 || M.cols == 0) {
+            return N;
+        }
+        GenPolynomial<C> zero = M.ring.getZERO();
+        //System.out.println("zero = " + zero);
+
+        //ModuleList<C> Np = null;
+        PolynomialList<C> F = M.getPolynomialList();
+        int modv = M.cols; // > 0  
+        //System.out.println("modv = " + modv);
+        List<List<GenPolynomial<C>>> G = zeroRelationsArbitrary(modv, F.list);
+        List<List<GenPolynomial<C>>> Z = new ArrayList<List<GenPolynomial<C>>>();
+        for (int i = 0; i < G.size(); i++) {
+            //F = new PolynomialList(F.ring,(List)G.get(i));
+            List<GenPolynomial<C>> Gi = G.get(i);
+            List<GenPolynomial<C>> Zi = new ArrayList<GenPolynomial<C>>();
+            // System.out.println("\nG("+i+") = " + G.get(i));
+            for (int j = 0; j < Gi.size(); j++) {
+                //System.out.println("\nG("+i+","+j+") = " + Gi.get(j));
+                GenPolynomial<C> p = Gi.get(j);
+                if (p != null) {
+                    Map<ExpVector, GenPolynomial<C>> r = p.contract(M.ring);
+                    int s = 0;
+                    for (GenPolynomial<C> vi : r.values()) {
+                        Zi.add(vi);
+                        s++;
+                    }
+                    if (s == 0) {
+                        Zi.add(zero);
+                    } else if (s > 1) { // will not happen
+                        System.out.println("p = " + p);
+                        System.out.println("map(" + i + "," + j + ") = " + r + ", size = " + r.size());
+                        throw new RuntimeException("Map.size() > 1 = " + r.size());
+                    }
+                }
+            }
+            //System.out.println("\nZ("+i+") = " + Zi);
+            Z.add(Zi);
+        }
+        N = new ModuleList<C>(M.ring, Z);
+        //System.out.println("\n\nN = " + N);
+        return N;
+    }
+
+}
+
+
+/**
+ * Container for module resolution components.
+ * @param <C> coefficient type
+ */
+class ResPart<C extends RingElem<C>> implements Serializable {
+
+
+    public final ModuleList<C> module;
+
+
+    public final ModuleList<C> GB;
+
+
+    public final ModuleList<C> syzygy;
+
+
+    /**
+     * ResPart.
+     * @param m a module list.
+     * @param g a module list GB.
+     * @param z a syzygy module list.
+     */
+    public ResPart(ModuleList<C> m, ModuleList<C> g, ModuleList<C> z) {
+        module = m;
+        GB = g;
+        syzygy = z;
+    }
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString() {
+        StringBuffer s = new StringBuffer("ResPart(\n");
+        s.append("module = " + module);
+        s.append("\n GB = " + GB);
+        s.append("\n syzygy = " + syzygy);
+        s.append(")");
+        return s.toString();
+    }
+}
+
+
+/**
+ * Container for polynomial resolution components.
+ */
+class ResPolPart<C extends RingElem<C>> implements Serializable {
+
+
+    public final PolynomialList<C> ideal;
+
+
+    public final PolynomialList<C> GB;
+
+
+    public final ModuleList<C> syzygy;
+
+
+    /**
+     * ResPolPart.
+     * @param m a polynomial list.
+     * @param g a polynomial list GB.
+     * @param z a syzygy module list.
+     */
+    public ResPolPart(PolynomialList<C> m, PolynomialList<C> g, ModuleList<C> z) {
+        ideal = m;
+        GB = g;
+        syzygy = z;
+    }
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString() {
+        StringBuffer s = new StringBuffer("ResPolPart(\n");
+        s.append("ideal = " + ideal);
+        s.append("\n GB = " + GB);
+        s.append("\n syzygy = " + syzygy);
+        s.append(")");
+        return s.toString();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/SyzygySeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/SyzygySeq.java
@@ -1,0 +1,311 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.ExtendedGB;
+import edu.jas.gb.GroebnerBaseAbstract;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.ModuleList;
+import edu.jas.poly.PolynomialList;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * SyzygySeq class. Implements Syzygy computations and tests.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class SyzygySeq<C extends GcdRingElem<C>> extends SyzygyAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(SyzygySeq.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Groebner base engine.
+     */
+    protected GroebnerBaseAbstract<C> bb;
+
+
+    /*
+     * Module Groebner base engine.
+    //protected ModGroebnerBaseAbstract<C> mbb;
+     */
+
+
+    /**
+     * Constructor.
+     * @param cf coefficient ring.
+     */
+    public SyzygySeq(RingFactory<C> cf) {
+        super();
+        bb = GBFactory.getImplementation(cf);
+        //mbb = new ModGroebnerBaseSeq<C>(cf);
+    }
+
+
+    /**
+     * Resolution of a module. Only with direct GBs.
+     * @param M a module list of a Groebner basis.
+     * @return a resolution of M.
+     */
+    public List<ResPart<C>> resolution(ModuleList<C> M) {
+        List<ResPart<C>> R = new ArrayList<ResPart<C>>();
+        ModuleList<C> MM = M;
+        ModuleList<C> GM;
+        ModuleList<C> Z;
+        //ModGroebnerBase<C> mbb = new ModGroebnerBaseSeq<C>(M.ring.coFac);
+        //assert cf == M.ring.coFac;
+        while (true) {
+            GM = bb.GB(MM);
+            Z = zeroRelations(GM);
+            R.add(new ResPart<C>(MM, GM, Z));
+            if (Z == null || Z.list == null || Z.list.size() == 0) {
+                break;
+            }
+            MM = Z;
+        }
+        return R;
+    }
+
+
+    /**
+     * Resolution of a polynomial list. Only with direct GBs.
+     * @param F a polynomial list of a Groebner basis.
+     * @return a resolution of F.
+     */
+    @SuppressWarnings("unchecked")
+    public List // <ResPart<C>|ResPolPart<C>>
+    resolution(PolynomialList<C> F) {
+        List<List<GenPolynomial<C>>> Z;
+        ModuleList<C> Zm;
+        List<GenPolynomial<C>> G;
+        PolynomialList<C> Gl;
+
+        //GroebnerBase<C> gb = GBFactory.getImplementation(F.ring.coFac);
+        //assert cf == F.ring.coFac;
+        G = bb.GB(F.list);
+        Z = zeroRelations(G);
+        Gl = new PolynomialList<C>(F.ring, G);
+        Zm = new ModuleList<C>(F.ring, Z);
+
+        List R = resolution(Zm); //// <ResPart<C>|ResPolPart<C>>
+        R.add(0, new ResPolPart<C>(F, Gl, Zm));
+        return R;
+    }
+
+
+    /**
+     * Resolution of a polynomial list.
+     * @param F a polynomial list of an arbitrary basis.
+     * @return a resolution of F.
+     */
+    @SuppressWarnings("unchecked")
+    public List // <ResPart<C>|ResPolPart<C>>
+    resolutionArbitrary(PolynomialList<C> F) {
+        List<List<GenPolynomial<C>>> Z;
+        ModuleList<C> Zm;
+        //List<GenPolynomial<C>> G;
+        PolynomialList<C> Gl = null;
+
+        //G = bb.GB(F.list);
+        Z = zeroRelationsArbitrary(F.list);
+        //Gl = new PolynomialList<C>(F.ring, F.list);
+        Zm = new ModuleList<C>(F.ring, Z);
+
+        List R = resolutionArbitrary(Zm); //// <ResPart<C>|ResPolPart<C>>
+        R.add(0, new ResPolPart<C>(F, Gl, Zm));
+        return R;
+    }
+
+
+    /**
+     * Resolution of a module.
+     * @param M a module list of an arbitrary basis.
+     * @return a resolution of M.
+     */
+    public List<ResPart<C>> resolutionArbitrary(ModuleList<C> M) {
+        List<ResPart<C>> R = new ArrayList<ResPart<C>>();
+        ModuleList<C> MM = M;
+        ModuleList<C> GM = null;
+        ModuleList<C> Z;
+        while (true) {
+            //GM = bb.GB(MM);
+            Z = zeroRelationsArbitrary(MM);
+            R.add(new ResPart<C>(MM, GM, Z));
+            if (Z == null || Z.list == null || Z.list.size() == 0) {
+                break;
+            }
+            MM = Z;
+        }
+        return R;
+    }
+
+
+    /**
+     * Syzygy module from arbitrary base.
+     * @param modv number of module variables.
+     * @param F a polynomial list.
+     * @return syz(F), a basis for the module of syzygies for F.
+     */
+    public List<List<GenPolynomial<C>>> zeroRelationsArbitrary(int modv, List<GenPolynomial<C>> F) {
+        if (F == null) {
+            return new ArrayList<List<GenPolynomial<C>>>();
+            //return zeroRelations(modv, F);
+        }
+        if (F.size() <= 1) {
+            return zeroRelations(modv, F);
+        }
+        //GroebnerBase<C> gb = GBFactory.getImplementation(F.get(0).ring.coFac);
+        // assert cf == F.get(0).ring.coFac;
+        final int lenf = F.size();
+        ExtendedGB<C> exgb = bb.extGB(F);
+        if (debug) {
+            logger.debug("exgb = " + exgb);
+            if (!bb.isReductionMatrix(exgb)) {
+                logger.error("is reduction matrix ? false");
+            }
+        }
+        List<GenPolynomial<C>> G = exgb.G;
+        List<List<GenPolynomial<C>>> G2F = exgb.G2F;
+        List<List<GenPolynomial<C>>> F2G = exgb.F2G;
+
+        List<List<GenPolynomial<C>>> sg = zeroRelations(modv, G);
+        GenPolynomialRing<C> ring = G.get(0).ring;
+        ModuleList<C> S = new ModuleList<C>(ring, sg);
+        if (debug) {
+            logger.debug("syz = " + S);
+            if (!isZeroRelation(sg, G)) {
+                logger.error("is syzygy ? false");
+            }
+        }
+        List<List<GenPolynomial<C>>> sf;
+        sf = new ArrayList<List<GenPolynomial<C>>>(sg.size());
+        //List<GenPolynomial<C>> row;
+        for (List<GenPolynomial<C>> r : sg) {
+            Iterator<GenPolynomial<C>> it = r.iterator();
+            Iterator<List<GenPolynomial<C>>> jt = G2F.iterator();
+
+            List<GenPolynomial<C>> rf;
+            rf = new ArrayList<GenPolynomial<C>>(lenf);
+            for (int m = 0; m < lenf; m++) {
+                rf.add(ring.getZERO());
+            }
+            while (it.hasNext() && jt.hasNext()) {
+                GenPolynomial<C> si = it.next();
+                List<GenPolynomial<C>> ai = jt.next();
+                //System.out.println("si = " + si);
+                //System.out.println("ai = " + ai);
+                if (si == null || ai == null) {
+                    continue;
+                }
+                List<GenPolynomial<C>> pi = blas.scalarProduct(si, ai);
+                //System.out.println("pi = " + pi);
+                rf = blas.vectorAdd(rf, pi);
+            }
+            if (it.hasNext() || jt.hasNext()) {
+                logger.error("zeroRelationsArbitrary wrong sizes");
+            }
+            //System.out.println("\nrf = " + rf + "\n");
+            sf.add(rf);
+        }
+        List<List<GenPolynomial<C>>> M;
+        M = new ArrayList<List<GenPolynomial<C>>>(lenf);
+        for (List<GenPolynomial<C>> r : F2G) {
+            Iterator<GenPolynomial<C>> it = r.iterator();
+            Iterator<List<GenPolynomial<C>>> jt = G2F.iterator();
+
+            List<GenPolynomial<C>> rf;
+            rf = new ArrayList<GenPolynomial<C>>(lenf);
+            for (int m = 0; m < lenf; m++) {
+                rf.add(ring.getZERO());
+            }
+            while (it.hasNext() && jt.hasNext()) {
+                GenPolynomial<C> si = it.next();
+                List<GenPolynomial<C>> ai = jt.next();
+                //System.out.println("si = " + si);
+                //System.out.println("ai = " + ai);
+                if (si == null || ai == null) {
+                    continue;
+                }
+                List<GenPolynomial<C>> pi = blas.scalarProduct(ai, si);
+                //System.out.println("pi = " + pi);
+                rf = blas.vectorAdd(rf, pi);
+            }
+            if (it.hasNext() || jt.hasNext()) {
+                logger.error("zeroRelationsArbitrary wrong sizes");
+            }
+            //System.out.println("\nMg Mf = " + rf + "\n");
+            M.add(rf);
+        }
+        //ModuleList<C> ML = new ModuleList<C>( ring, M );
+        //System.out.println("syz ML = " + ML);
+        // debug only:
+        /* not true in general
+        List<GenPolynomial<C>> F2 = new ArrayList<GenPolynomial<C>>( F.size() );
+        for ( List<GenPolynomial<C>> rr: M ) {
+            GenPolynomial<C> rrg = blas.scalarProduct( F, rr );
+            F2.add( rrg );
+        }
+        PolynomialList<C> pF = new PolynomialList<C>( ring, F );
+        PolynomialList<C> pF2 = new PolynomialList<C>( ring, F2 );
+        if ( ! pF.equals( pF2 ) ) {
+           logger.error("is FAB = F ? false");
+        }
+        */
+        int sflen = sf.size();
+        List<List<GenPolynomial<C>>> M2;
+        M2 = new ArrayList<List<GenPolynomial<C>>>(lenf);
+        int i = 0;
+        for (List<GenPolynomial<C>> ri : M) {
+            List<GenPolynomial<C>> r2i;
+            r2i = new ArrayList<GenPolynomial<C>>(ri.size());
+            int j = 0;
+            for (GenPolynomial<C> rij : ri) {
+                GenPolynomial<C> p = null;
+                if (i == j) {
+                    p = ring.getONE().subtract(rij);
+                } else {
+                    if (rij != null) {
+                        p = rij.negate();
+                    }
+                }
+                r2i.add(p);
+                j++;
+            }
+            M2.add(r2i);
+            if (!blas.isZero(r2i)) {
+                sf.add(r2i);
+            }
+            i++;
+        }
+        if (debug) {
+            ModuleList<C> M2L = new ModuleList<C>(ring, M2);
+            logger.debug("syz M2L = " + M2L);
+            ModuleList<C> SF = new ModuleList<C>(ring, sf);
+            logger.debug("syz sf = " + SF);
+            logger.debug("#syz " + sflen + ", " + sf.size());
+            if (!isZeroRelation(sf, F)) {
+                logger.error("is syz sf ? false");
+            }
+        }
+        return sf;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/WordGroebnerBasePseudoRecSeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/WordGroebnerBasePseudoRecSeq.java
@@ -1,0 +1,408 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.OrderedWordPairlist;
+import edu.jas.gb.WordGroebnerBaseAbstract;
+import edu.jas.gb.WordPair;
+import edu.jas.gb.WordPairList;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.GenWordPolynomial;
+import edu.jas.poly.GenWordPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.ufd.GCDFactory;
+import edu.jas.ufd.GreatestCommonDivisorAbstract;
+
+
+/**
+ * Non-commutative word Groebner Base sequential algorithm. Implements Groebner
+ * bases and GB test. Coefficients can for example be (commutative) multivariate
+ * polynomials.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class WordGroebnerBasePseudoRecSeq<C extends GcdRingElem<C>> extends
+                WordGroebnerBaseAbstract<GenPolynomial<C>> {
+
+
+    private static final Logger logger = LogManager.getLogger(WordGroebnerBasePseudoRecSeq.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Greatest common divisor engine for coefficient content and primitive
+     * parts.
+     */
+    protected final GreatestCommonDivisorAbstract<C> engine;
+
+
+    /**
+     * Reduction engine.
+     */
+    protected final WordPseudoReduction<C> redRec;
+
+
+    /**
+     * Reduction engine.
+     */
+    protected final WordPseudoReduction<GenPolynomial<C>> red;
+
+
+    /**
+     * Coefficient ring factory.
+     */
+    //protected final RingFactory<GenPolynomial<C>> cofac;
+    protected final GenPolynomialRing<C> cofac;
+
+
+    /**
+     * Constructor.
+     * @param rf coefficient ring factory.
+     */
+    public WordGroebnerBasePseudoRecSeq(RingFactory<GenPolynomial<C>> rf) {
+        this(rf, new WordPseudoReductionSeq<GenPolynomial<C>>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param rf coefficient ring factory.
+     * @param red Reduction engine
+     */
+    public WordGroebnerBasePseudoRecSeq(RingFactory<GenPolynomial<C>> rf,
+                    WordPseudoReductionSeq<GenPolynomial<C>> red) {
+        this(rf, red, new OrderedWordPairlist<GenPolynomial<C>>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param rf coefficient ring factory.
+     * @param red Reduction engine
+     * @param pl pair selection strategy
+     */
+    @SuppressWarnings("unchecked")
+    public WordGroebnerBasePseudoRecSeq(RingFactory<GenPolynomial<C>> rf,
+                    WordPseudoReductionSeq<GenPolynomial<C>> red, WordPairList<GenPolynomial<C>> pl) {
+        super(red, pl);
+        this.red = red;
+        redRec = (WordPseudoReduction<C>) (WordPseudoReduction) red;
+        cofac = (GenPolynomialRing<C>) rf;
+        if (!cofac.isCommutative()) {
+            logger.warn("reduction not correct for " + cofac.toScript());
+        }
+        engine = GCDFactory.<C> getImplementation(cofac.coFac);
+        //not used: engine = GCDFactory.<C>getProxy(cofac.coFac);
+    }
+
+
+    /**
+     * Word Groebner base using word pairlist class.
+     * @param F word polynomial list.
+     * @return GB(F) a finite non-commutative Groebner base of F, if it exists.
+     */
+    @Override
+    public List<GenWordPolynomial<GenPolynomial<C>>> GB(List<GenWordPolynomial<GenPolynomial<C>>> F) {
+        List<GenWordPolynomial<GenPolynomial<C>>> G = normalizeZerosOnes(F);
+        //G = PolyUtil.<C> wordMonic(G);
+        G = recursivePrimitivePart(G);
+        G = normalizeZerosOnes(G);
+        if (G.size() <= 1) {
+            return G;
+        }
+        GenWordPolynomialRing<GenPolynomial<C>> ring = G.get(0).ring;
+        if (!ring.coFac.isCommutative()) {
+            throw new IllegalArgumentException("coefficient ring not commutative");
+        }
+        //Collections.sort(G);
+        OrderedWordPairlist<GenPolynomial<C>> pairlist = (OrderedWordPairlist<GenPolynomial<C>>) strategy
+                        .create(ring);
+        pairlist.put(G);
+        logger.info("start " + pairlist);
+
+        WordPair<GenPolynomial<C>> pair;
+        GenWordPolynomial<GenPolynomial<C>> pi;
+        GenWordPolynomial<GenPolynomial<C>> pj;
+        List<GenWordPolynomial<GenPolynomial<C>>> S;
+        GenWordPolynomial<GenPolynomial<C>> H;
+        while (pairlist.hasNext()) {
+            pair = pairlist.removeNext();
+            //logger.debug("pair = " + pair);
+            if (pair == null) {
+                continue;
+            }
+            pi = pair.pi;
+            pj = pair.pj;
+            if (debug) {
+                logger.info("pi   = " + pi + ", pj = " + pj);
+                //logger.info("pj    = " + pj);
+            }
+
+            S = red.SPolynomials(pi, pj);
+            if (S.isEmpty()) {
+                continue;
+            }
+            for (GenWordPolynomial<GenPolynomial<C>> s : S) {
+                if (s.isZERO()) {
+                    //pair.setZero();
+                    continue;
+                }
+                if (debug) {
+                    logger.info("ht(S) = " + s.leadingWord());
+                }
+                boolean t = pairlist.criterion3(pair.i, pair.j, s.leadingWord());
+                //System.out.println("criterion3(" + pair.i + "," + pair.j + ") = " + t);
+                //if ( !t ) {
+                //    continue;  
+                //}
+
+                H = redRec.normalformRecursive(G, s);
+                if (debug) {
+                    //logger.info("pair = " + pair); 
+                    //logger.info("ht(S) = " + S.monic()); //.leadingWord() );
+                    logger.info("ht(H) = " + H.monic()); //.leadingWord() );
+                }
+                if (H.isZERO()) {
+                    //pair.setZero();
+                    continue;
+                }
+                if (!t) {
+                    logger.info("criterion3(" + pair.i + "," + pair.j + ") wrong: " + s.leadingWord()
+                                    + " --> '" + H.leadingWord() + "'");
+                }
+
+                //H = H.monic();
+                H = recursivePrimitivePart(H);
+                H = H.abs();
+                if (debug) {
+                    logger.info("ht(H) = " + H.leadingWord());
+                }
+                if (H.isONE()) {
+                    G.clear();
+                    G.add(H);
+                    return G; // since no threads are activated
+                }
+                if (debug) {
+                    logger.info("H = " + H);
+                }
+                if (H.length() > 0) {
+                    //l++;
+                    G.add(H);
+                    pairlist.put(H);
+                }
+            }
+        }
+        //logger.info("#sequential list = " + G.size());
+        G = minimalGB(G);
+        logger.info("" + pairlist);
+        //Collections.sort(G);
+        //Collections.reverse(G);
+        return G;
+    }
+
+
+    /**
+     * Minimal ordered Groebner basis.
+     * @param Gp a Groebner base.
+     * @return a reduced Groebner base of Gp.
+     */
+    @Override
+    public List<GenWordPolynomial<GenPolynomial<C>>> minimalGB(List<GenWordPolynomial<GenPolynomial<C>>> Gp) {
+        if (Gp == null || Gp.size() <= 1) {
+            return Gp;
+        }
+        // remove zero polynomials
+        List<GenWordPolynomial<GenPolynomial<C>>> G = new ArrayList<GenWordPolynomial<GenPolynomial<C>>>(
+                        Gp.size());
+        for (GenWordPolynomial<GenPolynomial<C>> a : Gp) {
+            if (a != null && !a.isZERO()) { // always true in GB()
+                // already positive a = a.abs();
+                G.add(a);
+            }
+        }
+        if (G.size() <= 1) {
+            return G;
+        }
+        // remove top reducible polynomials
+        GenWordPolynomial<GenPolynomial<C>> a;
+        List<GenWordPolynomial<GenPolynomial<C>>> F;
+        F = new ArrayList<GenWordPolynomial<GenPolynomial<C>>>(G.size());
+        while (G.size() > 0) {
+            a = G.remove(0);
+            if (red.isTopReducible(G, a) || red.isTopReducible(F, a)) {
+                // drop polynomial 
+                if (debug) {
+                    System.out.println("dropped " + a);
+                    List<GenWordPolynomial<GenPolynomial<C>>> ff;
+                    ff = new ArrayList<GenWordPolynomial<GenPolynomial<C>>>(G);
+                    ff.addAll(F);
+                    a = redRec.normalformRecursive(ff, a);
+                    if (!a.isZERO()) {
+                        System.out.println("error, nf(a) " + a);
+                    }
+                }
+            } else {
+                F.add(a);
+            }
+        }
+        G = F;
+        if (G.size() <= 1) {
+            return G;
+        }
+        // reduce remaining polynomials
+        Collections.reverse(G); // important for lex GB
+        int len = G.size();
+        if (debug) {
+            System.out.println("#G " + len);
+            for (GenWordPolynomial<GenPolynomial<C>> aa : G) {
+                System.out.println("aa = " + aa.length() + ", lt = " + aa.getMap().keySet());
+            }
+        }
+        int i = 0;
+        while (i < len) {
+            a = G.remove(0);
+            if (debug) {
+                System.out.println("doing " + a.length() + ", lt = " + a.leadingWord());
+            }
+            a = redRec.normalformRecursive(G, a);
+            G.add(a); // adds as last
+            i++;
+        }
+        return G;
+    }
+
+
+    /**
+     * Wird Groebner base simple test.
+     * @param F recursive polynomial list.
+     * @return true, if F is a Groebner base, else false.
+     */
+    @Override
+    public boolean isGB(List<GenWordPolynomial<GenPolynomial<C>>> F) {
+        if (F == null || F.isEmpty()) {
+            return true;
+        }
+        GenWordPolynomial<GenPolynomial<C>> pi, pj, h;
+        List<GenWordPolynomial<GenPolynomial<C>>> S;
+        for (int i = 0; i < F.size(); i++) {
+            pi = F.get(i);
+            for (int j = 0; j < F.size(); j++) {
+                if (i == j) {
+                    continue;
+                }
+                pj = F.get(j);
+
+                S = red.SPolynomials(pi, pj);
+                if (S.isEmpty()) {
+                    continue;
+                }
+                for (GenWordPolynomial<GenPolynomial<C>> s : S) {
+                    //System.out.println("i, j = " + i + ", " + j); 
+                    h = redRec.normalformRecursive(F, s);
+                    if (!h.isZERO()) {
+                        logger.info("no GB: pi = " + pi + ", pj = " + pj);
+                        logger.info("s  = " + s + ", h = " + h);
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * GenWordPolynomial recursive coefficient content.
+     * @param P recursive GenWordPolynomial.
+     * @return cont(P).
+     */
+    public GenPolynomial<C> recursiveContent(GenWordPolynomial<GenPolynomial<C>> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P != null");
+        }
+        if (P.isZERO()) {
+            return P.ring.getZEROCoefficient();
+        }
+        GenPolynomial<C> d = null;
+        for (GenPolynomial<C> c : P.getMap().values()) {
+            //System.out.println("value c = " + c.leadingExpVector());
+            if (d == null) {
+                d = c;
+            } else {
+                d = engine.gcd(d, c);
+            }
+            if (d.isONE()) {
+                return d;
+            }
+        }
+        if (d.signum() < 0) {
+            d = d.negate();
+        }
+        return d;
+    }
+
+
+    /**
+     * GenWordPolynomial recursive coefficient primitive part.
+     * @param P recursive GenWordPolynomial.
+     * @return pp(P).
+     */
+    public GenWordPolynomial<GenPolynomial<C>> recursivePrimitivePart(GenWordPolynomial<GenPolynomial<C>> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P != null");
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        GenPolynomial<C> d = recursiveContent(P);
+        if (d.isONE()) {
+            return P;
+        }
+        //GenWordPolynomial<GenPolynomial<C>> pp = P.divide(d);
+        GenWordPolynomial<GenPolynomial<C>> pp = PolyUtil.<C> recursiveDivide(P, d);
+        if (debug) {
+            GenWordPolynomial<GenPolynomial<C>> p = pp.multiply(d);
+            if (!p.equals(P)) {
+                throw new ArithmeticException("pp(p)*cont(p) != p: ");
+            }
+        }
+        return pp;
+    }
+
+
+    /**
+     * List of GenWordPolynomial recursive coefficient primitive part.
+     * @param F list of recursive GenWordPolynomials.
+     * @return pp(F).
+     */
+    public List<GenWordPolynomial<GenPolynomial<C>>> recursivePrimitivePart(
+                    List<GenWordPolynomial<GenPolynomial<C>>> F) {
+        if (F == null || F.isEmpty()) {
+            return F;
+        }
+        List<GenWordPolynomial<GenPolynomial<C>>> Pp = new ArrayList<GenWordPolynomial<GenPolynomial<C>>>(
+                        F.size());
+        for (GenWordPolynomial<GenPolynomial<C>> f : F) {
+            GenWordPolynomial<GenPolynomial<C>> p = recursivePrimitivePart(f);
+            Pp.add(p);
+        }
+        return Pp;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/WordGroebnerBasePseudoSeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/WordGroebnerBasePseudoSeq.java
@@ -1,0 +1,260 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.OrderedWordPairlist;
+import edu.jas.gb.WordGroebnerBaseAbstract;
+import edu.jas.gb.WordPair;
+import edu.jas.gb.WordPairList;
+import edu.jas.poly.GenWordPolynomial;
+import edu.jas.poly.GenWordPolynomialRing;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Non-commutative word Groebner Base sequential algorithm. Implements Groebner
+ * bases and GB test. Coefficients can for example be integers or (commutative)
+ * univariate polynomials.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class WordGroebnerBasePseudoSeq<C extends GcdRingElem<C>> extends WordGroebnerBaseAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(WordGroebnerBasePseudoSeq.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Coefficient ring factory.
+     */
+    protected final RingFactory<C> cofac;
+
+
+    /**
+     * Constructor.
+     * @param rf coefficient ring factory.
+     */
+    public WordGroebnerBasePseudoSeq(RingFactory<C> rf) {
+        this(rf, new WordPseudoReductionSeq<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param rf coefficient ring factory.
+     * @param red Reduction engine
+     */
+    public WordGroebnerBasePseudoSeq(RingFactory<C> rf, WordPseudoReductionSeq<C> red) {
+        this(rf, red, new OrderedWordPairlist<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param rf coefficient ring factory.
+     * @param red Reduction engine
+     * @param pl pair selection strategy
+     */
+    public WordGroebnerBasePseudoSeq(RingFactory<C> rf, WordPseudoReductionSeq<C> red, WordPairList<C> pl) {
+        super(red, pl);
+        cofac = rf;
+        if (!cofac.isCommutative()) {
+            logger.warn("reduction not correct for " + cofac.toScript());
+        }
+        //engine = GCDFactory.<C> getImplementation(rf);
+        //not used: engine = (GreatestCommonDivisorAbstract<C>)GCDFactory.<C>getProxy( rf );
+    }
+
+
+    /**
+     * Word Groebner base using word pairlist class.
+     * @param F word polynomial list.
+     * @return GB(F) a finite non-commutative Groebner base of F, if it exists.
+     */
+    @Override
+    public List<GenWordPolynomial<C>> GB(List<GenWordPolynomial<C>> F) {
+        List<GenWordPolynomial<C>> G = normalizeZerosOnes(F);
+        //G = PolyUtil.<C> wordMonic(G);
+        G = basePrimitivePart(G);
+        if (G.size() <= 1) {
+            return G;
+        }
+        GenWordPolynomialRing<C> ring = G.get(0).ring;
+        if (!ring.coFac.isCommutative()) {
+            throw new IllegalArgumentException("coefficient ring not commutative");
+        }
+        //Collections.sort(G);
+        OrderedWordPairlist<C> pairlist = (OrderedWordPairlist<C>) strategy.create(ring);
+        pairlist.put(G);
+        logger.info("start " + pairlist);
+
+        WordPair<C> pair;
+        GenWordPolynomial<C> pi;
+        GenWordPolynomial<C> pj;
+        List<GenWordPolynomial<C>> S;
+        GenWordPolynomial<C> H;
+        while (pairlist.hasNext()) {
+            pair = pairlist.removeNext();
+            //logger.debug("pair = " + pair);
+            if (pair == null) {
+                continue;
+            }
+            pi = pair.pi;
+            pj = pair.pj;
+            if (debug) {
+                logger.info("pi   = " + pi + ", pj = " + pj);
+                //logger.info("pj    = " + pj);
+            }
+
+            S = red.SPolynomials(pi, pj);
+            if (S.isEmpty()) {
+                continue;
+            }
+            for (GenWordPolynomial<C> s : S) {
+                if (s.isZERO()) {
+                    //pair.setZero();
+                    continue;
+                }
+                if (debug) {
+                    logger.info("ht(S) = " + s.leadingWord());
+                }
+                boolean t = pairlist.criterion3(pair.i, pair.j, s.leadingWord());
+                //System.out.println("criterion3(" + pair.i + "," + pair.j + ") = " + t);
+                //if ( !t ) {
+                //    continue;  
+                //}
+
+                H = red.normalform(G, s);
+                if (debug) {
+                    //logger.info("pair = " + pair); 
+                    //logger.info("ht(S) = " + S.monic()); //.leadingWord() );
+                    logger.info("ht(H) = " + H.monic()); //.leadingWord() );
+                }
+                if (H.isZERO()) {
+                    //pair.setZero();
+                    continue;
+                }
+                if (!t) {
+                    logger.info("criterion3(" + pair.i + "," + pair.j + ") wrong: " + s.leadingWord()
+                                    + " --> " + H.leadingWord());
+                }
+
+                //H = H.monic();
+                H = basePrimitivePart(H);
+                H = H.abs();
+                if (debug) {
+                    logger.info("ht(H) = " + H.leadingWord());
+                }
+                if (H.isONE()) {
+                    G.clear();
+                    G.add(H);
+                    return G; // since no threads are activated
+                }
+                if (debug) {
+                    logger.info("H = " + H);
+                }
+                if (H.length() > 0) {
+                    //l++;
+                    G.add(H);
+                    pairlist.put(H);
+                }
+            }
+        }
+        //logger.info("#sequential list = " + G.size());
+        G = minimalGB(G);
+        logger.info("" + pairlist);
+        //Collections.sort(G);
+        //Collections.reverse(G);
+        return G;
+    }
+
+
+    /**
+     * GenWordPolynomial base coefficient content.
+     * @param P GenWordPolynomial.
+     * @return cont(P).
+     */
+    public C baseContent(GenWordPolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P != null");
+        }
+        if (P.isZERO()) {
+            return P.ring.getZEROCoefficient();
+        }
+        C d = null;
+        for (C c : P.getMap().values()) {
+            if (d == null) {
+                d = c;
+            } else {
+                d = d.gcd(c);
+            }
+            if (d.isONE()) {
+                return d;
+            }
+        }
+        if (d.signum() < 0) {
+            d = d.negate();
+        }
+        return d;
+    }
+
+
+    /**
+     * GenWordPolynomial base coefficient primitive part.
+     * @param P GenWordPolynomial.
+     * @return pp(P).
+     */
+    public GenWordPolynomial<C> basePrimitivePart(GenWordPolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P != null");
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        C d = baseContent(P);
+        if (d.isONE()) {
+            return P;
+        }
+        GenWordPolynomial<C> pp = P.divide(d);
+        if (debug) {
+            GenWordPolynomial<C> p = pp.multiply(d);
+            if (!p.equals(P)) {
+                throw new ArithmeticException("pp(p)*cont(p) != p: ");
+            }
+        }
+        return pp;
+    }
+
+
+    /**
+     * List of GenWordPolynomial base coefficient primitive part.
+     * @param F list of GenWordPolynomials.
+     * @return pp(F).
+     */
+    public List<GenWordPolynomial<C>> basePrimitivePart(List<GenWordPolynomial<C>> F) {
+        if (F == null || F.isEmpty()) {
+            return F;
+        }
+        List<GenWordPolynomial<C>> Pp = new ArrayList<GenWordPolynomial<C>>(F.size());
+        for (GenWordPolynomial<C> f : F) {
+            GenWordPolynomial<C> p = basePrimitivePart(f);
+            Pp.add(p);
+        }
+        return Pp;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/WordPseudoReduction.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/WordPseudoReduction.java
@@ -1,0 +1,46 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.List;
+
+import edu.jas.gb.WordReduction;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenWordPolynomial;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Polynomial pseudo reduction interface. Defines additionally normalformFactor
+ * and normalformRecursive.
+ * @param <C> coefficient type.
+ * @author Heinz Kredel
+ */
+
+public interface WordPseudoReduction<C extends RingElem<C>> extends WordReduction<C> {
+
+
+    /**
+     * Left normalform with multiplication factor.
+     * @param Pp polynomial list.
+     * @param Ap polynomial.
+     * @return ( nf(Ap), mf ) with respect to Pp and mf as multiplication factor
+     *         for Ap.
+     */
+    public WordPseudoReductionEntry<C> normalformFactor(List<GenWordPolynomial<C>> Pp, GenWordPolynomial<C> Ap);
+
+
+    /**
+     * Left normalform recursive.
+     * @param Ap recursive polynomial.
+     * @param Pp recursive polynomial list.
+     * @return nf(Ap) with respect to Pp.
+     */
+    public GenWordPolynomial<GenPolynomial<C>> normalformRecursive(
+                    List<GenWordPolynomial<GenPolynomial<C>>> Pp, GenWordPolynomial<GenPolynomial<C>> Ap);
+
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/WordPseudoReductionEntry.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/WordPseudoReductionEntry.java
@@ -1,0 +1,32 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import edu.jas.poly.GenWordPolynomial;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Word polynomial reduction container. Used as container for the return value
+ * of normalformFactor.
+ * @author Heinz Kredel
+ */
+
+public class WordPseudoReductionEntry<C extends RingElem<C>> {
+
+
+    public final GenWordPolynomial<C> pol;
+
+
+    public final C multiplicator;
+
+
+    public WordPseudoReductionEntry(GenWordPolynomial<C> pol, C multiplicator) {
+        this.pol = pol;
+        this.multiplicator = multiplicator;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/WordPseudoReductionSeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/WordPseudoReductionSeq.java
@@ -1,0 +1,370 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.gbufd;
+
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.WordReductionAbstract;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenWordPolynomial;
+import edu.jas.poly.PolyUtil;
+import edu.jas.poly.Word;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Polynomial word reduction sequential use algorithm. Implements normalform.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class WordPseudoReductionSeq<C extends RingElem<C>> extends WordReductionAbstract<C> implements
+                WordPseudoReduction<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(WordPseudoReductionSeq.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     */
+    public WordPseudoReductionSeq() {
+    }
+
+
+    /**
+     * Normalform.
+     * @param Ap polynomial.
+     * @param Pp polynomial list.
+     * @return nf(Ap) with respect to Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public GenWordPolynomial<C> normalform(List<GenWordPolynomial<C>> Pp, GenWordPolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        if (!Ap.ring.coFac.isCommutative()) {
+            throw new IllegalArgumentException("coefficient ring not commutative");
+        }
+        Map.Entry<Word, C> m;
+        GenWordPolynomial<C>[] P = new GenWordPolynomial[0];
+        synchronized (Pp) {
+            P = Pp.toArray(P);
+        }
+        int l = P.length;
+        Word[] htl = new Word[l];
+        C[] lbc = (C[]) new RingElem[l];
+        GenWordPolynomial<C>[] p = new GenWordPolynomial[l];
+        int i;
+        int j = 0;
+        for (i = 0; i < l; i++) {
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        Word e;
+        C a;
+        boolean mt = false;
+        GenWordPolynomial<C> R = Ap.ring.getZERO().copy();
+        C cone = Ap.ring.coFac.getONE();
+        GenWordPolynomial<C> Q = null;
+        GenWordPolynomial<C> S = Ap.copy();
+        while (S.length() > 0) {
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt)
+                    break;
+            }
+            if (!mt) {
+                //logger.debug("irred");
+                //R = R.sum(a, e);
+                //S = S.subtract(a, e);
+                R.doPutToMap(e, a);
+                S.doRemoveFromMap(e, a);
+                // System.out.println(" S = " + S);
+            } else {
+                Word[] elr = e.divideWord(htl[i]);
+                e = elr[0];
+                Word f = elr[1];
+                if (debug) {
+                    logger.info("red divideWord: e = " + e + ", f = " + f);
+                }
+                C c = lbc[i];
+                if (a.remainder(c).isZERO()) {
+                    a = a.divide(c);
+                    Q = p[i].multiply(a, e, cone, f);
+                } else {
+                    R = R.multiply(c);
+                    S = S.multiply(c);
+                    Q = p[i].multiply(a, e, cone, f);
+                }
+                S = S.subtract(Q);
+            }
+        }
+        return R;
+    }
+
+
+    /**
+     * Normalform with left and right recording.
+     * @param lrow left recording matrix, is modified.
+     * @param rrow right recording matrix, is modified.
+     * @param Pp a polynomial list for reduction.
+     * @param Ap a polynomial.
+     * @return nf(Pp,Ap), the normal form of Ap wrt. Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public GenWordPolynomial<C> normalform(List<GenWordPolynomial<C>> lrow, List<GenWordPolynomial<C>> rrow,
+                    List<GenWordPolynomial<C>> Pp, GenWordPolynomial<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        if (!Ap.ring.coFac.isCommutative()) {
+            throw new IllegalArgumentException("coefficient ring not commutative");
+        }
+        GenWordPolynomial<C>[] P = new GenWordPolynomial[0];
+        synchronized (Pp) {
+            P = Pp.toArray(P);
+        }
+        int l = P.length;
+        Word[] htl = new Word[l];
+        C[] lbc = (C[]) new RingElem[l];
+        GenWordPolynomial<C>[] p = new GenWordPolynomial[l];
+        Map.Entry<Word, C> m;
+        int j = 0;
+        int i;
+        for (i = 0; i < l; i++) {
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        Word e;
+        C a;
+        boolean mt = false;
+        GenWordPolynomial<C> zero = Ap.ring.getZERO().copy();
+        GenWordPolynomial<C> R = Ap.ring.getZERO();
+        C cone = Ap.ring.coFac.getONE();
+        GenWordPolynomial<C> fac = null;
+        GenWordPolynomial<C> Q = null;
+        GenWordPolynomial<C> S = Ap.copy();
+        while (S.length() > 0) {
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt)
+                    break;
+            }
+            if (!mt) {
+                //logger.debug("irred");
+                //R = R.sum(a, e);
+                //S = S.subtract(a, e);
+                R.doPutToMap(e, a);
+                S.doRemoveFromMap(e, a);
+                // System.out.println(" S = " + S);
+            } else {
+                Word[] elr = e.divideWord(htl[i]);
+                e = elr[0];
+                Word f = elr[1];
+                if (debug) {
+                    logger.info("redRec divideWord: e = " + e + ", f = " + f);
+                }
+                C c = lbc[i];
+                if (a.remainder(c).isZERO()) {
+                    a = a.divide(c);
+                    Q = p[i].multiply(a, e, cone, f);
+                } else {
+                    R = R.multiply(c);
+                    S = S.multiply(c);
+                    Q = p[i].multiply(a, e, cone, f);
+                }
+                S = S.subtract(Q);
+                // left row
+                fac = lrow.get(i);
+                if (fac == null) {
+                    fac = zero.sum(cone, e);
+                } else {
+                    fac = fac.sum(cone, e);
+                }
+                lrow.set(i, fac);
+                // right row
+                fac = rrow.get(i);
+                if (fac == null) {
+                    fac = zero.sum(a, f);
+                } else {
+                    fac = fac.sum(a, f);
+                }
+                rrow.set(i, fac);
+            }
+        }
+        return R;
+    }
+
+
+    /**
+     * Normalform with multiplication factor.
+     * @param Pp polynomial list.
+     * @param Ap polynomial.
+     * @return ( nf(Ap), mf ) with respect to Pp and mf as multiplication factor
+     *         for Ap.
+     */
+    public WordPseudoReductionEntry<C> normalformFactor(List<GenWordPolynomial<C>> Pp, GenWordPolynomial<C> Ap) {
+        throw new UnsupportedOperationException("normalformFactor not imlemented");
+    }
+
+
+    /**
+     * Normalform with polynomial coefficients.
+     * @param Ap polynomial.
+     * @param Pp polynomial list.
+     * @return nf(Ap) with respect to Pp.
+     */
+    @SuppressWarnings("unchecked")
+    public GenWordPolynomial<GenPolynomial<C>> normalformRecursive(
+                    List<GenWordPolynomial<GenPolynomial<C>>> Pp, GenWordPolynomial<GenPolynomial<C>> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        if (!Ap.ring.coFac.isCommutative()) {
+            throw new IllegalArgumentException("coefficient ring not commutative");
+        }
+        Map.Entry<Word, GenPolynomial<C>> m;
+        GenWordPolynomial<GenPolynomial<C>>[] P = new GenWordPolynomial[0];
+        synchronized (Pp) {
+            P = Pp.toArray(P);
+        }
+        int l = P.length;
+        Word[] htl = new Word[l];
+        GenPolynomial<C>[] lbc = new GenPolynomial[l]; //(GenPolynomial<C>[]) 
+        GenWordPolynomial<GenPolynomial<C>>[] p = new GenWordPolynomial[l];
+        int i;
+        int j = 0;
+        for (i = 0; i < l; i++) {
+            p[i] = P[i];
+            m = p[i].leadingMonomial();
+            if (m != null) {
+                p[j] = p[i];
+                htl[j] = m.getKey();
+                lbc[j] = m.getValue();
+                j++;
+            }
+        }
+        l = j;
+        Word e, fr, fl;
+        GenPolynomial<C> a, b = null;
+        boolean mt = false;
+        GenWordPolynomial<GenPolynomial<C>> R = Ap.ring.getZERO().copy();
+        GenPolynomial<C> cone = Ap.ring.coFac.getONE();
+        GenWordPolynomial<GenPolynomial<C>> Q = null;
+        GenWordPolynomial<GenPolynomial<C>> S = Ap.copy();
+        GenWordPolynomial<GenPolynomial<C>> Sp;
+        while (S.length() > 0) {
+            m = S.leadingMonomial();
+            e = m.getKey();
+            a = m.getValue();
+            for (i = 0; i < l; i++) {
+                mt = e.multipleOf(htl[i]);
+                if (mt)
+                    break;
+            }
+            if (!mt) {
+                //logger.debug("irred");
+                //R = R.sum(a, e);
+                //S = S.subtract(a, e);
+                R.doPutToMap(e, a);
+                S.doRemoveFromMap(e, a);
+                // System.out.println(" S = " + S);
+            } else {
+                Word[] elr = e.divideWord(htl[i]);
+                fl = elr[0];
+                fr = elr[1];
+                if (debug) {
+                    logger.info("redRec divideWord: e = " + e + ", fl = " + fl + ", fr = " + fr);
+                }
+                GenPolynomial<C> c = lbc[i];
+                if (PolyUtil.<C> baseSparsePseudoRemainder(a, c).isZERO()) {
+                    b = PolyUtil.<C> basePseudoDivide(a, c);
+                    Q = p[i].multiply(b, fl, cone, fr);
+                } else {
+                    R = R.multiply(c);
+                    S = S.multiply(c);
+                    Q = p[i].multiply(a, fl, cone, fr);
+                }
+                Sp = S.subtract(Q);
+                if (e.equals(Sp.leadingWord())) { // TODO: avoid, not possible in general
+                    //logger.info("redRec: e = " + e + ", hti = " + htl[i] + ", fl = " + fl + ", fr = " + fr);
+                    //logger.info("redRec: S = " + S + ", Sp = " + Sp + ", a = " + a + ", b = " + b + ", c = " + c);
+                    //throw new RuntimeException("degree not descending");
+                    R = R.multiply(c);
+                    S = S.multiply(c);
+                    Q = p[i].multiply(a, fl, cone, fr);
+                    Sp = S.subtract(Q);
+                }
+                S = Sp;
+            }
+        }
+        return R;
+    }
+
+
+    @Override
+    public GenWordPolynomial<C> leftNormalform(List<GenWordPolynomial<C>> Pp, GenWordPolynomial<C> Ap) {
+        throw new UnsupportedOperationException("leftNormalform not imlemented");
+    }
+
+
+    @Override
+    public GenWordPolynomial<C> leftNormalform(List<GenWordPolynomial<C>> lrow,
+                    List<GenWordPolynomial<C>> Pp, GenWordPolynomial<C> Ap) {
+        throw new UnsupportedOperationException("leftNormalform not imlemented");
+    }
+
+
+    @Override
+    public GenWordPolynomial<C> rightNormalform(List<GenWordPolynomial<C>> Pp, GenWordPolynomial<C> Ap) {
+        throw new UnsupportedOperationException("rightNormalform not imlemented");
+    }
+
+
+    @Override
+    public GenWordPolynomial<C> rightNormalform(List<GenWordPolynomial<C>> rrow,
+                    List<GenWordPolynomial<C>> Pp, GenWordPolynomial<C> Ap) {
+        throw new UnsupportedOperationException("rightNormalform not imlemented");
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/package.html
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/gbufd/package.html
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "../DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>Groebner bases using unique factorization</title>
+  </head>
+
+  <body>
+    <h1>Groebner bases using unique factorization package.</h1>
+
+<p>
+  This package contains classes for polynomial pseudo reduction and
+  Groebner bases using pseudo reduction
+  <code>GroebnerBasePseudoSeq</code> and
+  <code>GroebnerBasePseudoRecSeq</code>.  
+  Groebner bases for polynomial rings over regular rings (direct
+  products of fields or integral domains) are implemented in
+  <code>RGroebnerBaseSeq</code> and
+  <code>RGroebnerBasePseudoSeq</code>.
+</p>
+
+
+    <hr />
+    <address><a href="mailto:kredel at rz.uni-mannheim.de">Heinz Kredel</a></address>
+<p>
+<!-- Created: Thu Dec 23 22:18:43 CET 2010 -->
+<!-- hhmts start -->
+Last modified: Fri Dec 24 15:00:40 CET 2010
+<!-- hhmts end -->
+</p>
+<p>$Id$ 
+</p>
+  </body>
+</html>

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/integrate/ElementaryIntegration.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/integrate/ElementaryIntegration.java
@@ -1,0 +1,541 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.integrate;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SortedMap;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.AlgebraicNumberRing;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.ufd.FactorAbstract;
+import edu.jas.ufd.FactorFactory;
+import edu.jas.ufd.GCDFactory;
+import edu.jas.ufd.GreatestCommonDivisorAbstract;
+import edu.jas.ufd.GreatestCommonDivisorSubres;
+import edu.jas.ufd.PolyUfdUtil;
+import edu.jas.ufd.Quotient;
+import edu.jas.ufd.QuotientRing;
+import edu.jas.ufd.SquarefreeAbstract;
+import edu.jas.ufd.SquarefreeFactory;
+
+
+/**
+ * Methods related to elementary integration. In particular there are methods
+ * for Hermite reduction and Rothstein-Trager integration of the logarithmic
+ * part.
+ * 
+ * @author Axel Kramer
+ * @author Heinz Kredel
+ * @param <C> coefficient type
+ */
+
+public class ElementaryIntegration<C extends GcdRingElem<C>> {
+
+
+    private static final Logger logger = LogManager.getLogger(ElementaryIntegration.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Engine for factorization.
+     */
+    public final FactorAbstract<C> irr;
+
+
+    /**
+     * Engine for squarefree decomposition.
+     */
+    public final SquarefreeAbstract<C> sqf;
+
+
+    /**
+     * Engine for greatest common divisors.
+     */
+    public final GreatestCommonDivisorAbstract<C> ufd;
+
+
+    /**
+     * Flag for irreducible input to integrateLogPart.
+     */
+    public boolean irredLogPart = true;
+
+
+    /**
+     * Constructor.
+     */
+    public ElementaryIntegration(RingFactory<C> br) {
+        ufd = GCDFactory.<C> getProxy(br);
+        sqf = SquarefreeFactory.<C> getImplementation(br);
+        irr = /*(FactorAbsolute<C>)*/FactorFactory.<C> getImplementation(br);
+        irredLogPart = true;
+    }
+
+
+    /**
+     * Integration of a rational function.
+     * @param r rational function
+     * @return Integral container, such that integrate(r) = sum_i(g_i) + sum_j(
+     *         an_j log(hd_j) )
+     */
+    public QuotIntegral<C> integrate(Quotient<C> r) {
+        Integral<C> integral = integrate(r.num, r.den);
+        return new QuotIntegral<C>(r.ring, integral);
+    }
+
+
+    /**
+     * Integration of a rational function.
+     * @param a numerator
+     * @param d denominator
+     * @return Integral container, such that integrate(a/d) = sum_i(gn_i/gd_i) +
+     *         integrate(h0) + sum_j( an_j log(hd_j) )
+     */
+    public Integral<C> integrate(GenPolynomial<C> a, GenPolynomial<C> d) {
+        if (d == null || a == null || d.isZERO()) {
+            throw new IllegalArgumentException("zero or null not allowed");
+        }
+        if (a.isZERO()) {
+            return new Integral<C>(a, d, a);
+        }
+        if (d.isONE()) {
+            GenPolynomial<C> pi = PolyUtil.<C> baseIntegral(a);
+            return new Integral<C>(a, d, pi);
+        }
+        GenPolynomialRing<C> pfac = d.ring;
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException("only for univariate polynomials " + pfac);
+        }
+        if (!pfac.coFac.isField()) {
+            throw new IllegalArgumentException("only for field coefficients " + pfac);
+        }
+
+        GenPolynomial<C>[] qr = PolyUtil.<C> basePseudoQuotientRemainder(a, d);
+        GenPolynomial<C> p = qr[0];
+        GenPolynomial<C> r = qr[1];
+
+        GenPolynomial<C> c = ufd.gcd(r, d);
+        if (!c.isONE()) {
+            r = PolyUtil.<C> basePseudoQuotientRemainder(r, c)[0];
+            d = PolyUtil.<C> basePseudoQuotientRemainder(d, c)[0];
+        }
+        List<GenPolynomial<C>>[] ih = integrateHermite(r, d);
+        List<GenPolynomial<C>> rat = ih[0];
+        List<GenPolynomial<C>> log = ih[1];
+
+        GenPolynomial<C> pp = log.remove(0);
+        p = p.sum(pp);
+        GenPolynomial<C> pi = PolyUtil.<C> baseIntegral(p);
+
+        if (debug) {
+            logger.debug("pi  = " + pi);
+            logger.debug("rat = " + rat);
+            logger.debug("log = " + log);
+        }
+        if (log.size() == 0) {
+            return new Integral<C>(a, d, pi, rat);
+        }
+
+        List<LogIntegral<C>> logi = new ArrayList<LogIntegral<C>>(log.size() / 2);
+        for (int i = 0; i < log.size(); i++) {
+            GenPolynomial<C> ln = log.get(i++);
+            GenPolynomial<C> ld = log.get(i);
+            LogIntegral<C> pf = integrateLogPartPrepare(ln, ld);
+            logi.add(pf);
+        }
+        if (debug) {
+            logger.debug("logi = " + logi);
+        }
+        return new Integral<C>(a, d, pi, rat, logi);
+    }
+
+
+    /**
+     * Integration of the rational part, Hermite reduction step.
+     * @param a numerator
+     * @param d denominator, gcd(a,d) == 1
+     * @return [ [ gn_i, gd_i ], [ h0, hn_j, hd_j ] ] such that integrate(a/d) =
+     *         sum_i(gn_i/gd_i) + integrate(h0) + sum_j( integrate(hn_j/hd_j) )
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    public List<GenPolynomial<C>>[] integrateHermite(GenPolynomial<C> a, GenPolynomial<C> d) {
+        if (d == null || d.isZERO()) {
+            throw new IllegalArgumentException("d == null or d == 0");
+        }
+        if (a == null || a.isZERO()) {
+            throw new IllegalArgumentException("a == null or a == 0");
+        }
+
+        // get squarefree decomposition
+        SortedMap<GenPolynomial<C>, Long> sfactors = sqf.squarefreeFactors(d);
+
+        List<GenPolynomial<C>> D = new ArrayList<GenPolynomial<C>>(sfactors.keySet());
+        List<GenPolynomial<C>> DP = new ArrayList<GenPolynomial<C>>();
+        for (GenPolynomial<C> f : D) {
+            long e = sfactors.get(f);
+            GenPolynomial<C> dp = f.power(e); //Power.<GenPolynomial<C>> positivePower(f, e);
+            DP.add(dp);
+        }
+        //System.out.println("D:      " + D);
+        //System.out.println("DP:     " + DP);
+
+        // get partial fraction decompostion 
+        List<GenPolynomial<C>> Ai = ufd.basePartialFraction(a, DP);
+        //System.out.println("Ai:     " + Ai);
+
+        List<GenPolynomial<C>> G = new ArrayList<GenPolynomial<C>>();
+        List<GenPolynomial<C>> H = new ArrayList<GenPolynomial<C>>();
+        H.add(Ai.remove(0)); // P
+
+        GenPolynomialRing<C> fac = d.ring;
+        int i = 0;
+        for (GenPolynomial<C> v : D) {
+            //System.out.println("V:" + v.toString());
+            GenPolynomial<C> Ak = Ai.get(i++);
+            //System.out.println("Ak:  " + Ak.toString());
+            long k = sfactors.get(v); // assert low power
+            for (long j = k - 1; j >= 1; j--) {
+                //System.out.println("Step(" + k + "," + j + ")");
+                GenPolynomial<C> DV_dx = PolyUtil.<C> baseDeriviative(v);
+                GenPolynomial<C> Aik = Ak.divide(fac.fromInteger(-j));
+                GenPolynomial<C>[] BC = ufd.baseGcdDiophant(DV_dx, v, Aik);
+                GenPolynomial<C> b = BC[0];
+                GenPolynomial<C> c = BC[1];
+                GenPolynomial<C> vj = v.power(j);
+                G.add(b); // B
+                G.add(vj); // v^j
+                Ak = fac.fromInteger(-j).multiply(c).subtract(PolyUtil.<C> baseDeriviative(b));
+                //System.out.println("B:   " + b.toString());
+                //System.out.println("C:   " + c.toString());
+            }
+            //System.out.println("V:" + v.toString());
+            //System.out.println("Ak:  " + Ak.toString());
+            if (!Ak.isZERO()) {
+                H.add(Ak); // A_k
+                H.add(v); // v
+            }
+        }
+        List<GenPolynomial<C>>[] ret = (List<GenPolynomial<C>>[]) new List[2];
+        ret[0] = G;
+        ret[1] = H;
+        return ret;
+    }
+
+
+    /**
+     * Univariate GenPolynomial integration of the logaritmic part, eventual
+     * preparation for irreducible factorization of P.
+     * @param A univariate GenPolynomial, deg(A) &lt; deg(P).
+     * @param P univariate squarefree GenPolynomial, gcd(A,P) == 1.
+     * @return logarithmic part container.
+     */
+    public LogIntegral<C> integrateLogPartPrepare(GenPolynomial<C> A, GenPolynomial<C> P) {
+        if (!irredLogPart) {
+            return integrateLogPart(A, P);
+        }
+        if (P == null || P.isZERO()) {
+            throw new IllegalArgumentException(" P == null or P == 0");
+        }
+        if (A == null || A.isZERO()) {
+            throw new IllegalArgumentException(" A == null or A == 0");
+        }
+        //System.out.println("\nP_base_algeb_part = " + P);
+        GenPolynomialRing<C> pfac = P.ring; // K[x]
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException("only for univariate polynomials " + pfac);
+        }
+        if (!pfac.coFac.isField()) {
+            throw new IllegalArgumentException("only for field coefficients " + pfac);
+        }
+        List<C> cfactors = new ArrayList<C>();
+        List<GenPolynomial<C>> cdenom = new ArrayList<GenPolynomial<C>>();
+        List<AlgebraicNumber<C>> afactors = new ArrayList<AlgebraicNumber<C>>();
+        List<GenPolynomial<AlgebraicNumber<C>>> adenom = new ArrayList<GenPolynomial<AlgebraicNumber<C>>>();
+
+        // P linear
+        if (P.degree(0) <= 1) {
+            cfactors.add(A.leadingBaseCoefficient());
+            cdenom.add(P);
+            return new LogIntegral<C>(A, P, cfactors, cdenom, afactors, adenom);
+        }
+        List<GenPolynomial<C>> Pfac = irr.baseFactorsSquarefree(P);
+        //System.out.println("\nPfac = " + Pfac);
+
+        List<GenPolynomial<C>> Afac = ufd.basePartialFraction(A, Pfac);
+
+        GenPolynomial<C> A0 = Afac.remove(0);
+        if (!A0.isZERO()) {
+            throw new RuntimeException(" A0 != 0: deg(A)>= deg(P)");
+        }
+
+        // algebraic and linear factors
+        int i = 0;
+        for (GenPolynomial<C> pi : Pfac) {
+            GenPolynomial<C> ai = Afac.get(i++);
+            if (pi.degree(0) <= 1) {
+                cfactors.add(ai.leadingBaseCoefficient());
+                cdenom.add(pi);
+                continue;
+            }
+            LogIntegral<C> pf = integrateLogPart(ai, pi);
+            cfactors.addAll(pf.cfactors);
+            cdenom.addAll(pf.cdenom);
+            afactors.addAll(pf.afactors);
+            adenom.addAll(pf.adenom);
+        }
+        return new LogIntegral<C>(A, P, cfactors, cdenom, afactors, adenom);
+    }
+
+
+    /**
+     * Univariate GenPolynomial integration of the logaritmic part,
+     * Rothstein-Trager algorithm.
+     * @param A univariate GenPolynomial, deg(A) &lt; deg(P).
+     * @param P univariate squarefree or irreducible GenPolynomial. // gcd(A,P)
+     *            == 1 automatic
+     * @return logarithmic part container.
+     */
+    public LogIntegral<C> integrateLogPart(GenPolynomial<C> A, GenPolynomial<C> P) {
+        if (P == null || P.isZERO()) {
+            throw new IllegalArgumentException("P == null or P == 0");
+        }
+        //System.out.println("\nP_base_algeb_part = " + P);
+        GenPolynomialRing<C> pfac = P.ring; // K[x]
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException("only for univariate polynomials " + pfac);
+        }
+        if (!pfac.coFac.isField()) {
+            throw new IllegalArgumentException("only for field coefficients " + pfac);
+        }
+        List<C> cfactors = new ArrayList<C>();
+        List<GenPolynomial<C>> cdenom = new ArrayList<GenPolynomial<C>>();
+        List<AlgebraicNumber<C>> afactors = new ArrayList<AlgebraicNumber<C>>();
+        List<GenPolynomial<AlgebraicNumber<C>>> adenom = new ArrayList<GenPolynomial<AlgebraicNumber<C>>>();
+
+        // P linear
+        if (P.degree(0) <= 1) {
+            cfactors.add(A.leadingBaseCoefficient());
+            cdenom.add(P);
+            return new LogIntegral<C>(A, P, cfactors, cdenom, afactors, adenom);
+        }
+
+        // deriviative
+        GenPolynomial<C> Pp = PolyUtil.<C> baseDeriviative(P);
+        //no: Pp = Pp.monic();
+        //System.out.println("\nP  = " + P);
+        //System.out.println("Pp = " + Pp);
+
+        // Q[t]
+        String[] vars = new String[] { "t" };
+        GenPolynomialRing<C> cfac = new GenPolynomialRing<C>(pfac.coFac, 1, pfac.tord, vars);
+        GenPolynomial<C> t = cfac.univariate(0);
+        //System.out.println("t = " + t);
+
+        // Q[x][t]
+        GenPolynomialRing<GenPolynomial<C>> rfac = new GenPolynomialRing<GenPolynomial<C>>(pfac, cfac); // sic
+        //System.out.println("rfac = " + rfac.toScript());
+
+        // transform polynomials to bi-variate polynomial
+        GenPolynomial<GenPolynomial<C>> Ac = PolyUfdUtil.<C> introduceLowerVariable(rfac, A);
+        //System.out.println("Ac = " + Ac);
+        GenPolynomial<GenPolynomial<C>> Pc = PolyUfdUtil.<C> introduceLowerVariable(rfac, P);
+        //System.out.println("Pc = " + Pc);
+        GenPolynomial<GenPolynomial<C>> Pcp = PolyUfdUtil.<C> introduceLowerVariable(rfac, Pp);
+        //System.out.println("Pcp = " + Pcp);
+
+        // Q[t][x]
+        GenPolynomialRing<GenPolynomial<C>> rfac1 = Pc.ring;
+        //System.out.println("rfac1 = " + rfac1.toScript());
+
+        // A - t P'
+        GenPolynomial<GenPolynomial<C>> tc = rfac1.getONE().multiply(t);
+        //System.out.println("tc = " + tc);
+        GenPolynomial<GenPolynomial<C>> At = Ac.subtract(tc.multiply(Pcp));
+        //System.out.println("At = " + At);
+
+        GreatestCommonDivisorSubres<C> engine = new GreatestCommonDivisorSubres<C>();
+        // = GCDFactory.<C>getImplementation( cfac.coFac );
+        GreatestCommonDivisorAbstract<AlgebraicNumber<C>> aengine = null;
+
+        GenPolynomial<GenPolynomial<C>> Rc = engine.recursiveUnivariateResultant(Pc, At);
+        //System.out.println("Rc = " + Rc);
+        GenPolynomial<C> res = Rc.leadingBaseCoefficient();
+        //no: res = res.monic();
+        //System.out.println("\nres = " + res);
+
+        SortedMap<GenPolynomial<C>, Long> resfac = irr.baseFactors(res);
+        //System.out.println("resfac = " + resfac + "\n");
+
+        for (GenPolynomial<C> r : resfac.keySet()) {
+            //System.out.println("\nr(t) = " + r);
+            if (r.isConstant()) {
+                continue;
+            }
+            //vars = new String[] { "z_" + Math.abs(r.hashCode() % 1000) };
+            vars = pfac.newVars("z_");
+            pfac = pfac.copy();
+            @SuppressWarnings("unused")
+            String[] unused = pfac.setVars(vars);
+            r = pfac.copy(r); // hack to exchange the variables
+            //System.out.println("r(z_) = " + r);
+            AlgebraicNumberRing<C> afac = new AlgebraicNumberRing<C>(r, true); // since irreducible
+            logger.debug("afac = " + afac.toScript());
+            AlgebraicNumber<C> a = afac.getGenerator();
+            //no: a = a.negate();
+            //System.out.println("a = " + a);
+
+            // K(alpha)[x]
+            GenPolynomialRing<AlgebraicNumber<C>> pafac = new GenPolynomialRing<AlgebraicNumber<C>>(afac,
+                            Pc.ring);
+            //System.out.println("pafac = " + pafac.toScript());
+
+            // convert to K(alpha)[x]
+            GenPolynomial<AlgebraicNumber<C>> Pa = PolyUtil.<C> convertToAlgebraicCoefficients(pafac, P);
+            //System.out.println("Pa = " + Pa);
+            GenPolynomial<AlgebraicNumber<C>> Pap = PolyUtil.<C> convertToAlgebraicCoefficients(pafac, Pp);
+            //System.out.println("Pap = " + Pap);
+            GenPolynomial<AlgebraicNumber<C>> Aa = PolyUtil.<C> convertToAlgebraicCoefficients(pafac, A);
+            //System.out.println("Aa = " + Aa);
+
+            // A - a P'
+            GenPolynomial<AlgebraicNumber<C>> Ap = Aa.subtract(Pap.multiply(a));
+            //System.out.println("Ap = " + Ap);
+
+            if (aengine == null) {
+                aengine = GCDFactory.<AlgebraicNumber<C>> getImplementation(afac);
+            }
+            GenPolynomial<AlgebraicNumber<C>> Ga = aengine.baseGcd(Pa, Ap);
+            //System.out.println("Ga = " + Ga);
+            if (Ga.isConstant()) {
+                //System.out.println("warning constant gcd ignored");
+                continue;
+            }
+            // If a is equal to zero
+            if (a.isZERO()) {
+                continue;
+            }
+            afactors.add(a);
+            adenom.add(Ga);
+            // special quadratic case
+            // todo: eventually implement special cases deg = 3, 4
+        }
+        return new LogIntegral<C>(A, P, cfactors, cdenom, afactors, adenom);
+    }
+
+
+    /**
+     * Derivation of a univariate rational function.
+     * @param r rational function
+     * @return dr/dx
+     */
+    public Quotient<C> deriviative(Quotient<C> r) {
+        GenPolynomial<C> num = r.num;
+        GenPolynomial<C> den = r.den;
+        GenPolynomial<C> nump = PolyUtil.<C> baseDeriviative(num);
+        if (den.isONE()) {
+            return new Quotient<C>(r.ring, nump, den);
+        }
+        GenPolynomial<C> denp = PolyUtil.<C> baseDeriviative(den);
+
+        GenPolynomial<C> n = den.multiply(nump).subtract(num.multiply(denp));
+        GenPolynomial<C> d = den.multiply(den);
+
+        Quotient<C> der = new Quotient<C>(r.ring, n, d);
+        return der;
+    }
+
+
+    /**
+     * Test of integration of a rational function.
+     * @param ri integral
+     * @return true, if ri is an integral, else false.
+     */
+    public boolean isIntegral(QuotIntegral<C> ri) {
+        Quotient<C> r = ri.quot;
+        QuotientRing<C> qr = r.ring;
+        Quotient<C> i = r.ring.getZERO();
+        for (Quotient<C> q : ri.rational) {
+            Quotient<C> qd = deriviative(q);
+            i = i.sum(qd);
+        }
+        if (ri.logarithm.size() == 0) {
+            return r.equals(i);
+        }
+        for (LogIntegral<C> li : ri.logarithm) {
+            Quotient<C> q = new Quotient<C>(qr, li.num, li.den);
+            i = i.sum(q);
+        }
+        boolean t = r.equals(i);
+        if (!t) {
+            return false;
+        }
+        for (LogIntegral<C> li : ri.logarithm) {
+            t = isIntegral(li);
+            if (!t) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Test of integration of the logarithmic part of a rational function.
+     * @param rl logarithmic part of an integral
+     * @return true, if rl is an integral, else false.
+     */
+    public boolean isIntegral(LogIntegral<C> rl) {
+        QuotientRing<C> qr = new QuotientRing<C>(rl.den.ring);
+        Quotient<C> r = new Quotient<C>(qr, rl.num, rl.den);
+        Quotient<C> i = qr.getZERO();
+        int j = 0;
+        for (GenPolynomial<C> d : rl.cdenom) {
+            GenPolynomial<C> dp = PolyUtil.<C> baseDeriviative(d);
+            dp = dp.multiply(rl.cfactors.get(j++));
+            Quotient<C> f = new Quotient<C>(qr, dp, d);
+            i = i.sum(f);
+        }
+        if (rl.afactors.size() == 0) {
+            return r.equals(i);
+        }
+        r = r.subtract(i);
+        QuotientRing<AlgebraicNumber<C>> aqr = new QuotientRing<AlgebraicNumber<C>>(rl.adenom.get(0).ring);
+        Quotient<AlgebraicNumber<C>> ai = aqr.getZERO();
+
+        GenPolynomial<AlgebraicNumber<C>> aqn = PolyUtil.<C> convertToAlgebraicCoefficients(aqr.ring, r.num);
+        GenPolynomial<AlgebraicNumber<C>> aqd = PolyUtil.<C> convertToAlgebraicCoefficients(aqr.ring, r.den);
+        Quotient<AlgebraicNumber<C>> ar = new Quotient<AlgebraicNumber<C>>(aqr, aqn, aqd);
+        j = 0;
+        for (GenPolynomial<AlgebraicNumber<C>> d : rl.adenom) {
+            GenPolynomial<AlgebraicNumber<C>> dp = PolyUtil.<AlgebraicNumber<C>> baseDeriviative(d);
+            dp = dp.multiply(rl.afactors.get(j++));
+            Quotient<AlgebraicNumber<C>> f = new Quotient<AlgebraicNumber<C>>(aqr, dp, d);
+            ai = ai.sum(f);
+        }
+        boolean t = ar.equals(ai);
+        if (t) {
+            return true;
+        }
+        logger.warn("log integral not verified");
+        //System.out.println("r        = " + r);
+        //System.out.println("afactors = " + rl.afactors);
+        //System.out.println("adenom   = " + rl.adenom);
+        //System.out.println("ar       = " + ar);
+        //System.out.println("ai       = " + ai);
+        return true;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/integrate/ElementaryIntegrationBernoulli.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/integrate/ElementaryIntegrationBernoulli.java
@@ -1,0 +1,91 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.integrate;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.ufd.FactorAbsolute;
+import edu.jas.ufd.PartialFraction;
+
+
+/**
+ * Methods related to the Bernoulli algorithm for elementary integration. The
+ * denominator is factored into linear factors over iterated algebraic
+ * extensions over the rational numbers.
+ * 
+ * @author Heinz Kredel
+ * @param <C> coefficient type
+ */
+
+public class ElementaryIntegrationBernoulli<C extends GcdRingElem<C>> extends ElementaryIntegration<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(ElementaryIntegrationBernoulli.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     */
+    public ElementaryIntegrationBernoulli(RingFactory<C> br) {
+        super(br);
+        if (!(irr instanceof FactorAbsolute)) {
+            logger.error("no absolute factorization available for coefficient ring " + br);
+            throw new IllegalArgumentException(
+                            "no absolute factorization available for coefficient ring " + br);
+        }
+        irredLogPart = true; // force to true?
+    }
+
+
+    /**
+     * Univariate GenPolynomial integration of the logarithmic part, Bernoulli
+     * linear factorization algorithm.
+     * @param A univariate GenPolynomial, deg(A) &lt; deg(P).
+     * @param P univariate squarefree or irreducible GenPolynomial. // gcd(A,P)
+     *            == 1 automatic
+     * @return logarithmic part container.
+     */
+    @Override
+    public LogIntegral<C> integrateLogPart(GenPolynomial<C> A, GenPolynomial<C> P) {
+        if (P == null || P.isZERO()) {
+            throw new IllegalArgumentException("P == null or P == 0");
+        }
+        //System.out.println("\nP_base_algeb_part = " + P);
+        GenPolynomialRing<C> pfac = P.ring; // K[x]
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException("only for univariate polynomials " + pfac);
+        }
+        // pfac.coFac.isField() by FactorAbsolute
+        List<C> cfactors = new ArrayList<C>();
+        List<GenPolynomial<C>> cdenom = new ArrayList<GenPolynomial<C>>();
+        List<AlgebraicNumber<C>> afactors = new ArrayList<AlgebraicNumber<C>>();
+        List<GenPolynomial<AlgebraicNumber<C>>> adenom = new ArrayList<GenPolynomial<AlgebraicNumber<C>>>();
+        // P linear
+        if (P.degree(0) <= 1) {
+            cfactors.add(A.leadingBaseCoefficient());
+            cdenom.add(P);
+            return new LogIntegral<C>(A, P, cfactors, cdenom, afactors, adenom);
+        }
+        // complete factorization to linear factors
+        PartialFraction<C> F = ((FactorAbsolute<C>) irr).baseAlgebraicPartialFraction(A, P);
+        //System.out.println("\npartial fraction " + F);
+
+        return new LogIntegral<C>(A, P, F.cfactors, F.cdenom, F.afactors, F.adenom);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/integrate/ElementaryIntegrationCzichowski.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/integrate/ElementaryIntegrationCzichowski.java
@@ -1,0 +1,185 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.integrate;
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.gb.GroebnerBaseAbstract;
+import edu.jas.gbufd.GBFactory;
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.AlgebraicNumberRing;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.ufd.PolyUfdUtil;
+
+
+/**
+ * Method related to elementary integration. Czichowski integration based on
+ * Groebner bases for the logarithmic part.
+ * 
+ * @author Youssef Elbarbary
+ * @param <C> coefficient type
+ */
+
+public class ElementaryIntegrationCzichowski<C extends GcdRingElem<C>> extends ElementaryIntegration<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(ElementaryIntegrationCzichowski.class);
+
+
+    /**
+     * Engine for Groebner basis.
+     */
+    public final GroebnerBaseAbstract<C> red;
+
+
+    /**
+     * Constructor.
+     */
+    public ElementaryIntegrationCzichowski(RingFactory<C> br) {
+        super(br);
+        red = GBFactory.<C> getImplementation(br);
+    }
+
+
+    /**
+     * Univariate GenPolynomial integration of the logaritmic part, Czichowski
+     * 
+     * @param A univariate GenPolynomial, deg(A) &lt; deg(P).
+     * @param P univariate irreducible GenPolynomial. // gcd(A,P) == 1 automatic
+     * @return logarithmic part container.
+     */
+    @Override
+    public LogIntegral<C> integrateLogPart(GenPolynomial<C> A, GenPolynomial<C> P) {
+        if (P == null || P.isZERO()) {
+            throw new IllegalArgumentException("P == null or P == 0");
+        }
+        // System.out.println("\nP_base_algeb_part = " + P);
+        GenPolynomialRing<C> pfac = P.ring; // K[x]
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException("only for univariate polynomials " + pfac);
+        }
+        if (!pfac.coFac.isField()) {
+            throw new IllegalArgumentException("only for field coefficients " + pfac);
+        }
+        List<C> cfactors = new ArrayList<C>();
+        List<GenPolynomial<C>> cdenom = new ArrayList<GenPolynomial<C>>();
+        List<AlgebraicNumber<C>> afactors = new ArrayList<AlgebraicNumber<C>>();
+        List<GenPolynomial<AlgebraicNumber<C>>> adenom = new ArrayList<GenPolynomial<AlgebraicNumber<C>>>();
+
+        // P linear
+        if (P.degree(0) <= 1) {
+            cfactors.add(A.leadingBaseCoefficient());
+            cdenom.add(P);
+            return new LogIntegral<C>(A, P, cfactors, cdenom, afactors, adenom);
+        }
+
+        // deriviative
+        GenPolynomial<C> Pp = PolyUtil.<C> baseDeriviative(P);
+        // no: Pp = Pp.monic();
+        // System.out.println("Pp = " + Pp);
+
+        // Q[t]
+        String[] vars = new String[] { "t" };
+        GenPolynomialRing<C> cfac = new GenPolynomialRing<C>(pfac.coFac, 1, pfac.tord, vars);
+        GenPolynomial<C> t = cfac.univariate(0);
+
+        // Q[x][t]
+        GenPolynomialRing<GenPolynomial<C>> rfac = new GenPolynomialRing<GenPolynomial<C>>(pfac, cfac); // sic
+        // System.out.println("rfac = " + rfac.toScript());
+
+        // transform polynomials to bi-variate polynomial
+        GenPolynomial<GenPolynomial<C>> Ac = PolyUfdUtil.<C> introduceLowerVariable(rfac, A);
+        // System.out.println("Ac = " + Ac);
+        GenPolynomial<GenPolynomial<C>> Pc = PolyUfdUtil.<C> introduceLowerVariable(rfac, P);
+        // System.out.println("Pc = " + Pc);
+        GenPolynomial<GenPolynomial<C>> Pcp = PolyUfdUtil.<C> introduceLowerVariable(rfac, Pp);
+        // System.out.println("Pcp = " + Pcp);
+
+        // Q[t][x]
+        GenPolynomialRing<GenPolynomial<C>> rfac1 = Pc.ring;
+        // System.out.println("rfac1 = " + rfac1.toScript());
+
+        // A - t P'
+        GenPolynomial<GenPolynomial<C>> tc = rfac1.getONE().multiply(t);
+        // System.out.println("tc = " + tc);
+        GenPolynomial<GenPolynomial<C>> At = Ac.subtract(tc.multiply(Pcp));
+        // System.out.println("At = " + At);
+
+        // Q[t][x] to Q[t,x]
+        GenPolynomialRing<C> dfac = pfac.distribute();
+        GenPolynomial<C> Atd = PolyUtil.distribute(dfac, At);
+        GenPolynomial<C> Pcd = PolyUtil.distribute(dfac, Pc);
+
+        // Groebner Basis
+        List<GenPolynomial<C>> myList = new ArrayList<GenPolynomial<C>>();
+        myList.add(Atd);
+        myList.add(Pcd);
+        List<GenPolynomial<C>> mGB = red.GB(myList);
+        Collections.sort(mGB); // OrderedPolynomialList
+
+        // Q[t,x] to Q[t][x]
+        List<GenPolynomial<GenPolynomial<C>>> gbList = PolyUtil.recursive(rfac1, mGB);
+
+        // Content & Primitive Part
+        int counter = 1;
+        for (GenPolynomial<GenPolynomial<C>> tmGB : gbList) {
+            if (counter == gbList.size()) {
+                continue;
+            }
+            GenPolynomial<C> content = ufd.recursiveContent(tmGB);
+
+            // Content of GB i+1
+            GenPolynomial<C> c = ufd.recursiveContent(gbList.get(counter));
+            GenPolynomial<C> Q = content.divide(c);
+
+            // Primitive Part of GB i+1
+            GenPolynomial<GenPolynomial<C>> ppS = ufd.baseRecursivePrimitivePart(gbList.get(counter));
+            // System.out.println("pp(S) = " + ppS);
+            counter++;
+
+            // vars = new String[] { "z_" + Math.abs(r.hashCode() % 1000) };
+            vars = pfac.newVars("z_");
+            pfac = pfac.copy();
+            @SuppressWarnings("unused")
+            String[] unused = pfac.setVars(vars);
+            if (Q.degreeMin() == 1) {
+                Q = Q.divide(t);
+            }
+            Q = pfac.copy(Q); // hack to exchange the variables
+            AlgebraicNumberRing<C> afac = new AlgebraicNumberRing<C>(Q);
+            logger.debug("afac = " + afac.toScript());
+            AlgebraicNumber<C> a = afac.getGenerator();
+            // no: a = a.negate();
+            // System.out.println("a = " + a);
+
+
+            // K(alpha)[x]
+            GenPolynomialRing<AlgebraicNumber<C>> pafac = new GenPolynomialRing<AlgebraicNumber<C>>(afac,
+                            ppS.ring);
+            // System.out.println("pafac = " + pafac.toScript());
+
+            // convert to K(alpha)[x]
+            GenPolynomial<AlgebraicNumber<C>> Sa = PolyUtil.convertRecursiveToAlgebraicCoefficients(pafac,
+                            ppS);
+            // System.out.println("Sa = " + Sa);
+
+            afactors.add(a);
+            adenom.add(Sa);
+            // adenom.add(Sa.monic());
+        }
+        return new LogIntegral<C>(A, P, cfactors, cdenom, afactors, adenom);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/integrate/ElementaryIntegrationLazard.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/integrate/ElementaryIntegrationLazard.java
@@ -1,0 +1,209 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.integrate;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.SortedMap;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.AlgebraicNumberRing;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.ufd.GCDFactory;
+import edu.jas.ufd.GreatestCommonDivisorAbstract;
+import edu.jas.ufd.GreatestCommonDivisorSubres;
+import edu.jas.ufd.PolyUfdUtil;
+
+
+/**
+ * Method related to elementary integration. Lazard-Rioboo-Trager integration of
+ * the logarithmic part.
+ * 
+ * @author Youssef Elbarbary
+ * @param <C> coefficient type
+ */
+
+public class ElementaryIntegrationLazard<C extends GcdRingElem<C>> extends ElementaryIntegration<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(ElementaryIntegrationLazard.class);
+
+
+    /**
+     * Constructor.
+     */
+    public ElementaryIntegrationLazard(RingFactory<C> br) {
+        super(br);
+    }
+
+
+    /**
+     * Univariate GenPolynomial integration of the logaritmic part, Lazard -
+     * Rioboo - Trager
+     * 
+     * @param A univariate GenPolynomial, deg(A) &lt; deg(P).
+     * @param P univariate irreducible GenPolynomial. // gcd(A,P) == 1 automatic
+     * @return logarithmic part container.
+     */
+    @Override
+    public LogIntegral<C> integrateLogPart(GenPolynomial<C> A, GenPolynomial<C> P) {
+        if (P == null || P.isZERO()) {
+            throw new IllegalArgumentException("P == null or P == 0");
+        }
+        // System.out.println("\nP_base_algeb_part = " + P);
+        GenPolynomialRing<C> pfac = P.ring; // K[x]
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException("only for univariate polynomials " + pfac);
+        }
+        if (!pfac.coFac.isField()) {
+            throw new IllegalArgumentException("only for field coefficients " + pfac);
+        }
+        List<C> cfactors = new ArrayList<C>();
+        List<GenPolynomial<C>> cdenom = new ArrayList<GenPolynomial<C>>();
+        List<AlgebraicNumber<C>> afactors = new ArrayList<AlgebraicNumber<C>>();
+        List<GenPolynomial<AlgebraicNumber<C>>> adenom = new ArrayList<GenPolynomial<AlgebraicNumber<C>>>();
+
+        // P linear
+        if (P.degree(0) <= 1) {
+            cfactors.add(A.leadingBaseCoefficient());
+            cdenom.add(P);
+            return new LogIntegral<C>(A, P, cfactors, cdenom, afactors, adenom);
+        }
+
+        // deriviative
+        GenPolynomial<C> Pp = PolyUtil.<C> baseDeriviative(P);
+        // no: Pp = Pp.monic();
+        // System.out.println("\nP = " + P);
+
+        // Q[t]
+        String[] vars = new String[] { "t" };
+        GenPolynomialRing<C> cfac = new GenPolynomialRing<C>(pfac.coFac, 1, pfac.tord, vars);
+        GenPolynomial<C> t = cfac.univariate(0);
+        // System.out.println("t = " + t);
+
+        // Q[x][t]
+        GenPolynomialRing<GenPolynomial<C>> rfac = new GenPolynomialRing<GenPolynomial<C>>(pfac, cfac); // sic
+        // System.out.println("rfac = " + rfac.toScript());
+
+        // transform polynomials to bi-variate polynomial
+        GenPolynomial<GenPolynomial<C>> Ac = PolyUfdUtil.<C> introduceLowerVariable(rfac, A);
+        GenPolynomial<GenPolynomial<C>> Pc = PolyUfdUtil.<C> introduceLowerVariable(rfac, P);
+        GenPolynomial<GenPolynomial<C>> Pcp = PolyUfdUtil.<C> introduceLowerVariable(rfac, Pp);
+
+        // Q[t][x]
+        GenPolynomialRing<GenPolynomial<C>> rfac1 = Pc.ring;
+        // System.out.println("rfac1 = " + rfac1.toScript());
+
+        // A - t P'
+        GenPolynomial<GenPolynomial<C>> tc = rfac1.getONE().multiply(t);
+        // System.out.println("tc = " + tc);
+        GenPolynomial<GenPolynomial<C>> At = Ac.subtract(tc.multiply(Pcp));
+        // System.out.println("A - tP' = " + At);
+
+        GreatestCommonDivisorSubres<C> engine = new GreatestCommonDivisorSubres<C>();
+        // = GCDFactory.<C>getImplementation( cfac.coFac );
+        GreatestCommonDivisorAbstract<AlgebraicNumber<C>> aengine = null;
+
+        // Subresultant von A - t P'
+        List<GenPolynomial<GenPolynomial<C>>> RcList = engine.recursiveUnivariateSubResultantList(Pc, At); // returning
+        GenPolynomial<GenPolynomial<C>> Rc = RcList.get(RcList.size() - 1); // just getting R
+        //System.out.println("R = " + Rc);
+
+        // SquareFree(R)
+        SortedMap<GenPolynomial<C>, Long> resSquareFree = sqf.squarefreeFactors(Rc.leadingBaseCoefficient());
+        if (logger.isInfoEnabled()) {
+            logger.info("SquareFree(R) = " + resSquareFree);
+        }
+
+        // First Loop
+        SortedMap<GenPolynomial<C>, Long> sfactors = null;
+        GenPolynomial<AlgebraicNumber<C>> Sa = null;
+        GenPolynomial<GenPolynomial<C>> S = null;
+        GenPolynomial<C> Q = null;
+        for (Entry<GenPolynomial<C>, Long> qi : resSquareFree.entrySet()) {
+            Q = qi.getKey();
+            // System.out.println("\nr(t) = " + r);
+            if (Q.isConstant()) {
+                continue;
+            }
+            if (Q.degreeMin() == 1) {
+                Q = Q.divide(t);
+            }
+            vars = pfac.newVars("z_");
+            pfac = pfac.copy();
+            @SuppressWarnings("unused")
+            String[] unused = pfac.setVars(vars);
+            GenPolynomial<C> qi2 = pfac.copy(Q); // hack to exchange the variables
+            // System.out.println("r(z_) = " + r);
+            AlgebraicNumberRing<C> afac = new AlgebraicNumberRing<C>(qi2);
+            if (logger.isDebugEnabled()) {
+                logger.debug("afac = " + afac.toScript());
+            }
+            AlgebraicNumber<C> a = afac.getGenerator();
+            // no: a = a.negate();
+            // System.out.println("a = " + a);
+
+            // K(alpha)[x]
+            GenPolynomialRing<AlgebraicNumber<C>> pafac = new GenPolynomialRing<AlgebraicNumber<C>>(afac,
+                            Pc.ring);
+
+            // 1Condition 2Condition i = deg(D) + Check condition again!
+            if (qi2.degree() > 0) {
+                if (qi.getValue() == Pc.degree()) {
+                    GenPolynomial<C> sExp = P;
+                    // convert to K(alpha)[x]
+                    Sa = PolyUtil.<C> convertToAlgebraicCoefficients(pafac, sExp);
+                    afactors.add(a);
+                    adenom.add(Sa);
+                    return new LogIntegral<C>(A, P, cfactors, cdenom, afactors, adenom);
+                }
+                int countj = 1;
+                // RcList.remove(RcList.size()-1);
+                for (GenPolynomial<GenPolynomial<C>> Ri : RcList) {
+                    if (qi.getValue() == Ri.degree()) {
+                        S = Ri;
+                        // convert to K(alpha)[x]
+                        Sa = PolyUtil.convertRecursiveToAlgebraicCoefficients(pafac, S);
+                        sfactors = sqf.squarefreeFactors(S.leadingBaseCoefficient());
+                        if (logger.isInfoEnabled()) {
+                            logger.info("SquareFree(S)" + sfactors);
+                        }
+                    }
+                }
+                for (GenPolynomial<C> ai : sfactors.keySet()) {
+                    GenPolynomial<AlgebraicNumber<C>> aiC = PolyUtil.<C> convertToAlgebraicCoefficients(pafac,
+                                    ai);
+                    GenPolynomial<AlgebraicNumber<C>> qiC = PolyUtil.<C> convertToAlgebraicCoefficients(pafac,
+                                    qi2);
+                    if (aengine == null) {
+                        aengine = GCDFactory.<AlgebraicNumber<C>> getImplementation(afac);
+                    }
+                    GenPolynomial<AlgebraicNumber<C>> gcd = aengine.baseGcd(aiC, qiC);
+                    gcd = gcd.power(countj);
+                    Sa = (Sa.divide(gcd));
+                    countj++;
+                    if (Sa.isZERO() || a.isZERO()) {
+                        System.out.println("warning constant Sa ignored");
+                        continue;
+                    }
+                }
+                //System.out.println("S = " + Sa);
+                afactors.add(a);
+                adenom.add(Sa.monic());
+                // adenom.add(Sa.monic());
+            }
+        }
+        return new LogIntegral<C>(A, P, cfactors, cdenom, afactors, adenom);
+    }
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/integrate/Examples.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/integrate/Examples.java
@@ -1,0 +1,266 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.integrate;
+
+
+import java.util.List;
+
+import edu.jas.arith.BigRational;
+import edu.jas.kern.ComputerThreads;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.TermOrder;
+import edu.jas.ufd.Quotient;
+import edu.jas.ufd.QuotientRing;
+
+
+/**
+ * Examples related to elementary integration.
+ * 
+ * @author Axel Kramer
+ * @author Heinz Kredel
+ */
+
+public class Examples {
+
+
+    /**
+     * Main program.
+     * 
+     * @param args
+     */
+    public static void main(String[] args) {
+        example1();
+        example2();
+        example3();
+    }
+
+
+    /**
+     * Example rationals.
+     */
+    public static void example1() {
+
+        BigRational br = new BigRational(0);
+        String[] vars = new String[] { "x" };
+        GenPolynomialRing<BigRational> fac;
+        fac = new GenPolynomialRing<BigRational>(br, vars.length, new TermOrder(TermOrder.INVLEX), vars);
+
+        ElementaryIntegration<BigRational> eIntegrator = new ElementaryIntegration<BigRational>(br);
+
+        GenPolynomial<BigRational> a = fac.parse("x^7 - 24 x^4 - 4 x^2 + 8 x - 8");
+        System.out.println("A: " + a.toString());
+        GenPolynomial<BigRational> d = fac.parse("x^8 + 6 x^6 + 12 x^4 + 8 x^2");
+        System.out.println("D: " + d.toString());
+        GenPolynomial<BigRational> gcd = a.gcd(d);
+        System.out.println("GCD: " + gcd.toString());
+        List<GenPolynomial<BigRational>>[] ret = eIntegrator.integrateHermite(a, d);
+        System.out.println("Result: " + ret[0] + " , " + ret[1]);
+
+        System.out.println("-----");
+
+        a = fac.parse("10 x^2 - 63 x + 29");
+        System.out.println("A: " + a.toString());
+        d = fac.parse("x^3 - 11 x^2 + 40 x -48");
+        System.out.println("D: " + d.toString());
+        gcd = a.gcd(d);
+        System.out.println("GCD: " + gcd.toString());
+        ret = eIntegrator.integrateHermite(a, d);
+        System.out.println("Result: " + ret[0] + " , " + ret[1]);
+
+        System.out.println("-----");
+
+        a = fac.parse("x+3");
+        System.out.println("A: " + a.toString());
+        d = fac.parse("x^2 - 3 x - 40");
+        System.out.println("D: " + d.toString());
+        gcd = a.gcd(d);
+        System.out.println("GCD: " + gcd.toString());
+        ret = eIntegrator.integrateHermite(a, d);
+        System.out.println("Result: " + ret[0] + " , " + ret[1]);
+
+        System.out.println("-----");
+
+        a = fac.parse("10 x^2+12 x + 20");
+        System.out.println("A: " + a.toString());
+        d = fac.parse("x^3 - 8");
+        System.out.println("D: " + d.toString());
+        gcd = a.gcd(d);
+        System.out.println("GCD: " + gcd.toString());
+        ret = eIntegrator.integrateHermite(a, d);
+        System.out.println("Result: " + ret[0] + " , " + ret[1]);
+
+        System.out.println("------------------------------------------------------\n");
+        ComputerThreads.terminate();
+    }
+
+
+    /**
+     * Example rational plus logarithm.
+     */
+    public static void example2() {
+
+        BigRational br = new BigRational(0);
+        String[] vars = new String[] { "x" };
+        GenPolynomialRing<BigRational> fac;
+        fac = new GenPolynomialRing<BigRational>(br, vars.length, new TermOrder(TermOrder.INVLEX), vars);
+
+        ElementaryIntegration<BigRational> eIntegrator = new ElementaryIntegration<BigRational>(br);
+
+        GenPolynomial<BigRational> a = fac.parse("x^7 - 24 x^4 - 4 x^2 + 8 x - 8");
+        System.out.println("A: " + a.toString());
+        GenPolynomial<BigRational> d = fac.parse("x^8 + 6 x^6 + 12 x^4 + 8 x^2");
+        System.out.println("D: " + d.toString());
+        GenPolynomial<BigRational> gcd = a.gcd(d);
+        System.out.println("GCD: " + gcd.toString());
+        Integral<BigRational> ret = eIntegrator.integrate(a, d);
+        System.out.println("Result: " + ret);
+
+        System.out.println("-----");
+
+        a = fac.parse("10 x^2 - 63 x + 29");
+        System.out.println("A: " + a.toString());
+        d = fac.parse("x^3 - 11 x^2 + 40 x -48");
+        System.out.println("D: " + d.toString());
+        gcd = a.gcd(d);
+        System.out.println("GCD: " + gcd.toString());
+        ret = eIntegrator.integrate(a, d);
+        System.out.println("Result: " + ret);
+
+        System.out.println("-----");
+
+        a = fac.parse("x+3");
+        System.out.println("A: " + a.toString());
+        d = fac.parse("x^2 - 3 x - 40");
+        System.out.println("D: " + d.toString());
+        gcd = a.gcd(d);
+        System.out.println("GCD: " + gcd.toString());
+        ret = eIntegrator.integrate(a, d);
+        System.out.println("Result: " + ret);
+
+        System.out.println("-----");
+
+        a = fac.parse("10 x^2+12 x + 20");
+        System.out.println("A: " + a.toString());
+        d = fac.parse("x^3 - 8");
+        System.out.println("D: " + d.toString());
+        gcd = a.gcd(d);
+        System.out.println("GCD: " + gcd.toString());
+        ret = eIntegrator.integrate(a, d);
+        System.out.println("Result: " + ret);
+
+        System.out.println("-----");
+
+        a = fac.parse("1");
+        System.out.println("A: " + a.toString());
+        d = fac.parse("(x**5 + x - 7)");
+        System.out.println("D: " + d.toString());
+        gcd = a.gcd(d);
+        System.out.println("GCD: " + gcd.toString());
+        ret = eIntegrator.integrate(a, d);
+        System.out.println("Result: " + ret);
+
+        System.out.println("-----");
+
+        a = fac.parse("1");
+        d = fac.parse("(x**5 + x - 7)");
+        a = a.sum(d);
+        System.out.println("A: " + a.toString());
+        System.out.println("D: " + d.toString());
+        gcd = a.gcd(d);
+        System.out.println("GCD: " + gcd.toString());
+        ret = eIntegrator.integrate(a, d);
+        System.out.println("Result: " + ret);
+
+        System.out.println("-----");
+        ComputerThreads.terminate();
+    }
+
+
+    /**
+     * Example quotients with rational plus logarithm.
+     */
+    public static void example3() {
+
+        BigRational br = new BigRational(0);
+        String[] vars = new String[] { "x" };
+        GenPolynomialRing<BigRational> fac;
+        fac = new GenPolynomialRing<BigRational>(br, vars.length, new TermOrder(TermOrder.INVLEX), vars);
+
+        QuotientRing<BigRational> qfac = new QuotientRing<BigRational>(fac);
+
+        ElementaryIntegration<BigRational> eIntegrator = new ElementaryIntegration<BigRational>(br);
+
+        GenPolynomial<BigRational> a = fac.parse("x^7 - 24 x^4 - 4 x^2 + 8 x - 8");
+        GenPolynomial<BigRational> d = fac.parse("x^8 + 6 x^6 + 12 x^4 + 8 x^2");
+        Quotient<BigRational> q = new Quotient<BigRational>(qfac, a, d);
+        System.out.println("q =  " + q);
+        QuotIntegral<BigRational> ret = eIntegrator.integrate(q);
+        System.out.println("Result: " + ret);
+
+        System.out.println("-----");
+
+        a = fac.parse("10 x^2 - 63 x + 29");
+        d = fac.parse("x^3 - 11 x^2 + 40 x -48");
+        q = new Quotient<BigRational>(qfac, a, d);
+        System.out.println("q =  " + q);
+        ret = eIntegrator.integrate(q);
+        System.out.println("Result: " + ret);
+
+        System.out.println("-----");
+
+        a = fac.parse("x+3");
+        d = fac.parse("x^2 - 3 x - 40");
+        q = new Quotient<BigRational>(qfac, a, d);
+        System.out.println("q =  " + q);
+        ret = eIntegrator.integrate(q);
+        System.out.println("Result: " + ret);
+
+        System.out.println("-----");
+
+        a = fac.parse("10 x^2+12 x + 20");
+        d = fac.parse("x^3 - 8");
+        q = new Quotient<BigRational>(qfac, a, d);
+        System.out.println("q =  " + q);
+        ret = eIntegrator.integrate(q);
+        System.out.println("Result: " + ret);
+
+        System.out.println("-----");
+
+        a = fac.parse("1");
+        d = fac.parse("(x**5 + x - 7)");
+        q = new Quotient<BigRational>(qfac, a, d);
+        System.out.println("q =  " + q);
+        ret = eIntegrator.integrate(q);
+        System.out.println("Result: " + ret);
+
+        System.out.println("-----");
+
+        a = fac.parse("1");
+        d = fac.parse("(x**5 + x - 7)");
+        a = a.sum(d);
+        q = new Quotient<BigRational>(qfac, a, d);
+        System.out.println("q =  " + q);
+        ret = eIntegrator.integrate(q);
+        System.out.println("Result: " + ret);
+
+        System.out.println("-----");
+
+        Quotient<BigRational> qi = qfac.random(7);
+        //qi = qi.sum( qfac.random(5) );
+        q = eIntegrator.deriviative(qi);
+        System.out.println("qi =  " + qi);
+        System.out.println("q  =  " + q);
+        ret = eIntegrator.integrate(q);
+        System.out.println("Result: " + ret);
+        boolean t = eIntegrator.isIntegral(ret);
+        System.out.println("isIntegral = " + t);
+
+        System.out.println("-----");
+        ComputerThreads.terminate();
+    }
+
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/integrate/ExamplesMore.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/integrate/ExamplesMore.java
@@ -1,0 +1,180 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.integrate;
+
+
+import edu.jas.arith.BigRational;
+import edu.jas.kern.ComputerThreads;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.TermOrder;
+import edu.jas.ufd.Quotient;
+import edu.jas.ufd.QuotientRing;
+
+
+/**
+ * More examples for integrating rational functions.
+ * 
+ * @author Youssef Elbarbary
+ */
+
+public class ExamplesMore {
+
+
+    /**
+     * Main program.
+     * 
+     * @param args
+     */
+    public static void main(String[] args) {
+        exampleRothstein();
+        exampleLazard();
+        exampleCzichwoski();
+        exampleBernoulli();
+        ComputerThreads.terminate();
+    }
+
+
+    /**
+     * Example for integrating a rational function using Rothstein-Trager
+     * algorithm.
+     */
+    public static void exampleRothstein() {
+        BigRational br = new BigRational(0);
+        String[] vars = new String[] { "x" };
+        GenPolynomialRing<BigRational> fac;
+        fac = new GenPolynomialRing<BigRational>(br, vars.length, new TermOrder(TermOrder.INVLEX), vars);
+
+        QuotientRing<BigRational> qfac = new QuotientRing<BigRational>(fac);
+        ElementaryIntegration<BigRational> eIntegrator = new ElementaryIntegration<BigRational>(br);
+
+        GenPolynomial<BigRational> a = fac.parse("x^4 - 3 x^2 + 6");
+        GenPolynomial<BigRational> d = fac.parse("x^6 - 5 x^4 + 5 x^2 + 4");
+        // GenPolynomial<BigRational> a = fac.parse("36");
+        // GenPolynomial<BigRational> d = fac.parse("x^5 - 2 x^4 - 2 x^3 + 4 x^2 + x - 2");
+        // GenPolynomial<BigRational> a = fac.parse("8 x^9 + x^8 - 12 x^7 - 4 x^6 - 26 x^5 - 6 x^4 + 30 x^3 + 23 x^2 - 2 x - 7");
+        // GenPolynomial<BigRational> d = fac.parse("x^10 - 2 x^8 - 2 x^7 - 4 x^6 + 7 x^4 + 10 x^3 + 3 x^2 - 4 x - 2");
+        // GenPolynomial<BigRational> a = fac.parse("x^5 - x^4 + 4 x^3 + x^2 - x + 5");
+        // GenPolynomial<BigRational> d = fac.parse("x^4 - 2 x^3 + 5 x^2 - 4 x + 4");
+
+        Quotient<BigRational> q = new Quotient<BigRational>(qfac, a, d);
+        eIntegrator.irredLogPart = true;
+
+        double startTime = System.currentTimeMillis();
+        edu.jas.integrate.QuotIntegral<BigRational> ret = eIntegrator.integrate(q);
+        double endTime = System.currentTimeMillis();
+        System.out.println("Rothstein took " + ((endTime - startTime) / 1000) + " seconds");
+        System.out.println("Result: " + ret);
+
+        boolean testAnswer = eIntegrator.isIntegral(ret);
+        System.out.println(testAnswer);
+    }
+
+
+    /**
+     * Example for integrating a rational function using Lazard algorithm.
+     */
+    public static void exampleLazard() {
+        BigRational br = new BigRational(0);
+        String[] vars = new String[] { "x" };
+        GenPolynomialRing<BigRational> fac;
+        fac = new GenPolynomialRing<BigRational>(br, vars.length, new TermOrder(TermOrder.INVLEX), vars);
+
+        QuotientRing<BigRational> qfac = new QuotientRing<BigRational>(fac);
+        ElementaryIntegration<BigRational> eIntegratorLaz = new ElementaryIntegrationLazard<BigRational>(br);
+
+        GenPolynomial<BigRational> a = fac.parse("x^4 - 3 x^2 + 6");
+        GenPolynomial<BigRational> d = fac.parse("x^6 - 5 x^4 + 5 x^2 + 4");
+        // GenPolynomial<BigRational> a = fac.parse("36");
+        // GenPolynomial<BigRational> d = fac.parse("x^5 - 2 x^4 - 2 x^3 + 4 x^2 + x - 2");
+        // GenPolynomial<BigRational> a = fac.parse("8 x^9 + x^8 - 12 x^7 - 4 x^6 - 26 x^5 - 6 x^4 + 30 x^3 + 23 x^2 - 2 x - 7");
+        // GenPolynomial<BigRational> d = fac.parse("x^10 - 2 x^8 - 2 x^7 - 4 x^6 + 7 x^4 + 10 x^3 + 3 x^2 - 4 x - 2");
+        // GenPolynomial<BigRational> a = fac.parse("x^5 - x^4 + 4 x^3 + x^2 - x + 5");
+        // GenPolynomial<BigRational> d = fac.parse("x^4 - 2 x^3 + 5 x^2 - 4 x + 4");
+
+        Quotient<BigRational> q = new Quotient<BigRational>(qfac, a, d);
+        eIntegratorLaz.irredLogPart = true;
+
+        double startTime = System.currentTimeMillis();
+        QuotIntegral<BigRational> ret = eIntegratorLaz.integrate(q);
+        double endTime = System.currentTimeMillis();
+        System.out.println("Lazard took " + ((endTime - startTime) / 1000) + " seconds");
+        System.out.println("Result: " + ret);
+
+        boolean testAnswer = eIntegratorLaz.isIntegral(ret);
+        System.out.println(testAnswer);
+        // System.out.println("-----");
+    }
+
+
+    /**
+     * Example for integrating a rational function using Czichowski algorithm.
+     */
+    public static void exampleCzichwoski() {
+        BigRational br = new BigRational(0);
+        String[] vars = new String[] { "x" };
+        GenPolynomialRing<BigRational> fac;
+        fac = new GenPolynomialRing<BigRational>(br, vars.length, new TermOrder(TermOrder.INVLEX), vars);
+
+        QuotientRing<BigRational> qfac = new QuotientRing<BigRational>(fac);
+        ElementaryIntegration<BigRational> eIntegratorCzi = new ElementaryIntegrationCzichowski<BigRational>(
+                        br);
+
+        // GenPolynomial<BigRational> a = fac.parse("x^4 - 3 x^2 + 6");
+        // GenPolynomial<BigRational> d = fac.parse("x^6 - 5 x^4 + 5 x^2 + 4");
+        // GenPolynomial<BigRational> a = fac.parse("36");
+        // GenPolynomial<BigRational> d = fac.parse("x^5 - 2 x^4 - 2 x^3 + 4 x^2 + x - 2");
+        // GenPolynomial<BigRational> a = fac.parse("8 x^9 + x^8 - 12 x^7 - 4 x^6 - 26 x^5 - 6 x^4 + 30 x^3 + 23 x^2 - 2 x - 7");
+        // GenPolynomial<BigRational> d = fac.parse("x^10 - 2 x^8 - 2 x^7 - 4 x^6 + 7 x^4 + 10 x^3 + 3 x^2 - 4 x - 2");
+        GenPolynomial<BigRational> a = fac.parse("x^5 - x^4 + 4 x^3 + x^2 - x + 5");
+        GenPolynomial<BigRational> d = fac.parse("x^4 - 2 x^3 + 5 x^2 - 4 x + 4");
+
+        Quotient<BigRational> q = new Quotient<BigRational>(qfac, a, d);
+        eIntegratorCzi.irredLogPart = true;
+
+        double startTime = System.currentTimeMillis();
+        QuotIntegral<BigRational> ret = eIntegratorCzi.integrate(q); //
+        double endTime = System.currentTimeMillis();
+        System.out.println("Czichowski took " + ((endTime - startTime) / 1000) + " seconds");
+        System.out.println("Result: " + ret);
+
+        boolean testAnswer = eIntegratorCzi.isIntegral(ret);
+        System.out.println(testAnswer);
+    }
+
+
+    /**
+     * Example for integrating a rational function using Bernoulli algorithm.
+     */
+    public static void exampleBernoulli() {
+        BigRational br = new BigRational(0);
+        String[] vars = new String[] { "x" };
+        GenPolynomialRing<BigRational> fac;
+        fac = new GenPolynomialRing<BigRational>(br, vars.length, new TermOrder(TermOrder.INVLEX), vars);
+
+        QuotientRing<BigRational> qfac = new QuotientRing<BigRational>(fac);
+        ElementaryIntegration<BigRational> eIntegratorBer = new ElementaryIntegrationBernoulli<BigRational>(
+                        br);
+
+        GenPolynomial<BigRational> a = fac.parse("x^4 - 3 x^2 + 6");
+        GenPolynomial<BigRational> d = fac.parse("x^6 - 5 x^4 + 5 x^2 + 4");
+        // GenPolynomial<BigRational> a = fac.parse("36");
+        // GenPolynomial<BigRational> d = fac.parse("x^5 - 2 x^4 - 2 x^3 + 4 x^2 + x - 2");
+        // GenPolynomial<BigRational> a = fac.parse("x^5 - x^4 + 4 x^3 + x^2 - x + 5");
+        // GenPolynomial<BigRational> d = fac.parse("x^4 - 2 x^3 + 5 x^2 - 4 x + 4");
+
+        Quotient<BigRational> q = new Quotient<BigRational>(qfac, a, d);
+
+        double startTime = System.currentTimeMillis();
+        edu.jas.integrate.QuotIntegral<BigRational> ret = eIntegratorBer.integrate(q);
+        double endTime = System.currentTimeMillis();
+        System.out.println("Bernoulli took " + ((endTime - startTime) / 1000) + " seconds");
+        System.out.println("Result: " + ret);
+
+        // boolean testAnswer = eIntegratorBer.isIntegral(ret);
+        // System.out.println(testAnswer);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/integrate/Integral.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/integrate/Integral.java
@@ -1,0 +1,180 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.integrate;
+
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Container for a rational function integral, polynomial version.
+ * integral(num/den) = pol + sum_rat( rat_i/rat_{i+1} ) + sum_log( a_i log ( d_i
+ * ) )
+ * @author Heinz Kredel
+ * @param <C> coefficient type
+ */
+
+public class Integral<C extends GcdRingElem<C>> implements Serializable {
+
+
+    /**
+     * Original numerator polynomial with coefficients from C.
+     */
+    public final GenPolynomial<C> num;
+
+
+    /**
+     * Original denominator polynomial with coefficients from C.
+     */
+    public final GenPolynomial<C> den;
+
+
+    /**
+     * Integral of the polynomial part.
+     */
+    public final GenPolynomial<C> pol;
+
+
+    /**
+     * Integral of the rational part.
+     */
+    public final List<GenPolynomial<C>> rational;
+
+
+    /**
+     * Integral of the logarithmic part.
+     */
+    public final List<LogIntegral<C>> logarithm;
+
+
+    /**
+     * Constructor.
+     * @param n numerator GenPolynomial over C.
+     * @param d denominator GenPolynomial over C.
+     * @param p integral of polynomial part. n/d =
+     */
+    public Integral(GenPolynomial<C> n, GenPolynomial<C> d, GenPolynomial<C> p) {
+        this(n, d, p, new ArrayList<GenPolynomial<C>>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param n numerator GenPolynomial over C.
+     * @param d denominator GenPolynomial over C.
+     * @param p integral of polynomial part.
+     * @param rat list of rational integrals. n/d =
+     */
+    public Integral(GenPolynomial<C> n, GenPolynomial<C> d, GenPolynomial<C> p, List<GenPolynomial<C>> rat) {
+        this(n, d, p, rat, new ArrayList<LogIntegral<C>>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param n numerator GenPolynomial over C.
+     * @param d denominator GenPolynomial over C.
+     * @param p integral of polynomial part.
+     * @param rat list of rational integrals.
+     * @param log list of logarithmic part. n/d =
+     */
+    public Integral(GenPolynomial<C> n, GenPolynomial<C> d, GenPolynomial<C> p, List<GenPolynomial<C>> rat,
+                    List<LogIntegral<C>> log) {
+        num = n;
+        den = d;
+        pol = p;
+        rational = rat;
+        logarithm = log;
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        sb.append("integral( (" + num.toString());
+        sb.append(") / (");
+        sb.append(den.toString() + ") )");
+        sb.append(" =\n");
+        if (!pol.isZERO()) {
+            sb.append(pol.toString());
+        }
+        boolean first = true;
+        if (rational.size() != 0) {
+            if (!pol.isZERO()) {
+                sb.append(" + ");
+            }
+            for (int i = 0; i < rational.size(); i++) {
+                if (first) {
+                    first = false;
+                } else {
+                    sb.append(" + ");
+                }
+                sb.append("(" + rational.get(i++) + ")/(");
+                sb.append(rational.get(i) + ")");
+            }
+        }
+        if (logarithm.size() != 0) {
+            if (!pol.isZERO() || rational.size() != 0) {
+                sb.append(" + ");
+            }
+            first = true;
+            for (LogIntegral<C> pf : logarithm) {
+                if (first) {
+                    first = false;
+                } else {
+                    sb.append(" + ");
+                }
+                sb.append(pf);
+            }
+            sb.append("\n");
+        }
+        return sb.toString();
+    }
+
+
+    /**
+     * Hash code for Integral.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h = num.hashCode();
+        h = h * 37 + den.hashCode();
+        h = h * 37 + pol.hashCode();
+        h = h * 37 + rational.hashCode();
+        h = h * 37 + logarithm.hashCode();
+        return h;
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object B) {
+        Integral<C> b = null;
+        try {
+            b = (Integral<C>) B;
+        } catch (ClassCastException ignored) {
+        }
+        if (b == null) {
+            return false;
+        }
+        return num.equals(b.num) && den.equals(b.den) && pol.equals(b.pol) && rational.equals(b.rational)
+                        && logarithm.equals(b.logarithm);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/integrate/LogIntegral.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/integrate/LogIntegral.java
@@ -1,0 +1,247 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.integrate;
+
+
+import java.io.Serializable;
+import java.util.List;
+
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.AlgebraicNumberRing;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Container for the logarithmic part of a rational function integral. num/den =
+ * sum( a_i ( der(d_i) / d_i ) ) integrate(num/den) = sum( a_i log ( d_i ) )
+ * @author Heinz Kredel
+ * @param <C> coefficient type
+ */
+
+public class LogIntegral<C extends GcdRingElem<C>> implements Serializable {
+
+
+    /**
+     * Original numerator polynomial with coefficients from C and deg(num) &lt;
+     * deg(den).
+     */
+    public final GenPolynomial<C> num;
+
+
+    /**
+     * Original (irreducible) denominator polynomial with coefficients from C.
+     */
+    public final GenPolynomial<C> den;
+
+
+    /**
+     * List of numbers from C.
+     */
+    public final List<C> cfactors;
+
+
+    /**
+     * List of linear factors of the denominator with coefficients from C.
+     */
+    public final List<GenPolynomial<C>> cdenom;
+
+
+    /**
+     * List of algebraic numbers of an algebraic field extension over C.
+     */
+    public final List<AlgebraicNumber<C>> afactors;
+
+
+    /**
+     * List of factors of the denominator with coefficients from an
+     * AlgebraicNumberRing&lt;C&gt;.
+     */
+    public final List<GenPolynomial<AlgebraicNumber<C>>> adenom;
+
+
+    /**
+     * Constructor.
+     * @param n numerator GenPolynomial over C.
+     * @param d irreducible denominator GenPolynomial over C.
+     * @param cf list of elements a_i.
+     * @param cd list of linear factors d_i of d.
+     * @param af list of algebraic elements a_i.
+     * @param ad list of irreducible factors d_i of d with algebraic
+     *            coefficients. n/d = sum( a_i ( der(d_i) / d_i ) )
+     */
+    public LogIntegral(GenPolynomial<C> n, GenPolynomial<C> d, List<C> cf, List<GenPolynomial<C>> cd,
+                    List<AlgebraicNumber<C>> af, List<GenPolynomial<AlgebraicNumber<C>>> ad) {
+        num = n;
+        den = d;
+        cfactors = cf;
+        cdenom = cd;
+        afactors = af;
+        adenom = ad;
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        //         sb.append("(" + num.toString() + ")");
+        //         sb.append(" / ");
+        //         sb.append("(" + den.toString() + ")");
+        //         sb.append(" =\n");
+        boolean first = true;
+        for (int i = 0; i < cfactors.size(); i++) {
+            C cp = cfactors.get(i);
+            if (first) {
+                first = false;
+            } else {
+                sb.append(" + ");
+            }
+            sb.append("(" + cp.toString() + ")");
+            GenPolynomial<C> p = cdenom.get(i);
+            sb.append(" log( " + p.toString() + ")");
+        }
+        if (!first && afactors.size() > 0) {
+            sb.append(" + ");
+        }
+        first = true;
+        for (int i = 0; i < afactors.size(); i++) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append(" + ");
+            }
+            AlgebraicNumber<C> ap = afactors.get(i);
+            AlgebraicNumberRing<C> ar = ap.factory();
+            //sb.append(" ## over " + ap.factory() + "\n");
+            GenPolynomial<AlgebraicNumber<C>> p = adenom.get(i);
+            if (p.degree(0) < ar.modul.degree(0) && ar.modul.degree(0) > 2) {
+                sb.append("sum_(" + ar.getGenerator() + " in ");
+                sb.append("rootOf(" + ar.modul + ") ) ");
+            } else {
+                //sb.append("sum_("+ar+") ");
+            }
+            sb.append("(" + ap.toString() + ")");
+            sb.append(" log( " + p.toString() + ")");
+        }
+        return sb.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this container.
+     * @see edu.jas.structure.ElemFactory#toScript()
+     */
+    public String toScript() {
+        // Python case
+        StringBuffer sb = new StringBuffer();
+
+        sb.append(num.toScript());
+        sb.append(" / ");
+        sb.append(den.toScript());
+        sb.append(" = ");
+        boolean first = true;
+        for (C cp : cfactors) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append(", ");
+            }
+            sb.append(cp.toScript());
+        }
+        if (!first) {
+            sb.append(" linear denominators: ");
+        }
+        first = true;
+        for (GenPolynomial<C> cp : cdenom) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append(", ");
+            }
+            sb.append(cp.toScript());
+        }
+        if (!first) {
+            sb.append(", ");
+        }
+        first = true;
+        for (AlgebraicNumber<C> ap : afactors) {
+            if (first) {
+                first = false;
+            } else {
+                //sb.append(", ");
+            }
+            sb.append(ap.toScript());
+            sb.append(" ## over " + ap.toScriptFactory() + "\n");
+        }
+        sb.append(" denominators: ");
+        first = true;
+        for (GenPolynomial<AlgebraicNumber<C>> ap : adenom) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append(", ");
+            }
+            sb.append(ap.toScript());
+        }
+        return sb.toString();
+    }
+
+
+    /**
+     * Hash code for this Factors.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h = num.hashCode();
+        h = h * 37 + den.hashCode();
+        h = h * 37 + cfactors.hashCode();
+        h = h * 37 + cdenom.hashCode();
+        h = h * 37 + afactors.hashCode();
+        h = h * 37 + adenom.hashCode();
+        return h;
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object B) {
+        if (B == null) {
+            return false;
+        }
+        if (!(B instanceof LogIntegral)) {
+            return false;
+        }
+        LogIntegral<C> a = (LogIntegral<C>) B;
+        boolean t = num.equals(a.num) && den.equals(a.den);
+        if (!t) {
+            return t;
+        }
+        t = cfactors.equals(a.cfactors);
+        if (!t) {
+            return t;
+        }
+        t = cdenom.equals(a.cdenom);
+        if (!t) {
+            return t;
+        }
+        t = afactors.equals(a.afactors);
+        if (!t) {
+            return t;
+        }
+        t = adenom.equals(a.adenom);
+        return t;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/integrate/QuotIntegral.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/integrate/QuotIntegral.java
@@ -1,0 +1,171 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.integrate;
+
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.ufd.Quotient;
+import edu.jas.ufd.QuotientRing;
+
+
+/**
+ * Container for a rational function integral, quotient version .
+ * integral(num/den) = pol + sum_rat( rat_i/rat_{i+1} ) + sum_log( a_i log ( d_i
+ * ) )
+ * @author Heinz Kredel
+ * @param <C> coefficient type
+ */
+
+public class QuotIntegral<C extends GcdRingElem<C>> implements Serializable {
+
+
+    /**
+     * Original rational function with coefficients from C.
+     */
+    public final Quotient<C> quot;
+
+
+    /**
+     * Integral of the polynomial and rational part.
+     */
+    public final List<Quotient<C>> rational;
+
+
+    /**
+     * Integral of the logarithmic part.
+     */
+    public final List<LogIntegral<C>> logarithm;
+
+
+    /**
+     * Constructor.
+     * @param ri integral.
+     */
+    public QuotIntegral(Integral<C> ri) {
+        this(new QuotientRing<C>(ri.den.ring), ri);
+    }
+
+
+    /**
+     * Constructor.
+     * @param r rational function QuotientRing over C.
+     * @param ri integral.
+     */
+    public QuotIntegral(QuotientRing<C> r, Integral<C> ri) {
+        this(new Quotient<C>(r, ri.num, ri.den), ri.pol, ri.rational, ri.logarithm);
+    }
+
+
+    /**
+     * Constructor.
+     * @param r rational function Quotient over C.
+     * @param p integral of polynomial part.
+     * @param rat list of rational integrals.
+     */
+    public QuotIntegral(Quotient<C> r, GenPolynomial<C> p, List<GenPolynomial<C>> rat) {
+        this(r, p, rat, new ArrayList<LogIntegral<C>>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param r rational function Quotient over C.
+     * @param p integral of polynomial part.
+     * @param rat list of rational integrals.
+     * @param log list of logarithmic part.
+     */
+    public QuotIntegral(Quotient<C> r, GenPolynomial<C> p, List<GenPolynomial<C>> rat,
+                    List<LogIntegral<C>> log) {
+        quot = r;
+        QuotientRing<C> qr = r.ring;
+        rational = new ArrayList<Quotient<C>>();
+        if (!p.isZERO()) {
+            rational.add(new Quotient<C>(qr, p));
+        }
+        for (int i = 0; i < rat.size(); i++) {
+            GenPolynomial<C> rn = rat.get(i++);
+            GenPolynomial<C> rd = rat.get(i);
+            rational.add(new Quotient<C>(qr, rn, rd));
+        }
+        logarithm = log;
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        sb.append("integral( " + quot.toString() + " )");
+        sb.append(" =\n");
+        boolean first = true;
+        if (rational.size() != 0) {
+            for (int i = 0; i < rational.size(); i++) {
+                if (first) {
+                    first = false;
+                } else {
+                    sb.append(" + ");
+                }
+                sb.append("(" + rational.get(i) + ")");
+            }
+        }
+        if (logarithm.size() != 0) {
+            if (rational.size() != 0) {
+                sb.append(" + ");
+            }
+            first = true;
+            for (LogIntegral<C> pf : logarithm) {
+                if (first) {
+                    first = false;
+                } else {
+                    sb.append(" + ");
+                }
+                sb.append(pf);
+            }
+            sb.append("\n");
+        }
+        return sb.toString();
+    }
+
+
+    /**
+     * Hash code for QuotIntegral.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h = quot.hashCode();
+        h = h * 37 + rational.hashCode();
+        h = h * 37 + logarithm.hashCode();
+        return h;
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object B) {
+        QuotIntegral<C> b = null;
+        try {
+            b = (QuotIntegral<C>) B;
+        } catch (ClassCastException ignored) {
+        }
+        if (b == null) {
+            return false;
+        }
+        return quot.equals(b.quot) && rational.equals(b.rational) && logarithm.equals(b.logarithm);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/integrate/package.html
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/integrate/package.html
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "../DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>Elementary Integration package</title>
+  </head>
+
+  <body>
+    <h1>Elementary Integration package.</h1>
+
+<p>
+  This package contains classes for elementary integration of 
+  (univariate) polynomials and rational functions. 
+</p>
+<p>
+  The implementation follows 
+  Bronstein <em>Symbolic Integration I - Transcendental Functions</em>.
+</p>
+
+    <hr />
+    <address><a href="mailto:kredel at rz.uni-mannheim.de">Heinz Kredel</a></address>
+<p>
+<!-- Created: Sun Nov  8 19:53:34 CET 2009 -->
+<!-- hhmts start -->
+Last modified: Fri Nov 27 22:23:52 CET 2009
+<!-- hhmts end -->
+</p>
+<p>$Id$ 
+</p>
+  </body>
+</html>

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/kern/ComputerThreads.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/kern/ComputerThreads.java
@@ -1,0 +1,227 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.kern;
+
+
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * ComputerThreads, provides global thread / executor service.
+ * <p>
+ * <b>Usage:</b> To obtain a reference to the thread pool use
+ * <code>ComputerThreads.getPool()</code>. Once a pool has been created it must
+ * be shutdown with <code>ComputerThreads.terminate()</code> to exit JAS.
+ * </p>
+ * @author Heinz Kredel
+ */
+
+public class ComputerThreads {
+
+
+    private static final Logger logger = LogManager.getLogger(ComputerThreads.class);
+
+
+    // private static final boolean debug = logger.isInfoEnabled(); //logger.isInfoEnabled();
+
+
+    /**
+     * Flag for thread usage. <b>Note:</b> Only introduced because Google app
+     * engine does not support threads.
+     * @see edu.jas.ufd.GCDFactory#getProxy(edu.jas.structure.RingFactory)
+     */
+    public static boolean NO_THREADS = false;
+
+
+    /**
+     * Number of processors.
+     */
+    public static final int N_CPUS = Runtime.getRuntime().availableProcessors();
+
+
+    /*
+      * Core number of threads.
+      * N_CPUS x 1.5, x 2, x 2.5, min 3, ?.
+      */
+    public static final int N_THREADS = (N_CPUS < 3 ? 3 : N_CPUS + N_CPUS / 2);
+
+
+    //public static final int N_THREADS = ( N_CPUS < 3 ? 5 : 3*N_CPUS );
+
+
+    /**
+     * Timeout for timed execution.
+     * @see edu.jas.fd.SGCDParallelProxy
+     */
+    static long timeout = 10L; //-1L;
+
+
+    /**
+     * TimeUnit for timed execution.
+     * @see edu.jas.fd.SGCDParallelProxy
+     */
+    static TimeUnit timeunit = TimeUnit.SECONDS;
+
+
+    /*
+      * Saturation policy.
+      */
+    //public static final RejectedExecutionHandler REH = new ThreadPoolExecutor.CallerRunsPolicy();
+    //public static final RejectedExecutionHandler REH = new ThreadPoolExecutor.AbortPolicy();
+
+    /**
+     * ExecutorService thread pool.
+     */
+    //static ThreadPoolExecutor pool = null;
+    static ExecutorService pool = null;
+
+
+    /**
+     * No public constructor.
+     */
+    private ComputerThreads() {
+    }
+
+
+    /**
+     * Test if a pool is running.
+     * @return true if a thread pool has been started or is running, else false.
+     */
+    public static synchronized boolean isRunning() {
+        if (pool == null) {
+            return false;
+        }
+        if (pool.isTerminated() || pool.isShutdown()) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Get the thread pool.
+     * @return pool ExecutorService.
+     */
+    public static synchronized ExecutorService getPool() {
+        if (pool == null) {
+            // workpile = new ArrayBlockingQueue<Runnable>(Q_CAPACITY);
+            //            pool = Executors.newFixedThreadPool(N_THREADS);
+            pool = Executors.newCachedThreadPool();
+            //             pool = new ThreadPoolExecutor(N_CPUS, N_THREADS,
+            //                                           100L, TimeUnit.MILLISECONDS,
+            //                                           workpile, REH);
+            //             pool = new ThreadPoolExecutor(N_CPUS, N_THREADS,
+            //                                           1000L, TimeUnit.MILLISECONDS,
+            //                                           workpile);
+        }
+        //System.out.println("pool_init = " + pool);
+        return pool;
+        //return Executors.unconfigurableExecutorService(pool);
+
+        /* not useful, is not run from jython
+        final GCDProxy<C> proxy = this;
+        Runtime.getRuntime().addShutdownHook( 
+                         new Thread() {
+                             public void run() {
+                                    logger.info("running shutdown hook");
+                                    proxy.terminate();
+                             }
+                         }
+        );
+        */
+    }
+
+
+    /**
+     * Stop execution.
+     */
+    public static synchronized void terminate() {
+        if (pool == null) {
+            return;
+        }
+        if (pool instanceof ThreadPoolExecutor) {
+            ThreadPoolExecutor tpe = (ThreadPoolExecutor) pool;
+            //logger.info("task queue size         " + Q_CAPACITY);
+            //logger.info("reject execution handler" + REH.getClass().getName());
+            logger.info("number of CPUs            " + N_CPUS);
+            logger.info("core number of threads    " + N_THREADS);
+            logger.info("current number of threads " + tpe.getPoolSize());
+            logger.info("maximal number of threads " + tpe.getLargestPoolSize());
+            BlockingQueue<Runnable> workpile = tpe.getQueue();
+            if (workpile != null) {
+                logger.info("queued tasks              " + workpile.size());
+            }
+            List<Runnable> r = tpe.shutdownNow();
+            if (r.size() != 0) {
+                logger.info("unfinished tasks          " + r.size());
+            }
+            logger.info("number of sheduled tasks  " + tpe.getTaskCount());
+            logger.info("number of completed tasks " + tpe.getCompletedTaskCount());
+        }
+        pool = null;
+        //workpile = null;
+    }
+
+
+    /**
+     * Set no thread usage.
+     */
+    public static synchronized void setNoThreads() {
+        NO_THREADS = true;
+    }
+
+
+    /**
+     * Set thread usage.
+     */
+    public static synchronized void setThreads() {
+        NO_THREADS = false;
+    }
+
+
+    /**
+     * Set timeout.
+     * @param t time value to set
+     */
+    public static synchronized void setTimeout(long t) {
+        timeout = t;
+    }
+
+
+    /**
+     * Get timeout.
+     * @return timeout value
+     */
+    public static synchronized long getTimeout() {
+        return timeout;
+    }
+
+
+    /**
+     * Set TimeUnit.
+     * @param t TimeUnit value to set
+     */
+    public static synchronized void setTimeUnit(TimeUnit t) {
+        timeunit = t;
+    }
+
+
+    /**
+     * Get TimeUnit.
+     * @return timeunit value
+     */
+    public static synchronized TimeUnit getTimeUnit() {
+        return timeunit;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/kern/PreemptStatus.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/kern/PreemptStatus.java
@@ -1,0 +1,53 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.kern;
+
+
+/**
+ * PreemptStatus, defines global status for preemptive interruption handling.
+ * @author Heinz Kredel
+ */
+
+public class PreemptStatus {
+
+
+    /**
+     * Global status flag.
+     */
+    private static boolean allowPreempt = true;
+
+
+    /**
+     * No public constructor.
+     */
+    protected PreemptStatus() {
+    }
+
+
+    /**
+     * isAllowed.
+     * @return true, preemtive interruption is allowed, else false.
+     */
+    public static boolean isAllowed() {
+        return allowPreempt;
+    }
+
+
+    /**
+     * setAllow, set preemtive interruption to allowed status.
+     */
+    public static void setAllow() {
+        allowPreempt = true;
+    }
+
+
+    /**
+     * setNotAllow, set preemtive interruption to not allowed status.
+     */
+    public static void setNotAllow() {
+        allowPreempt = false;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/kern/PreemptingException.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/kern/PreemptingException.java
@@ -1,0 +1,36 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.kern;
+
+
+/**
+ * Preempting Exception class. Runtime Exception to be thrown when a thread is
+ * interrupted.
+ * @author Heinz Kredel
+ */
+
+public class PreemptingException extends RuntimeException {
+
+
+    public PreemptingException() {
+        super("PreemptingException");
+    }
+
+
+    public PreemptingException(String c) {
+        super(c);
+    }
+
+
+    public PreemptingException(String c, Throwable t) {
+        super(c, t);
+    }
+
+
+    public PreemptingException(Throwable t) {
+        super("PreemptingException", t);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/kern/PrettyPrint.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/kern/PrettyPrint.java
@@ -1,0 +1,47 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.kern;
+
+
+/**
+ * PrettyPrint, defines global pretty print status.
+ * @author Heinz Kredel
+ */
+
+public class PrettyPrint {
+
+
+    private static volatile boolean doPretty = true;
+
+
+    protected PrettyPrint() {
+    }
+
+
+    /**
+     * isTrue.
+     * @return true, if to use pretty printing, else false.
+     */
+    public static boolean isTrue() {
+        return doPretty;
+    }
+
+
+    /**
+     * setPretty. Set use pretty printing to true.
+     */
+    public static void setPretty() {
+        doPretty = true;
+    }
+
+
+    /**
+     * setInternal. Set use pretty printing to false.
+     */
+    public static void setInternal() {
+        doPretty = false;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/kern/Scripting.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/kern/Scripting.java
@@ -1,0 +1,101 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.kern;
+
+
+/**
+ * Scripting, defines script language for output in toScript() method.
+ * @author Heinz Kredel
+ */
+
+public class Scripting {
+
+
+    public static enum Lang {
+        Python, Ruby
+    };
+
+
+    private static Lang script = Lang.Python;
+
+
+    public static enum CAS {
+        JAS, Math, Sage, Singular
+    };
+
+
+    private static CAS cas = CAS.JAS;
+
+
+    private static int precision = -1; // == fraction output
+
+
+    protected Scripting() {
+    }
+
+
+    /**
+     * Get scripting language which is in effect.
+     * @return language which is to be used for toScript().
+     */
+    public static Lang getLang() {
+        return script;
+    }
+
+
+    /**
+     * Set scripting language.
+     * @param s language which is to be used for toScript()
+     * @return old language setting.
+     */
+    public static Lang setLang(Lang s) {
+        Lang o = script;
+        script = s;
+        return o;
+    }
+
+
+    /**
+     * Get CAS for Order which is in effect.
+     * @return CAS which is to be used for toScript().
+     */
+    public static CAS getCAS() {
+        return cas;
+    }
+
+
+    /**
+     * Set CAS for order.
+     * @param s CAS which is to be used for toScript()
+     * @return old CAS setting.
+     */
+    public static CAS setCAS(CAS s) {
+        CAS o = cas;
+        cas = s;
+        return o;
+    }
+
+
+    /**
+     * Get decimal approximation precision for scripting.
+     * @return number of decimals after '.'.
+     */
+    public static int getPrecision() {
+        return precision;
+    }
+
+
+    /**
+     * Set decimal approximation precision for scripting.
+     * @param p number of decimals after '.'
+     * @return old number of decimals after '.'.
+     */
+    public static int setPrecision(int p) {
+        int o = precision;
+        precision = p;
+        return o;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/kern/StringUtil.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/kern/StringUtil.java
@@ -1,0 +1,136 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.kern;
+
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringWriter;
+
+
+/**
+ * Static String and Reader methods.
+ * @author Heinz Kredel
+ */
+
+public class StringUtil {
+
+
+    /**
+     * Parse white space delimited String from Reader.
+     * @param r Reader.
+     * @return next non white space String from r.
+     */
+    public static String nextString(Reader r) {
+        StringWriter sw = new StringWriter();
+        try {
+            char buffer;
+            int i;
+            // skip white space
+            while ((i = r.read()) > -1) {
+                buffer = (char) i;
+                if (!Character.isWhitespace(buffer)) {
+                    sw.write(buffer);
+                    break;
+                }
+            }
+            // read non white space, ignore new lines ?
+            while ((i = r.read()) > -1) {
+                buffer = (char) i;
+                if (Character.isWhitespace(buffer)) {
+                    break;
+                }
+                sw.write(buffer);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return sw.toString();
+    }
+
+
+    /**
+     * Parse String with given delimiter from Reader.
+     * @param c delimiter.
+     * @param r Reader.
+     * @return next String up to c from r.
+     */
+    public static String nextString(Reader r, char c) {
+        StringWriter sw = new StringWriter();
+        try {
+            char buffer;
+            int i;
+            // read chars != c, ignore new lines ?
+            while ((i = r.read()) > -1) {
+                buffer = (char) i;
+                if (buffer == c) {
+                    break;
+                }
+                sw.write(buffer);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return sw.toString();
+    }
+
+
+    /**
+     * Parse paired String with given delimiters from Reader.
+     * @param b opposite delimiter.
+     * @param c delimiter.
+     * @param r Reader.
+     * @return next nested matching String up to c from r.
+     */
+    public static String nextPairedString(Reader r, char b, char c) {
+        StringWriter sw = new StringWriter();
+        try {
+            int level = 0;
+            char buffer;
+            int i;
+            // read chars != c, ignore new lines ?
+            while ((i = r.read()) > -1) {
+                buffer = (char) i;
+                if (buffer == b) {
+                    level++;
+                }
+                if (buffer == c) {
+                    level--;
+                    if (level < 0) {
+                        break; // skip last closing 'brace' 
+                    }
+                }
+                sw.write(buffer);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return sw.toString();
+    }
+
+
+    /**
+     * Select stack trace parts.
+     * @param expr regular matching expression.
+     * @return stack trace with elements matching expr.
+     */
+    public static String selectStackTrace(String expr) {
+        StackTraceElement[] stack = Thread.currentThread().getStackTrace();
+        StringBuffer sb = new StringBuffer();
+        for (int i = 0; i < stack.length; i++) {
+            String s = stack[i].toString();
+            if (s.indexOf("selectStackTrace") >= 0) {
+                continue;
+            }
+            if (s.matches(expr)) {
+                sb.append("\nstack[" + i + "] = ");
+                sb.append(s);
+            }
+            //System.out.println("stack["+i+"] = " + s);
+        }
+        return sb.toString();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/kern/TimeExceededException.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/kern/TimeExceededException.java
@@ -1,0 +1,36 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.kern;
+
+
+/**
+ * Time exceeded exception class. Runtime Exception to be thrown when the
+ * run-time has exceeded a certain limit.
+ * @author Heinz Kredel
+ */
+
+public class TimeExceededException extends RuntimeException {
+
+
+    public TimeExceededException() {
+        super("TimeExceededException");
+    }
+
+
+    public TimeExceededException(String c) {
+        super(c);
+    }
+
+
+    public TimeExceededException(String c, Throwable t) {
+        super(c, t);
+    }
+
+
+    public TimeExceededException(Throwable t) {
+        super("TimeExceededException", t);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/kern/TimeStatus.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/kern/TimeStatus.java
@@ -1,0 +1,131 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.kern;
+
+
+import java.util.concurrent.Callable;
+
+
+/**
+ * Run-time status, defines global status and handling for run time limits.
+ * @author Heinz Kredel
+ */
+
+public class TimeStatus {
+
+
+    /**
+     * Global status flag.
+     */
+    private static boolean allowTime = false;
+
+
+    /**
+     * Global run-time limit in milliseconds.
+     */
+    private static long limitTime = Long.MAX_VALUE;
+
+
+    /**
+     * Global run-time limit in milliseconds.
+     */
+    private static long startTime = System.currentTimeMillis();
+
+
+    /**
+     * Call back method. true means continue, false means throw exception.
+     */
+    private static Callable<Boolean> callBack = null;
+
+
+    /**
+     * No public constructor.
+     */
+    protected TimeStatus() {
+    }
+
+
+    /**
+     * isActive.
+     * @return true, if run-time interruption is active, else false.
+     */
+    public static boolean isActive() {
+        return allowTime;
+    }
+
+
+    /**
+     * setAllow, set run-time interruption to allowed status.
+     */
+    public static void setActive() {
+        allowTime = true;
+    }
+
+
+    /**
+     * setNotActive, set run-time interruption to not active status.
+     */
+    public static void setNotActive() {
+        allowTime = false;
+    }
+
+
+    /**
+     * setLimit, set run-time limit in milliseconds.
+     */
+    public static void setLimit(long t) {
+        limitTime = t;
+    }
+
+
+    /**
+     * Restart timer, set run-time to current time.
+     */
+    public static void restart() {
+        startTime = System.currentTimeMillis();
+    }
+
+
+    /**
+     * set call back, set the Callabe object.
+     */
+    public static void setCallBack(Callable<Boolean> cb) {
+        callBack = cb;
+    }
+
+
+    /**
+     * Check for exceeded time, test if time has exceeded and throw an exception
+     * if so.
+     * @param msg the message to be send with the exception.
+     */
+    public static void checkTime(String msg) {
+        if (!allowTime) {
+            return;
+        }
+        if (limitTime == Long.MAX_VALUE) {
+            return;
+        }
+        long tt = (System.currentTimeMillis() - startTime - limitTime);
+        //System.out.println("tt  = " + tt);
+        if (tt <= 0L) {
+            return;
+        }
+        if (callBack != null) {
+            try {
+                boolean t = callBack.call();
+                if (t) {
+                    return;
+                }
+            } catch (Exception e) {
+            }
+        }
+        if (msg == null) {
+            msg = "";
+        }
+        throw new TimeExceededException(msg + " over time = " + tt);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/kern/package.html
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/kern/package.html
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "../DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>JAS run-time kernel package</title>
+  </head>
+
+  <body>
+    <h1>JAS run-time kernel package.</h1>
+
+<p>
+  This package contains classes used in global execution of all JAS packages.
+  E.g. <code>PrettyPrint</code> is used to control the print (i.e. the toString()) 
+  of many classes.
+  <code>PreemptingException</code> and <code>PreemptStatus</code> 
+  are used to preemptively cancel long running computations.
+</p>
+
+
+    <hr />
+    <address><a href="mailto:kredel at rz.uni-mannheim.de">Heinz Kredel</a></address>
+<p>
+<!-- Created: Wed Jul 11 17:50:57 CEST 2007 -->
+<!-- hhmts start -->
+Last modified: Wed Jul 11 19:06:14 CEST 2007
+<!-- hhmts end -->
+</p>
+<p>$Id$ 
+</p>
+  </body>
+</html>

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/AlgebraicNotInvertibleException.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/AlgebraicNotInvertibleException.java
@@ -1,0 +1,120 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import edu.jas.structure.NotInvertibleException;
+
+
+/**
+ * Algebraic number NotInvertibleException class. Runtime Exception to be thrown
+ * for not invertible algebraic numbers. Container for the non-trivial factors
+ * found by the inversion algorithm. <b>Note: </b> cannot be generic because of
+ * Throwable.
+ * @author Heinz Kredel
+ */
+public class AlgebraicNotInvertibleException extends NotInvertibleException {
+
+
+    public final GenPolynomial f; // = f1 * f2
+
+
+    public final GenPolynomial f1;
+
+
+    public final GenPolynomial f2;
+
+
+    public AlgebraicNotInvertibleException() {
+        this(null, null, null);
+    }
+
+
+    public AlgebraicNotInvertibleException(String c) {
+        this(c, null, null, null);
+    }
+
+
+    public AlgebraicNotInvertibleException(String c, Throwable t) {
+        this(c, t, null, null, null);
+    }
+
+
+    public AlgebraicNotInvertibleException(Throwable t) {
+        this(t, null, null, null);
+    }
+
+
+    /**
+     * Constructor.
+     * @param f polynomial with f = f1 * f2.
+     * @param f1 polynomial.
+     * @param f2 polynomial.
+     */
+    public AlgebraicNotInvertibleException(GenPolynomial f, GenPolynomial f1, GenPolynomial f2) {
+        super("AlgebraicNotInvertibleException");
+        this.f = f;
+        this.f1 = f1;
+        this.f2 = f2;
+    }
+
+
+    /**
+     * Constructor.
+     * @param f polynomial with f = f1 * f2.
+     * @param f1 polynomial.
+     * @param f2 polynomial.
+     */
+    public AlgebraicNotInvertibleException(String c, GenPolynomial f, GenPolynomial f1, GenPolynomial f2) {
+        super(c);
+        this.f = f;
+        this.f1 = f1;
+        this.f2 = f2;
+    }
+
+
+    /**
+     * Constructor.
+     * @param f polynomial with f = f1 * f2.
+     * @param f1 polynomial.
+     * @param f2 polynomial.
+     */
+    public AlgebraicNotInvertibleException(String c, Throwable t, GenPolynomial f, GenPolynomial f1,
+                    GenPolynomial f2) {
+        super(c, t);
+        this.f = f;
+        this.f1 = f1;
+        this.f2 = f2;
+    }
+
+
+    /**
+     * Constructor.
+     * @param f polynomial with f = f1 * f2.
+     * @param f1 polynomial.
+     * @param f2 polynomial.
+     */
+    public AlgebraicNotInvertibleException(Throwable t, GenPolynomial f, GenPolynomial f1, GenPolynomial f2) {
+        super("AlgebraicNotInvertibleException", t);
+        this.f = f;
+        this.f1 = f1;
+        this.f2 = f2;
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        String s = super.toString();
+        if (f != null || f1 != null || f2 != null) {
+            s += ", f = " + f + ", f1 = " + f1 + ", f2 = " + f2;
+        }
+        return s;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/AlgebraicNumber.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/AlgebraicNumber.java
@@ -1,0 +1,515 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import edu.jas.kern.PrettyPrint;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.NotInvertibleException;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Algebraic number class. Based on GenPolynomial with RingElem interface.
+ * Objects of this class are immutable.
+ * @author Heinz Kredel
+ */
+
+public class AlgebraicNumber<C extends RingElem<C>> implements GcdRingElem<AlgebraicNumber<C>> {
+
+
+    /**
+     * Ring part of the data structure.
+     */
+    public final AlgebraicNumberRing<C> ring;
+
+
+    /**
+     * Value part of the element data structure.
+     */
+    public final GenPolynomial<C> val;
+
+
+    /**
+     * Flag to remember if this algebraic number is a unit. -1 is unknown, 1 is
+     * unit, 0 not a unit.
+     */
+    protected int isunit = -1; // initially unknown
+
+
+    /**
+     * The constructor creates a AlgebraicNumber object from AlgebraicNumberRing
+     * modul and a GenPolynomial value.
+     * @param r ring AlgebraicNumberRing<C>.
+     * @param a value GenPolynomial<C>.
+     */
+    public AlgebraicNumber(AlgebraicNumberRing<C> r, GenPolynomial<C> a) {
+        ring = r; // assert r != 0
+        val = a.remainder(ring.modul); //.monic() no go
+        if (val.isZERO()) {
+            isunit = 0;
+        }
+        if (ring.isField()) {
+            isunit = 1;
+        }
+    }
+
+
+    /**
+     * The constructor creates a AlgebraicNumber object from a GenPolynomial
+     * object module.
+     * @param r ring AlgebraicNumberRing<C>.
+     */
+    public AlgebraicNumber(AlgebraicNumberRing<C> r) {
+        this(r, r.ring.getZERO());
+    }
+
+
+    /**
+     * Get the value part.
+     * @return val.
+     */
+    public GenPolynomial<C> getVal() {
+        return val;
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public AlgebraicNumberRing<C> factory() {
+        return ring;
+    }
+
+
+    /**
+     * Copy this.
+     * @see edu.jas.structure.Element#copy()
+     */
+    @Override
+    public AlgebraicNumber<C> copy() {
+        return new AlgebraicNumber<C>(ring, val);
+    }
+
+
+    /**
+     * Is AlgebraicNumber zero.
+     * @return If this is 0 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isZERO()
+     */
+    public boolean isZERO() {
+        return val.equals(ring.ring.getZERO());
+    }
+
+
+    /**
+     * Is AlgebraicNumber one.
+     * @return If this is 1 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isONE()
+     */
+    public boolean isONE() {
+        return val.equals(ring.ring.getONE());
+    }
+
+
+    /**
+     * Is AlgebraicNumber unit.
+     * @return If this is a unit then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isUnit()
+     */
+    public boolean isUnit() {
+        if (isunit > 0) {
+            return true;
+        }
+        if (isunit == 0) {
+            return false;
+        }
+        // not jet known
+        if (val.isZERO()) {
+            isunit = 0;
+            return false;
+        }
+        if (ring.isField()) {
+            isunit = 1;
+            return true;
+        }
+        boolean u = val.gcd(ring.modul).isUnit();
+        if (u) {
+            isunit = 1;
+        } else {
+            isunit = 0;
+        }
+        return u;
+    }
+
+
+    /**
+     * Is AlgebraicNumber a root of unity.
+     * @return true if |this**i| == 1, for some 0 &lt; i &le; deg(modul), else
+     *         false.
+     */
+    public boolean isRootOfUnity() {
+        long d = ring.modul.degree();
+        AlgebraicNumber<C> t = ring.getONE();
+        for (long i = 1; i <= d; i++) {
+            t = t.multiply(this);
+            if (t.abs().isONE()) {
+                //System.out.println("isRootOfUnity for i = " + i);
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    /**
+     * Get the String representation as RingElem.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        if (PrettyPrint.isTrue()) {
+            return val.toString(ring.ring.vars);
+        }
+        return "AlgebraicNumber[ " + val.toString() + " ]";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        return val.toScript();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python case
+        return factory().toScript();
+    }
+
+
+    /**
+     * AlgebraicNumber comparison.
+     * @param b AlgebraicNumber.
+     * @return sign(this-b).
+     */
+    @Override
+    public int compareTo(AlgebraicNumber<C> b) {
+        int s = 0;
+        if (ring.modul != b.ring.modul) { // avoid compareTo if possible
+            s = ring.modul.compareTo(b.ring.modul);
+        }
+        if (s != 0) {
+            return s;
+        }
+        return val.compareTo(b.val);
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (b == null) {
+            return false;
+        }
+        if (!(b instanceof AlgebraicNumber)) {
+            return false;
+        }
+        AlgebraicNumber<C> a = (AlgebraicNumber<C>) b;
+        if (!ring.equals(a.ring)) {
+            return false;
+        }
+        return (0 == compareTo(a));
+    }
+
+
+    /**
+     * Hash code for this AlgebraicNumber.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return 37 * val.hashCode() + ring.hashCode();
+    }
+
+
+    /**
+     * AlgebraicNumber absolute value.
+     * @return the absolute value of this.
+     * @see edu.jas.structure.RingElem#abs()
+     */
+    public AlgebraicNumber<C> abs() {
+        return new AlgebraicNumber<C>(ring, val.abs());
+    }
+
+
+    /**
+     * AlgebraicNumber summation.
+     * @param S AlgebraicNumber.
+     * @return this+S.
+     */
+    public AlgebraicNumber<C> sum(AlgebraicNumber<C> S) {
+        return new AlgebraicNumber<C>(ring, val.sum(S.val));
+    }
+
+
+    /**
+     * AlgebraicNumber summation.
+     * @param c coefficient.
+     * @return this+c.
+     */
+    public AlgebraicNumber<C> sum(GenPolynomial<C> c) {
+        return new AlgebraicNumber<C>(ring, val.sum(c));
+    }
+
+
+    /**
+     * AlgebraicNumber summation.
+     * @param c polynomial.
+     * @return this+c.
+     */
+    public AlgebraicNumber<C> sum(C c) {
+        return new AlgebraicNumber<C>(ring, val.sum(c));
+    }
+
+
+    /**
+     * AlgebraicNumber negate.
+     * @return -this.
+     * @see edu.jas.structure.RingElem#negate()
+     */
+    public AlgebraicNumber<C> negate() {
+        return new AlgebraicNumber<C>(ring, val.negate());
+    }
+
+
+    /**
+     * AlgebraicNumber signum.
+     * @see edu.jas.structure.RingElem#signum()
+     * @return signum(this).
+     */
+    public int signum() {
+        return val.signum();
+    }
+
+
+    /**
+     * AlgebraicNumber subtraction.
+     * @param S AlgebraicNumber.
+     * @return this-S.
+     */
+    public AlgebraicNumber<C> subtract(AlgebraicNumber<C> S) {
+        return new AlgebraicNumber<C>(ring, val.subtract(S.val));
+    }
+
+
+    /**
+     * AlgebraicNumber division.
+     * @param S AlgebraicNumber.
+     * @return this/S.
+     */
+    public AlgebraicNumber<C> divide(AlgebraicNumber<C> S) {
+        return multiply(S.inverse());
+    }
+
+
+    /**
+     * AlgebraicNumber inverse.
+     * @see edu.jas.structure.RingElem#inverse()
+     * @throws NotInvertibleException if the element is not invertible.
+     * @return S with S = 1/this if defined.
+     */
+    public AlgebraicNumber<C> inverse() {
+        try {
+            return new AlgebraicNumber<C>(ring, val.modInverse(ring.modul));
+        } catch (AlgebraicNotInvertibleException e) {
+            //System.out.println(e);
+            throw e;
+        } catch (NotInvertibleException e) {
+            throw new AlgebraicNotInvertibleException(e + ", val = " + val + ", modul = " + ring.modul
+                            + ", gcd = " + val.gcd(ring.modul), e);
+        }
+    }
+
+
+    /**
+     * AlgebraicNumber remainder.
+     * @param S AlgebraicNumber.
+     * @return this - (this/S)*S.
+     */
+    public AlgebraicNumber<C> remainder(AlgebraicNumber<C> S) {
+        if (S == null || S.isZERO()) {
+            throw new ArithmeticException("division by zero");
+        }
+        if (S.isONE()) {
+            return ring.getZERO();
+        }
+        if (S.isUnit()) {
+            return ring.getZERO();
+        }
+        GenPolynomial<C> x = val.remainder(S.val);
+        return new AlgebraicNumber<C>(ring, x);
+    }
+
+
+    /**
+     * Quotient and remainder by division of this by S.
+     * @param S a AlgebraicNumber
+     * @return [this/S, this - (this/S)*S].
+     */
+    @SuppressWarnings("unchecked")
+    public AlgebraicNumber<C>[] quotientRemainder(AlgebraicNumber<C> S) {
+        return new AlgebraicNumber[] { divide(S), remainder(S) };
+    }
+
+
+    /**
+     * AlgebraicNumber multiplication.
+     * @param S AlgebraicNumber.
+     * @return this*S.
+     */
+    public AlgebraicNumber<C> multiply(AlgebraicNumber<C> S) {
+        GenPolynomial<C> x = val.multiply(S.val);
+        return new AlgebraicNumber<C>(ring, x);
+    }
+
+
+    /**
+     * AlgebraicNumber multiplication.
+     * @param c coefficient.
+     * @return this*c.
+     */
+    public AlgebraicNumber<C> multiply(C c) {
+        GenPolynomial<C> x = val.multiply(c);
+        return new AlgebraicNumber<C>(ring, x);
+    }
+
+
+    /**
+     * AlgebraicNumber multiplication.
+     * @param c polynomial.
+     * @return this*c.
+     */
+    public AlgebraicNumber<C> multiply(GenPolynomial<C> c) {
+        GenPolynomial<C> x = val.multiply(c);
+        return new AlgebraicNumber<C>(ring, x);
+    }
+
+
+    /**
+     * AlgebraicNumber monic.
+     * @return this with monic value part.
+     */
+    public AlgebraicNumber<C> monic() {
+        return new AlgebraicNumber<C>(ring, val.monic());
+    }
+
+
+    /**
+     * AlgebraicNumber greatest common divisor.
+     * @param S AlgebraicNumber.
+     * @return gcd(this,S).
+     */
+    public AlgebraicNumber<C> gcd(AlgebraicNumber<C> S) {
+        if (S.isZERO()) {
+            return this;
+        }
+        if (isZERO()) {
+            return S;
+        }
+        if (isUnit() || S.isUnit()) {
+            return ring.getONE();
+        }
+        return new AlgebraicNumber<C>(ring, val.gcd(S.val));
+    }
+
+
+    /**
+     * AlgebraicNumber extended greatest common divisor.
+     * @param S AlgebraicNumber.
+     * @return [ gcd(this,S), a, b ] with a*this + b*S = gcd(this,S).
+     */
+    @SuppressWarnings("unchecked")
+    public AlgebraicNumber<C>[] egcd(AlgebraicNumber<C> S) {
+        AlgebraicNumber<C>[] ret = new AlgebraicNumber[3];
+        ret[0] = null;
+        ret[1] = null;
+        ret[2] = null;
+        if (S == null || S.isZERO()) {
+            ret[0] = this;
+            return ret;
+        }
+        if (isZERO()) {
+            ret[0] = S;
+            return ret;
+        }
+        if (this.isUnit() || S.isUnit()) {
+            ret[0] = ring.getONE();
+            if (this.isUnit() && S.isUnit()) {
+                AlgebraicNumber<C> half = ring.fromInteger(2).inverse();
+                ret[1] = this.inverse().multiply(half);
+                ret[2] = S.inverse().multiply(half);
+                return ret;
+            }
+            if (this.isUnit()) {
+                // oder inverse(S-1)?
+                ret[1] = this.inverse();
+                ret[2] = ring.getZERO();
+                return ret;
+            }
+            // if ( S.isUnit() ) {
+            // oder inverse(this-1)?
+            ret[1] = ring.getZERO();
+            ret[2] = S.inverse();
+            return ret;
+            //}
+        }
+        //System.out.println("this = " + this + ", S = " + S);
+        GenPolynomial<C>[] qr;
+        GenPolynomial<C> q = this.val;
+        GenPolynomial<C> r = S.val;
+        GenPolynomial<C> c1 = ring.ring.getONE();
+        GenPolynomial<C> d1 = ring.ring.getZERO();
+        GenPolynomial<C> c2 = ring.ring.getZERO();
+        GenPolynomial<C> d2 = ring.ring.getONE();
+        GenPolynomial<C> x1;
+        GenPolynomial<C> x2;
+        while (!r.isZERO()) {
+            qr = q.quotientRemainder(r);
+            q = qr[0];
+            x1 = c1.subtract(q.multiply(d1));
+            x2 = c2.subtract(q.multiply(d2));
+            c1 = d1;
+            c2 = d2;
+            d1 = x1;
+            d2 = x2;
+            q = r;
+            r = qr[1];
+        }
+        //System.out.println("q = " + q + "\n c1 = " + c1 + "\n c2 = " + c2);
+        ret[0] = new AlgebraicNumber<C>(ring, q);
+        ret[1] = new AlgebraicNumber<C>(ring, c1);
+        ret[2] = new AlgebraicNumber<C>(ring, c2);
+        return ret;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/AlgebraicNumberRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/AlgebraicNumberRing.java
@@ -1,0 +1,627 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.kern.Scripting;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.util.CartesianProduct;
+import edu.jas.util.CartesianProductInfinite;
+
+
+/**
+ * Algebraic number factory. Based on GenPolynomial factory with RingElem
+ * interface. Objects of this class are immutable.
+ * @author Heinz Kredel
+ */
+
+public class AlgebraicNumberRing<C extends RingElem<C>>
+                implements RingFactory<AlgebraicNumber<C>>, Iterable<AlgebraicNumber<C>> {
+
+
+    /**
+     * Ring part of the factory data structure.
+     */
+    public final GenPolynomialRing<C> ring;
+
+
+    /**
+     * Module part of the factory data structure.
+     */
+    public final GenPolynomial<C> modul;
+
+
+    /**
+     * Indicator if this ring is a field
+     */
+    protected int isField = -1; // initially unknown
+
+
+    private static final Logger logger = LogManager.getLogger(AlgebraicNumberRing.class);
+
+
+    //  private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * The constructor creates a AlgebraicNumber factory object from a
+     * GenPolynomial objects module.
+     * @param m module GenPolynomial<C>.
+     */
+    public AlgebraicNumberRing(GenPolynomial<C> m) {
+        ring = m.ring;
+        modul = m; // assert m != 0
+        if (ring.nvar > 1) {
+            throw new IllegalArgumentException("only univariate polynomials allowed");
+        }
+    }
+
+
+    /**
+     * The constructor creates a AlgebraicNumber factory object from a
+     * GenPolynomial objects module.
+     * @param m module GenPolynomial<C>.
+     * @param isField indicator if m is prime.
+     */
+    public AlgebraicNumberRing(GenPolynomial<C> m, boolean isField) {
+        ring = m.ring;
+        modul = m; // assert m != 0
+        this.isField = (isField ? 1 : 0);
+        if (ring.nvar > 1) {
+            throw new IllegalArgumentException("only univariate polynomials allowed");
+        }
+    }
+
+
+    /**
+     * Get the module part.
+     * @return modul.
+     */
+    public GenPolynomial<C> getModul() {
+        return modul;
+    }
+
+
+    /**
+     * Copy AlgebraicNumber element c.
+     * @param c algebraic number to copy.
+     * @return a copy of c.
+     */
+    public AlgebraicNumber<C> copy(AlgebraicNumber<C> c) {
+        return new AlgebraicNumber<C>(this, c.val);
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as AlgebraicNumber.
+     */
+    public AlgebraicNumber<C> getZERO() {
+        return new AlgebraicNumber<C>(this, ring.getZERO());
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as AlgebraicNumber.
+     */
+    public AlgebraicNumber<C> getONE() {
+        return new AlgebraicNumber<C>(this, ring.getONE());
+    }
+
+
+    /**
+     * Get the generating element.
+     * @return alpha as AlgebraicNumber.
+     */
+    public AlgebraicNumber<C> getGenerator() {
+        return new AlgebraicNumber<C>(this, ring.univariate(0));
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     * @see edu.jas.structure.ElemFactory#generators()
+     */
+    public List<AlgebraicNumber<C>> generators() {
+        List<GenPolynomial<C>> gc = ring.generators();
+        List<AlgebraicNumber<C>> gens = new ArrayList<AlgebraicNumber<C>>(gc.size());
+        for (GenPolynomial<C> g : gc) {
+            gens.add(new AlgebraicNumber<C>(this, g));
+        }
+        return gens;
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite()
+     */
+    public boolean isFinite() {
+        return ring.coFac.isFinite();
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true if this ring is commutative, else false.
+     */
+    public boolean isCommutative() {
+        return ring.isCommutative();
+    }
+
+
+    /**
+     * Query if this ring is associative.
+     * @return true if this ring is associative, else false.
+     */
+    public boolean isAssociative() {
+        return ring.isAssociative();
+    }
+
+
+    /**
+     * Query if this ring is a field.
+     * @return true if modul is prime, else false.
+     */
+    public boolean isField() {
+        if (isField > 0) {
+            return true;
+        }
+        if (isField == 0) {
+            return false;
+        }
+        if (!ring.coFac.isField()) {
+            isField = 0;
+            return false;
+        }
+        return false;
+    }
+
+
+    /**
+     * Set field property of this ring.
+     * @param field true, if this ring is determined to be a field, false, if it
+     *            is determined that it is not a field.
+     */
+    public void setField(boolean field) {
+        if (isField > 0 && field) {
+            return;
+        }
+        if (isField == 0 && !field) {
+            return;
+        }
+        if (field) {
+            isField = 1;
+        } else {
+            isField = 0;
+        }
+        return;
+    }
+
+
+    /**
+     * Get the internal field indicator.
+     * @return internal field indicator.
+     */
+    public int getField() {
+        return isField;
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic() {
+        return ring.characteristic();
+    }
+
+
+    /**
+     * Get an AlgebraicNumber element from a BigInteger value.
+     * If a = a_k p^k + ... + a_0 p^0 then b = a_k x^k + ... + a_0 x^0,
+     * where p = characteristic( this ).
+     * @param a BigInteger.
+     * @return b an AlgebraicNumber.
+     */
+    public AlgebraicNumber<C> fillFromInteger(java.math.BigInteger a) {
+        if (characteristic().signum() == 0) {
+            return new AlgebraicNumber<C>(this, ring.fromInteger(a));
+        }
+        java.math.BigInteger p = characteristic();
+        java.math.BigInteger b = a;
+        GenPolynomial<C> v = ring.getZERO();
+        GenPolynomial<C> x = ring.univariate(0, 1L);
+        GenPolynomial<C> t = ring.getONE();
+        do {
+            java.math.BigInteger[] qr = b.divideAndRemainder(p);
+            java.math.BigInteger q = qr[0];
+            java.math.BigInteger r = qr[1];
+            //System.out.println("q = " + q + ", r = " +r);
+            GenPolynomial<C> rp = ring.fromInteger(r);
+            v = v.sum(t.multiply(rp));
+            t = t.multiply(x);
+            b = q;
+        } while (!b.equals(java.math.BigInteger.ZERO));
+        AlgebraicNumber<C> an = new AlgebraicNumber<C>(this, v);
+        logger.info("fill(" + a + ") = " + v + ", mod: " + an);
+        //RuntimeException e = new RuntimeException("hihihi");
+        //e.printStackTrace();
+        return an;
+    }
+
+
+    /**
+     * Get a AlgebraicNumber element from a long value.
+     * @param a long.
+     * @return a AlgebraicNumber.
+     */
+    public AlgebraicNumber<C> fillFromInteger(long a) {
+        return fillFromInteger(new java.math.BigInteger("" + a));
+    }
+
+
+    /**
+     * Get a AlgebraicNumber element from a BigInteger value.
+     * @param a BigInteger.
+     * @return a AlgebraicNumber.
+     */
+    public AlgebraicNumber<C> fromInteger(java.math.BigInteger a) {
+        return new AlgebraicNumber<C>(this, ring.fromInteger(a));
+    }
+
+
+    /**
+     * Get a AlgebraicNumber element from a long value.
+     * @param a long.
+     * @return a AlgebraicNumber.
+     */
+    public AlgebraicNumber<C> fromInteger(long a) {
+        return new AlgebraicNumber<C>(this, ring.fromInteger(a));
+        //         if ( characteristic().signum() == 0 ) {
+        //         }
+        //         return fromInteger( new java.math.BigInteger(""+a) );
+    }
+
+
+    /**
+     * Get the String representation as RingFactory.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "AlgebraicNumberRing[ " + modul.toString() + " | isField=" + isField + " :: " + ring.toString()
+                        + " ]";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.ElemFactory#toScript()
+     */
+    @Override
+    public String toScript() {
+        StringBuffer s = new StringBuffer();
+        s.append("AN(");
+        s.append(modul.toScript());
+        switch (Scripting.getLang()) {
+        case Ruby:
+            s.append((isField() ? ",true" : ",false"));
+            break;
+        case Python:
+        default:
+            s.append((isField() ? ",True" : ",False"));
+        }
+        s.append(",");
+        s.append(ring.toScript());
+        s.append(")");
+        return s.toString();
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    // not jet working
+    public boolean equals(Object b) {
+        if (b == null) {
+            return false;
+        }
+        if (!(b instanceof AlgebraicNumberRing)) {
+            return false;
+        }
+        AlgebraicNumberRing<C> a = (AlgebraicNumberRing<C>) b;
+        return modul.equals(a.modul);
+    }
+
+
+    /**
+     * Hash code for this AlgebraicNumber.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return 37 * modul.hashCode() + ring.hashCode();
+    }
+
+
+    /**
+     * AlgebraicNumber random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @return a random integer mod modul.
+     */
+    public AlgebraicNumber<C> random(int n) {
+        GenPolynomial<C> x = ring.random(n).monic();
+        return new AlgebraicNumber<C>(this, x);
+    }
+
+
+    /**
+     * AlgebraicNumber random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @param rnd is a source for random bits.
+     * @return a random integer mod modul.
+     */
+    public AlgebraicNumber<C> random(int n, Random rnd) {
+        GenPolynomial<C> x = ring.random(n, rnd).monic();
+        return new AlgebraicNumber<C>(this, x);
+    }
+
+
+    /**
+     * Parse AlgebraicNumber from String.
+     * @param s String.
+     * @return AlgebraicNumber from s.
+     */
+    public AlgebraicNumber<C> parse(String s) {
+        GenPolynomial<C> x = ring.parse(s);
+        return new AlgebraicNumber<C>(this, x);
+    }
+
+
+    /**
+     * Parse AlgebraicNumber from Reader.
+     * @param r Reader.
+     * @return next AlgebraicNumber from r.
+     */
+    public AlgebraicNumber<C> parse(Reader r) {
+        GenPolynomial<C> x = ring.parse(r);
+        return new AlgebraicNumber<C>(this, x);
+    }
+
+
+    /**
+     * AlgebraicNumber chinese remainder algorithm. Assert deg(c.modul) &ge;
+     * deg(a.modul) and c.modul * a.modul = this.modul.
+     * @param c AlgebraicNumber.
+     * @param ci inverse of c.modul in ring of a.
+     * @param a other AlgebraicNumber.
+     * @return S, with S mod c.modul == c and S mod a.modul == a.
+     */
+    public AlgebraicNumber<C> chineseRemainder(AlgebraicNumber<C> c, AlgebraicNumber<C> ci,
+                    AlgebraicNumber<C> a) {
+        if (true) { // debug
+            if (c.ring.modul.compareTo(a.ring.modul) < 1) {
+                System.out.println("AlgebraicNumber error " + c + ", " + a);
+            }
+        }
+        AlgebraicNumber<C> b = new AlgebraicNumber<C>(a.ring, c.val);
+        // c mod a.modul
+        // c( tbcf(a.modul) ) if deg(a.modul)==1
+        AlgebraicNumber<C> d = a.subtract(b); // a-c mod a.modul
+        if (d.isZERO()) {
+            return new AlgebraicNumber<C>(this, c.val);
+        }
+        b = d.multiply(ci); // b = (a-c)*ci mod a.modul
+        // (c.modul*b)+c mod this.modul = c mod c.modul = 
+        // (c.modul*ci*(a-c)+c) mod a.modul = a mod a.modul
+        GenPolynomial<C> s = c.ring.modul.multiply(b.val);
+        s = s.sum(c.val);
+        return new AlgebraicNumber<C>(this, s);
+    }
+
+
+    /**
+     * AlgebraicNumber interpolation algorithm. Assert deg(c.modul) &ge;
+     * deg(A.modul) and c.modul * A.modul = this.modul. Special case with
+     * deg(A.modul) == 1. Similar algorithm as chinese remainder algortihm.
+     * @param c AlgebraicNumber.
+     * @param ci inverse of (c.modul)(a) in ring of A.
+     * @param am trailing base coefficient of modul of other AlgebraicNumber A.
+     * @param a value of other AlgebraicNumber A.
+     * @return S, with S(c) == c and S(A) == a.
+     */
+    public AlgebraicNumber<C> interpolate(AlgebraicNumber<C> c, C ci, C am, C a) {
+        C b = PolyUtil.<C> evaluateMain(ring.coFac /*a*/, c.val, am);
+        // c mod a.modul
+        // c( tbcf(a.modul) ) if deg(a.modul)==1
+        C d = a.subtract(b); // a-c mod a.modul
+        if (d.isZERO()) {
+            return new AlgebraicNumber<C>(this, c.val);
+        }
+        b = d.multiply(ci); // b = (a-c)*ci mod a.modul
+        // (c.modul*b)+c mod this.modul = c mod c.modul = 
+        // (c.modul*ci*(a-c)+c) mod a.modul = a mod a.modul
+        GenPolynomial<C> s = c.ring.modul.multiply(b);
+        s = s.sum(c.val);
+        return new AlgebraicNumber<C>(this, s);
+    }
+
+
+    /**
+     * Depth of extension field tower.
+     * @return number of nested algebraic extension fields
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    public int depth() {
+        AlgebraicNumberRing<C> arr = this;
+        int depth = 1;
+        RingFactory<C> cf = arr.ring.coFac;
+        if (cf instanceof AlgebraicNumberRing) {
+            arr = (AlgebraicNumberRing<C>) (Object) cf;
+            depth += arr.depth();
+        }
+        return depth;
+    }
+
+
+    /**
+     * Degree of extension field.
+     * @return degree of this algebraic extension field
+     */
+    public long extensionDegree() {
+        long degree = modul.degree(0);
+        return degree;
+    }
+
+
+    /**
+     * Total degree of nested extension fields.
+     * @return degree of tower of algebraic extension fields
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    public long totalExtensionDegree() {
+        long degree = modul.degree(0);
+        AlgebraicNumberRing<C> arr = this;
+        RingFactory<C> cf = arr.ring.coFac;
+        if (cf instanceof AlgebraicNumberRing) {
+            arr = (AlgebraicNumberRing<C>) (Object) cf;
+            if (degree == 0L) {
+                degree = arr.totalExtensionDegree();
+            } else {
+                degree *= arr.totalExtensionDegree();
+            }
+        }
+        return degree;
+    }
+
+
+    /**
+     * Get a AlgebraicNumber iterator. <b>Note: </b> Only for finite field
+     * coefficients or fields which are iterable.
+     * @return a iterator over all algebraic numbers in this ring.
+     */
+    public Iterator<AlgebraicNumber<C>> iterator() {
+        return new AlgebraicNumberIterator<C>(this);
+    }
+
+}
+
+
+/**
+ * Algebraic number iterator.
+ * @author Heinz Kredel
+ */
+class AlgebraicNumberIterator<C extends RingElem<C>> implements Iterator<AlgebraicNumber<C>> {
+
+
+    /**
+     * data structure.
+     */
+    final Iterator<List<C>> iter;
+
+
+    final List<GenPolynomial<C>> powers;
+
+
+    final AlgebraicNumberRing<C> aring;
+
+
+    private static final Logger logger = LogManager.getLogger(AlgebraicNumberIterator.class);
+
+
+    //  private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * CartesianProduct iterator constructor.
+     * @param aring AlgebraicNumberRing components of the Cartesian product.
+     */
+    @SuppressWarnings("unchecked")
+    public AlgebraicNumberIterator(AlgebraicNumberRing<C> aring) {
+        RingFactory<C> cf = aring.ring.coFac;
+        this.aring = aring;
+        long d = aring.modul.degree(0);
+        //System.out.println("d = " + d);
+        powers = new ArrayList<GenPolynomial<C>>((int) d);
+        for (long j = d - 1; j >= 0L; j--) {
+            powers.add(aring.ring.univariate(0, j));
+        }
+        //System.out.println("powers = " + powers);
+        if (!(cf instanceof Iterable)) {
+            throw new IllegalArgumentException("only for iterable coefficients implemented");
+        }
+        List<Iterable<C>> comps = new ArrayList<Iterable<C>>((int) d);
+        Iterable<C> cfi = (Iterable<C>) cf;
+        for (long j = 0L; j < d; j++) {
+            comps.add(cfi);
+        }
+        if (cf.isFinite()) {
+            CartesianProduct<C> tuples = new CartesianProduct<C>(comps);
+            iter = tuples.iterator();
+        } else {
+            CartesianProductInfinite<C> tuples = new CartesianProductInfinite<C>(comps);
+            iter = tuples.iterator();
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("iterator for degree " + d + ", finite = " + cf.isFinite());
+        }
+    }
+
+
+    /**
+     * Test for availability of a next tuple.
+     * @return true if the iteration has more tuples, else false.
+     */
+    public boolean hasNext() {
+        return iter.hasNext();
+    }
+
+
+    /**
+     * Get next tuple.
+     * @return next tuple.
+     */
+    public AlgebraicNumber<C> next() {
+        List<C> coeffs = iter.next();
+        //System.out.println("coeffs = " + coeffs);
+        GenPolynomial<C> pol = aring.ring.getZERO();
+        int i = 0;
+        for (GenPolynomial<C> f : powers) {
+            C c = coeffs.get(i++);
+            if (c.isZERO()) {
+                continue;
+            }
+            pol = pol.sum(f.multiply(c));
+        }
+        return new AlgebraicNumber<C>(aring, pol);
+    }
+
+
+    /**
+     * Remove a tuple if allowed.
+     */
+    public void remove() {
+        throw new UnsupportedOperationException("cannnot remove tuples");
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/Complex.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/Complex.java
@@ -1,0 +1,632 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.arith.BigComplex;
+import edu.jas.arith.BigDecimal;
+import edu.jas.arith.BigInteger;
+import edu.jas.arith.BigRational;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.StarRingElem;
+
+
+/**
+ * Generic Complex class implementing the RingElem interface. Objects of this
+ * class are immutable.
+ * @param <C> base type of RingElem (for complex polynomials).
+ * @author Heinz Kredel
+ */
+public class Complex<C extends RingElem<C>> implements StarRingElem<Complex<C>>, GcdRingElem<Complex<C>> {
+
+
+    private static final Logger logger = LogManager.getLogger(Complex.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Complex class factory data structure.
+     */
+    public final ComplexRing<C> ring;
+
+
+    /**
+     * Real part of the data structure.
+     */
+    protected final C re;
+
+
+    /**
+     * Imaginary part of the data structure.
+     */
+    protected final C im;
+
+
+    /**
+     * The constructor creates a Complex object from two C objects as real and
+     * imaginary part.
+     * @param ring factory for Complex objects.
+     * @param r real part.
+     * @param i imaginary part.
+     */
+    public Complex(ComplexRing<C> ring, C r, C i) {
+        this.ring = ring;
+        re = r;
+        im = i;
+    }
+
+
+    /**
+     * The constructor creates a Complex object from a C object as real part,
+     * the imaginary part is set to 0.
+     * @param r real part.
+     */
+    public Complex(ComplexRing<C> ring, C r) {
+        this(ring, r, ring.ring.getZERO());
+    }
+
+
+    /**
+     * The constructor creates a Complex object from a long element as real
+     * part, the imaginary part is set to 0.
+     * @param r real part.
+     */
+    public Complex(ComplexRing<C> ring, long r) {
+        this(ring, ring.ring.fromInteger(r));
+    }
+
+
+    /**
+     * The constructor creates a Complex object with real part 0 and imaginary
+     * part 0.
+     */
+    public Complex(ComplexRing<C> ring) {
+        this(ring, ring.ring.getZERO());
+    }
+
+
+    /**
+     * The constructor creates a Complex object from a String representation.
+     * @param s string of a Complex.
+     * @throws NumberFormatException
+     */
+    public Complex(ComplexRing<C> ring, String s) throws NumberFormatException {
+        this.ring = ring;
+        if (s == null || s.length() == 0) {
+            re = ring.ring.getZERO();
+            im = ring.ring.getZERO();
+            return;
+        }
+        s = s.trim();
+        int i = s.indexOf("i");
+        if (i < 0) {
+            re = ring.ring.parse(s);
+            im = ring.ring.getZERO();
+            return;
+        }
+        //logger.warn("String constructor not done");
+        String sr = "";
+        if (i > 0) {
+            sr = s.substring(0, i);
+        }
+        String si = "";
+        if (i < s.length()) {
+            si = s.substring(i + 1, s.length());
+        }
+        //int j = sr.indexOf("+");
+        re = ring.ring.parse(sr.trim());
+        im = ring.ring.parse(si.trim());
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public ComplexRing<C> factory() {
+        return ring;
+    }
+
+
+    /**
+     * Get the real part.
+     * @return re.
+     */
+    public C getRe() {
+        return re;
+    }
+
+
+    /**
+     * Get the imaginary part.
+     * @return im.
+     */
+    public C getIm() {
+        return im;
+    }
+
+
+    /**
+     * Copy this.
+     * @see edu.jas.structure.Element#copy()
+     */
+    @Override
+    public Complex<C> copy() {
+        return new Complex<C>(ring, re, im);
+    }
+
+
+    /**
+     * Get the String representation.
+     */
+    @Override
+    public String toString() {
+        String s = re.toString();
+        //logger.info("compareTo "+im+" ? 0 = "+i);
+        if (im.isZERO()) {
+            return s;
+        }
+        s += "i" + im;
+        return s;
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        StringBuffer s = new StringBuffer();
+        if (im.isZERO()) {
+            s.append(re.toScript());
+        } else {
+            C mi = im;
+            //s.append("");
+            if (!re.isZERO()) {
+                s.append(re.toScript());
+                if (mi.signum() > 0) {
+                    s.append(" + ");
+                } else {
+                    s.append(" - ");
+                    mi = mi.negate();
+                }
+            }
+            if (mi.isONE()) {
+                s.append("I");
+            } else {
+                s.append(mi.toScript()).append(" * I");
+            }
+            s.append("");
+        }
+        return s.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python case
+        return ring.toScript();
+    }
+
+
+    /**
+     * Is Complex number zero.
+     * @return If this is 0 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isZERO()
+     */
+    public boolean isZERO() {
+        return re.isZERO() && im.isZERO();
+    }
+
+
+    /**
+     * Is Complex number one.
+     * @return If this is 1 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isONE()
+     */
+    public boolean isONE() {
+        return re.isONE() && im.isZERO();
+    }
+
+
+    /**
+     * Is Complex imaginary one.
+     * @return If this is i then true is returned, else false.
+     */
+    public boolean isIMAG() {
+        return re.isZERO() && im.isONE();
+    }
+
+
+    /**
+     * Is Complex unit element.
+     * @return If this is a unit then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isUnit()
+     */
+    public boolean isUnit() {
+        if (isZERO()) {
+            return false;
+        }
+        if (ring.isField()) {
+            return true;
+        }
+        return norm().re.isUnit();
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (b == null) {
+            return false;
+        }
+        if (!(b instanceof Complex)) {
+            return false;
+        }
+        Complex<C> bc = (Complex<C>) b;
+        if (!ring.equals(bc.ring)) {
+            return false;
+        }
+        return re.equals(bc.re) && im.equals(bc.im);
+    }
+
+
+    /**
+     * Hash code for this Complex.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return 37 * re.hashCode() + im.hashCode();
+    }
+
+
+    /**
+     * Since complex numbers are unordered, we use lexicographical order of re
+     * and im.
+     * @return 0 if this is equal to b; 1 if re &gt; b.re, or re == b.re and im
+     *         &gt; b.im; -1 if re &lt; b.re, or re == b.re and im &lt; b.im
+     */
+    @Override
+    public int compareTo(Complex<C> b) {
+        int s = re.compareTo(b.re);
+        if (s != 0) {
+            return s;
+        }
+        return im.compareTo(b.im);
+    }
+
+
+    /**
+     * Since complex numbers are unordered, we use lexicographical order of re
+     * and im.
+     * @return 0 if this is equal to 0; 1 if re &gt; 0, or re == 0 and im &gt;
+     *         0; -1 if re &lt; 0, or re == 0 and im &lt; 0
+     * @see edu.jas.structure.RingElem#signum()
+     */
+    public int signum() {
+        int s = re.signum();
+        if (s != 0) {
+            return s;
+        }
+        return im.signum();
+    }
+
+
+    /* arithmetic operations: +, -, -
+     */
+
+    /**
+     * Complex number summation.
+     * @param B a Complex<C> number.
+     * @return this+B.
+     */
+    public Complex<C> sum(Complex<C> B) {
+        return new Complex<C>(ring, re.sum(B.re), im.sum(B.im));
+    }
+
+
+    /**
+     * Complex number subtract.
+     * @param B a Complex<C> number.
+     * @return this-B.
+     */
+    public Complex<C> subtract(Complex<C> B) {
+        return new Complex<C>(ring, re.subtract(B.re), im.subtract(B.im));
+    }
+
+
+    /**
+     * Complex number negative.
+     * @return -this.
+     * @see edu.jas.structure.RingElem#negate()
+     */
+    public Complex<C> negate() {
+        return new Complex<C>(ring, re.negate(), im.negate());
+    }
+
+
+    /* arithmetic operations: conjugate, absolut value 
+     */
+
+    /**
+     * Complex number conjugate.
+     * @return the complex conjugate of this.
+     */
+    public Complex<C> conjugate() {
+        return new Complex<C>(ring, re, im.negate());
+    }
+
+
+    /**
+     * Complex number norm.
+     * @see edu.jas.structure.StarRingElem#norm()
+     * @return ||this||.
+     */
+    public Complex<C> norm() {
+        // this.multiply(this.conjugate());
+        C v = re.multiply(re);
+        v = v.sum(im.multiply(im));
+        return new Complex<C>(ring, v);
+    }
+
+
+    /**
+     * Complex number absolute value.
+     * @see edu.jas.structure.RingElem#abs()
+     * @return |this|^2. <b>Note:</b> The square root is not jet implemented.
+     */
+    public Complex<C> abs() {
+        Complex<C> n = norm();
+        logger.error("abs() square root missing");
+        // n = n.sqrt();
+        return n;
+    }
+
+
+    /* arithmetic operations: *, inverse, / 
+     */
+
+
+    /**
+     * Complex number product.
+     * @param B is a complex number.
+     * @return this*B.
+     */
+    public Complex<C> multiply(Complex<C> B) {
+        return new Complex<C>(ring, re.multiply(B.re).subtract(im.multiply(B.im)),
+                        re.multiply(B.im).sum(im.multiply(B.re)));
+    }
+
+
+    /**
+     * Complex number inverse.
+     * @return S with S*this = 1, if it is defined.
+     * @see edu.jas.structure.RingElem#inverse()
+     */
+    public Complex<C> inverse() {
+        C a = norm().re.inverse();
+        return new Complex<C>(ring, re.multiply(a), im.multiply(a.negate()));
+    }
+
+
+    /**
+     * Complex number remainder.
+     * @param S is a complex number.
+     * @return 0.
+     */
+    public Complex<C> remainder(Complex<C> S) {
+        if (ring.isField()) {
+            return ring.getZERO();
+        }
+        return quotientRemainder(S)[1];
+    }
+
+
+    /**
+     * Complex number divide.
+     * @param B is a complex number, non-zero.
+     * @return this/B.
+     */
+    public Complex<C> divide(Complex<C> B) {
+        if (ring.isField()) {
+            return this.multiply(B.inverse());
+        }
+        return quotientRemainder(B)[0];
+    }
+
+
+    /**
+     * Complex number quotient and remainder.
+     * @param S Complex.
+     * @return Complex[] { q, r } with q = this/S and r = rem(this,S).
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    public Complex<C>[] quotientRemainder(Complex<C> S) {
+        Complex<C>[] ret = new Complex[2];
+        C n = S.norm().re;
+        Complex<C> Sp = this.multiply(S.conjugate()); // == this*inv(S)*n
+        C qr = Sp.re.divide(n);
+        C rr = Sp.re.remainder(n);
+        C qi = Sp.im.divide(n);
+        C ri = Sp.im.remainder(n);
+        C rr1 = rr;
+        C ri1 = ri;
+        if (rr.signum() < 0) {
+            rr = rr.negate();
+        }
+        if (ri.signum() < 0) {
+            ri = ri.negate();
+        }
+        C one = n.factory().fromInteger(1);
+        if (rr.sum(rr).compareTo(n) > 0) { // rr > n/2
+            if (rr1.signum() < 0) {
+                qr = qr.subtract(one);
+            } else {
+                qr = qr.sum(one);
+            }
+        }
+        if (ri.sum(ri).compareTo(n) > 0) { // ri > n/2
+            if (ri1.signum() < 0) {
+                qi = qi.subtract(one);
+            } else {
+                qi = qi.sum(one);
+            }
+        }
+        Sp = new Complex<C>(ring, qr, qi);
+        Complex<C> Rp = this.subtract(Sp.multiply(S));
+        if (debug && n.compareTo(Rp.norm().re) < 0) {
+            System.out.println("n = " + n);
+            System.out.println("qr   = " + qr);
+            System.out.println("qi   = " + qi);
+            System.out.println("rr   = " + rr);
+            System.out.println("ri   = " + ri);
+            System.out.println("rr1  = " + rr1);
+            System.out.println("ri1  = " + ri1);
+            System.out.println("this = " + this);
+            System.out.println("S    = " + S);
+            System.out.println("Sp   = " + Sp);
+            BigInteger tr = (BigInteger) (Object) this.re;
+            BigInteger ti = (BigInteger) (Object) this.im;
+            BigInteger sr = (BigInteger) (Object) S.re;
+            BigInteger si = (BigInteger) (Object) S.im;
+            BigComplex tc = new BigComplex(new BigRational(tr), new BigRational(ti));
+            BigComplex sc = new BigComplex(new BigRational(sr), new BigRational(si));
+            BigComplex qc = tc.divide(sc);
+            System.out.println("qc   = " + qc);
+            BigDecimal qrd = new BigDecimal(qc.getRe());
+            BigDecimal qid = new BigDecimal(qc.getIm());
+            System.out.println("qrd  = " + qrd);
+            System.out.println("qid  = " + qid);
+            throw new ArithmeticException("QR norm not decreasing " + Rp + ", " + Rp.norm());
+        }
+        ret[0] = Sp;
+        ret[1] = Rp;
+        return ret;
+    }
+
+
+    /**
+     * Complex number greatest common divisor.
+     * @param S Complex<C>.
+     * @return gcd(this,S).
+     */
+    public Complex<C> gcd(Complex<C> S) {
+        if (S == null || S.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return S;
+        }
+        if (ring.isField()) {
+            return ring.getONE();
+        }
+        Complex<C> a = this;
+        Complex<C> b = S;
+        if (a.re.signum() < 0) {
+            a = a.negate();
+        }
+        if (b.re.signum() < 0) {
+            b = b.negate();
+        }
+        while (!b.isZERO()) {
+            if (debug) {
+                logger.info("norm(b), a, b = " + b.norm() + ", " + a + ", " + b);
+            }
+            Complex<C>[] qr = a.quotientRemainder(b);
+            if (qr[0].isZERO()) {
+                System.out.println("a = " + a);
+            }
+            a = b;
+            b = qr[1];
+        }
+        if (a.re.signum() < 0) {
+            a = a.negate();
+        }
+        return a;
+    }
+
+
+    /**
+     * Complex extended greatest common divisor.
+     * @param S Complex<C>.
+     * @return [ gcd(this,S), a, b ] with a*this + b*S = gcd(this,S).
+     */
+    @SuppressWarnings("unchecked")
+    public Complex<C>[] egcd(Complex<C> S) {
+        Complex<C>[] ret = new Complex[3];
+        ret[0] = null;
+        ret[1] = null;
+        ret[2] = null;
+        if (S == null || S.isZERO()) {
+            ret[0] = this;
+            return ret;
+        }
+        if (this.isZERO()) {
+            ret[0] = S;
+            return ret;
+        }
+        if (ring.isField()) {
+            Complex<C> half = new Complex<C>(ring, ring.ring.fromInteger(1).divide(ring.ring.fromInteger(2)));
+            ret[0] = ring.getONE();
+            ret[1] = this.inverse().multiply(half);
+            ret[2] = S.inverse().multiply(half);
+            return ret;
+        }
+        Complex<C>[] qr;
+        Complex<C> q = this;
+        Complex<C> r = S;
+        Complex<C> c1 = ring.getONE();
+        Complex<C> d1 = ring.getZERO();
+        Complex<C> c2 = ring.getZERO();
+        Complex<C> d2 = ring.getONE();
+        Complex<C> x1;
+        Complex<C> x2;
+        while (!r.isZERO()) {
+            if (debug) {
+                logger.info("norm(r), q, r = " + r.norm() + ", " + q + ", " + r);
+            }
+            qr = q.quotientRemainder(r);
+            q = qr[0];
+            x1 = c1.subtract(q.multiply(d1));
+            x2 = c2.subtract(q.multiply(d2));
+            c1 = d1;
+            c2 = d2;
+            d1 = x1;
+            d2 = x2;
+            q = r;
+            r = qr[1];
+        }
+        if (q.re.signum() < 0) {
+            q = q.negate();
+            c1 = c1.negate();
+            c2 = c2.negate();
+        }
+        ret[0] = q;
+        ret[1] = c1;
+        ret[2] = c2;
+        return ret;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/ComplexRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/ComplexRing.java
@@ -1,0 +1,304 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.io.Reader;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.kern.StringUtil;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Generic Complex ring factory implementing the RingFactory interface. Objects
+ * of this class are immutable.
+ * @param <C> base type.
+ * @author Heinz Kredel
+ */
+public class ComplexRing<C extends RingElem<C>> implements RingFactory<Complex<C>> {
+
+
+    private final static Random random = new Random();
+
+
+    @SuppressWarnings("unused")
+    private static final Logger logger = LogManager.getLogger(ComplexRing.class);
+
+
+    /**
+     * Complex class elements factory data structure.
+     */
+    public final RingFactory<C> ring;
+
+
+    /**
+     * The constructor creates a ComplexRing object.
+     * @param ring factory for Complex real and imaginary parts.
+     */
+    public ComplexRing(RingFactory<C> ring) {
+        this.ring = ring;
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     * @see edu.jas.structure.ElemFactory#generators()
+     */
+    public List<Complex<C>> generators() {
+        List<C> gens = ring.generators();
+        List<Complex<C>> g = new ArrayList<Complex<C>>(gens.size() + 1);
+        for (C x : gens) {
+            Complex<C> cx = new Complex<C>(this, x);
+            g.add(cx);
+        }
+        g.add(getIMAG());
+        return g;
+    }
+
+
+    /**
+     * Corresponding algebraic number ring.
+     * @return algebraic number ring. not jet possible.
+     */
+    public AlgebraicNumberRing<C> algebraicRing() {
+        GenPolynomialRing<C> pfac = new GenPolynomialRing<C>(ring, TermOrderByName.INVLEX, new String[] { "I" });
+        GenPolynomial<C> I = pfac.univariate(0, 2L).sum(pfac.getONE());
+        AlgebraicNumberRing<C> afac = new AlgebraicNumberRing<C>(I, ring.isField()); // must indicate field
+        return afac;
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite()
+     */
+    public boolean isFinite() {
+        return ring.isFinite();
+    }
+
+
+    /**
+     * Copy Complex element c.
+     * @param c Complex&lt;C&gt;.
+     * @return a copy of c.
+     */
+    public Complex<C> copy(Complex<C> c) {
+        return new Complex<C>(this, c.re, c.im);
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as Complex&lt;C&gt;.
+     */
+    public Complex<C> getZERO() {
+        return new Complex<C>(this);
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as Complex&lt;C&gt;.
+     */
+    public Complex<C> getONE() {
+        return new Complex<C>(this, ring.getONE());
+    }
+
+
+    /**
+     * Get the i element.
+     * @return i as Complex&lt;C&gt;.
+     */
+    public Complex<C> getIMAG() {
+        return new Complex<C>(this, ring.getZERO(), ring.getONE());
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true.
+     */
+    public boolean isCommutative() {
+        return ring.isCommutative();
+    }
+
+
+    /**
+     * Query if this ring is associative.
+     * @return true.
+     */
+    public boolean isAssociative() {
+        return ring.isAssociative();
+    }
+
+
+    /**
+     * Query if this ring is a field.
+     * @return true.
+     */
+    public boolean isField() {
+        return ring.isField();
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic() {
+        return ring.characteristic();
+    }
+
+
+    /**
+     * Get a Complex element from a BigInteger.
+     * @param a BigInteger.
+     * @return a Complex&lt;C&gt;.
+     */
+    public Complex<C> fromInteger(BigInteger a) {
+        return new Complex<C>(this, ring.fromInteger(a));
+    }
+
+
+    /**
+     * Get a Complex element from a long.
+     * @param a long.
+     * @return a Complex&lt;C&gt;.
+     */
+    public Complex<C> fromInteger(long a) {
+        return new Complex<C>(this, ring.fromInteger(a));
+    }
+
+
+    /**
+     * Get the String representation.
+     */
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        sb.append("Complex[");
+        if (ring instanceof RingElem) {
+            RingElem ri = (RingElem) ring;
+            sb.append(ri.toScriptFactory());
+        } else {
+            sb.append(ring.toString());
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        StringBuffer s = new StringBuffer();
+        s.append("CR(");
+        if (ring instanceof RingElem) {
+            RingElem ri = (RingElem) ring;
+            s.append(ri.toScriptFactory());
+        } else {
+            s.append(ring.toScript());
+        }
+        s.append(")");
+        return s.toString();
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (b == null) {
+            return false;
+        }
+        if (!(b instanceof ComplexRing)) {
+            return false;
+        }
+        ComplexRing<C> a = (ComplexRing<C>) b;
+        if (!ring.equals(a.ring)) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Hash code for this ComplexRing&lt;C&gt;.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return ring.hashCode();
+    }
+
+
+    /**
+     * Complex number random. Random base numbers A and B are generated using
+     * random(n). Then R is the complex number with real part A and imaginary
+     * part B.
+     * @param n such that 0 &le; A, B &le; (2<sup>n</sup>-1).
+     * @return R.
+     */
+    public Complex<C> random(int n) {
+        return random(n, random);
+        //         C r = ring.random( n ).abs();
+        //         C i = ring.random( n ).abs();
+        //         return new Complex<C>(this, r, i ); 
+    }
+
+
+    /**
+     * Complex number random. Random base numbers A and B are generated using
+     * random(n). Then R is the complex number with real part A and imaginary
+     * part B.
+     * @param n such that 0 &le; A, B &le; (2<sup>n</sup>-1).
+     * @param rnd is a source for random bits.
+     * @return R.
+     */
+    public Complex<C> random(int n, Random rnd) {
+        C r = ring.random(n, rnd);
+        C i = ring.random(n, rnd);
+        return new Complex<C>(this, r, i);
+    }
+
+
+    /**
+     * Parse complex number from string.
+     * @param s String.
+     * @return Complex<C> from s.
+     */
+    public Complex<C> parse(String s) {
+        return new Complex<C>(this, s);
+    }
+
+
+    /**
+     * Parse complex number from Reader.
+     * @param r Reader.
+     * @return next Complex<C> from r.
+     */
+    public Complex<C> parse(Reader r) {
+        return parse(StringUtil.nextString(r));
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/Examples.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/Examples.java
@@ -1,0 +1,586 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.jas.arith.BigInteger;
+import edu.jas.arith.BigRational;
+import edu.jas.arith.ModInteger;
+import edu.jas.arith.ModIntegerRing;
+
+
+/**
+ * Examples for polynomials usage.
+ * @author Heinz Kredel
+ */
+
+public class Examples {
+
+
+    /**
+     * main.
+     */
+    public static void main(String[] args) {
+        //example0();
+        /*
+          example1();
+          example2();
+          example3();
+          example4();
+          example5();
+        */
+        //example6(); 
+        example7();
+        example7();
+        //example8();
+        //example9();
+        //example10();
+        //example11();
+        //example12();
+        //example13();
+    }
+
+
+    /**
+     * example0. for PPPJ 2006.
+     */
+    public static void example0() {
+        BigInteger z = new BigInteger();
+
+        TermOrder to = new TermOrder();
+        String[] vars = new String[] { "x1", "x2", "x3" };
+        GenPolynomialRing<BigInteger> ring;
+        ring = new GenPolynomialRing<BigInteger>(z, 3, to, vars);
+        System.out.println("ring = " + ring);
+
+        GenPolynomial<BigInteger> pol;
+        pol = ring.parse("3 x1^2 x3^4 + 7 x2^5 - 61");
+        System.out.println("pol = " + pol);
+        System.out.println("pol = " + pol.toString(ring.getVars()));
+
+        GenPolynomial<BigInteger> one;
+        one = ring.parse("1");
+        System.out.println("one = " + one);
+        System.out.println("one = " + one.toString(ring.getVars()));
+
+        GenPolynomial<BigInteger> p;
+        p = pol.subtract(pol);
+        System.out.println("p = " + p);
+        System.out.println("p = " + p.toString(ring.getVars()));
+
+        p = pol.multiply(pol);
+        System.out.println("p = " + p);
+        System.out.println("p = " + p.toString(ring.getVars()));
+    }
+
+
+    /**
+     * example1. random polynomial with rational coefficients. Q[x_1,...x_7]
+     */
+    public static void example1() {
+        System.out.println("\n\n example 1");
+
+        BigRational cfac = new BigRational();
+        System.out.println("cfac = " + cfac);
+        String[] vars = new String[] { "x1", "x2", "x3", "x4", "x5", "x6", "x7" };
+        GenPolynomialRing<BigRational> fac;
+        fac = new GenPolynomialRing<BigRational>(cfac, 7, vars);
+        //System.out.println("fac = " + fac);
+        System.out.println("fac = " + fac);
+
+        GenPolynomial<BigRational> a = fac.random(10);
+        System.out.println("a = " + a);
+    }
+
+
+    /**
+     * example2. random polynomial with coefficients of rational polynomials.
+     * Q[x_1,...x_7][y_1,...,y_3]
+     */
+    public static void example2() {
+        System.out.println("\n\n example 2");
+
+        BigRational cfac = new BigRational();
+        System.out.println("cfac = " + cfac);
+        String[] cvars = new String[] { "x1", "x2", "x3", "x4", "x5", "x6", "x7" };
+        GenPolynomialRing<BigRational> fac;
+        fac = new GenPolynomialRing<BigRational>(cfac, 7, cvars);
+        System.out.println("fac = " + fac);
+
+        String[] vars = new String[] { "y1", "y2", "y3" };
+        GenPolynomialRing<GenPolynomial<BigRational>> gfac;
+        gfac = new GenPolynomialRing<GenPolynomial<BigRational>>(fac, 3, vars);
+        System.out.println("gfac = " + gfac);
+
+        GenPolynomial<GenPolynomial<BigRational>> a = gfac.random(10);
+        System.out.println("a = " + a);
+    }
+
+
+    /**
+     * example3. random rational algebraic number. Q(alpha)
+     */
+    public static void example3() {
+        System.out.println("\n\n example 3");
+
+        BigRational cfac = new BigRational();
+        System.out.println("cfac = " + cfac);
+
+        String[] vars = new String[] { "alpha" };
+        GenPolynomialRing<BigRational> mfac;
+        mfac = new GenPolynomialRing<BigRational>(cfac, 1, vars);
+        System.out.println("mfac = " + mfac);
+
+        GenPolynomial<BigRational> modul = mfac.random(8).monic();
+        // assume !mo.isUnit()
+        System.out.println("modul = " + modul);
+
+        AlgebraicNumberRing<BigRational> fac;
+        fac = new AlgebraicNumberRing<BigRational>(modul);
+        System.out.println("fac = " + fac);
+
+        AlgebraicNumber<BigRational> a = fac.random(15);
+        System.out.println("a = " + a);
+    }
+
+
+    protected static long getPrime() {
+        long prime = 2; //2^60-93; // 2^30-35; //19; knuth (2,390)
+        for (int i = 1; i < 60; i++) {
+            prime *= 2;
+        }
+        prime -= 93;
+        //System.out.println("prime = " + prime);
+        return prime;
+    }
+
+
+    /**
+     * example4. random modular algebraic number. Z_p(alpha)
+     */
+    public static void example4() {
+        System.out.println("\n\n example 4");
+
+        long prime = getPrime();
+        ModIntegerRing cfac = new ModIntegerRing(prime);
+        System.out.println("cfac = " + cfac);
+
+        String[] vars = new String[] { "alpha" };
+        GenPolynomialRing<ModInteger> mfac;
+        mfac = new GenPolynomialRing<ModInteger>(cfac, 1, vars);
+        System.out.println("mfac = " + mfac);
+
+        GenPolynomial<ModInteger> modul = mfac.random(8).monic();
+        // assume !modul.isUnit()
+        System.out.println("modul = " + modul);
+
+        AlgebraicNumberRing<ModInteger> fac;
+        fac = new AlgebraicNumberRing<ModInteger>(modul);
+        System.out.println("fac = " + fac);
+
+        AlgebraicNumber<ModInteger> a = fac.random(12);
+        System.out.println("a = " + a);
+    }
+
+
+    /**
+     * example5. random solvable polynomial with rational coefficients.
+     * Q{x_1,...x_6, {x_2 * x_1 = x_1 x_2 +1, ...} }
+     */
+    public static void example5() {
+        System.out.println("\n\n example 5");
+
+        BigRational cfac = new BigRational();
+        System.out.println("cfac = " + cfac);
+        GenSolvablePolynomialRing<BigRational> sfac;
+        sfac = new GenSolvablePolynomialRing<BigRational>(cfac, 6);
+        //System.out.println("sfac = " + sfac);
+
+        RelationGenerator<BigRational> wl = new WeylRelations<BigRational>();
+        //wl.generate(sfac);
+        sfac.addRelations(wl);
+        System.out.println("sfac = " + sfac);
+
+        GenSolvablePolynomial<BigRational> a = sfac.random(5);
+        System.out.println("a = " + a);
+        System.out.println("a = " + a.toString(sfac.vars));
+
+        GenSolvablePolynomial<BigRational> b = a.multiply(a);
+        System.out.println("b = " + b);
+        System.out.println("b = " + b.toString(sfac.vars));
+
+        System.out.println("sfac = " + sfac);
+    }
+
+
+    /**
+     * example6. Fateman benchmark: p = (x+y+z)^20; q = p * (p+1) Z[z,y,x]
+     */
+    public static void example6() {
+        System.out.println("\n\n example 6");
+
+        BigInteger cfac = new BigInteger();
+        System.out.println("cfac = " + cfac);
+
+        TermOrder to = new TermOrder(TermOrder.INVLEX);
+        System.out.println("to   = " + to);
+
+        GenPolynomialRing<BigInteger> fac;
+        fac = new GenPolynomialRing<BigInteger>(cfac, 3, to);
+        System.out.println("fac = " + fac);
+        fac.setVars(new String[] { "z", "y", "x" });
+        System.out.println("fac = " + fac);
+
+        GenPolynomial<BigInteger> x = fac.univariate(0);
+        GenPolynomial<BigInteger> y = fac.univariate(1);
+        GenPolynomial<BigInteger> z = fac.univariate(2);
+
+        System.out.println("x = " + x);
+        System.out.println("x = " + x.toString(fac.vars));
+        System.out.println("y = " + y);
+        System.out.println("y = " + y.toString(fac.vars));
+        System.out.println("z = " + z);
+        System.out.println("z = " + z.toString(fac.vars));
+
+        GenPolynomial<BigInteger> p = x.sum(y).sum(z).sum(fac.getONE());
+        //BigInteger f = cfac.fromInteger(10000000001L);
+        // p = p.multiply( f );
+        System.out.println("p = " + p);
+        System.out.println("p = " + p.toString(fac.vars));
+
+        GenPolynomial<BigInteger> q = p;
+        for (int i = 1; i < 20; i++) {
+            q = q.multiply(p);
+        }
+        //System.out.println("q = " + q.toString( fac.vars ) );
+        System.out.println("q = " + q.length());
+
+        GenPolynomial<BigInteger> q1 = q.sum(fac.getONE());
+
+        GenPolynomial<BigInteger> q2;
+        long t = System.currentTimeMillis();
+        q2 = q.multiply(q1);
+        t = System.currentTimeMillis() - t;
+
+        System.out.println("q2 = " + q2.length());
+        System.out.println("time = " + t + " ms");
+    }
+
+
+    /**
+     * example7. Fateman benchmark: p = (x+y+z)^20; q = p * (p+1) Q[z,y,x]
+     */
+    public static void example7() {
+        System.out.println("\n\n example 7");
+
+        BigRational cfac = new BigRational();
+        System.out.println("cfac = " + cfac);
+
+        TermOrder to = new TermOrder(TermOrder.INVLEX);
+        System.out.println("to   = " + to);
+
+        GenPolynomialRing<BigRational> fac;
+        fac = new GenPolynomialRing<BigRational>(cfac, 3, to);
+        System.out.println("fac = " + fac);
+        fac.setVars(new String[] { "z", "y", "x" });
+        System.out.println("fac = " + fac);
+
+        long mi = 1L;
+        //long mi = Integer.MAX_VALUE;
+        GenPolynomial<BigRational> x = fac.univariate(0, mi);
+        GenPolynomial<BigRational> y = fac.univariate(1, mi);
+        GenPolynomial<BigRational> z = fac.univariate(2, mi);
+
+        // System.out.println("x = " + x);
+        System.out.println("x = " + x.toString(fac.vars));
+        // System.out.println("y = " + y);
+        System.out.println("y = " + y.toString(fac.vars));
+        // System.out.println("z = " + z);
+        System.out.println("z = " + z.toString(fac.vars));
+
+        GenPolynomial<BigRational> p = x.sum(y).sum(z).sum(fac.getONE());
+        //BigRational f = cfac.fromInteger(10000000001L);
+        // f = f.multiply( f );
+        //p = p.multiply( f );
+        // System.out.println("p = " + p);
+        System.out.println("p = " + p.toString(fac.vars));
+
+        int mpow = 20;
+        System.out.println("mpow = " + mpow);
+        GenPolynomial<BigRational> q = p;
+        for (int i = 1; i < mpow; i++) {
+            q = q.multiply(p);
+        }
+        //System.out.println("q = " + q.toString( fac.vars ) );
+        System.out.println("len(q) = " + q.length());
+        System.out.println("deg(q) = " + q.degree());
+
+        GenPolynomial<BigRational> q1 = q.sum(fac.getONE());
+
+        GenPolynomial<BigRational> q2;
+        long t = System.currentTimeMillis();
+        q2 = q.multiply(q1);
+        t = System.currentTimeMillis() - t;
+
+        System.out.println("len(q2)    = " + q2.length());
+        System.out.println("deg(q2)    = " + q2.degree());
+        System.out.println("LeadEV(q2) = " + q2.leadingExpVector());
+        System.out.println("time       = " + t + " ms");
+    }
+
+
+    /**
+     * example8. Chebyshev polynomials
+     * 
+     * T(0) = 1 T(1) = x T(n) = 2x * T(n-1) - T(n-2)
+     */
+    public static void example8() {
+        int m = 10;
+        BigInteger fac = new BigInteger();
+        String[] var = new String[] { "x" };
+
+        GenPolynomialRing<BigInteger> ring = new GenPolynomialRing<BigInteger>(fac, 1, var);
+
+        List<GenPolynomial<BigInteger>> T = new ArrayList<GenPolynomial<BigInteger>>(m);
+
+        GenPolynomial<BigInteger> t, one, x, x2, x2b;
+
+        one = ring.getONE();
+        x = ring.univariate(0);
+        //x2  = ring.parse("2 x");
+        //x2a = x.multiply( fac.fromInteger(2) );
+        x2b = x.multiply(new BigInteger(2));
+        x2 = x2b;
+
+        T.add(one);
+        T.add(x);
+        for (int n = 2; n < m; n++) {
+            t = x2.multiply(T.get(n - 1)).subtract(T.get(n - 2));
+            T.add(t);
+        }
+        for (int n = 0 /*m-2*/; n < m; n++) {
+            System.out.println("T[" + n + "] = " + T.get(n)); //.toString(var) );
+        }
+    }
+
+
+    /**
+     * example9. Legendre polynomials
+     * 
+     * P(0) = 1 P(1) = x P(n) = 1/n [ (2n-1) * x * P(n-1) - (n-1) * P(n-2) ]
+     */
+    // P(n+1) = 1/(n+1) [ (2n+1) * x * P(n) - n * P(n-1) ]
+    public static void example9() {
+        int n = 10;
+
+        BigRational fac = new BigRational();
+        String[] var = new String[] { "x" };
+
+        GenPolynomialRing<BigRational> ring = new GenPolynomialRing<BigRational>(fac, 1, var);
+
+        List<GenPolynomial<BigRational>> P = new ArrayList<GenPolynomial<BigRational>>(n);
+
+        GenPolynomial<BigRational> t, one, x, xc;
+        BigRational n21, nn;
+
+        one = ring.getONE();
+        x = ring.univariate(0);
+
+        P.add(one);
+        P.add(x);
+        for (int i = 2; i < n; i++) {
+            n21 = new BigRational(2 * i - 1);
+            xc = x.multiply(n21);
+            t = xc.multiply(P.get(i - 1));
+            nn = new BigRational(i - 1);
+            xc = P.get(i - 2).multiply(nn);
+            t = t.subtract(xc);
+            nn = new BigRational(1, i);
+            t = t.multiply(nn);
+            P.add(t);
+        }
+        for (int i = 0; i < n; i++) {
+            System.out.println("P[" + i + "] = " + P.get(i).toString(var));
+            System.out.println();
+        }
+    }
+
+
+    /**
+     * example10. Hermite polynomials
+     * 
+     * H(0) = 1 H(1) = 2 x H(n) = 2 * x * H(n-1) - 2 * (n-1) * H(n-2)
+     */
+    // H(n+1) = 2 * x * H(n) - 2 * n * H(n-1)
+    public static void example10() {
+        int n = 100;
+
+        BigInteger fac = new BigInteger();
+        String[] var = new String[] { "x" };
+
+        GenPolynomialRing<BigInteger> ring = new GenPolynomialRing<BigInteger>(fac, 1, var);
+
+        List<GenPolynomial<BigInteger>> H = new ArrayList<GenPolynomial<BigInteger>>(n);
+
+        GenPolynomial<BigInteger> t, one, x2, xc, x;
+        BigInteger n2, nn;
+
+        one = ring.getONE();
+        x = ring.univariate(0);
+        n2 = new BigInteger(2);
+        x2 = x.multiply(n2);
+        H.add(one);
+        H.add(x2);
+        for (int i = 2; i < n; i++) {
+            t = x2.multiply(H.get(i - 1));
+            nn = new BigInteger(2 * (i - 1));
+            xc = H.get(i - 2).multiply(nn);
+            t = t.subtract(xc);
+            H.add(t);
+        }
+        for (int i = n - 1; i < n; i++) {
+            System.out.println("H[" + i + "] = " + H.get(i).toString(var));
+            System.out.println();
+        }
+    }
+
+
+    /**
+     * example11. degree matrix;
+     * 
+     */
+    @SuppressWarnings("unchecked")
+    public static void example11() {
+        int n = 50;
+        BigRational fac = new BigRational();
+        GenPolynomialRing<BigRational> ring = new GenPolynomialRing<BigRational>(fac, n);
+        System.out.println("ring = " + ring + "\n");
+
+        GenPolynomial<BigRational> p = ring.random(5, 3, 6, 0.5f);
+        System.out.println("p = " + p + "\n");
+
+        List<GenPolynomial<BigInteger>> dem = TermOrderOptimization.<BigRational> degreeMatrix(p);
+
+        System.out.println("dem = " + dem + "\n");
+
+        List<GenPolynomial<BigRational>> polys = new ArrayList<GenPolynomial<BigRational>>();
+        polys.add(p);
+        for (int i = 0; i < 5; i++) {
+            polys.add(ring.random(5, 3, 6, 0.1f));
+        }
+        System.out.println("polys = " + polys + "\n");
+
+        dem = TermOrderOptimization.<BigRational> degreeMatrix(polys);
+        System.out.println("dem = " + dem + "\n");
+
+        List<Integer> perm;
+        perm = TermOrderOptimization.optimalPermutation(dem);
+        System.out.println("perm = " + perm + "\n");
+
+        List<GenPolynomial<BigInteger>> pdem;
+        pdem = TermOrderOptimization.<GenPolynomial<BigInteger>> listPermutation(perm, dem);
+        System.out.println("pdem = " + pdem + "\n");
+
+        GenPolynomialRing<BigRational> pring;
+        pring = TermOrderOptimization.<BigRational> permutation(perm, ring);
+        System.out.println("ring  = " + ring);
+        System.out.println("pring = " + pring + "\n");
+
+        List<GenPolynomial<BigRational>> ppolys;
+        ppolys = TermOrderOptimization.<BigRational> permutation(perm, pring, polys);
+        System.out.println("ppolys = " + ppolys + "\n");
+
+        dem = TermOrderOptimization.<BigRational> degreeMatrix(ppolys);
+        //System.out.println("pdem = " + dem + "\n");
+
+        perm = TermOrderOptimization.optimalPermutation(dem);
+        //System.out.println("pperm = " + perm + "\n");
+        int i = 0;
+        for (Integer j : perm) {
+            if (i != (int) j) {
+                System.out.println("error = " + i + " != " + j + "\n");
+            }
+            i++;
+        }
+
+        OptimizedPolynomialList<BigRational> op;
+        op = TermOrderOptimization.<BigRational> optimizeTermOrder(ring, polys);
+        System.out.println("op:\n" + op);
+        if (!op.equals(new PolynomialList<BigRational>(pring, ppolys))) {
+            System.out.println("error = " + "\n" + op);
+        }
+    }
+
+
+    /**
+     * example12. type games.
+     */
+    public static void example12() {
+        System.out.println("\n\n example 12");
+
+        BigRational t1 = new BigRational();
+        System.out.println("t1 = " + t1);
+
+        BigInteger t2 = new BigInteger();
+        System.out.println("t2 = " + t2);
+
+        System.out.println("t1.isAssignableFrom(t2) = " + t1.getClass().isAssignableFrom(t2.getClass()));
+        System.out.println("t2.isAssignableFrom(t1) = " + t2.getClass().isAssignableFrom(t1.getClass()));
+
+        String[] vars = new String[] { "x1", "x2", "x3" };
+        GenPolynomialRing<BigInteger> t3 = new GenPolynomialRing<BigInteger>(t2, 3, vars);
+        System.out.println("t3 = " + t3);
+
+        GenSolvablePolynomialRing<BigInteger> t4 = new GenSolvablePolynomialRing<BigInteger>(t2, vars);
+        System.out.println("t4 = " + t4);
+
+        System.out.println("t3.isAssignableFrom(t4) = " + t3.getClass().isAssignableFrom(t4.getClass()));
+        System.out.println("t4.isAssignableFrom(t3) = " + t4.getClass().isAssignableFrom(t3.getClass()));
+
+        GenPolynomialRing<BigRational> t5 = new GenPolynomialRing<BigRational>(t1, 3, vars);
+        System.out.println("t5 = " + t5);
+
+        System.out.println("t3.isAssignableFrom(t5) = " + t3.getClass().isAssignableFrom(t5.getClass()));
+        System.out.println("t5.isAssignableFrom(t3) = " + t5.getClass().isAssignableFrom(t3.getClass()));
+    }
+
+
+    /**
+     * example13. poly parser for strange syntax.
+     */
+    public static void example13() {
+        System.out.println("\n\n example 13");
+        TermOrder to = new TermOrder(TermOrder.INVLEX);
+        BigRational cfraction = new BigRational(1);
+        String[] vars = new String[] { "x" };
+
+        //Scripting.setPrecision(5);
+
+        GenPolynomialRing<BigRational> pfac = new GenPolynomialRing<BigRational>(cfraction, 1, to, vars);
+        GenPolynomial<BigRational> FF0 = pfac.parse("19(6)/10");
+        System.out.println("FF0 = " + FF0);
+        FF0 = pfac.parse("19(6)1/10");
+        System.out.println("FF0 = " + FF0);
+        FF0 = pfac.parse("19 6/10");
+        System.out.println("FF0 = " + FF0);
+        FF0 = pfac.parse("19*6/10");
+        System.out.println("FF0 = " + FF0);
+        FF0 = pfac.parse("19+6/10");
+        System.out.println("FF0 = " + FF0);
+        FF0 = pfac.parse("(x).2");
+        System.out.println("FF0 = " + FF0);
+        FF0 = pfac.parse("4.0/9.0");
+        System.out.println("FF0 = " + FF0);
+        FF0 = pfac.parse("4/9.0");
+        System.out.println("FF0 = " + FF0);
+        FF0 = pfac.parse("4.0/9");
+        System.out.println("FF0 = " + FF0);
+        FF0 = pfac.parse("-4.0/9");
+        System.out.println("FF0 = " + FF0);
+    }
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/ExpVector.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/ExpVector.java
@@ -1,0 +1,1264 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+
+import edu.jas.arith.BigInteger;
+import edu.jas.structure.AbelianGroupElem;
+import edu.jas.structure.AbelianGroupFactory;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * ExpVector implements exponent vectors for polynomials. Exponent vectors are
+ * implemented as arrays of Java elementary types, like long, int, short and
+ * byte. ExpVector provides also the familiar MAS static method names. The
+ * implementation is only tested for nonnegative exponents but should work also
+ * for negative exponents. Objects of this class are intended to be immutable,
+ * but exponents can be set (during construction); also the hash code is only
+ * computed once, when needed. The different storage unit implementations are
+ * <code>ExpVectorLong</code> <code>ExpVectorInteger</code>,
+ * <code>ExpVectorShort</code> and <code>ExpVectorByte</code>. The static
+ * factory methods <code>create()</code> of <code>ExpVector</code> select the
+ * respective storage unit. The selection of the desired storage unit is
+ * internally done via the static variable <code>storunit</code>. This varaible
+ * should not be changed dynamically.
+ * @author Heinz Kredel
+ */
+
+public abstract class ExpVector implements AbelianGroupElem<ExpVector> {
+
+
+    /**
+     * Stored hash code.
+     */
+    transient protected int hash = -1;
+
+
+    /**
+     * Stored bitLength.
+     */
+    transient protected long blen = -1;
+
+
+    /**
+     * Random number generator.
+     */
+    private final static Random random = new Random();
+
+
+    /**
+     * Storage representation of exponent arrays.
+     */
+    public static enum StorUnit {
+        LONG, INT, SHORT, BYTE
+    };
+
+
+    /**
+     * Used storage representation of exponent arrays. <b>Note:</b> Set this
+     * only statically and not dynamically.
+     */
+    public final static StorUnit storunit = StorUnit.LONG;
+
+
+    /**
+     * Constructor for ExpVector.
+     */
+    public ExpVector() {
+        hash = 0;
+    }
+
+
+    /**
+     * Factory constructor for ExpVector.
+     * @param n length of exponent vector.
+     */
+    public final static ExpVector create(int n) {
+        switch (storunit) {
+        case INT:
+            return new ExpVectorInteger(n);
+        case LONG:
+            return new ExpVectorLong(n);
+        case SHORT:
+            return new ExpVectorShort(n);
+        case BYTE:
+            return new ExpVectorByte(n);
+        default:
+            return new ExpVectorInteger(n);
+        }
+    }
+
+
+    /**
+     * Factory constructor for ExpVector. Sets exponent i to e.
+     * @param n length of exponent vector.
+     * @param i index of exponent to be set.
+     * @param e exponent to be set.
+     */
+    public final static ExpVector create(int n, int i, long e) {
+        switch (storunit) {
+        case INT:
+            return new ExpVectorInteger(n, i, e);
+        case LONG:
+            return new ExpVectorLong(n, i, e);
+        case SHORT:
+            return new ExpVectorShort(n, i, e);
+        case BYTE:
+            return new ExpVectorByte(n, i, e);
+        default:
+            return new ExpVectorInteger(n, i, e);
+        }
+    }
+
+
+    /**
+     * Internal factory constructor for ExpVector. Sets val.
+     * @param v internal representation array.
+     */
+    public final static ExpVector create(long[] v) {
+        switch (storunit) {
+        case INT:
+            return new ExpVectorInteger(v);
+        case LONG:
+            return new ExpVectorLong(v);
+        case SHORT:
+            return new ExpVectorShort(v);
+        case BYTE:
+            return new ExpVectorByte(v);
+        default:
+            return new ExpVectorInteger(v);
+        }
+    }
+
+
+    /**
+     * Factory constructor for ExpVector. Converts a String representation to an
+     * ExpVector. Accepted format = (1,2,3,4,5,6,7).
+     * @param s String representation.
+     */
+    public final static ExpVector create(String s) {
+        switch (storunit) {
+        case INT:
+            return new ExpVectorInteger(s);
+        case LONG:
+            return new ExpVectorLong(s);
+        case SHORT:
+            return new ExpVectorShort(s);
+        case BYTE:
+            return new ExpVectorByte(s);
+        default:
+            return new ExpVectorInteger(s);
+        }
+    }
+
+
+    /**
+     * Factory constructor for ExpVector. Sets val.
+     * @param v collection of exponents.
+     */
+    public final static ExpVector create(Collection<Long> v) {
+        long[] w = new long[v.size()];
+        int i = 0;
+        for (Long k : v) {
+            w[i++] = k;
+        }
+        return create(w);
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public AbelianGroupFactory<ExpVector> factory() {
+        throw new UnsupportedOperationException("no factory implemented for ExpVector");
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite() <b>Note: </b> returns true
+     *      because of finite set of values in each index.
+     */
+    public boolean isFinite() {
+        return true;
+    }
+
+
+    /**
+     * Clone this.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public abstract ExpVector copy();
+
+
+    /**
+     * Get the exponent vector.
+     * @return val.
+     */
+    public abstract long[] getVal();
+
+
+    /**
+     * Get the exponent at position i.
+     * @param i position.
+     * @return val[i].
+     */
+    public abstract long getVal(int i);
+
+
+    /**
+     * Set the exponent at position i to e.
+     * @param i
+     * @param e
+     * @return old val[i].
+     */
+    protected abstract long setVal(int i, long e);
+
+
+    /**
+     * Get the length of this exponent vector.
+     * @return val.length.
+     */
+    public abstract int length();
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend this by i
+     * elements and set val[j] to e.
+     * @param i number of elements to extend.
+     * @param j index of element to be set.
+     * @param e new exponent for val[j].
+     * @return extended exponent vector.
+     */
+    public abstract ExpVector extend(int i, int j, long e);
+
+
+    /**
+     * Extend lower variables. Extend this by i lower elements and set val[j] to
+     * e.
+     * @param i number of elements to extend.
+     * @param j index of element to be set.
+     * @param e new exponent for val[j].
+     * @return extended exponent vector.
+     */
+    public abstract ExpVector extendLower(int i, int j, long e);
+
+
+    /**
+     * Contract variables. Used e.g. in module embedding. Contract this to len
+     * elements.
+     * @param i position of first element to be copied.
+     * @param len new length.
+     * @return contracted exponent vector.
+     */
+    public abstract ExpVector contract(int i, int len);
+
+
+    /**
+     * Reverse variables. Used e.g. in opposite rings.
+     * @return reversed exponent vector.
+     */
+    public abstract ExpVector reverse();
+
+
+    /**
+     * Reverse lower j variables. Used e.g. in opposite rings. Reverses the
+     * first j-1 variables, the rest is unchanged.
+     * @param j index of first variable reversed.
+     * @return reversed exponent vector.
+     */
+    public abstract ExpVector reverse(int j);
+
+
+    /**
+     * Combine with ExpVector. Combine this with the other ExpVector V.
+     * @param V the other exponent vector.
+     * @return combined exponent vector.
+     */
+    public abstract ExpVector combine(ExpVector V);
+
+
+    /**
+     * Permutation of exponent vector.
+     * @param P permutation.
+     * @return P(e).
+     */
+    public abstract ExpVector permutation(List<Integer> P);
+
+
+    /**
+     * Get the string representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer s = new StringBuffer("(");
+        for (int i = 0; i < length(); i++) {
+            s.append(getVal(i));
+            if (i < length() - 1) {
+                s.append(",");
+            }
+        }
+        s.append(")");
+        return s.toString();
+    }
+
+
+    /**
+     * Get the string representation with variable names.
+     * @param vars names of variables.
+     * @see java.lang.Object#toString()
+     */
+    public String toString(String[] vars) {
+        StringBuffer s = new StringBuffer();
+        boolean pit;
+        int r = length();
+        if (r != vars.length) {
+            //logger.warn("length mismatch " + r + " <> " + vars.length);
+            return toString();
+        }
+        if (r == 0) {
+            return s.toString();
+        }
+        long vi;
+        for (int i = r - 1; i > 0; i--) {
+            vi = getVal(i);
+            if (vi != 0) {
+                s.append(vars[r - 1 - i]);
+                if (vi != 1) {
+                    s.append("^" + vi);
+                }
+                pit = false;
+                for (int j = i - 1; j >= 0; j--) {
+                    if (getVal(j) != 0) {
+                        pit = true;
+                    }
+                }
+                if (pit) {
+                    s.append(" * ");
+                }
+            }
+        }
+        vi = getVal(0);
+        if (vi != 0) {
+            s.append(vars[r - 1]);
+            if (vi != 1) {
+                s.append("^" + vi);
+            }
+        }
+        return s.toString();
+    }
+
+
+    /**
+     * Get the string representation of the variables.
+     * @param vars names of variables.
+     * @return string representation of the variables.
+     * @see java.util.Arrays#toString()
+     */
+    public final static String varsToString(String[] vars) {
+        if (vars == null) {
+            return "null";
+        }
+        StringBuffer s = new StringBuffer();
+        for (int i = 0; i < vars.length; i++) {
+            s.append(vars[i]);
+            if (i < vars.length - 1) {
+                s.append(",");
+            }
+        }
+        return s.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        return toScript(stdVars());
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    // @Override
+    public String toScript(String[] vars) {
+        // Python case
+        int r = length();
+        if (r != vars.length) {
+            return toString();
+        }
+        StringBuffer s = new StringBuffer();
+        boolean pit;
+        long vi;
+        for (int i = r - 1; i > 0; i--) {
+            vi = getVal(i);
+            if (vi != 0) {
+                s.append(vars[r - 1 - i]);
+                if (vi != 1) {
+                    s.append("**" + vi);
+                }
+                pit = false;
+                for (int j = i - 1; j >= 0; j--) {
+                    if (getVal(j) != 0) {
+                        pit = true;
+                    }
+                }
+                if (pit) {
+                    s.append(" * ");
+                }
+            }
+        }
+        vi = getVal(0);
+        if (vi != 0) {
+            s.append(vars[r - 1]);
+            if (vi != 1) {
+                s.append("**" + vi);
+            }
+        }
+        return s.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python case
+        return "ExpVector()";
+    }
+
+
+    /**
+     * Get the variable name at index.
+     * @param idx index of the variable
+     * @param vars array of names of variables
+     * @return name of variable at the given index.
+     */
+    public String indexVarName(int idx, String... vars) {
+        return vars[length() - idx - 1];
+    }
+
+
+    /**
+     * Get the array index of a variable at index.
+     * @param idx index of the variable
+     * @return array index of the variable.
+     */
+    public int varIndex(int idx) {
+        return length() - idx - 1;
+    }
+
+
+    /**
+     * Get the index of a variable.
+     * @param x variable name to be searched.
+     * @param vars array of names of variables
+     * @return index of x in vars.
+     */
+    public int indexVar(String x, String... vars) {
+        for (int i = 0; i < length(); i++) {
+            if (x.equals(vars[i])) {
+                return length() - i - 1;
+            }
+        }
+        return -1; // not found
+    }
+
+
+    /**
+     * Evaluate.
+     * @param cf ring factory for elements of a.
+     * @param a list of values.
+     * @return a_1^{e_1} * ... * a_n^{e_n}.
+     */
+    public <C extends RingElem<C>> C evaluate(RingFactory<C> cf, List<C> a) {
+        C c = cf.getONE();
+        for (int i = 0; i < length(); i++) {
+            long ei = getVal(i);
+            if (ei == 0L) {
+                continue;
+            }
+            C ai = a.get(length() - 1 - i);
+            if (ai.isZERO()) {
+                return ai;
+            }
+            C pi = ai.power(ei);
+            c = c.multiply(pi);
+        }
+        return c;
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object B) {
+        if (!(B instanceof ExpVector)) {
+            return false;
+        }
+        ExpVector b = (ExpVector) B;
+        int t = this.invLexCompareTo(b);
+        //System.out.println("equals: this = " + this + " B = " + B + " t = " + t);
+        return (0 == t);
+    }
+
+
+    /**
+     * hashCode. Optimized for small exponents, i.e. &le; 2<sup>4</sup> and
+     * small number of variables, i.e. &le; 8.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        if (hash < 0) {
+            int h = 0;
+            for (int i = 0; i < length(); i++) {
+                h = (h << 4) + (int) getVal(i);
+            }
+            hash = h;
+        }
+        return hash;
+    }
+
+
+    /**
+     * Returns the number of bits in the representation of this exponent vector.
+     * @return number of bits in the representation of this ExpVector, including
+     *         sign bits.
+     */
+    public long bitLength() {
+        if (blen < 0L) {
+            long n = 0L;
+            for (int i = 0; i < length(); i++) {
+                n += BigInteger.bitLength(getVal(i));
+            }
+            blen = n;
+            //System.out.println("bitLength(ExpVector) = " + blen);
+        }
+        return blen;
+    }
+
+
+    /**
+     * Is ExpVector zero.
+     * @return If this has all elements 0 then true is returned, else false.
+     */
+    public boolean isZERO() {
+        return (0 == this.signum());
+    }
+
+
+    /**
+     * Standard variable names. Generate standard names for variables, i.e. x0
+     * to x(n-1).
+     * @return standard names.
+     */
+    public String[] stdVars() {
+        return STDVARS("x", length());
+    }
+
+
+    /**
+     * Generate variable names. Generate names for variables, i.e. prefix0 to
+     * prefix(n-1).
+     * @param prefix name prefix.
+     * @return standard names.
+     */
+    public String[] stdVars(String prefix) {
+        return STDVARS(prefix, length());
+    }
+
+
+    /**
+     * Standard variable names. Generate standard names for variables, i.e. x0
+     * to x(n-1).
+     * @param n size of names array
+     * @return standard names.
+     */
+    public final static String[] STDVARS(int n) {
+        return STDVARS("x", n);
+    }
+
+
+    /**
+     * Generate variable names. Generate names for variables from given prefix.
+     * i.e. prefix0 to prefix(n-1).
+     * @param n size of names array.
+     * @param prefix name prefix.
+     * @return vatiable names.
+     */
+    public final static String[] STDVARS(String prefix, int n) {
+        String[] vars = new String[n];
+        if (prefix == null || prefix.length() == 0) {
+            prefix = "x";
+        }
+        for (int i = 0; i < n; i++) {
+            vars[i] = prefix + i; //(n-1-i);
+        }
+        return vars;
+    }
+
+
+    /**
+     * ExpVector absolute value.
+     * @param U
+     * @return abs(U).
+     */
+    public final static ExpVector EVABS(ExpVector U) {
+        return U.abs();
+    }
+
+
+    /**
+     * ExpVector absolute value.
+     * @return abs(this).
+     */
+    public abstract ExpVector abs();
+
+
+    /**
+     * ExpVector negate.
+     * @param U
+     * @return -U.
+     */
+    public final static ExpVector EVNEG(ExpVector U) {
+        return U.negate();
+    }
+
+
+    /**
+     * ExpVector negate.
+     * @return -this.
+     */
+    public abstract ExpVector negate();
+
+
+    /**
+     * ExpVector summation.
+     * @param U
+     * @param V
+     * @return U+V.
+     */
+    public final static ExpVector EVSUM(ExpVector U, ExpVector V) {
+        return U.sum(V);
+    }
+
+
+    /**
+     * ExpVector summation.
+     * @param V
+     * @return this+V.
+     */
+    public abstract ExpVector sum(ExpVector V);
+
+
+    /**
+     * ExpVector difference. Result may have negative entries.
+     * @param U
+     * @param V
+     * @return U-V.
+     */
+    public final static ExpVector EVDIF(ExpVector U, ExpVector V) {
+        return U.subtract(V);
+    }
+
+
+    /**
+     * ExpVector subtract. Result may have negative entries.
+     * @param V
+     * @return this-V.
+     */
+    public abstract ExpVector subtract(ExpVector V);
+
+
+    /**
+     * ExpVector multiply by scalar.
+     * @param s scalar
+     * @return s*this.
+     */
+    public abstract ExpVector scalarMultiply(long s);
+
+
+    /**
+     * ExpVector substitution. Clone and set exponent to d at position i.
+     * @param U
+     * @param i position.
+     * @param d new exponent.
+     * @return substituted ExpVector.
+     */
+    public final static ExpVector EVSU(ExpVector U, int i, long d) {
+        return U.subst(i, d);
+    }
+
+
+    /**
+     * ExpVector substitution. Clone and set exponent to d at position i.
+     * @param i position.
+     * @param d new exponent.
+     * @return substituted ExpVector.
+     */
+    public ExpVector subst(int i, long d) {
+        ExpVector V = this.copy();
+        //long e = 
+        V.setVal(i, d);
+        return V;
+    }
+
+
+    /**
+     * Generate a random ExpVector.
+     * @param r length of new ExpVector.
+     * @param k maximal degree in each exponent.
+     * @param q density of nozero exponents.
+     * @return random ExpVector.
+     */
+    public final static ExpVector EVRAND(int r, long k, float q) {
+        return random(r, k, q, random);
+    }
+
+
+    /**
+     * Generate a random ExpVector.
+     * @param r length of new ExpVector.
+     * @param k maximal degree in each exponent.
+     * @param q density of nozero exponents.
+     * @param rnd is a source for random bits.
+     * @return random ExpVector.
+     */
+    public final static ExpVector EVRAND(int r, long k, float q, Random rnd) {
+        return random(r, k, q, rnd);
+    }
+
+
+    /**
+     * Generate a random ExpVector.
+     * @param r length of new ExpVector.
+     * @param k maximal degree in each exponent.
+     * @param q density of nozero exponents.
+     * @return random ExpVector.
+     */
+    public final static ExpVector random(int r, long k, float q) {
+        return random(r, k, q, random);
+    }
+
+
+    /**
+     * Generate a random ExpVector.
+     * @param r length of new ExpVector.
+     * @param k maximal degree in each exponent.
+     * @param q density of nozero exponents.
+     * @param rnd is a source for random bits.
+     * @return random ExpVector.
+     */
+    public final static ExpVector random(int r, long k, float q, Random rnd) {
+        long[] w = new long[r];
+        long e;
+        float f;
+        for (int i = 0; i < w.length; i++) {
+            f = rnd.nextFloat();
+            if (f > q) {
+                e = 0;
+            } else {
+                e = rnd.nextLong() % k;
+                if (e < 0) {
+                    e = -e;
+                }
+            }
+            w[i] = e;
+        }
+        return create(w);
+    }
+
+
+    /**
+     * ExpVector sign.
+     * @param U
+     * @return 0 if U is zero, -1 if some entry is negative, 1 if no entry is
+     *         negativ and at least one entry is positive.
+     */
+    public final static int EVSIGN(ExpVector U) {
+        return U.signum();
+    }
+
+
+    /**
+     * ExpVector signum.
+     * @return 0 if this is zero, -1 if some entry is negative, 1 if no entry is
+     *         negative and at least one entry is positive.
+     */
+    public abstract int signum();
+
+
+    /**
+     * ExpVector total degree.
+     * @param U
+     * @return sum of all exponents.
+     */
+    public final static long EVTDEG(ExpVector U) {
+        return U.totalDeg();
+    }
+
+
+    /**
+     * ExpVector degree.
+     * @return total degree of all exponents.
+     */
+    public long degree() {
+        return totalDeg();
+    }
+
+
+    /**
+     * ExpVector total degree.
+     * @return sum of all exponents.
+     */
+    public abstract long totalDeg();
+
+
+    /**
+     * ExpVector maximal degree.
+     * @param U
+     * @return maximal exponent.
+     */
+    public final static long EVMDEG(ExpVector U) {
+        return U.maxDeg();
+    }
+
+
+    /**
+     * ExpVector maximal degree.
+     * @return maximal exponent.
+     */
+    public abstract long maxDeg();
+
+
+    /**
+     * ExpVector minimal degree.
+     * @param U
+     * @return minimal exponent.
+     */
+    public final static long EVMINDEG(ExpVector U) {
+        return U.minDeg();
+    }
+
+
+    /**
+     * ExpVector minimal degree.
+     * @return minimal exponent.
+     */
+    public abstract long minDeg();
+
+
+    /**
+     * ExpVector weighted degree.
+     * @param w weights.
+     * @param U
+     * @return weighted sum of all exponents.
+     */
+    public final static long EVWDEG(long[][] w, ExpVector U) {
+        return U.weightDeg(w);
+    }
+
+
+    /**
+     * ExpVector weighted degree.
+     * @param w weights.
+     * @return weighted sum of all exponents.
+     */
+    public abstract long weightDeg(long[][] w);
+
+
+    /**
+     * ExpVector weighted degree.
+     * @param w weights.
+     * @return weighted sum of all exponents.
+     */
+    public abstract long weightDeg(long[] w);
+
+
+    /**
+     * ExpVector least common multiple.
+     * @param U
+     * @param V
+     * @return component wise maximum of U and V.
+     */
+    public final static ExpVector EVLCM(ExpVector U, ExpVector V) {
+        return U.lcm(V);
+    }
+
+
+    /**
+     * ExpVector least common multiple.
+     * @param V
+     * @return component wise maximum of this and V.
+     */
+    public abstract ExpVector lcm(ExpVector V);
+
+
+    /**
+     * ExpVector greatest common divisor.
+     * @param U
+     * @param V
+     * @return component wise minimum of U and V.
+     */
+    public final static ExpVector EVGCD(ExpVector U, ExpVector V) {
+        return U.gcd(V);
+    }
+
+
+    /**
+     * ExpVector greatest common divisor.
+     * @param V
+     * @return component wise minimum of this and V.
+     */
+    public abstract ExpVector gcd(ExpVector V);
+
+
+    /**
+     * ExpVector dependency on variables.
+     * @param U
+     * @return array of indices where U has positive exponents.
+     */
+    public final static int[] EVDOV(ExpVector U) {
+        return U.dependencyOnVariables();
+    }
+
+
+    /**
+     * ExpVector dependent variables.
+     * @return number of indices where val has positive exponents.
+     */
+    public abstract int dependentVariables();
+
+
+    /**
+     * ExpVector dependency on variables.
+     * @return array of indices where val has positive exponents.
+     */
+    public abstract int[] dependencyOnVariables();
+
+
+    /**
+     * ExpVector multiple test. Test if U is component wise greater or equal to
+     * V.
+     * @param U
+     * @param V
+     * @return true if U is a multiple of V, else false.
+     */
+    public final static boolean EVMT(ExpVector U, ExpVector V) {
+        return U.multipleOf(V);
+    }
+
+
+    /**
+     * ExpVector multiple test. Test if this is component wise greater or equal
+     * to V.
+     * @param V
+     * @return true if this is a multiple of V, else false.
+     */
+    public abstract boolean multipleOf(ExpVector V);
+
+
+    /**
+     * ExpVector divides test. Test if V is component wise greater or equal to
+     * this.
+     * @param V
+     * @return true if this divides V, else false.
+     */
+    public boolean divides(ExpVector V) {
+        return V.multipleOf(this);
+    }
+
+
+    /**
+     * ExpVector compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int compareTo(ExpVector V) {
+        return this.invLexCompareTo(V);
+    }
+
+
+    /**
+     * Inverse lexicographical compare.
+     * @param U
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    public final static int EVILCP(ExpVector U, ExpVector V) {
+        return U.invLexCompareTo(V);
+    }
+
+
+    /**
+     * ExpVector inverse lexicographical compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    public abstract int invLexCompareTo(ExpVector V);
+
+
+    /**
+     * Inverse lexicographical compare part. Compare entries between begin and
+     * end (-1).
+     * @param U
+     * @param V
+     * @param begin
+     * @param end
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    public final static int EVILCP(ExpVector U, ExpVector V, int begin, int end) {
+        return U.invLexCompareTo(V, begin, end);
+    }
+
+
+    /**
+     * ExpVector inverse lexicographical compareTo.
+     * @param V
+     * @param begin
+     * @param end
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    public abstract int invLexCompareTo(ExpVector V, int begin, int end);
+
+
+    /**
+     * Inverse graded lexicographical compare.
+     * @param U
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    public final static int EVIGLC(ExpVector U, ExpVector V) {
+        return U.invGradCompareTo(V);
+    }
+
+
+    /**
+     * ExpVector inverse graded lexicographical compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    public abstract int invGradCompareTo(ExpVector V);
+
+
+    /**
+     * Inverse graded lexicographical compare part. Compare entries between
+     * begin and end (-1).
+     * @param U
+     * @param V
+     * @param begin
+     * @param end
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    public final static int EVIGLC(ExpVector U, ExpVector V, int begin, int end) {
+        return U.invGradCompareTo(V, begin, end);
+    }
+
+
+    /**
+     * ExpVector inverse graded lexicographical compareTo.
+     * @param V
+     * @param begin
+     * @param end
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    public abstract int invGradCompareTo(ExpVector V, int begin, int end);
+
+
+    /**
+     * Reverse inverse lexicographical compare.
+     * @param U
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    public final static int EVRILCP(ExpVector U, ExpVector V) {
+        return U.revInvLexCompareTo(V);
+    }
+
+
+    /**
+     * ExpVector reverse inverse lexicographical compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    public abstract int revInvLexCompareTo(ExpVector V);
+
+
+    /**
+     * Reverse inverse lexicographical compare part. Compare entries between
+     * begin and end (-1).
+     * @param U
+     * @param V
+     * @param begin
+     * @param end
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    public final static int EVRILCP(ExpVector U, ExpVector V, int begin, int end) {
+        return U.revInvLexCompareTo(V, begin, end);
+    }
+
+
+    /**
+     * ExpVector reverse inverse lexicographical compareTo.
+     * @param V
+     * @param begin
+     * @param end
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    public abstract int revInvLexCompareTo(ExpVector V, int begin, int end);
+
+
+    /**
+     * Reverse inverse graded lexicographical compare.
+     * @param U
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    public final static int EVRIGLC(ExpVector U, ExpVector V) {
+        return U.revInvGradCompareTo(V);
+    }
+
+
+    /**
+     * ExpVector reverse inverse graded compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    public abstract int revInvGradCompareTo(ExpVector V);
+
+
+    /**
+     * Reverse inverse graded lexicographical compare part. Compare entries
+     * between begin and end (-1).
+     * @param U
+     * @param V
+     * @param begin
+     * @param end
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    public final static int EVRIGLC(ExpVector U, ExpVector V, int begin, int end) {
+        return U.revInvGradCompareTo(V, begin, end);
+    }
+
+
+    /**
+     * ExpVector reverse inverse graded compareTo.
+     * @param V
+     * @param begin
+     * @param end
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    public abstract int revInvGradCompareTo(ExpVector V, int begin, int end);
+
+
+    /**
+     * Inverse total degree lexicographical compare.
+     * @param U
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    public final static int EVITDEGLC(ExpVector U, ExpVector V) {
+        return U.invTdegCompareTo(V);
+    }
+
+
+    /**
+     * ExpVector inverse total degree lexicographical compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    public abstract int invTdegCompareTo(ExpVector V);
+
+
+    /**
+     * Reverse lexicographical inverse total degree compare.
+     * @param U
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    public final static int EVRLITDEGC(ExpVector U, ExpVector V) {
+        return U.revLexInvTdegCompareTo(V);
+    }
+
+
+    /**
+     * ExpVector reverse lexicographical inverse total degree compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    public abstract int revLexInvTdegCompareTo(ExpVector V);
+
+
+    /**
+     * Inverse weighted lexicographical compare.
+     * @param w weight array.
+     * @param U
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    public final static int EVIWLC(long[][] w, ExpVector U, ExpVector V) {
+        return U.invWeightCompareTo(w, V);
+    }
+
+
+    /**
+     * ExpVector inverse weighted lexicographical compareTo.
+     * @param w weight array.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    public abstract int invWeightCompareTo(long[][] w, ExpVector V);
+
+
+    /**
+     * Inverse weighted lexicographical compare part. Compare entries between
+     * begin and end (-1).
+     * @param w weight array.
+     * @param U
+     * @param V
+     * @param begin
+     * @param end
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    public final static int EVIWLC(long[][] w, ExpVector U, ExpVector V, int begin, int end) {
+        return U.invWeightCompareTo(w, V, begin, end);
+    }
+
+
+    /**
+     * ExpVector inverse weighted lexicographical compareTo.
+     * @param w weight array.
+     * @param V
+     * @param begin
+     * @param end
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    public abstract int invWeightCompareTo(long[][] w, ExpVector V, int begin, int end);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/ExpVectorByte.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/ExpVectorByte.java
@@ -1,0 +1,1139 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ * ExpVectorByte implements exponent vectors for polynomials using arrays of
+ * byte as storage unit. This class is used by ExpVector internally, there is no
+ * need to use this class directly.
+ * @see ExpVector
+ * @author Heinz Kredel
+ */
+
+public final class ExpVectorByte extends ExpVector
+/*implements AbelianGroupElem<ExpVectorByte>*/{
+
+
+    /**
+     * The data structure is an array of byte.
+     */
+    /*package*/final byte[] val;
+
+
+    /**
+     * Largest byte.
+     */
+    public static final long maxByte = (long) Byte.MAX_VALUE / 2;
+
+
+    /**
+     * Smallest byte.
+     */
+    public static final long minByte = (long) Byte.MIN_VALUE / 2;
+
+
+    /**
+     * Constructor for ExpVector.
+     * @param n length of exponent vector.
+     */
+    public ExpVectorByte(int n) {
+        this(new byte[n]);
+    }
+
+
+    /**
+     * Constructor for ExpVector. Sets exponent i to e.
+     * @param n length of exponent vector.
+     * @param i index of exponent to be set.
+     * @param e exponent to be set.
+     */
+    public ExpVectorByte(int n, int i, byte e) {
+        this(n);
+        val[i] = e;
+    }
+
+
+    /**
+     * Constructor for ExpVector. Sets exponent i to e.
+     * @param n length of exponent vector.
+     * @param i index of exponent to be set.
+     * @param e exponent to be set.
+     */
+    public ExpVectorByte(int n, int i, long e) {
+        this(n);
+        if (e >= maxByte || e <= minByte) {
+            throw new IllegalArgumentException("exponent to large: " + e);
+        }
+        val[i] = (byte) e;
+    }
+
+
+    /**
+     * Internal constructor for ExpVector. Sets val.
+     * @param v internal representation array.
+     */
+    protected ExpVectorByte(byte[] v) {
+        super();
+        val = v;
+    }
+
+
+    /**
+     * Constructor for ExpVector. Sets val, converts from long array.
+     * @param v long representation array.
+     */
+    public ExpVectorByte(long[] v) {
+        this(v.length);
+        for (int i = 0; i < v.length; i++) {
+            if (v[i] >= maxByte || v[i] <= minByte) {
+                throw new IllegalArgumentException("exponent to large: " + v[i]);
+            }
+            val[i] = (byte) v[i];
+        }
+    }
+
+
+    /**
+     * Constructor for ExpVector. Converts a String representation to an
+     * ExpVector. Accepted format = (1,2,3,4,5,6,7).
+     * @param s String representation.
+     */
+    public ExpVectorByte(String s) throws NumberFormatException {
+        super();
+        // first format = (1,2,3,4,5,6,7)
+        List<Byte> exps = new ArrayList<Byte>();
+        s = s.trim();
+        int b = s.indexOf('(');
+        int e = s.indexOf(')', b + 1);
+        String teil;
+        int k;
+        byte a;
+        if (b >= 0 && e >= 0) {
+            b++;
+            while ((k = s.indexOf(',', b)) >= 0) {
+                teil = s.substring(b, k);
+                a = Byte.parseByte(teil);
+                exps.add(Byte.valueOf(a));
+                b = k + 1;
+            }
+            if (b <= e) {
+                teil = s.substring(b, e);
+                a = Byte.parseByte(teil);
+                exps.add(Byte.valueOf(a));
+            }
+            int length = exps.size();
+            val = new byte[length];
+            for (int j = 0; j < length; j++) {
+                val[j] = exps.get(j).byteValue();
+            }
+        } else {
+            // not implemented
+            val = null;
+            // length = -1;
+            //Vector names = new Vector();
+            //vars = s;
+        }
+    }
+
+
+    /**
+     * Clone this.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public ExpVectorByte copy() {
+        byte[] w = new byte[val.length];
+        System.arraycopy(val, 0, w, 0, val.length);
+        return new ExpVectorByte(w);
+    }
+
+
+    /**
+     * Get the exponent vector.
+     * @return val as long.
+     */
+    @Override
+    public long[] getVal() {
+        long v[] = new long[val.length];
+        for (int i = 0; i < val.length; i++) {
+            v[i] = val[i];
+        }
+        return v;
+    }
+
+
+    /**
+     * Get the exponent at position i.
+     * @param i position.
+     * @return val[i].
+     */
+    @Override
+    public long getVal(int i) {
+        return val[i];
+    }
+
+
+    /**
+     * Set the exponent at position i to e.
+     * @param i
+     * @param e
+     * @return old val[i].
+     */
+    @Override
+    protected long setVal(int i, long e) {
+        byte x = val[i];
+        if (e >= maxByte || e <= minByte) {
+            throw new IllegalArgumentException("exponent to large: " + e);
+        }
+        val[i] = (byte) e;
+        hash = 0; // beware of race condition
+        return x;
+    }
+
+
+    /**
+     * Set the exponent at position i to e.
+     * @param i
+     * @param e
+     * @return old val[i].
+     */
+    protected byte setVal(int i, byte e) {
+        byte x = val[i];
+        val[i] = e;
+        hash = 0; // beware of race condition
+        return x;
+    }
+
+
+    /**
+     * Get the length of this exponent vector.
+     * @return val.length.
+     */
+    @Override
+    public int length() {
+        return val.length;
+    }
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend this by i
+     * elements and set val[j] to e.
+     * @param i number of elements to extend.
+     * @param j index of element to be set.
+     * @param e new exponent for val[j].
+     * @return extended exponent vector.
+     */
+    @Override
+    public ExpVectorByte extend(int i, int j, long e) {
+        byte[] w = new byte[val.length + i];
+        System.arraycopy(val, 0, w, i, val.length);
+        if (j >= i) {
+            throw new IllegalArgumentException("i " + i + " <= j " + j + " invalid");
+        }
+        if (e >= maxByte || e <= minByte) {
+            throw new IllegalArgumentException("exponent to large: " + e);
+        }
+        w[j] = (byte) e;
+        return new ExpVectorByte(w);
+    }
+
+
+    /**
+     * Extend lower variables. Extend this by i lower elements and set val[j] to
+     * e.
+     * @param i number of elements to extend.
+     * @param j index of element to be set.
+     * @param e new exponent for val[j].
+     * @return extended exponent vector.
+     */
+    @Override
+    public ExpVectorByte extendLower(int i, int j, long e) {
+        byte[] w = new byte[val.length + i];
+        System.arraycopy(val, 0, w, 0, val.length);
+        if (j >= i) {
+            throw new IllegalArgumentException("i " + i + " <= j " + j + " invalid");
+        }
+        w[val.length + j] = (byte) e;
+        return new ExpVectorByte(w);
+    }
+
+
+    /**
+     * Contract variables. Used e.g. in module embedding. Contract this to len
+     * elements.
+     * @param i position of first element to be copied.
+     * @param len new length.
+     * @return contracted exponent vector.
+     */
+    @Override
+    public ExpVectorByte contract(int i, int len) {
+        if (i + len > val.length) {
+            throw new IllegalArgumentException("len " + len + " > val.len " + val.length);
+        }
+        byte[] w = new byte[len];
+        System.arraycopy(val, i, w, 0, len);
+        return new ExpVectorByte(w);
+    }
+
+
+    /**
+     * Reverse variables. Used e.g. in opposite rings.
+     * @return reversed exponent vector.
+     */
+    @Override
+    public ExpVectorByte reverse() {
+        byte[] w = new byte[val.length];
+        for (int i = 0; i < val.length; i++) {
+            w[i] = val[val.length - 1 - i];
+        }
+        return new ExpVectorByte(w);
+    }
+
+
+    /**
+     * Reverse lower j variables. Used e.g. in opposite rings. Reverses the
+     * first j-1 variables, the rest is unchanged.
+     * @param j index of first variable reversed.
+     * @return reversed exponent vector.
+     */
+    @Override
+    public ExpVectorByte reverse(int j) {
+        if (j <= 0 || j > val.length) {
+            return this;
+        }
+        byte[] w = new byte[val.length];
+        for (int i = 0; i < j; i++) {
+            w[i] = val[i];
+        }
+        for (int i = j; i < val.length; i++) {
+            w[i] = val[val.length + j - 1 - i];
+        }
+        return new ExpVectorByte(w);
+    }
+
+
+    /**
+     * Combine with ExpVector. Combine this with the other ExpVector V.
+     * @param V the other exponent vector.
+     * @return combined exponent vector.
+     */
+    @Override
+    public ExpVectorByte combine(ExpVector V) {
+        if (V == null || V.length() == 0) {
+            return this;
+        }
+        ExpVectorByte Vi = (ExpVectorByte) V;
+        if (val.length == 0) {
+            return Vi;
+        }
+        byte[] w = new byte[val.length + Vi.val.length];
+        System.arraycopy(val, 0, w, 0, val.length);
+        System.arraycopy(Vi.val, 0, w, val.length, Vi.val.length);
+        return new ExpVectorByte(w);
+    }
+
+
+    /**
+     * Permutation of exponent vector.
+     * @param P permutation.
+     * @return P(e).
+     */
+    @Override
+    public ExpVectorByte permutation(List<Integer> P) {
+        byte[] w = new byte[val.length];
+        int j = 0;
+        for (Integer i : P) {
+            w[j++] = val[i];
+        }
+        return new ExpVectorByte(w);
+    }
+
+
+    /**
+     * Get the string representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return super.toString() + ":byte";
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object B) {
+        if (!(B instanceof ExpVectorByte)) {
+            return false;
+        }
+        ExpVectorByte b = (ExpVectorByte) B;
+        int t = this.invLexCompareTo(b);
+        //System.out.println("equals: this = " + this + " B = " + B + " t = " + t);
+        return (0 == t);
+    }
+
+
+    /**
+     * hashCode for this exponent vector.
+     * @see java.lang.Object#hashCode() Only for findbugs.
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+
+    /**
+     * ExpVector absolute value.
+     * @return abs(this).
+     */
+    @Override
+    public ExpVectorByte abs() {
+        byte[] u = val;
+        byte[] w = new byte[u.length];
+        for (int i = 0; i < u.length; i++) {
+            if (u[i] >= 0L) {
+                w[i] = u[i];
+            } else {
+                w[i] = (byte) (-u[i]);
+            }
+        }
+        return new ExpVectorByte(w);
+        //return EVABS(this);
+    }
+
+
+    /**
+     * ExpVector negate.
+     * @return -this.
+     */
+    @Override
+    public ExpVectorByte negate() {
+        byte[] u = val;
+        byte[] w = new byte[u.length];
+        for (int i = 0; i < u.length; i++) {
+            w[i] = (byte) (-u[i]);
+        }
+        return new ExpVectorByte(w);
+        // return EVNEG(this);
+    }
+
+
+    /**
+     * ExpVector summation.
+     * @param V
+     * @return this+V.
+     */
+    @Override
+    public ExpVectorByte sum(ExpVector V) {
+        byte[] u = val;
+        byte[] v = ((ExpVectorByte) V).val;
+        byte[] w = new byte[u.length];
+        for (int i = 0; i < u.length; i++) {
+            w[i] = (byte) (u[i] + v[i]);
+        }
+        return new ExpVectorByte(w);
+        // return EVSUM(this, V);
+    }
+
+
+    /**
+     * ExpVector subtract. Result may have negative entries.
+     * @param V
+     * @return this-V.
+     */
+    @Override
+    public ExpVectorByte subtract(ExpVector V) {
+        byte[] u = val;
+        byte[] v = ((ExpVectorByte) V).val;
+        byte[] w = new byte[u.length];
+        for (int i = 0; i < u.length; i++) {
+            w[i] = (byte) (u[i] - v[i]);
+        }
+        return new ExpVectorByte(w);
+        //return EVDIF(this, V);
+    }
+
+
+    /**
+     * ExpVector multiply by scalar.
+     * @param s scalar
+     * @return s*this.
+     */
+    @Override
+    public ExpVectorByte scalarMultiply(long s) {
+        if (s >= maxByte || s <= minByte) {
+            throw new IllegalArgumentException("scalar to large: " + s);
+        }
+        byte[] u = val;
+        byte[] w = new byte[u.length];
+        byte sb = (byte) s;
+        for (int i = 0; i < u.length; i++) {
+            w[i] = (byte) (sb * u[i]);
+        }
+        return new ExpVectorByte(w);
+    }
+
+
+    /**
+     * ExpVector substitution. Clone and set exponent to d at position i.
+     * @param i position.
+     * @param d new exponent.
+     * @return substituted ExpVector.
+     */
+    public ExpVectorByte subst(int i, byte d) {
+        ExpVectorByte V = this.copy();
+        //long e = 
+        V.setVal(i, d);
+        return V;
+        //return EVSU(this, i, d);
+    }
+
+
+    /**
+     * ExpVector substitution. Clone and set exponent to d at position i.
+     * @param i position.
+     * @param d new exponent.
+     * @return substituted ExpVector.
+     */
+    @Override
+    public ExpVectorByte subst(int i, long d) {
+        ExpVectorByte V = this.copy();
+        //long e = 
+        V.setVal(i, d);
+        return V;
+        //return EVSU(this, i, d);
+    }
+
+
+    /**
+     * ExpVector signum.
+     * @return 0 if this is zero, -1 if some entry is negative, 1 if no entry is
+     *         negative and at least one entry is positive.
+     */
+    @Override
+    public int signum() {
+        int t = 0;
+        byte[] u = val;
+        for (int i = 0; i < u.length; i++) {
+            if (u[i] < 0) {
+                return -1;
+            }
+            if (u[i] > 0) {
+                t = 1;
+            }
+        }
+        return t;
+        //return EVSIGN(this);
+    }
+
+
+    /**
+     * ExpVector total degree.
+     * @return sum of all exponents.
+     */
+    @Override
+    public long totalDeg() {
+        long t = 0;
+        byte[] u = val; // U.val;
+        for (int i = 0; i < u.length; i++) {
+            t += u[i];
+        }
+        return t;
+        //return EVTDEG(this);
+    }
+
+
+    /**
+     * ExpVector maximal degree.
+     * @return maximal exponent.
+     */
+    @Override
+    public long maxDeg() {
+        long t = 0;
+        byte[] u = val;
+        for (int i = 0; i < u.length; i++) {
+            if (u[i] > t) {
+                t = u[i];
+            }
+        }
+        return t;
+        //return EVMDEG(this);
+    }
+
+
+    /**
+     * ExpVector minimal degree.
+     * @return minimal exponent.
+     */
+    @Override
+    public long minDeg() {
+        long t = Byte.MAX_VALUE;
+        byte[] u = val;
+        for (int i = 0; i < u.length; i++) {
+            if (u[i] < t) {
+                t = u[i];
+            }
+        }
+        return t;
+    }
+
+
+    /**
+     * ExpVector weighted degree.
+     * @param w weights.
+     * @return weighted sum of all exponents.
+     */
+    @Override
+    public long weightDeg(long[][] w) {
+        if (w == null || w.length == 0) {
+            return totalDeg(); // assume weight 1 
+        }
+        long t = 0;
+        byte[] u = val;
+        for (int j = 0; j < w.length; j++) {
+            long[] wj = w[j];
+            for (int i = 0; i < u.length; i++) {
+                t += wj[i] * u[i];
+            }
+        }
+        return t;
+    }
+
+
+    /**
+     * ExpVector weighted degree.
+     * @param w weights.
+     * @return weighted sum of all exponents.
+     */
+    @Override
+    public long weightDeg(long[] w) {
+        if (w == null || w.length == 0) {
+            return totalDeg(); // assume weight 1 
+        }
+        long t = 0;
+        byte[] u = val;
+        for (int i = 0; i < w.length; i++) {
+             t += w[i] * u[i];
+        }
+        return t;
+    }
+
+
+    /**
+     * ExpVector least common multiple.
+     * @param V
+     * @return component wise maximum of this and V.
+     */
+    @Override
+    public ExpVectorByte lcm(ExpVector V) {
+        byte[] u = val;
+        byte[] v = ((ExpVectorByte) V).val;
+        byte[] w = new byte[u.length];
+        for (int i = 0; i < u.length; i++) {
+            w[i] = (u[i] >= v[i] ? u[i] : v[i]);
+        }
+        return new ExpVectorByte(w);
+        //return EVLCM(this, V);
+    }
+
+
+    /**
+     * ExpVector greatest common divisor.
+     * @param V
+     * @return component wise minimum of this and V.
+     */
+    @Override
+    public ExpVectorByte gcd(ExpVector V) {
+        byte[] u = val;
+        byte[] v = ((ExpVectorByte) V).val;
+        byte[] w = new byte[u.length];
+        for (int i = 0; i < u.length; i++) {
+            w[i] = (u[i] <= v[i] ? u[i] : v[i]);
+        }
+        return new ExpVectorByte(w);
+        //return EVGCD(this, V);
+    }
+
+
+    /**
+     * ExpVector dependent variables.
+     * @return number of indices where val has positive exponents.
+     */
+    public int dependentVariables() {
+        int l = 0;
+        for (int i = 0; i < val.length; i++) {
+            if (val[i] > 0) {
+                l++;
+            }
+        }
+        return l;
+    }
+
+
+    /**
+     * ExpVector dependency on variables.
+     * @return array of indices where val has positive exponents.
+     */
+    @Override
+    public int[] dependencyOnVariables() {
+        byte[] u = val;
+        int l = dependentVariables();
+        int[] dep = new int[l];
+        if (l == 0) {
+            return dep;
+        }
+        int j = 0;
+        for (int i = 0; i < u.length; i++) {
+            if (u[i] > 0) {
+                dep[j] = i;
+                j++;
+            }
+        }
+        return dep;
+    }
+
+
+    /**
+     * ExpVector multiple test. Test if this is component wise greater or equal
+     * to V.
+     * @param V
+     * @return true if this is a multiple of V, else false.
+     */
+    @Override
+    public boolean multipleOf(ExpVector V) {
+        byte[] u = val;
+        byte[] v = ((ExpVectorByte) V).val;
+        boolean t = true;
+        for (int i = 0; i < u.length; i++) {
+            if (u[i] < v[i]) {
+                return false;
+            }
+        }
+        return t;
+        //return EVMT(this, V);
+    }
+
+
+    /**
+     * ExpVector compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int compareTo(ExpVector V) {
+        return this.invLexCompareTo(V);
+    }
+
+
+    /**
+     * ExpVector inverse lexicographical compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int invLexCompareTo(ExpVector V) {
+        byte[] u = val;
+        byte[] v = ((ExpVectorByte) V).val;
+        int t = 0;
+        for (int i = 0; i < u.length; i++) {
+            if (u[i] > v[i])
+                return 1;
+            if (u[i] < v[i])
+                return -1;
+        }
+        return t;
+        //return EVILCP(this, V);
+    }
+
+
+    /**
+     * ExpVector inverse lexicographical compareTo.
+     * @param V
+     * @param begin
+     * @param end
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int invLexCompareTo(ExpVector V, int begin, int end) {
+        byte[] u = val;
+        byte[] v = ((ExpVectorByte) V).val;
+        if (begin < 0) {
+            begin = 0;;
+        }
+        if (end >= val.length) {
+            end = val.length;
+        }
+        int t = 0;
+        for (int i = begin; i < end; i++) {
+            if (u[i] > v[i])
+                return 1;
+            if (u[i] < v[i])
+                return -1;
+        }
+        return t;
+        //return EVILCP(this, V, begin, end);
+    }
+
+
+    /**
+     * ExpVector inverse graded lexicographical compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int invGradCompareTo(ExpVector V) {
+        byte[] u = val;
+        byte[] v = ((ExpVectorByte) V).val;
+        int t = 0;
+        int i;
+        for (i = 0; i < u.length; i++) {
+            if (u[i] > v[i]) {
+                t = 1;
+                break;
+            }
+            if (u[i] < v[i]) {
+                t = -1;
+                break;
+            }
+        }
+        if (t == 0) {
+            return t;
+        }
+        long up = 0;
+        long vp = 0;
+        for (int j = i; j < u.length; j++) {
+            up += u[j];
+            vp += v[j];
+        }
+        if (up > vp) {
+            t = 1;
+        } else {
+            if (up < vp) {
+                t = -1;
+            }
+        }
+        return t;
+        //return EVIGLC(this, V);
+    }
+
+
+    /**
+     * ExpVector inverse graded lexicographical compareTo.
+     * @param V
+     * @param begin
+     * @param end
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int invGradCompareTo(ExpVector V, int begin, int end) {
+        byte[] u = val;
+        byte[] v = ((ExpVectorByte) V).val;
+        if (begin < 0) {
+            begin = 0;;
+        }
+        if (end >= val.length) {
+            end = val.length;
+        }
+        int t = 0;
+        int i;
+        for (i = begin; i < end; i++) {
+            if (u[i] > v[i]) {
+                t = 1;
+                break;
+            }
+            if (u[i] < v[i]) {
+                t = -1;
+                break;
+            }
+        }
+        if (t == 0) {
+            return t;
+        }
+        long up = 0;
+        long vp = 0;
+        for (int j = i; j < end; j++) {
+            up += u[j];
+            vp += v[j];
+        }
+        if (up > vp) {
+            t = 1;
+        } else {
+            if (up < vp) {
+                t = -1;
+            }
+        }
+        return t;
+        //return EVIGLC(this, V, begin, end);
+    }
+
+
+    /**
+     * ExpVector reverse inverse lexicographical compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int revInvLexCompareTo(ExpVector V) {
+        byte[] u = val;
+        byte[] v = ((ExpVectorByte) V).val;
+        int t = 0;
+        for (int i = u.length - 1; i >= 0; i--) {
+            if (u[i] > v[i])
+                return 1;
+            if (u[i] < v[i])
+                return -1;
+        }
+        return t;
+        //return EVRILCP(this, V);
+    }
+
+
+    /**
+     * ExpVector reverse inverse lexicographical compareTo.
+     * @param V
+     * @param begin
+     * @param end
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int revInvLexCompareTo(ExpVector V, int begin, int end) {
+        byte[] u = val;
+        byte[] v = ((ExpVectorByte) V).val;
+        if (begin < 0) {
+            begin = 0;;
+        }
+        if (end >= val.length) {
+            end = val.length;
+        }
+        int t = 0;
+        for (int i = end - 1; i >= begin; i--) {
+            if (u[i] > v[i])
+                return 1;
+            if (u[i] < v[i])
+                return -1;
+        }
+        return t;
+        //return EVRILCP(this, V, begin, end);
+    }
+
+
+    /**
+     * ExpVector reverse inverse graded compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int revInvGradCompareTo(ExpVector V) {
+        byte[] u = val;
+        byte[] v = ((ExpVectorByte) V).val;
+        int t = 0;
+        int i;
+        for (i = u.length - 1; i >= 0; i--) {
+            if (u[i] > v[i]) {
+                t = 1;
+                break;
+            }
+            if (u[i] < v[i]) {
+                t = -1;
+                break;
+            }
+        }
+        if (t == 0) {
+            return t;
+        }
+        long up = 0;
+        long vp = 0;
+        for (int j = i; j >= 0; j--) {
+            up += u[j];
+            vp += v[j];
+        }
+        if (up > vp) {
+            t = 1;
+        } else {
+            if (up < vp) {
+                t = -1;
+            }
+        }
+        return t;
+        //return EVRIGLC(this, V);
+    }
+
+
+    /**
+     * ExpVector reverse inverse graded compareTo.
+     * @param V
+     * @param begin
+     * @param end
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int revInvGradCompareTo(ExpVector V, int begin, int end) {
+        byte[] u = val;
+        byte[] v = ((ExpVectorByte) V).val;
+        if (begin < 0) {
+            begin = 0;;
+        }
+        if (end >= val.length) {
+            end = val.length;
+        }
+        int t = 0;
+        int i;
+        for (i = end - 1; i >= begin; i--) {
+            if (u[i] > v[i]) {
+                t = 1;
+                break;
+            }
+            if (u[i] < v[i]) {
+                t = -1;
+                break;
+            }
+        }
+        if (t == 0) {
+            return t;
+        }
+        long up = 0;
+        long vp = 0;
+        for (int j = i; j >= begin; j--) {
+            up += u[j];
+            vp += v[j];
+        }
+        if (up > vp) {
+            t = 1;
+        } else {
+            if (up < vp) {
+                t = -1;
+            }
+        }
+        return t;
+        //return EVRIGLC(this, V, begin, end);
+    }
+
+
+    /**
+     * ExpVector inverse total degree lexicographical compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int invTdegCompareTo(ExpVector V) {
+        throw new UnsupportedOperationException("not implemented for byte ExpVector");
+    }
+
+
+    /**
+     * ExpVector reverse lexicographical inverse total degree compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int revLexInvTdegCompareTo(ExpVector V) {
+        throw new UnsupportedOperationException("not implemented for byte ExpVector");
+    }
+
+
+    /**
+     * ExpVector inverse weighted lexicographical compareTo.
+     * @param w weight array.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int invWeightCompareTo(long[][] w, ExpVector V) {
+        byte[] u = val;
+        byte[] v = ((ExpVectorByte) V).val;
+        int t = 0;
+        int i;
+        for (i = 0; i < u.length; i++) {
+            if (u[i] > v[i]) {
+                t = 1;
+                break;
+            }
+            if (u[i] < v[i]) {
+                t = -1;
+                break;
+            }
+        }
+        if (t == 0) {
+            return t;
+        }
+        for (int k = 0; k < w.length; k++) {
+            long[] wk = w[k];
+            long up = 0;
+            long vp = 0;
+            for (int j = i; j < u.length; j++) {
+                up += wk[j] * u[j];
+                vp += wk[j] * v[j];
+            }
+            if (up > vp) {
+                return 1;
+            } else if (up < vp) {
+                return -1;
+            }
+        }
+        return t;
+        //return EVIWLC(w, this, V);
+    }
+
+
+    /**
+     * ExpVector inverse weighted lexicographical compareTo.
+     * @param w weight array.
+     * @param V
+     * @param begin
+     * @param end
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int invWeightCompareTo(long[][] w, ExpVector V, int begin, int end) {
+        byte[] u = val;
+        byte[] v = ((ExpVectorByte) V).val;
+        if (begin < 0) {
+            begin = 0;;
+        }
+        if (end >= val.length) {
+            end = val.length;
+        }
+        int t = 0;
+        int i;
+        for (i = begin; i < end; i++) {
+            if (u[i] > v[i]) {
+                t = 1;
+                break;
+            }
+            if (u[i] < v[i]) {
+                t = -1;
+                break;
+            }
+        }
+        if (t == 0) {
+            return t;
+        }
+        for (int k = 0; k < w.length; k++) {
+            long[] wk = w[k];
+            long up = 0;
+            long vp = 0;
+            for (int j = i; j < end; j++) {
+                up += wk[j] * u[j];
+                vp += wk[j] * v[j];
+            }
+            if (up > vp) {
+                return 1;
+            } else if (up < vp) {
+                return -1;
+            }
+        }
+        return t;
+        //return EVIWLC(w, this, V, begin, end);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/ExpVectorInteger.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/ExpVectorInteger.java
@@ -1,0 +1,1199 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ * ExpVectorInteger implements exponent vectors for polynomials using arrays of
+ * int as storage unit. This class is used by ExpVector internally, there is no
+ * need to use this class directly.
+ * @see ExpVector
+ * @author Heinz Kredel
+ */
+
+public final class ExpVectorInteger extends ExpVector
+/*implements AbelianGroupElem<ExpVectorInteger>*/{
+
+
+    /**
+     * The data structure is an array of int.
+     */
+    /*package*/final int[] val;
+
+
+    /**
+     * Largest integer.
+     */
+    public static final long maxInt = (long) Integer.MAX_VALUE / 2;
+
+
+    /**
+     * Smallest integer.
+     */
+    public static final long minInt = (long) Integer.MIN_VALUE / 2;
+
+
+    /**
+     * Constructor for ExpVector.
+     * @param n length of exponent vector.
+     */
+    public ExpVectorInteger(int n) {
+        this(new int[n]);
+    }
+
+
+    /**
+     * Constructor for ExpVector. Sets exponent i to e.
+     * @param n length of exponent vector.
+     * @param i index of exponent to be set.
+     * @param e exponent to be set.
+     */
+    public ExpVectorInteger(int n, int i, int e) {
+        this(n);
+        val[i] = e;
+    }
+
+
+    /**
+     * Constructor for ExpVector. Sets exponent i to e.
+     * @param n length of exponent vector.
+     * @param i index of exponent to be set.
+     * @param e exponent to be set.
+     */
+    public ExpVectorInteger(int n, int i, long e) {
+        this(n);
+        if (e >= maxInt || e <= minInt) {
+            throw new IllegalArgumentException("exponent to large: " + e);
+        }
+        val[i] = (int) e;
+    }
+
+
+    /**
+     * Internal constructor for ExpVector. Sets val.
+     * @param v internal representation array.
+     */
+    protected ExpVectorInteger(int[] v) {
+        super();
+        val = v;
+    }
+
+
+    /**
+     * Constructor for ExpVector. Sets val, converts from long array.
+     * @param v long representation array.
+     */
+    public ExpVectorInteger(long[] v) {
+        this(v.length);
+        for (int i = 0; i < v.length; i++) {
+            if (v[i] >= maxInt || v[i] <= minInt) {
+                throw new IllegalArgumentException("exponent to large: " + v[i]);
+            }
+            val[i] = (int) v[i];
+        }
+    }
+
+
+    /**
+     * Constructor for ExpVector. Converts a String representation to an
+     * ExpVector. Accepted format = (1,2,3,4,5,6,7).
+     * @param s String representation.
+     */
+    public ExpVectorInteger(String s) throws NumberFormatException {
+        super();
+        // first format = (1,2,3,4,5,6,7)
+        List<Integer> exps = new ArrayList<Integer>();
+        s = s.trim();
+        int b = s.indexOf('(');
+        int e = s.indexOf(')', b + 1);
+        String teil;
+        int k;
+        int a;
+        if (b >= 0 && e >= 0) {
+            b++;
+            while ((k = s.indexOf(',', b)) >= 0) {
+                teil = s.substring(b, k);
+                a = Integer.parseInt(teil);
+                exps.add(Integer.valueOf(a));
+                b = k + 1;
+            }
+            if (b <= e) {
+                teil = s.substring(b, e);
+                a = Integer.parseInt(teil);
+                exps.add(Integer.valueOf(a));
+            }
+            int length = exps.size();
+            val = new int[length];
+            for (int j = 0; j < length; j++) {
+                val[j] = exps.get(j).intValue();
+            }
+        } else {
+            // not implemented
+            val = null;
+            // length = -1;
+            //Vector names = new Vector();
+            //vars = s;
+        }
+    }
+
+
+    /**
+     * Clone this.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public ExpVectorInteger copy() {
+        int[] w = new int[val.length];
+        System.arraycopy(val, 0, w, 0, val.length);
+        return new ExpVectorInteger(w);
+    }
+
+
+    /**
+     * Get the exponent vector.
+     * @return val as long.
+     */
+    @Override
+    public long[] getVal() {
+        long v[] = new long[val.length];
+        for (int i = 0; i < val.length; i++) {
+            v[i] = val[i];
+        }
+        return v;
+    }
+
+
+    /**
+     * Get the exponent at position i.
+     * @param i position.
+     * @return val[i].
+     */
+    @Override
+    public long getVal(int i) {
+        return val[i];
+    }
+
+
+    /**
+     * Set the exponent at position i to e.
+     * @param i
+     * @param e
+     * @return old val[i].
+     */
+    @Override
+    protected long setVal(int i, long e) {
+        int x = val[i];
+        if (e >= maxInt || e <= minInt) {
+            throw new IllegalArgumentException("exponent to large: " + e);
+        }
+        val[i] = (int) e;
+        hash = 0; // beware of race condition
+        return x;
+    }
+
+
+    /**
+     * Set the exponent at position i to e.
+     * @param i
+     * @param e
+     * @return old val[i].
+     */
+    protected int setVal(int i, int e) {
+        int x = val[i];
+        val[i] = e;
+        hash = 0; // beware of race condition
+        return x;
+    }
+
+
+    /**
+     * Get the length of this exponent vector.
+     * @return val.length.
+     */
+    @Override
+    public int length() {
+        return val.length;
+    }
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend this by i
+     * elements and set val[j] to e.
+     * @param i number of elements to extend.
+     * @param j index of element to be set.
+     * @param e new exponent for val[j].
+     * @return extended exponent vector.
+     */
+    @Override
+    public ExpVectorInteger extend(int i, int j, long e) {
+        int[] w = new int[val.length + i];
+        System.arraycopy(val, 0, w, i, val.length);
+        if (j >= i) {
+            throw new IllegalArgumentException("i " + i + " <= j " + j + " invalid");
+        }
+        if (e >= maxInt || e <= minInt) {
+            throw new IllegalArgumentException("exponent to large: " + e);
+        }
+        w[j] = (int) e;
+        return new ExpVectorInteger(w);
+    }
+
+
+    /**
+     * Extend lower variables. Extend this by i lower elements and set val[j] to
+     * e.
+     * @param i number of elements to extend.
+     * @param j index of element to be set.
+     * @param e new exponent for val[j].
+     * @return extended exponent vector.
+     */
+    @Override
+    public ExpVectorInteger extendLower(int i, int j, long e) {
+        int[] w = new int[val.length + i];
+        System.arraycopy(val, 0, w, 0, val.length);
+        if (j >= i) {
+            throw new IllegalArgumentException("i " + i + " <= j " + j + " invalid");
+        }
+        w[val.length + j] = (int) e;
+        return new ExpVectorInteger(w);
+    }
+
+
+    /**
+     * Contract variables. Used e.g. in module embedding. Contract this to len
+     * elements.
+     * @param i position of first element to be copied.
+     * @param len new length.
+     * @return contracted exponent vector.
+     */
+    @Override
+    public ExpVectorInteger contract(int i, int len) {
+        if (i + len > val.length) {
+            throw new IllegalArgumentException("len " + len + " > val.len " + val.length);
+        }
+        int[] w = new int[len];
+        System.arraycopy(val, i, w, 0, len);
+        return new ExpVectorInteger(w);
+    }
+
+
+    /**
+     * Reverse variables. Used e.g. in opposite rings.
+     * @return reversed exponent vector.
+     */
+    @Override
+    public ExpVectorInteger reverse() {
+        int[] w = new int[val.length];
+        for (int i = 0; i < val.length; i++) {
+            w[i] = val[val.length - 1 - i];
+        }
+        return new ExpVectorInteger(w);
+    }
+
+
+    /**
+     * Reverse lower j variables. Used e.g. in opposite rings. Reverses the
+     * first j-1 variables, the rest is unchanged.
+     * @param j index of first variable reversed.
+     * @return reversed exponent vector.
+     */
+    @Override
+    public ExpVectorInteger reverse(int j) {
+        if (j <= 0 || j > val.length) {
+            return this;
+        }
+        int[] w = new int[val.length];
+        for (int i = 0; i < j; i++) {
+            w[i] = val[i];
+        }
+        // copy rest
+        for (int i = j; i < val.length; i++) {
+            w[i] = val[val.length + j - 1 - i];
+        }
+        return new ExpVectorInteger(w);
+    }
+
+
+    /**
+     * Combine with ExpVector. Combine this with the other ExpVector V.
+     * @param V the other exponent vector.
+     * @return combined exponent vector.
+     */
+    @Override
+    public ExpVectorInteger combine(ExpVector V) {
+        if (V == null || V.length() == 0) {
+            return this;
+        }
+        ExpVectorInteger Vi = (ExpVectorInteger) V;
+        if (val.length == 0) {
+            return Vi;
+        }
+        int[] w = new int[val.length + Vi.val.length];
+        System.arraycopy(val, 0, w, 0, val.length);
+        System.arraycopy(Vi.val, 0, w, val.length, Vi.val.length);
+        return new ExpVectorInteger(w);
+    }
+
+
+    /**
+     * Permutation of exponent vector.
+     * @param P permutation.
+     * @return P(e).
+     */
+    @Override
+    public ExpVectorInteger permutation(List<Integer> P) {
+        int[] w = new int[val.length];
+        int j = 0;
+        for (Integer i : P) {
+            w[j++] = val[i];
+        }
+        return new ExpVectorInteger(w);
+    }
+
+
+    /**
+     * Get the string representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return super.toString() + ":int";
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object B) {
+        if (!(B instanceof ExpVectorInteger)) {
+            return false;
+        }
+        ExpVectorInteger b = (ExpVectorInteger) B;
+        int t = this.invLexCompareTo(b);
+        //System.out.println("equals: this = " + this + " B = " + B + " t = " + t);
+        return (0 == t);
+    }
+
+
+    /**
+     * hashCode for this exponent vector.
+     * @see java.lang.Object#hashCode() Only for findbugs.
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+
+    /**
+     * ExpVector absolute value.
+     * @return abs(this).
+     */
+    @Override
+    public ExpVectorInteger abs() {
+        int[] u = val;
+        int[] w = new int[u.length];
+        for (int i = 0; i < u.length; i++) {
+            if (u[i] >= 0L) {
+                w[i] = u[i];
+            } else {
+                w[i] = -u[i];
+            }
+        }
+        return new ExpVectorInteger(w);
+        //return EVABS(this);
+    }
+
+
+    /**
+     * ExpVector negate.
+     * @return -this.
+     */
+    @Override
+    public ExpVectorInteger negate() {
+        int[] u = val;
+        int[] w = new int[u.length];
+        for (int i = 0; i < u.length; i++) {
+            w[i] = -u[i];
+        }
+        return new ExpVectorInteger(w);
+        // return EVNEG(this);
+    }
+
+
+    /**
+     * ExpVector summation.
+     * @param V
+     * @return this+V.
+     */
+    @Override
+    public ExpVectorInteger sum(ExpVector V) {
+        int[] u = val;
+        int[] v = ((ExpVectorInteger) V).val;
+        int[] w = new int[u.length];
+        for (int i = 0; i < u.length; i++) {
+            w[i] = u[i] + v[i];
+        }
+        return new ExpVectorInteger(w);
+        // return EVSUM(this, V);
+    }
+
+
+    /**
+     * ExpVector subtract. Result may have negative entries.
+     * @param V
+     * @return this-V.
+     */
+    @Override
+    public ExpVectorInteger subtract(ExpVector V) {
+        int[] u = val;
+        int[] v = ((ExpVectorInteger) V).val;
+        int[] w = new int[u.length];
+        for (int i = 0; i < u.length; i++) {
+            w[i] = u[i] - v[i];
+        }
+        return new ExpVectorInteger(w);
+    }
+
+
+    /**
+     * ExpVector multiply by scalar.
+     * @param s scalar
+     * @return s*this.
+     */
+    @Override
+    public ExpVectorInteger scalarMultiply(long s) {
+        if (s >= maxInt || s <= minInt) {
+            throw new IllegalArgumentException("scalar to large: " + s);
+        }
+        int[] u = val;
+        int[] w = new int[u.length];
+        int si = (int)s;
+        for (int i = 0; i < u.length; i++) {
+            w[i] = si * u[i];
+        }
+        return new ExpVectorInteger(w);
+    }
+
+
+    /**
+     * ExpVector substitution. Clone and set exponent to d at position i.
+     * @param i position.
+     * @param d new exponent.
+     * @return substituted ExpVector.
+     */
+    @Override
+    public ExpVectorInteger subst(int i, long d) {
+        ExpVectorInteger V = this.copy();
+        //long e = 
+        V.setVal(i, d);
+        return V;
+        //return EVSU(this, i, d);
+    }
+
+
+    /**
+     * ExpVector substitution. Clone and set exponent to d at position i.
+     * @param i position.
+     * @param d new exponent.
+     * @return substituted ExpVector.
+     */
+    public ExpVectorInteger subst(int i, int d) {
+        ExpVectorInteger V = this.copy();
+        //long e = 
+        V.setVal(i, d);
+        return V;
+        //return EVSU(this, i, d);
+    }
+
+
+    /**
+     * ExpVector signum.
+     * @return 0 if this is zero, -1 if some entry is negative, 1 if no entry is
+     *         negative and at least one entry is positive.
+     */
+    @Override
+    public int signum() {
+        int t = 0;
+        int[] u = val;
+        for (int i = 0; i < u.length; i++) {
+            if (u[i] < 0) {
+                return -1;
+            }
+            if (u[i] > 0) {
+                t = 1;
+            }
+        }
+        return t;
+        //return EVSIGN(this);
+    }
+
+
+    /**
+     * ExpVector total degree.
+     * @return sum of all exponents.
+     */
+    @Override
+    public long totalDeg() {
+        long t = 0;
+        int[] u = val; // U.val;
+        for (int i = 0; i < u.length; i++) {
+            t += u[i];
+        }
+        return t;
+        //return EVTDEG(this);
+    }
+
+
+    /**
+     * ExpVector maximal degree.
+     * @return maximal exponent.
+     */
+    @Override
+    public long maxDeg() {
+        long t = 0;
+        int[] u = val;
+        for (int i = 0; i < u.length; i++) {
+            if (u[i] > t) {
+                t = u[i];
+            }
+        }
+        return t;
+        //return EVMDEG(this);
+    }
+
+
+    /**
+     * ExpVector minimal degree.
+     * @return minimal exponent.
+     */
+    @Override
+    public long minDeg() {
+        long t = Integer.MAX_VALUE;
+        int[] u = val;
+        for (int i = 0; i < u.length; i++) {
+            if (u[i] < t) {
+                t = u[i];
+            }
+        }
+        return t;
+    }
+
+
+    /**
+     * ExpVector weighted degree.
+     * @param w weights.
+     * @return weighted sum of all exponents.
+     */
+    @Override
+    public long weightDeg(long[][] w) {
+        if (w == null || w.length == 0) {
+            return totalDeg(); // assume weight 1 
+        }
+        long t = 0;
+        int[] u = val;
+        for (int j = 0; j < w.length; j++) {
+            long[] wj = w[j];
+            for (int i = 0; i < u.length; i++) {
+                t += wj[i] * u[i];
+            }
+        }
+        return t;
+    }
+
+
+    /**
+     * ExpVector weighted degree.
+     * @param w weights.
+     * @return weighted sum of all exponents.
+     */
+    @Override
+    public long weightDeg(long[] w) {
+        if (w == null || w.length == 0) {
+            return totalDeg(); // assume weight 1 
+        }
+        long t = 0;
+        int[] u = val;
+        for (int i = 0; i < w.length; i++) {
+             t += w[i] * u[i];
+        }
+        return t;
+    }
+
+
+    /**
+     * ExpVector least common multiple.
+     * @param V
+     * @return component wise maximum of this and V.
+     */
+    @Override
+    public ExpVectorInteger lcm(ExpVector V) {
+        int[] u = val;
+        int[] v = ((ExpVectorInteger) V).val;
+        int[] w = new int[u.length];
+        for (int i = 0; i < u.length; i++) {
+            w[i] = (u[i] >= v[i] ? u[i] : v[i]);
+        }
+        return new ExpVectorInteger(w);
+        //return EVLCM(this, V);
+    }
+
+
+    /**
+     * ExpVector greatest common divisor.
+     * @param V
+     * @return component wise minimum of this and V.
+     */
+    @Override
+    public ExpVectorInteger gcd(ExpVector V) {
+        int[] u = val;
+        int[] v = ((ExpVectorInteger) V).val;
+        int[] w = new int[u.length];
+        for (int i = 0; i < u.length; i++) {
+            w[i] = (u[i] <= v[i] ? u[i] : v[i]);
+        }
+        return new ExpVectorInteger(w);
+        //return EVGCD(this, V);
+    }
+
+
+    /**
+     * ExpVector dependent variables.
+     * @return number of indices where val has positive exponents.
+     */
+    public int dependentVariables() {
+        int l = 0;
+        for (int i = 0; i < val.length; i++) {
+            if (val[i] > 0) {
+                l++;
+            }
+        }
+        return l;
+    }
+
+
+    /**
+     * ExpVector dependency on variables.
+     * @return array of indices where val has positive exponents.
+     */
+    @Override
+    public int[] dependencyOnVariables() {
+        int[] u = val;
+        int l = dependentVariables();
+        int[] dep = new int[l];
+        if (l == 0) {
+            return dep;
+        }
+        int j = 0;
+        for (int i = 0; i < u.length; i++) {
+            if (u[i] > 0) {
+                dep[j] = i;
+                j++;
+            }
+        }
+        return dep;
+    }
+
+
+    /**
+     * ExpVector multiple test. Test if this is component wise greater or equal
+     * to V.
+     * @param V
+     * @return true if this is a multiple of V, else false.
+     */
+    @Override
+    public boolean multipleOf(ExpVector V) {
+        int[] u = val;
+        int[] v = ((ExpVectorInteger) V).val;
+        boolean t = true;
+        for (int i = 0; i < u.length; i++) {
+            if (u[i] < v[i]) {
+                return false;
+            }
+        }
+        return t;
+        //return EVMT(this, V);
+    }
+
+
+    /**
+     * ExpVector compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int compareTo(ExpVector V) {
+        return this.invLexCompareTo(V);
+    }
+
+
+    /**
+     * ExpVector inverse lexicographical compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int invLexCompareTo(ExpVector V) {
+        int[] u = val;
+        int[] v = ((ExpVectorInteger) V).val;
+        int t = 0;
+        for (int i = 0; i < u.length; i++) {
+            if (u[i] > v[i])
+                return 1;
+            if (u[i] < v[i])
+                return -1;
+        }
+        return t;
+        //return EVILCP(this, V);
+    }
+
+
+    /**
+     * ExpVector inverse lexicographical compareTo.
+     * @param V
+     * @param begin
+     * @param end
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int invLexCompareTo(ExpVector V, int begin, int end) {
+        int[] u = val;
+        int[] v = ((ExpVectorInteger) V).val;
+        if (begin < 0) {
+            begin = 0;;
+        }
+        if (end >= val.length) {
+            end = val.length;
+        }
+        int t = 0;
+        for (int i = begin; i < end; i++) {
+            if (u[i] > v[i])
+                return 1;
+            if (u[i] < v[i])
+                return -1;
+        }
+        return t;
+        //return EVILCP(this, V, begin, end);
+    }
+
+
+    /**
+     * ExpVector inverse graded lexicographical compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int invGradCompareTo(ExpVector V) {
+        int[] u = val;
+        int[] v = ((ExpVectorInteger) V).val;
+        int t = 0;
+        int i;
+        for (i = 0; i < u.length; i++) {
+            if (u[i] > v[i]) {
+                t = 1;
+                break;
+            }
+            if (u[i] < v[i]) {
+                t = -1;
+                break;
+            }
+        }
+        if (t == 0) {
+            return t;
+        }
+        long up = 0;
+        long vp = 0;
+        for (int j = i; j < u.length; j++) {
+            up += u[j];
+            vp += v[j];
+        }
+        if (up > vp) {
+            t = 1;
+        } else {
+            if (up < vp) {
+                t = -1;
+            }
+        }
+        return t;
+        //return EVIGLC(this, V);
+    }
+
+
+    /**
+     * ExpVector inverse graded lexicographical compareTo.
+     * @param V
+     * @param begin
+     * @param end
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int invGradCompareTo(ExpVector V, int begin, int end) {
+        int[] u = val;
+        int[] v = ((ExpVectorInteger) V).val;
+        if (begin < 0) {
+            begin = 0;;
+        }
+        if (end >= val.length) {
+            end = val.length;
+        }
+        int t = 0;
+        int i;
+        for (i = begin; i < end; i++) {
+            if (u[i] > v[i]) {
+                t = 1;
+                break;
+            }
+            if (u[i] < v[i]) {
+                t = -1;
+                break;
+            }
+        }
+        if (t == 0) {
+            return t;
+        }
+        long up = 0;
+        long vp = 0;
+        for (int j = i; j < end; j++) {
+            up += u[j];
+            vp += v[j];
+        }
+        if (up > vp) {
+            t = 1;
+        } else {
+            if (up < vp) {
+                t = -1;
+            }
+        }
+        return t;
+        //return EVIGLC(this, V, begin, end);
+    }
+
+
+    /**
+     * ExpVector reverse inverse lexicographical compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int revInvLexCompareTo(ExpVector V) {
+        int[] u = val;
+        int[] v = ((ExpVectorInteger) V).val;
+        int t = 0;
+        for (int i = u.length - 1; i >= 0; i--) {
+            if (u[i] > v[i])
+                return 1;
+            if (u[i] < v[i])
+                return -1;
+        }
+        return t;
+        //return EVRILCP(this, V);
+    }
+
+
+    /**
+     * ExpVector reverse inverse lexicographical compareTo.
+     * @param V
+     * @param begin
+     * @param end
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int revInvLexCompareTo(ExpVector V, int begin, int end) {
+        int[] u = val;
+        int[] v = ((ExpVectorInteger) V).val;
+        if (begin < 0) {
+            begin = 0;;
+        }
+        if (end >= val.length) {
+            end = val.length;
+        }
+        int t = 0;
+        for (int i = end - 1; i >= begin; i--) {
+            if (u[i] > v[i])
+                return 1;
+            if (u[i] < v[i])
+                return -1;
+        }
+        return t;
+        //return EVRILCP(this, V, begin, end);
+    }
+
+
+    /**
+     * ExpVector reverse inverse graded compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int revInvGradCompareTo(ExpVector V) {
+        int[] u = val;
+        int[] v = ((ExpVectorInteger) V).val;
+        int t = 0;
+        int i;
+        for (i = u.length - 1; i >= 0; i--) {
+            if (u[i] > v[i]) {
+                t = 1;
+                break;
+            }
+            if (u[i] < v[i]) {
+                t = -1;
+                break;
+            }
+        }
+        if (t == 0) {
+            return t;
+        }
+        long up = 0;
+        long vp = 0;
+        for (int j = i; j >= 0; j--) {
+            up += u[j];
+            vp += v[j];
+        }
+        if (up > vp) {
+            t = 1;
+        } else {
+            if (up < vp) {
+                t = -1;
+            }
+        }
+        return t;
+        //return EVRIGLC(this, V);
+    }
+
+
+    /**
+     * ExpVector reverse inverse graded compareTo.
+     * @param V
+     * @param begin
+     * @param end
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int revInvGradCompareTo(ExpVector V, int begin, int end) {
+        int[] u = val;
+        int[] v = ((ExpVectorInteger) V).val;
+        if (begin < 0) {
+            begin = 0;;
+        }
+        if (end >= val.length) {
+            end = val.length;
+        }
+        int t = 0;
+        int i;
+        for (i = end - 1; i >= begin; i--) {
+            if (u[i] > v[i]) {
+                t = 1;
+                break;
+            }
+            if (u[i] < v[i]) {
+                t = -1;
+                break;
+            }
+        }
+        if (t == 0) {
+            return t;
+        }
+        long up = 0;
+        long vp = 0;
+        for (int j = i; j >= begin; j--) {
+            up += u[j];
+            vp += v[j];
+        }
+        if (up > vp) {
+            t = 1;
+        } else {
+            if (up < vp) {
+                t = -1;
+            }
+        }
+        return t;
+        //return EVRIGLC(this, V, begin, end);
+    }
+
+
+    /**
+     * ExpVector inverse total degree lexicographical compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int invTdegCompareTo(ExpVector V) {
+        int[] u = val;
+        int[] v = ((ExpVectorInteger) V).val;
+        int t = 0;
+        int i;
+        for (i = 0; i < u.length; i++) {
+            if (u[i] < v[i]) {
+                t = 1;
+                break;
+            }
+            if (u[i] > v[i]) {
+                t = -1;
+                break;
+            }
+        }
+        if (t == 0) {
+            return t;
+        }
+        int up = 0;
+        int vp = 0;
+        for (int j = i; j < u.length; j++) {
+            up += u[j];
+            vp += v[j];
+        }
+        if (up > vp) {
+            t = 1;
+        } else {
+            if (up < vp) {
+                t = -1;
+            }
+        }
+        return t;
+    }
+
+
+    /**
+     * ExpVector reverse lexicographical inverse total degree compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int revLexInvTdegCompareTo(ExpVector V) {
+        int[] u = val;
+        int[] v = ((ExpVectorInteger) V).val;
+        int t = 0;
+        int i;
+        for (i = u.length - 1; i >= 0; i--) {
+            if (u[i] < v[i]) {
+                t = 1;
+                break;
+            }
+            if (u[i] > v[i]) {
+                t = -1;
+                break;
+            }
+        }
+        if (t == 0) {
+            return t;
+        }
+        int up = 0;
+        int vp = 0;
+        for (int j = i; j >= 0; j--) {
+            up += u[j];
+            vp += v[j];
+        }
+        if (up > vp) {
+            t = 1; 
+        } else {
+            if (up < vp) {
+                t = -1;
+            }
+        }
+        return t;
+    }
+
+
+    /**
+     * ExpVector inverse weighted lexicographical compareTo.
+     * @param w weight array.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int invWeightCompareTo(long[][] w, ExpVector V) {
+        int[] u = val;
+        int[] v = ((ExpVectorInteger) V).val;
+        int t = 0;
+        int i;
+        for (i = 0; i < u.length; i++) {
+            if (u[i] > v[i]) {
+                t = 1;
+                break;
+            }
+            if (u[i] < v[i]) {
+                t = -1;
+                break;
+            }
+        }
+        if (t == 0) {
+            return t;
+        }
+        for (int k = 0; k < w.length; k++) {
+            long[] wk = w[k];
+            long up = 0;
+            long vp = 0;
+            for (int j = i; j < u.length; j++) {
+                up += wk[j] * u[j];
+                vp += wk[j] * v[j];
+            }
+            if (up > vp) {
+                return 1;
+            } else if (up < vp) {
+                return -1;
+            }
+        }
+        return t;
+        //return EVIWLC(w, this, V);
+    }
+
+
+    /**
+     * ExpVector inverse weighted lexicographical compareTo.
+     * @param w weight array.
+     * @param V
+     * @param begin
+     * @param end
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int invWeightCompareTo(long[][] w, ExpVector V, int begin, int end) {
+        int[] u = val;
+        int[] v = ((ExpVectorInteger) V).val;
+        if (begin < 0) {
+            begin = 0;;
+        }
+        if (end >= val.length) {
+            end = val.length;
+        }
+        int t = 0;
+        int i;
+        for (i = begin; i < end; i++) {
+            if (u[i] > v[i]) {
+                t = 1;
+                break;
+            }
+            if (u[i] < v[i]) {
+                t = -1;
+                break;
+            }
+        }
+        if (t == 0) {
+            return t;
+        }
+        for (int k = 0; k < w.length; k++) {
+            long[] wk = w[k];
+            long up = 0;
+            long vp = 0;
+            for (int j = i; j < end; j++) {
+                up += wk[j] * u[j];
+                vp += wk[j] * v[j];
+            }
+            if (up > vp) {
+                return 1;
+            } else if (up < vp) {
+                return -1;
+            }
+        }
+        return t;
+        //return EVIWLC(w, this, V, begin, end);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/ExpVectorLong.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/ExpVectorLong.java
@@ -1,0 +1,1146 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+
+/**
+ * ExpVectorLong implements exponent vectors for polynomials using arrays of
+ * long as storage unit. This class is used by ExpVector internally, there is no
+ * need to use this class directly.
+ * @see ExpVector
+ * @author Heinz Kredel
+ */
+
+public final class ExpVectorLong extends ExpVector
+/*implements AbelianGroupElem<ExpVectorLong>*/{
+
+
+    /**
+     * The data structure is an array of longs.
+     */
+    /*package*/final long[] val;
+
+
+    /**
+     * Constructor for ExpVector.
+     * @param n length of exponent vector.
+     */
+    public ExpVectorLong(int n) {
+        this(new long[n], true);
+    }
+
+
+    /**
+     * Constructor for ExpVector. Sets exponent i to e.
+     * @param n length of exponent vector.
+     * @param i index of exponent to be set.
+     * @param e exponent to be set.
+     */
+    public ExpVectorLong(int n, int i, long e) {
+        this(new long[n], true);
+        val[i] = e;
+    }
+
+
+    /**
+     * Constructor for ExpVector. Sets val.
+     * @param v representation array.
+     */
+    public ExpVectorLong(long[] v) {
+        this(v, false);
+    }
+
+
+    /**
+     * Internal constructor for ExpVector. Sets val.
+     * @param v internal representation array.
+     * @param alloc true if internal representation array is newly
+     * allocated, else false.
+     */
+    protected ExpVectorLong(long[] v, boolean alloc) {
+        super();
+        if (v == null) {
+            throw new IllegalArgumentException("null val not allowed");
+        }
+        if (alloc) {
+            val = v;
+        } else {
+            val = Arrays.copyOf(v, v.length); // > Java-5
+        }
+    }
+
+
+    /**
+     * Constructor for ExpVector. Converts a String representation to an
+     * ExpVector. Accepted format = (1,2,3,4,5,6,7).
+     * @param s String representation.
+     */
+    public ExpVectorLong(String s) throws NumberFormatException {
+        this(parse(s).val, true);
+    }
+
+
+    /**
+     * parser for ExpVector. Converts a String representation to an
+     * ExpVector. Accepted format = (1,2,3,4,5,6,7).
+     * @param s String representation.
+     * @return paresed ExpVector
+     */
+    public static ExpVectorLong parse(String s) throws NumberFormatException {
+        long[] v = null;
+        // first format = (1,2,3,4,5,6,7)
+        List<Long> exps = new ArrayList<Long>();
+        s = s.trim();
+        int b = s.indexOf('(');
+        int e = s.indexOf(')', b + 1);
+        String teil;
+        int k;
+        long a;
+        if (b >= 0 && e >= 0) {
+            b++;
+            while ((k = s.indexOf(',', b)) >= 0) {
+                teil = s.substring(b, k);
+                a = Long.parseLong(teil);
+                exps.add(Long.valueOf(a));
+                b = k + 1;
+            }
+            if (b <= e) {
+                teil = s.substring(b, e);
+                a = Long.parseLong(teil);
+                exps.add(Long.valueOf(a));
+            }
+            int length = exps.size();
+            v = new long[length];
+            for (int j = 0; j < length; j++) {
+                v[j] = exps.get(j).longValue();
+            }
+        }
+        return new ExpVectorLong(v,true);
+    }
+
+
+    /**
+     * Clone this.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public ExpVectorLong copy() {
+        long[] w = new long[val.length];
+        System.arraycopy(val, 0, w, 0, val.length);
+        return new ExpVectorLong(w, true);
+    }
+
+
+    /**
+     * Get the exponent vector.
+     * @return val.
+     */
+    @Override
+    public long[] getVal() {
+        long[] w = new long[val.length];
+        System.arraycopy(val, 0, w, 0, val.length);
+        return w;
+        //return val;
+    }
+
+
+    /**
+     * Get the exponent at position i.
+     * @param i position.
+     * @return val[i].
+     */
+    @Override
+    public long getVal(int i) {
+        return val[i];
+    }
+
+
+    /**
+     * Set the exponent at position i to e.
+     * @param i
+     * @param e
+     * @return old val[i].
+     */
+    @Override
+    protected long setVal(int i, long e) {
+        long x = val[i];
+        val[i] = e;
+        hash = 0; // beware of race condition
+        return x;
+    }
+
+
+    /**
+     * Get the length of this exponent vector.
+     * @return val.length.
+     */
+    @Override
+    public int length() {
+        return val.length;
+    }
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend this by i
+     * elements and set val[j] to e.
+     * @param i number of elements to extend.
+     * @param j index of element to be set.
+     * @param e new exponent for val[j].
+     * @return extended exponent vector.
+     */
+    @Override
+    public ExpVectorLong extend(int i, int j, long e) {
+        long[] w = new long[val.length + i];
+        System.arraycopy(val, 0, w, i, val.length);
+        if (j >= i) {
+            throw new IllegalArgumentException("i " + i + " <= j " + j + " invalid");
+        }
+        w[j] = e;
+        return new ExpVectorLong(w, true);
+    }
+
+
+    /**
+     * Extend lower variables. Extend this by i lower elements and set val[j] to
+     * e.
+     * @param i number of elements to extend.
+     * @param j index of element to be set.
+     * @param e new exponent for val[j].
+     * @return extended exponent vector.
+     */
+    @Override
+    public ExpVectorLong extendLower(int i, int j, long e) {
+        long[] w = new long[val.length + i];
+        System.arraycopy(val, 0, w, 0, val.length);
+        if (j >= i) {
+            throw new IllegalArgumentException("i " + i + " <= j " + j + " invalid");
+        }
+        w[val.length + j] = e;
+        return new ExpVectorLong(w, true);
+    }
+
+
+    /**
+     * Contract variables. Used e.g. in module embedding. Contract this to len
+     * elements.
+     * @param i position of first element to be copied.
+     * @param len new length.
+     * @return contracted exponent vector.
+     */
+    @Override
+    public ExpVectorLong contract(int i, int len) {
+        if (i + len > val.length) {
+            throw new IllegalArgumentException("len " + len + " > val.len " + val.length);
+        }
+        long[] w = new long[len];
+        System.arraycopy(val, i, w, 0, len);
+        return new ExpVectorLong(w, true);
+    }
+
+
+    /**
+     * Reverse variables. Used e.g. in opposite rings.
+     * @return reversed exponent vector.
+     */
+    @Override
+    public ExpVectorLong reverse() {
+        long[] w = new long[val.length];
+        for (int i = 0; i < val.length; i++) {
+            w[i] = val[val.length - 1 - i];
+        }
+        return new ExpVectorLong(w, true);
+    }
+
+
+    /**
+     * Reverse lower j variables. Used e.g. in opposite rings. Reverses the
+     * first j-1 variables, the rest is unchanged.
+     * @param j index of first variable reversed.
+     * @return reversed exponent vector.
+     */
+    @Override
+    public ExpVectorLong reverse(int j) {
+        if (j <= 0 || j > val.length) {
+            return this;
+        }
+        long[] w = new long[val.length];
+        // copy first
+        for (int i = 0; i < j; i++) {
+            w[i] = val[i];
+        }
+        // reverse rest
+        for (int i = j; i < val.length; i++) {
+            w[i] = val[val.length + j - 1 - i];
+        }
+        //System.out.println("val = " + Arrays.toString(val));
+        //System.out.println("w   = " + Arrays.toString(w));
+        return new ExpVectorLong(w, true);
+    }
+
+
+    /**
+     * Reverse upper j variables. Reverses the last j-1 variables, the rest is
+     * unchanged.
+     * @param j index of first variable not reversed.
+     * @return reversed exponent vector.
+     */
+    public ExpVectorLong reverseUpper(int j) {
+        if (j <= 0 || j > val.length) {
+            return this;
+        }
+        long[] w = new long[val.length];
+        for (int i = 0; i < j; i++) {
+            w[i] = val[j - 1 - i];
+        }
+        // copy rest
+        for (int i = j; i < val.length; i++) {
+            w[i] = val[i];
+        }
+        return new ExpVectorLong(w, true);
+    }
+
+
+    /**
+     * Combine with ExpVector. Combine this with the other ExpVector V.
+     * @param V the other exponent vector.
+     * @return combined exponent vector.
+     */
+    @Override
+    public ExpVectorLong combine(ExpVector V) {
+        if (V == null || V.length() == 0) {
+            return this;
+        }
+        ExpVectorLong Vl = (ExpVectorLong) V;
+        if (val.length == 0) {
+            return Vl;
+        }
+        long[] w = new long[val.length + Vl.val.length];
+        System.arraycopy(val, 0, w, 0, val.length);
+        System.arraycopy(Vl.val, 0, w, val.length, Vl.val.length);
+        return new ExpVectorLong(w, true);
+    }
+
+
+    /**
+     * Permutation of exponent vector.
+     * @param P permutation.
+     * @return P(e).
+     */
+    @Override
+    public ExpVectorLong permutation(List<Integer> P) {
+        long[] w = new long[val.length];
+        int j = 0;
+        for (Integer i : P) {
+            w[j++] = val[i];
+        }
+        return new ExpVectorLong(w, true);
+    }
+
+
+    /**
+     * Get the string representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return super.toString() + ":long";
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object B) {
+        if (!(B instanceof ExpVectorLong)) {
+            return false;
+        }
+        ExpVectorLong b = (ExpVectorLong) B;
+        int t = this.invLexCompareTo(b);
+        //System.out.println("equals: this = " + this + " B = " + B + " t = " + t);
+        return (0 == t);
+    }
+
+
+    /**
+     * hashCode for this exponent vector.
+     * @see java.lang.Object#hashCode() Only for findbugs.
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+
+    /**
+     * ExpVector absolute value.
+     * @return abs(this).
+     */
+    @Override
+    public ExpVectorLong abs() {
+        long[] u = val;
+        long[] w = new long[u.length];
+        for (int i = 0; i < u.length; i++) {
+            if (u[i] >= 0L) {
+                w[i] = u[i];
+            } else {
+                w[i] = -u[i];
+            }
+        }
+        return new ExpVectorLong(w, true);
+    }
+
+
+    /**
+     * ExpVector negate.
+     * @return -this.
+     */
+    @Override
+    public ExpVectorLong negate() {
+        long[] u = val;
+        long[] w = new long[u.length];
+        for (int i = 0; i < u.length; i++) {
+            w[i] = -u[i];
+        }
+        return new ExpVectorLong(w, true);
+    }
+
+
+    /**
+     * ExpVector summation.
+     * @param V
+     * @return this+V.
+     */
+    @Override
+    public ExpVectorLong sum(ExpVector V) {
+        long[] u = val;
+        long[] v = ((ExpVectorLong) V).val;
+        long[] w = new long[u.length];
+        for (int i = 0; i < u.length; i++) {
+            w[i] = u[i] + v[i];
+        }
+        return new ExpVectorLong(w, true);
+    }
+
+
+    /**
+     * ExpVector subtract. Result may have negative entries.
+     * @param V
+     * @return this-V.
+     */
+    @Override
+    public ExpVectorLong subtract(ExpVector V) {
+        long[] u = val;
+        long[] v = ((ExpVectorLong) V).val;
+        long[] w = new long[u.length];
+        for (int i = 0; i < u.length; i++) {
+            w[i] = u[i] - v[i];
+        }
+        return new ExpVectorLong(w, true);
+    }
+
+
+    /**
+     * ExpVector multiply by scalar.
+     * @param s scalar
+     * @return s*this.
+     */
+    @Override
+    public ExpVectorLong scalarMultiply(long s) {
+        long[] u = val;
+        long[] w = new long[u.length];
+        for (int i = 0; i < u.length; i++) {
+            w[i] = s * u[i];
+        }
+        return new ExpVectorLong(w, true);
+    }
+
+
+    /**
+     * ExpVector substitution. Clone and set exponent to d at position i.
+     * @param i position.
+     * @param d new exponent.
+     * @return substituted ExpVector.
+     */
+    @Override
+    public ExpVectorLong subst(int i, long d) {
+        ExpVectorLong V = this.copy();
+        //long e = 
+        V.setVal(i, d);
+        return V;
+    }
+
+
+    /**
+     * ExpVector signum.
+     * @return 0 if this is zero, -1 if some entry is negative, 1 if no entry is
+     *         negative and at least one entry is positive.
+     */
+    @Override
+    public int signum() {
+        int t = 0;
+        long[] u = val;
+        for (int i = 0; i < u.length; i++) {
+            if (u[i] < 0) {
+                return -1;
+            }
+            if (u[i] > 0) {
+                t = 1;
+            }
+        }
+        return t;
+    }
+
+
+    /**
+     * ExpVector total degree.
+     * @return sum of all exponents.
+     */
+    @Override
+    public long totalDeg() {
+        long t = 0;
+        long[] u = val; // U.val;
+        for (int i = 0; i < u.length; i++) {
+            t += u[i];
+        }
+        return t;
+    }
+
+
+    /**
+     * ExpVector maximal degree.
+     * @return maximal exponent.
+     */
+    @Override
+    public long maxDeg() {
+        long t = 0;
+        long[] u = val;
+        for (int i = 0; i < u.length; i++) {
+            if (u[i] > t) {
+                t = u[i];
+            }
+        }
+        return t;
+    }
+
+
+    /**
+     * ExpVector minimal degree.
+     * @return minimal exponent.
+     */
+    @Override
+    public long minDeg() {
+        long t = Long.MAX_VALUE;
+        long[] u = val;
+        for (int i = 0; i < u.length; i++) {
+            if (u[i] < t) {
+                t = u[i];
+            }
+        }
+        return t;
+    }
+
+
+    /**
+     * ExpVector weighted degree.
+     * @param w weights.
+     * @return weighted sum of all exponents.
+     */
+    @Override
+    public long weightDeg(long[][] w) {
+        if (w == null || w.length == 0) {
+            return totalDeg(); // assume weight 1 
+        }
+        long t = 0;
+        long[] u = val;
+        for (int j = 0; j < w.length; j++) {
+            long[] wj = w[j];
+            for (int i = 0; i < u.length; i++) {
+                t += wj[i] * u[i];
+            }
+        }
+        return t;
+    }
+
+
+    /**
+     * ExpVector weighted degree.
+     * @param w weights.
+     * @return weighted sum of all exponents.
+     */
+    @Override
+    public long weightDeg(long[] w) {
+        if (w == null || w.length == 0) {
+            return totalDeg(); // assume weight 1 
+        }
+        long t = 0;
+        long[] u = val;
+        for (int i = 0; i < w.length; i++) {
+             t += w[i] * u[i];
+        }
+        return t;
+    }
+
+
+    /**
+     * ExpVector least common multiple.
+     * @param V
+     * @return component wise maximum of this and V.
+     */
+    @Override
+    public ExpVectorLong lcm(ExpVector V) {
+        long[] u = val;
+        long[] v = ((ExpVectorLong) V).val;
+        long[] w = new long[u.length];
+        for (int i = 0; i < u.length; i++) {
+            w[i] = (u[i] >= v[i] ? u[i] : v[i]);
+        }
+        return new ExpVectorLong(w, true);
+    }
+
+
+    /**
+     * ExpVector greatest common divisor.
+     * @param V
+     * @return component wise minimum of this and V.
+     */
+    @Override
+    public ExpVectorLong gcd(ExpVector V) {
+        long[] u = val;
+        long[] v = ((ExpVectorLong) V).val;
+        long[] w = new long[u.length];
+        for (int i = 0; i < u.length; i++) {
+            w[i] = (u[i] <= v[i] ? u[i] : v[i]);
+        }
+        return new ExpVectorLong(w, true);
+    }
+
+
+    /**
+     * ExpVector dependent variables.
+     * @return number of indices where val has positive exponents.
+     */
+    public int dependentVariables() {
+        int l = 0;
+        for (int i = 0; i < val.length; i++) {
+            if (val[i] > 0) {
+                l++;
+            }
+        }
+        return l;
+    }
+
+
+    /**
+     * ExpVector dependency on variables.
+     * @return array of indices where val has positive exponents.
+     */
+    @Override
+    public int[] dependencyOnVariables() {
+        long[] u = val;
+        int l = dependentVariables();
+        int[] dep = new int[l];
+        if (l == 0) {
+            return dep;
+        }
+        int j = 0;
+        for (int i = 0; i < u.length; i++) {
+            if (u[i] > 0) {
+                dep[j] = i;
+                j++;
+            }
+        }
+        return dep;
+    }
+
+
+    /**
+     * ExpVector multiple test. Test if this is component wise greater or equal
+     * to V.
+     * @param V
+     * @return true if this is a multiple of V, else false.
+     */
+    @Override
+    public boolean multipleOf(ExpVector V) {
+        long[] u = val;
+        long[] v = ((ExpVectorLong) V).val;
+        for (int i = 0; i < u.length; i++) {
+            if (u[i] < v[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * ExpVector compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int compareTo(ExpVector V) {
+        return this.invLexCompareTo(V);
+    }
+
+
+    /**
+     * ExpVector inverse lexicographical compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int invLexCompareTo(ExpVector V) {
+        long[] u = val;
+        long[] v = ((ExpVectorLong) V).val;
+        int t = 0;
+        for (int i = 0; i < u.length; i++) {
+            if (u[i] > v[i])
+                return 1;
+            if (u[i] < v[i])
+                return -1;
+        }
+        return t;
+    }
+
+
+    /**
+     * ExpVector inverse lexicographical compareTo.
+     * @param V
+     * @param begin
+     * @param end
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int invLexCompareTo(ExpVector V, int begin, int end) {
+        long[] u = val;
+        long[] v = ((ExpVectorLong) V).val;
+        if (begin < 0) {
+            begin = 0;;
+        }
+        if (end >= val.length) {
+            end = val.length;
+        }
+        int t = 0;
+        for (int i = begin; i < end; i++) {
+            if (u[i] > v[i])
+                return 1;
+            if (u[i] < v[i])
+                return -1;
+        }
+        return t;
+    }
+
+
+    /**
+     * ExpVector inverse graded lexicographical compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int invGradCompareTo(ExpVector V) {
+        long[] u = val;
+        long[] v = ((ExpVectorLong) V).val;
+        int t = 0;
+        int i;
+        for (i = 0; i < u.length; i++) {
+            if (u[i] > v[i]) {
+                t = 1;
+                break;
+            }
+            if (u[i] < v[i]) {
+                t = -1;
+                break;
+            }
+        }
+        if (t == 0) {
+            return t;
+        }
+        long up = 0;
+        long vp = 0;
+        for (int j = i; j < u.length; j++) {
+            up += u[j];
+            vp += v[j];
+        }
+        if (up > vp) {
+            t = 1;
+        } else {
+            if (up < vp) {
+                t = -1;
+            }
+        }
+        return t;
+    }
+
+
+    /**
+     * ExpVector inverse graded lexicographical compareTo.
+     * @param V
+     * @param begin
+     * @param end
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int invGradCompareTo(ExpVector V, int begin, int end) {
+        long[] u = val;
+        long[] v = ((ExpVectorLong) V).val;
+        if (begin < 0) {
+            begin = 0;;
+        }
+        if (end >= val.length) {
+            end = val.length;
+        }
+        int t = 0;
+        int i;
+        for (i = begin; i < end; i++) {
+            if (u[i] > v[i]) {
+                t = 1;
+                break;
+            }
+            if (u[i] < v[i]) {
+                t = -1;
+                break;
+            }
+        }
+        if (t == 0) {
+            return t;
+        }
+        long up = 0;
+        long vp = 0;
+        for (int j = i; j < end; j++) {
+            up += u[j];
+            vp += v[j];
+        }
+        if (up > vp) {
+            t = 1;
+        } else {
+            if (up < vp) {
+                t = -1;
+            }
+        }
+        return t;
+    }
+
+
+    /**
+     * ExpVector reverse inverse lexicographical compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int revInvLexCompareTo(ExpVector V) {
+        long[] u = val;
+        long[] v = ((ExpVectorLong) V).val;
+        int t = 0;
+        for (int i = u.length - 1; i >= 0; i--) {
+            if (u[i] > v[i])
+                return 1;
+            if (u[i] < v[i])
+                return -1;
+        }
+        return t;
+    }
+
+
+    /**
+     * ExpVector reverse inverse lexicographical compareTo.
+     * @param V
+     * @param begin
+     * @param end
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int revInvLexCompareTo(ExpVector V, int begin, int end) {
+        long[] u = val;
+        long[] v = ((ExpVectorLong) V).val;
+        if (begin < 0) {
+            begin = 0;;
+        }
+        if (end >= val.length) {
+            end = val.length;
+        }
+        int t = 0;
+        for (int i = end - 1; i >= begin; i--) {
+            if (u[i] > v[i])
+                return 1;
+            if (u[i] < v[i])
+                return -1;
+        }
+        return t;
+    }
+
+
+    /**
+     * ExpVector reverse inverse graded compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int revInvGradCompareTo(ExpVector V) {
+        long[] u = val;
+        long[] v = ((ExpVectorLong) V).val;
+        int t = 0;
+        int i;
+        for (i = u.length - 1; i >= 0; i--) {
+            if (u[i] > v[i]) {
+                t = 1;
+                break;
+            }
+            if (u[i] < v[i]) {
+                t = -1;
+                break;
+            }
+        }
+        if (t == 0) {
+            return t;
+        }
+        long up = 0;
+        long vp = 0;
+        for (int j = i; j >= 0; j--) {
+            up += u[j];
+            vp += v[j];
+        }
+        if (up > vp) {
+            t = 1;
+        } else {
+            if (up < vp) {
+                t = -1;
+            }
+        }
+        return t;
+    }
+
+
+    /**
+     * ExpVector reverse inverse graded compareTo.
+     * @param V
+     * @param begin
+     * @param end
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int revInvGradCompareTo(ExpVector V, int begin, int end) {
+        long[] u = val;
+        long[] v = ((ExpVectorLong) V).val;
+        if (begin < 0) {
+            begin = 0;;
+        }
+        if (end >= val.length) {
+            end = val.length;
+        }
+        int t = 0;
+        int i;
+        for (i = end - 1; i >= begin; i--) {
+            if (u[i] > v[i]) {
+                t = 1;
+                break;
+            }
+            if (u[i] < v[i]) {
+                t = -1;
+                break;
+            }
+        }
+        if (t == 0) {
+            return t;
+        }
+        long up = 0;
+        long vp = 0;
+        for (int j = i; j >= begin; j--) {
+            up += u[j];
+            vp += v[j];
+        }
+        if (up > vp) {
+            t = 1;
+        } else {
+            if (up < vp) {
+                t = -1;
+            }
+        }
+        return t;
+    }
+
+
+    /**
+     * ExpVector inverse total degree lexicographical compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int invTdegCompareTo(ExpVector V) {
+        long[] u = val;
+        long[] v = ((ExpVectorLong) V).val;
+        int t = 0;
+        int i;
+        for (i = 0; i < u.length; i++) {
+            if (u[i] < v[i]) {
+                t = 1;
+                break;
+            }
+            if (u[i] > v[i]) {
+                t = -1;
+                break;
+            }
+        }
+        if (t == 0) {
+            return t;
+        }
+        long up = 0;
+        long vp = 0;
+        for (int j = i; j < u.length; j++) {
+            up += u[j];
+            vp += v[j];
+        }
+        if (up > vp) {
+            t = 1;
+        } else {
+            if (up < vp) {
+                t = -1;
+            }
+        }
+        return t;
+    }
+
+
+    /**
+     * ExpVector reverse lexicographical inverse total degree compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int revLexInvTdegCompareTo(ExpVector V) {
+        long[] u = val;
+        long[] v = ((ExpVectorLong) V).val;
+        int t = 0;
+        int i;
+        for (i = u.length - 1; i >= 0; i--) {
+            if (u[i] < v[i]) {
+                t = 1;
+                break;
+            }
+            if (u[i] > v[i]) {
+                t = -1;
+                break;
+            }
+        }
+        if (t == 0) {
+            return t;
+        }
+        long up = 0;
+        long vp = 0;
+        for (int j = i; j >= 0; j--) {
+            up += u[j];
+            vp += v[j];
+        }
+        if (up > vp) {
+            t = 1; 
+        } else {
+            if (up < vp) {
+                t = -1;
+            }
+        }
+        return t;
+    }
+
+
+    /**
+     * ExpVector inverse weighted lexicographical compareTo.
+     * @param w weight array.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int invWeightCompareTo(long[][] w, ExpVector V) {
+        long[] u = val;
+        long[] v = ((ExpVectorLong) V).val;
+        int t = 0;
+        int i;
+        for (i = 0; i < u.length; i++) {
+            if (u[i] > v[i]) {
+                t = 1;
+                break;
+            }
+            if (u[i] < v[i]) {
+                t = -1;
+                break;
+            }
+        }
+        if (t == 0) {
+            return t;
+        }
+        for (int k = 0; k < w.length; k++) {
+            long[] wk = w[k];
+            long up = 0;
+            long vp = 0;
+            for (int j = i; j < u.length; j++) {
+                up += wk[j] * u[j];
+                vp += wk[j] * v[j];
+            }
+            if (up > vp) {
+                return 1;
+            } else if (up < vp) {
+                return -1;
+            }
+        }
+        return t;
+    }
+
+
+    /**
+     * ExpVector inverse weighted lexicographical compareTo.
+     * @param w weight array.
+     * @param V
+     * @param begin
+     * @param end
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int invWeightCompareTo(long[][] w, ExpVector V, int begin, int end) {
+        long[] u = val;
+        long[] v = ((ExpVectorLong) V).val;
+        if (begin < 0) {
+            begin = 0;;
+        }
+        if (end >= val.length) {
+            end = val.length;
+        }
+        int t = 0;
+        int i;
+        for (i = begin; i < end; i++) {
+            if (u[i] > v[i]) {
+                t = 1;
+                break;
+            }
+            if (u[i] < v[i]) {
+                t = -1;
+                break;
+            }
+        }
+        if (t == 0) {
+            return t;
+        }
+        for (int k = 0; k < w.length; k++) {
+            long[] wk = w[k];
+            long up = 0;
+            long vp = 0;
+            for (int j = i; j < end; j++) {
+                up += wk[j] * u[j];
+                vp += wk[j] * v[j];
+            }
+            if (up > vp) {
+                return 1;
+            } else if (up < vp) {
+                return -1;
+            }
+        }
+        return t;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/ExpVectorPair.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/ExpVectorPair.java
@@ -1,0 +1,123 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+import java.io.Serializable;
+
+
+/**
+ * ExpVectorPair 
+ * implements pairs of exponent vectors for S-polynomials.
+ * Objects of this class are immutable.
+ * @author Heinz Kredel
+ */
+
+
+public class ExpVectorPair implements Serializable {
+
+    private final ExpVector e1;
+    private final ExpVector e2;
+
+
+    /**
+     * Constructors for ExpVectorPair.
+     * @param e first part.
+     * @param f second part.
+     */
+    public ExpVectorPair(ExpVector e, ExpVector f) {
+        e1 = e;
+        e2 = f;
+    }
+
+
+    /**
+     * @return first part.
+     */
+    public ExpVector getFirst() {
+        return e1;
+    } 
+
+
+    /**
+     * @return second part.
+     */
+    public ExpVector getSecond() {
+        return e2;
+    } 
+
+
+    /**
+     * @return total degree of both parts.
+     */
+    public long totalDeg() {
+        return e1.totalDeg() + e2.totalDeg();
+    } 
+
+
+    /**
+     * toString.
+     */
+    @Override
+     public String toString() {
+        StringBuffer s = new StringBuffer("ExpVectorPair[");
+        s.append(e1.toString());
+        s.append(",");
+        s.append(e2.toString());
+        s.append("]");
+        return s.toString();
+    }
+
+
+    /**
+     * equals.
+     * @param B other.
+     * @return true, if this == b, else false.
+     */
+    @Override
+     public boolean equals(Object B) { 
+       if ( ! (B instanceof ExpVectorPair) ) return false;
+       return equals( (ExpVectorPair)B );
+    }
+
+
+    /**
+     * equals.
+     * @param b other.
+     * @return true, if this == b, else false.
+     */
+    public boolean equals(ExpVectorPair b) { 
+       boolean t = e1.equals( b.getFirst() ); 
+       t = t && e2.equals( b.getSecond() ); 
+       return t;
+    }
+
+
+    /** hash code.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+       return (e1.hashCode() << 16) + e2.hashCode();
+    }
+
+        
+    /**
+     * isMultiple.
+     * @param p other.
+     * @return true, if this is a multiple of b, else false.
+     */
+    public boolean isMultiple(ExpVectorPair p) {
+       boolean w =  e1.multipleOf( p.getFirst() );
+       if ( !w ) {
+           return w;
+       }
+       w =  e2.multipleOf( p.getSecond() );
+       if ( !w ) {
+           return w;
+       }
+       return true;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/ExpVectorShort.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/ExpVectorShort.java
@@ -1,0 +1,1141 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ * ExpVectorShort implements exponent vectors for polynomials using arrays of
+ * short as storage unit. This class is used by ExpVector internally, there is
+ * no need to use this class directly.
+ * @see ExpVector
+ * @author Heinz Kredel
+ */
+
+public final class ExpVectorShort extends ExpVector
+/*implements AbelianGroupElem<ExpVectorShort>*/{
+
+
+    /**
+     * The data structure is an array of short.
+     */
+    /*package*/final short[] val;
+
+
+    /**
+     * Largest short.
+     */
+    public static final long maxShort = (long) Short.MAX_VALUE / 2;
+
+
+    /**
+     * Smallest short.
+     */
+    public static final long minShort = (long) Short.MIN_VALUE / 2;
+
+
+    /**
+     * Constructor for ExpVector.
+     * @param n length of exponent vector.
+     */
+    public ExpVectorShort(int n) {
+        this(new short[n]);
+    }
+
+
+    /**
+     * Constructor for ExpVector. Sets exponent i to e.
+     * @param n length of exponent vector.
+     * @param i index of exponent to be set.
+     * @param e exponent to be set.
+     */
+    public ExpVectorShort(int n, int i, short e) {
+        this(n);
+        val[i] = e;
+    }
+
+
+    /**
+     * Constructor for ExpVector. Sets exponent i to e.
+     * @param n length of exponent vector.
+     * @param i index of exponent to be set.
+     * @param e exponent to be set.
+     */
+    public ExpVectorShort(int n, int i, long e) {
+        this(n);
+        if (e >= maxShort || e <= minShort) {
+            throw new IllegalArgumentException("exponent to large: " + e);
+        }
+        val[i] = (short) e;
+    }
+
+
+    /**
+     * Internal constructor for ExpVector. Sets val.
+     * @param v internal representation array.
+     */
+    protected ExpVectorShort(short[] v) {
+        super();
+        val = v;
+    }
+
+
+    /**
+     * Constructor for ExpVector. Sets val, converts from long array.
+     * @param v long representation array.
+     */
+    public ExpVectorShort(long[] v) {
+        this(v.length);
+        for (int i = 0; i < v.length; i++) {
+            if (v[i] >= maxShort || v[i] <= minShort) {
+                throw new IllegalArgumentException("exponent to large: " + v[i]);
+            }
+            val[i] = (short) v[i];
+        }
+    }
+
+
+    /**
+     * Constructor for ExpVector. Converts a String representation to an
+     * ExpVector. Accepted format = (1,2,3,4,5,6,7).
+     * @param s String representation.
+     */
+    public ExpVectorShort(String s) throws NumberFormatException {
+        super();
+        // first format = (1,2,3,4,5,6,7)
+        List<Short> exps = new ArrayList<Short>();
+        s = s.trim();
+        int b = s.indexOf('(');
+        int e = s.indexOf(')', b + 1);
+        String teil;
+        int k;
+        short a;
+        if (b >= 0 && e >= 0) {
+            b++;
+            while ((k = s.indexOf(',', b)) >= 0) {
+                teil = s.substring(b, k);
+                a = Short.parseShort(teil);
+                exps.add(Short.valueOf(a));
+                b = k + 1;
+            }
+            if (b <= e) {
+                teil = s.substring(b, e);
+                a = Short.parseShort(teil);
+                exps.add(Short.valueOf(a));
+            }
+            int length = exps.size();
+            val = new short[length];
+            for (int j = 0; j < length; j++) {
+                val[j] = exps.get(j).shortValue();
+            }
+        } else {
+            // not implemented
+            val = null;
+            // length = -1;
+            //Vector names = new Vector();
+            //vars = s;
+        }
+    }
+
+
+    /**
+     * Clone this.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public ExpVectorShort copy() {
+        short[] w = new short[val.length];
+        System.arraycopy(val, 0, w, 0, val.length);
+        return new ExpVectorShort(w);
+    }
+
+
+    /**
+     * Get the exponent vector.
+     * @return val as long.
+     */
+    @Override
+    public long[] getVal() {
+        long v[] = new long[val.length];
+        for (int i = 0; i < val.length; i++) {
+            v[i] = val[i];
+        }
+        return v;
+    }
+
+
+    /**
+     * Get the exponent at position i.
+     * @param i position.
+     * @return val[i].
+     */
+    @Override
+    public long getVal(int i) {
+        return val[i];
+    }
+
+
+    /**
+     * Set the exponent at position i to e.
+     * @param i
+     * @param e
+     * @return old val[i].
+     */
+    @Override
+    protected long setVal(int i, long e) {
+        short x = val[i];
+        if (e >= maxShort || e <= minShort) {
+            throw new IllegalArgumentException("exponent to large: " + e);
+        }
+        val[i] = (short) e;
+        hash = 0; // beware of race condition
+        return x;
+    }
+
+
+    /**
+     * Set the exponent at position i to e.
+     * @param i
+     * @param e
+     * @return old val[i].
+     */
+    protected short setVal(int i, short e) {
+        short x = val[i];
+        val[i] = e;
+        hash = 0; // beware of race condition
+        return x;
+    }
+
+
+    /**
+     * Get the length of this exponent vector.
+     * @return val.length.
+     */
+    @Override
+    public int length() {
+        return val.length;
+    }
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend this by i
+     * elements and set val[j] to e.
+     * @param i number of elements to extend.
+     * @param j index of element to be set.
+     * @param e new exponent for val[j].
+     * @return extended exponent vector.
+     */
+    @Override
+    public ExpVectorShort extend(int i, int j, long e) {
+        short[] w = new short[val.length + i];
+        System.arraycopy(val, 0, w, i, val.length);
+        if (j >= i) {
+            throw new IllegalArgumentException("i " + i + " <= j " + j + " invalid");
+        }
+        if (e >= maxShort || e <= minShort) {
+            throw new IllegalArgumentException("exponent to large: " + e);
+        }
+        w[j] = (short) e;
+        return new ExpVectorShort(w);
+    }
+
+
+    /**
+     * Extend lower variables. Extend this by i lower elements and set val[j] to
+     * e.
+     * @param i number of elements to extend.
+     * @param j index of element to be set.
+     * @param e new exponent for val[j].
+     * @return extended exponent vector.
+     */
+    @Override
+    public ExpVectorShort extendLower(int i, int j, long e) {
+        short[] w = new short[val.length + i];
+        System.arraycopy(val, 0, w, 0, val.length);
+        if (j >= i) {
+            throw new IllegalArgumentException("i " + i + " <= j " + j + " invalid");
+        }
+        w[val.length + j] = (short) e;
+        return new ExpVectorShort(w);
+    }
+
+
+    /**
+     * Contract variables. Used e.g. in module embedding. Contract this to len
+     * elements.
+     * @param i position of first element to be copied.
+     * @param len new length.
+     * @return contracted exponent vector.
+     */
+    @Override
+    public ExpVectorShort contract(int i, int len) {
+        if (i + len > val.length) {
+            throw new IllegalArgumentException("len " + len + " > val.len " + val.length);
+        }
+        short[] w = new short[len];
+        System.arraycopy(val, i, w, 0, len);
+        return new ExpVectorShort(w);
+    }
+
+
+    /**
+     * Reverse variables. Used e.g. in opposite rings.
+     * @return reversed exponent vector.
+     */
+    @Override
+    public ExpVectorShort reverse() {
+        short[] w = new short[val.length];
+        for (int i = 0; i < val.length; i++) {
+            w[i] = val[val.length - 1 - i];
+        }
+        return new ExpVectorShort(w);
+    }
+
+
+    /**
+     * Reverse lower j variables. Used e.g. in opposite rings. Reverses the
+     * first j-1 variables, the rest is unchanged.
+     * @param j index of first variable reversed.
+     * @return reversed exponent vector.
+     */
+    @Override
+    public ExpVectorShort reverse(int j) {
+        if (j <= 0 || j > val.length) {
+            return this;
+        }
+        short[] w = new short[val.length];
+        for (int i = 0; i < j; i++) {
+            w[i] = val[i];
+        }
+        // copy rest
+        for (int i = j; i < val.length; i++) {
+            w[i] = val[val.length + j - 1 - i];
+        }
+        return new ExpVectorShort(w);
+    }
+
+
+    /**
+     * Combine with ExpVector. Combine this with the other ExpVector V.
+     * @param V the other exponent vector.
+     * @return combined exponent vector.
+     */
+    @Override
+    public ExpVectorShort combine(ExpVector V) {
+        if (V == null || V.length() == 0) {
+            return this;
+        }
+        ExpVectorShort Vi = (ExpVectorShort) V;
+        if (val.length == 0) {
+            return Vi;
+        }
+        short[] w = new short[val.length + Vi.val.length];
+        System.arraycopy(val, 0, w, 0, val.length);
+        System.arraycopy(Vi.val, 0, w, val.length, Vi.val.length);
+        return new ExpVectorShort(w);
+    }
+
+
+    /**
+     * Permutation of exponent vector.
+     * @param P permutation.
+     * @return P(e).
+     */
+    @Override
+    public ExpVectorShort permutation(List<Integer> P) {
+        short[] w = new short[val.length];
+        int j = 0;
+        for (Integer i : P) {
+            w[j++] = val[i];
+        }
+        return new ExpVectorShort(w);
+    }
+
+
+    /**
+     * Get the string representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return super.toString() + ":short";
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object B) {
+        if (!(B instanceof ExpVectorShort)) {
+            return false;
+        }
+        ExpVectorShort b = (ExpVectorShort) B;
+        int t = this.invLexCompareTo(b);
+        //System.out.println("equals: this = " + this + " B = " + B + " t = " + t);
+        return (0 == t);
+    }
+
+
+    /**
+     * hashCode for this exponent vector.
+     * @see java.lang.Object#hashCode() Only for findbugs.
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+
+    /**
+     * ExpVector absolute value.
+     * @return abs(this).
+     */
+    @Override
+    public ExpVectorShort abs() {
+        short[] u = val;
+        short[] w = new short[u.length];
+        for (int i = 0; i < u.length; i++) {
+            if (u[i] >= 0L) {
+                w[i] = u[i];
+            } else {
+                w[i] = (short) (-u[i]);
+            }
+        }
+        return new ExpVectorShort(w);
+        //return EVABS(this);
+    }
+
+
+    /**
+     * ExpVector negate.
+     * @return -this.
+     */
+    @Override
+    public ExpVectorShort negate() {
+        short[] u = val;
+        short[] w = new short[u.length];
+        for (int i = 0; i < u.length; i++) {
+            w[i] = (short) (-u[i]);
+        }
+        return new ExpVectorShort(w);
+        // return EVNEG(this);
+    }
+
+
+    /**
+     * ExpVector summation.
+     * @param V
+     * @return this+V.
+     */
+    @Override
+    public ExpVectorShort sum(ExpVector V) {
+        short[] u = val;
+        short[] v = ((ExpVectorShort) V).val;
+        short[] w = new short[u.length];
+        for (int i = 0; i < u.length; i++) {
+            w[i] = (short) (u[i] + v[i]);
+        }
+        return new ExpVectorShort(w);
+        // return EVSUM(this, V);
+    }
+
+
+    /**
+     * ExpVector subtract. Result may have negative entries.
+     * @param V
+     * @return this-V.
+     */
+    @Override
+    public ExpVectorShort subtract(ExpVector V) {
+        short[] u = val;
+        short[] v = ((ExpVectorShort) V).val;
+        short[] w = new short[u.length];
+        for (int i = 0; i < u.length; i++) {
+            w[i] = (short) (u[i] - v[i]);
+        }
+        return new ExpVectorShort(w);
+        //return EVDIF(this, V);
+    }
+
+
+    /**
+     * ExpVector multiply by scalar.
+     * @param s scalar
+     * @return s*this.
+     */
+    @Override
+    public ExpVectorShort scalarMultiply(long s) {
+        if (s >= maxShort || s <= minShort) {
+            throw new IllegalArgumentException("scalar to large: " + s);
+        }
+        short[] u = val;
+        short[] w = new short[u.length];
+        short ss = (short) s;
+        for (int i = 0; i < u.length; i++) {
+            w[i] = (short) (ss * u[i]);
+        }
+        return new ExpVectorShort(w);
+    }
+
+
+    /**
+     * ExpVector substitution. Clone and set exponent to d at position i.
+     * @param i position.
+     * @param d new exponent.
+     * @return substituted ExpVector.
+     */
+    public ExpVectorShort subst(int i, short d) {
+        ExpVectorShort V = this.copy();
+        //long e = 
+        V.setVal(i, d);
+        return V;
+        //return EVSU(this, i, d);
+    }
+
+
+    /**
+     * ExpVector substitution. Clone and set exponent to d at position i.
+     * @param i position.
+     * @param d new exponent.
+     * @return substituted ExpVector.
+     */
+    @Override
+    public ExpVectorShort subst(int i, long d) {
+        ExpVectorShort V = this.copy();
+        //long e = 
+        V.setVal(i, d);
+        return V;
+        //return EVSU(this, i, d);
+    }
+
+
+    /**
+     * ExpVector signum.
+     * @return 0 if this is zero, -1 if some entry is negative, 1 if no entry is
+     *         negative and at least one entry is positive.
+     */
+    @Override
+    public int signum() {
+        int t = 0;
+        short[] u = val;
+        for (int i = 0; i < u.length; i++) {
+            if (u[i] < 0) {
+                return -1;
+            }
+            if (u[i] > 0) {
+                t = 1;
+            }
+        }
+        return t;
+        //return EVSIGN(this);
+    }
+
+
+    /**
+     * ExpVector total degree.
+     * @return sum of all exponents.
+     */
+    @Override
+    public long totalDeg() {
+        long t = 0;
+        short[] u = val; // U.val;
+        for (int i = 0; i < u.length; i++) {
+            t += u[i];
+        }
+        return t;
+        //return EVTDEG(this);
+    }
+
+
+    /**
+     * ExpVector maximal degree.
+     * @return maximal exponent.
+     */
+    @Override
+    public long maxDeg() {
+        long t = 0;
+        short[] u = val;
+        for (int i = 0; i < u.length; i++) {
+            if (u[i] > t) {
+                t = u[i];
+            }
+        }
+        return t;
+        //return EVMDEG(this);
+    }
+
+
+    /**
+     * ExpVector minimal degree.
+     * @return minimal exponent.
+     */
+    @Override
+    public long minDeg() {
+        long t = Short.MAX_VALUE;
+        short[] u = val;
+        for (int i = 0; i < u.length; i++) {
+            if (u[i] < t) {
+                t = u[i];
+            }
+        }
+        return t;
+    }
+
+
+    /**
+     * ExpVector weighted degree.
+     * @param w weights.
+     * @return weighted sum of all exponents.
+     */
+    @Override
+    public long weightDeg(long[][] w) {
+        if (w == null || w.length == 0) {
+            return totalDeg(); // assume weight 1 
+        }
+        long t = 0;
+        short[] u = val;
+        for (int j = 0; j < w.length; j++) {
+            long[] wj = w[j];
+            for (int i = 0; i < u.length; i++) {
+                t += wj[i] * u[i];
+            }
+        }
+        return t;
+        //return EVWDEG( w, this );
+    }
+
+
+    /**
+     * ExpVector weighted degree.
+     * @param w weights.
+     * @return weighted sum of all exponents.
+     */
+    @Override
+    public long weightDeg(long[] w) {
+        if (w == null || w.length == 0) {
+            return totalDeg(); // assume weight 1 
+        }
+        long t = 0;
+        short[] u = val;
+        for (int i = 0; i < w.length; i++) {
+             t += w[i] * u[i];
+        }
+        return t;
+    }
+
+
+    /**
+     * ExpVector least common multiple.
+     * @param V
+     * @return component wise maximum of this and V.
+     */
+    @Override
+    public ExpVectorShort lcm(ExpVector V) {
+        short[] u = val;
+        short[] v = ((ExpVectorShort) V).val;
+        short[] w = new short[u.length];
+        for (int i = 0; i < u.length; i++) {
+            w[i] = (u[i] >= v[i] ? u[i] : v[i]);
+        }
+        return new ExpVectorShort(w);
+        //return EVLCM(this, V);
+    }
+
+
+    /**
+     * ExpVector greatest common divisor.
+     * @param V
+     * @return component wise minimum of this and V.
+     */
+    @Override
+    public ExpVectorShort gcd(ExpVector V) {
+        short[] u = val;
+        short[] v = ((ExpVectorShort) V).val;
+        short[] w = new short[u.length];
+        for (int i = 0; i < u.length; i++) {
+            w[i] = (u[i] <= v[i] ? u[i] : v[i]);
+        }
+        return new ExpVectorShort(w);
+        //return EVGCD(this, V);
+    }
+
+
+    /**
+     * ExpVector dependent variables.
+     * @return number of indices where val has positive exponents.
+     */
+    public int dependentVariables() {
+        int l = 0;
+        for (int i = 0; i < val.length; i++) {
+            if (val[i] > 0) {
+                l++;
+            }
+        }
+        return l;
+    }
+
+
+    /**
+     * ExpVector dependency on variables.
+     * @return array of indices where val has positive exponents.
+     */
+    @Override
+    public int[] dependencyOnVariables() {
+        short[] u = val;
+        int l = dependentVariables();
+        int[] dep = new int[l];
+        if (l == 0) {
+            return dep;
+        }
+        int j = 0;
+        for (int i = 0; i < u.length; i++) {
+            if (u[i] > 0) {
+                dep[j] = i;
+                j++;
+            }
+        }
+        return dep;
+    }
+
+
+    /**
+     * ExpVector multiple test. Test if this is component wise greater or equal
+     * to V.
+     * @param V
+     * @return true if this is a multiple of V, else false.
+     */
+    @Override
+    public boolean multipleOf(ExpVector V) {
+        short[] u = val;
+        short[] v = ((ExpVectorShort) V).val;
+        boolean t = true;
+        for (int i = 0; i < u.length; i++) {
+            if (u[i] < v[i]) {
+                return false;
+            }
+        }
+        return t;
+        //return EVMT(this, V);
+    }
+
+
+    /**
+     * ExpVector compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int compareTo(ExpVector V) {
+        return this.invLexCompareTo(V);
+    }
+
+
+    /**
+     * ExpVector inverse lexicographical compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int invLexCompareTo(ExpVector V) {
+        short[] u = val;
+        short[] v = ((ExpVectorShort) V).val;
+        int t = 0;
+        for (int i = 0; i < u.length; i++) {
+            if (u[i] > v[i])
+                return 1;
+            if (u[i] < v[i])
+                return -1;
+        }
+        return t;
+        //return EVILCP(this, V);
+    }
+
+
+    /**
+     * ExpVector inverse lexicographical compareTo.
+     * @param V
+     * @param begin
+     * @param end
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int invLexCompareTo(ExpVector V, int begin, int end) {
+        short[] u = val;
+        short[] v = ((ExpVectorShort) V).val;
+        if (begin < 0) {
+            begin = 0;;
+        }
+        if (end >= val.length) {
+            end = val.length;
+        }
+        int t = 0;
+        for (int i = begin; i < end; i++) {
+            if (u[i] > v[i])
+                return 1;
+            if (u[i] < v[i])
+                return -1;
+        }
+        return t;
+        //return EVILCP(this, V, begin, end);
+    }
+
+
+    /**
+     * ExpVector inverse graded lexicographical compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int invGradCompareTo(ExpVector V) {
+        short[] u = val;
+        short[] v = ((ExpVectorShort) V).val;
+        int t = 0;
+        int i;
+        for (i = 0; i < u.length; i++) {
+            if (u[i] > v[i]) {
+                t = 1;
+                break;
+            }
+            if (u[i] < v[i]) {
+                t = -1;
+                break;
+            }
+        }
+        if (t == 0) {
+            return t;
+        }
+        long up = 0;
+        long vp = 0;
+        for (int j = i; j < u.length; j++) {
+            up += u[j];
+            vp += v[j];
+        }
+        if (up > vp) {
+            t = 1;
+        } else {
+            if (up < vp) {
+                t = -1;
+            }
+        }
+        return t;
+        //return EVIGLC(this, V);
+    }
+
+
+    /**
+     * ExpVector inverse graded lexicographical compareTo.
+     * @param V
+     * @param begin
+     * @param end
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int invGradCompareTo(ExpVector V, int begin, int end) {
+        short[] u = val;
+        short[] v = ((ExpVectorShort) V).val;
+        if (begin < 0) {
+            begin = 0;;
+        }
+        if (end >= val.length) {
+            end = val.length;
+        }
+        int t = 0;
+        int i;
+        for (i = begin; i < end; i++) {
+            if (u[i] > v[i]) {
+                t = 1;
+                break;
+            }
+            if (u[i] < v[i]) {
+                t = -1;
+                break;
+            }
+        }
+        if (t == 0) {
+            return t;
+        }
+        long up = 0;
+        long vp = 0;
+        for (int j = i; j < end; j++) {
+            up += u[j];
+            vp += v[j];
+        }
+        if (up > vp) {
+            t = 1;
+        } else {
+            if (up < vp) {
+                t = -1;
+            }
+        }
+        return t;
+        //return EVIGLC(this, V, begin, end);
+    }
+
+
+    /**
+     * ExpVector reverse inverse lexicographical compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int revInvLexCompareTo(ExpVector V) {
+        short[] u = val;
+        short[] v = ((ExpVectorShort) V).val;
+        int t = 0;
+        for (int i = u.length - 1; i >= 0; i--) {
+            if (u[i] > v[i])
+                return 1;
+            if (u[i] < v[i])
+                return -1;
+        }
+        return t;
+        //return EVRILCP(this, V);
+    }
+
+
+    /**
+     * ExpVector reverse inverse lexicographical compareTo.
+     * @param V
+     * @param begin
+     * @param end
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int revInvLexCompareTo(ExpVector V, int begin, int end) {
+        short[] u = val;
+        short[] v = ((ExpVectorShort) V).val;
+        if (begin < 0) {
+            begin = 0;;
+        }
+        if (end >= val.length) {
+            end = val.length;
+        }
+        int t = 0;
+        for (int i = end - 1; i >= begin; i--) {
+            if (u[i] > v[i])
+                return 1;
+            if (u[i] < v[i])
+                return -1;
+        }
+        return t;
+        //return EVRILCP(this, V, begin, end);
+    }
+
+
+    /**
+     * ExpVector reverse inverse graded compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int revInvGradCompareTo(ExpVector V) {
+        short[] u = val;
+        short[] v = ((ExpVectorShort) V).val;
+        int t = 0;
+        int i;
+        for (i = u.length - 1; i >= 0; i--) {
+            if (u[i] > v[i]) {
+                t = 1;
+                break;
+            }
+            if (u[i] < v[i]) {
+                t = -1;
+                break;
+            }
+        }
+        if (t == 0) {
+            return t;
+        }
+        long up = 0;
+        long vp = 0;
+        for (int j = i; j >= 0; j--) {
+            up += u[j];
+            vp += v[j];
+        }
+        if (up > vp) {
+            t = 1;
+        } else {
+            if (up < vp) {
+                t = -1;
+            }
+        }
+        return t;
+        //return EVRIGLC(this, V);
+    }
+
+
+    /**
+     * ExpVector reverse inverse graded compareTo.
+     * @param V
+     * @param begin
+     * @param end
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int revInvGradCompareTo(ExpVector V, int begin, int end) {
+        short[] u = val;
+        short[] v = ((ExpVectorShort) V).val;
+        if (begin < 0) {
+            begin = 0;;
+        }
+        if (end >= val.length) {
+            end = val.length;
+        }
+        int t = 0;
+        int i;
+        for (i = end - 1; i >= begin; i--) {
+            if (u[i] > v[i]) {
+                t = 1;
+                break;
+            }
+            if (u[i] < v[i]) {
+                t = -1;
+                break;
+            }
+        }
+        if (t == 0) {
+            return t;
+        }
+        long up = 0;
+        long vp = 0;
+        for (int j = i; j >= begin; j--) {
+            up += u[j];
+            vp += v[j];
+        }
+        if (up > vp) {
+            t = 1;
+        } else {
+            if (up < vp) {
+                t = -1;
+            }
+        }
+        return t;
+        //return EVRIGLC(this, V, begin, end);
+    }
+
+
+    /**
+     * ExpVector inverse total degree lexicographical compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int invTdegCompareTo(ExpVector V) {
+        throw new UnsupportedOperationException("not implemented for short ExpVector");
+    }
+
+
+    /**
+     * ExpVector reverse lexicographical inverse total degree compareTo.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int revLexInvTdegCompareTo(ExpVector V) {
+        throw new UnsupportedOperationException("not implemented for short ExpVector");
+    }
+
+
+    /**
+     * ExpVector inverse weighted lexicographical compareTo.
+     * @param w weight array.
+     * @param V
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int invWeightCompareTo(long[][] w, ExpVector V) {
+        short[] u = val;
+        short[] v = ((ExpVectorShort) V).val;
+        int t = 0;
+        int i;
+        for (i = 0; i < u.length; i++) {
+            if (u[i] > v[i]) {
+                t = 1;
+                break;
+            }
+            if (u[i] < v[i]) {
+                t = -1;
+                break;
+            }
+        }
+        if (t == 0) {
+            return t;
+        }
+        for (int k = 0; k < w.length; k++) {
+            long[] wk = w[k];
+            long up = 0;
+            long vp = 0;
+            for (int j = i; j < u.length; j++) {
+                up += wk[j] * u[j];
+                vp += wk[j] * v[j];
+            }
+            if (up > vp) {
+                return 1;
+            } else if (up < vp) {
+                return -1;
+            }
+        }
+        return t;
+        //return EVIWLC(w, this, V);
+    }
+
+
+    /**
+     * ExpVector inverse weighted lexicographical compareTo.
+     * @param w weight array.
+     * @param V
+     * @param begin
+     * @param end
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int invWeightCompareTo(long[][] w, ExpVector V, int begin, int end) {
+        short[] u = val;
+        short[] v = ((ExpVectorShort) V).val;
+        if (begin < 0) {
+            begin = 0;;
+        }
+        if (end >= val.length) {
+            end = val.length;
+        }
+        int t = 0;
+        int i;
+        for (i = begin; i < end; i++) {
+            if (u[i] > v[i]) {
+                t = 1;
+                break;
+            }
+            if (u[i] < v[i]) {
+                t = -1;
+                break;
+            }
+        }
+        if (t == 0) {
+            return t;
+        }
+        for (int k = 0; k < w.length; k++) {
+            long[] wk = w[k];
+            long up = 0;
+            long vp = 0;
+            for (int j = i; j < end; j++) {
+                up += wk[j] * u[j];
+                vp += wk[j] * v[j];
+            }
+            if (up > vp) {
+                return 1;
+            } else if (up < vp) {
+                return -1;
+            }
+        }
+        return t;
+        //return EVIWLC(w, this, V, begin, end);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/GenPolynomial.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/GenPolynomial.java
@@ -1,0 +1,2605 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.Spliterator;
+import java.util.TreeMap;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.kern.PreemptingException;
+import edu.jas.kern.PrettyPrint;
+import edu.jas.structure.NotInvertibleException;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.UnaryFunctor;
+import edu.jas.util.MapEntry;
+
+
+/**
+ * GenPolynomial generic polynomials implementing RingElem. n-variate ordered
+ * polynomials over coefficients C. The variables commute with each other and
+ * with the coefficients. For non-commutative coefficients some care is taken to
+ * respect the multiplication order.
+ *
+ * Objects of this class are intended to be immutable. The implementation is
+ * based on TreeMap respectively SortedMap from exponents to coefficients. Only
+ * the coefficients are modeled with generic types, the exponents are fixed to
+ * ExpVector with long entries (@see edu.jas.poly.ExpVector StorUnit). C can
+ * also be a non integral domain, e.g. a ModInteger, i.e. it may contain zero
+ * divisors, since multiply() does check for zeros. <b>Note:</b> multiply() now
+ * checks for wrong method dispatch for GenSolvablePolynomial.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+public class GenPolynomial<C extends RingElem<C>>
+                implements RingElem<GenPolynomial<C>>, /* not yet Polynomial<C> */
+                Iterable<Monomial<C>> {
+
+
+    /**
+     * The factory for the polynomial ring.
+     */
+    public final GenPolynomialRing<C> ring;
+
+
+    /**
+     * The data structure for polynomials.
+     */
+    protected final SortedMap<ExpVector, C> val; // do not change to TreeMap
+
+
+    /**
+     * Stored hash code.
+     */
+    transient protected int hash = -1;
+
+
+    /**
+     * Stored bitLength.
+     */
+    transient protected long blen = -1;
+
+
+    private static final Logger logger = LogManager.getLogger(GenPolynomial.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    // protected GenPolynomial() { ring = null; val = null; } // don't use
+
+
+    /**
+     * Private constructor for GenPolynomial.
+     * @param r polynomial ring factory.
+     * @param t TreeMap with correct ordering.
+     */
+    private GenPolynomial(GenPolynomialRing<C> r, TreeMap<ExpVector, C> t) {
+        ring = r;
+        val = t;
+        if (ring.checkPreempt) {
+            if (Thread.currentThread().isInterrupted()) {
+                logger.debug("throw PreemptingException");
+                throw new PreemptingException();
+            }
+        }
+    }
+
+
+    /**
+     * Constructor for zero GenPolynomial.
+     * @param r polynomial ring factory.
+     */
+    public GenPolynomial(GenPolynomialRing<C> r) {
+        this(r, new TreeMap<ExpVector, C>(r.tord.getDescendComparator()));
+    }
+
+
+    /**
+     * Constructor for GenPolynomial c * x<sup>e</sup>.
+     * @param r polynomial ring factory.
+     * @param c coefficient.
+     * @param e exponent.
+     */
+    public GenPolynomial(GenPolynomialRing<C> r, C c, ExpVector e) {
+        this(r);
+        if (!c.isZERO()) {
+            val.put(e, c);
+        }
+    }
+
+
+    /**
+     * Constructor for GenPolynomial c * x<sup>0</sup>.
+     * @param r polynomial ring factory.
+     * @param c coefficient.
+     */
+    public GenPolynomial(GenPolynomialRing<C> r, C c) {
+        this(r, c, r.evzero);
+    }
+
+
+    /**
+     * Constructor for GenPolynomial x<sup>e</sup>.
+     * @param r polynomial ring factory.
+     * @param e exponent.
+     */
+    public GenPolynomial(GenPolynomialRing<C> r, ExpVector e) {
+        this(r, r.coFac.getONE(), e);
+    }
+
+
+    /**
+     * Constructor for GenPolynomial.
+     * @param r polynomial ring factory.
+     * @param v the SortedMap of some other polynomial.
+     */
+    protected GenPolynomial(GenPolynomialRing<C> r, SortedMap<ExpVector, C> v) {
+        this(r);
+        if (v.size() > 0) {
+            GenPolynomialRing.creations++;
+            val.putAll(v); // assume no zero coefficients and val is empty
+            assert !val.values().contains(r.coFac.getZERO()) : "illegal coefficient zero: " + v;
+        }
+    }
+
+
+    /**
+     * Constructor for GenPolynomial.
+     * @param r polynomial ring factory.
+     * @param v some Map from ExpVector to coefficients.
+     */
+    protected GenPolynomial(GenPolynomialRing<C> r, Map<ExpVector, C> v) {
+        this(r);
+        if (v.size() > 0) {
+            GenPolynomialRing.creations++;
+            val.putAll(v); // assume no zero coefficients and val is empty
+            assert !val.values().contains(r.coFac.getZERO()) : "illegal coefficient zero: " + v;
+        }
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public GenPolynomialRing<C> factory() {
+        return ring;
+    }
+
+
+    /**
+     * Copy this GenPolynomial.
+     * @return copy of this.
+     */
+    public GenPolynomial<C> copy() {
+        return new GenPolynomial<C>(ring, this.val);
+    }
+
+
+    /**
+     * Length of GenPolynomial.
+     * @return number of coefficients of this GenPolynomial.
+     */
+    public int length() {
+        return val.size();
+    }
+
+
+    /**
+     * ExpVector to coefficient map of GenPolynomial.
+     * @return val as unmodifiable SortedMap.
+     */
+    public SortedMap<ExpVector, C> getMap() {
+        // return val;
+        return Collections.<ExpVector, C> unmodifiableSortedMap(val);
+    }
+
+
+    /**
+     * Put an ExpVector to coefficient entry into the internal map of this
+     * GenPolynomial. <b>Note:</b> Do not use this method unless you are
+     * constructing a new polynomial. this is modified and breaks the
+     * immutability promise of this class.
+     * @param c coefficient.
+     * @param e exponent.
+     */
+    public void doPutToMap(ExpVector e, C c) {
+        if (debug) {
+            C a = val.get(e);
+            if (a != null) {
+                logger.error("map entry exists " + e + " to " + a + " new " + c);
+            }
+            hash = -1;
+            blen = -1;
+        }
+        if (!c.isZERO()) {
+            val.put(e, c);
+        }
+    }
+
+
+    /**
+     * Remove an ExpVector to coefficient entry from the internal map of this
+     * GenPolynomial. <b>Note:</b> Do not use this method unless you are
+     * constructing a new polynomial. this is modified and breaks the
+     * immutability promise of this class.
+     * @param e exponent.
+     * @param c expected coefficient, null for ignore.
+     */
+    public void doRemoveFromMap(ExpVector e, C c) {
+        C b = val.remove(e);
+        if (true) { //||debug
+            hash = -1;
+            blen = -1;
+            if (c == null) { // ignore b
+                return;
+            }
+            if (!c.equals(b)) {
+                logger.error("map entry wrong " + e + " to " + c + " old " + b);
+                throw new RuntimeException("c != b");
+            }
+        }
+    }
+
+
+    /**
+     * Put an a sorted map of exponents to coefficients into the internal map of
+     * this GenPolynomial. <b>Note:</b> Do not use this method unless you are
+     * constructing a new polynomial. this is modified and breaks the
+     * immutability promise of this class.
+     * @param vals sorted map of exponents and coefficients.
+     */
+    public void doPutToMap(SortedMap<ExpVector, C> vals) {
+        for (Map.Entry<ExpVector, C> me : vals.entrySet()) {
+            ExpVector e = me.getKey();
+            if (debug) {
+                C a = val.get(e);
+                if (a != null) {
+                    logger.error("map entry exists " + e + " to " + a + " new " + me.getValue());
+                }
+                hash = -1;
+                blen = -1;
+            }
+            C c = me.getValue();
+            if (!c.isZERO()) {
+                val.put(e, c);
+            }
+        }
+    }
+
+
+    /**
+     * String representation of GenPolynomial.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        if (ring.vars != null) {
+            return toString(ring.vars);
+        }
+        StringBuffer s = new StringBuffer();
+        s.append(this.getClass().getSimpleName() + ":");
+        s.append(ring.coFac.getClass().getSimpleName());
+        if (ring.coFac.characteristic().signum() != 0) {
+            s.append("(" + ring.coFac.characteristic() + ")");
+        }
+        s.append("[ ");
+        boolean first = true;
+        for (Map.Entry<ExpVector, C> m : val.entrySet()) {
+            if (first) {
+                first = false;
+            } else {
+                s.append(", ");
+            }
+            s.append(m.getValue().toString());
+            s.append(" ");
+            s.append(m.getKey().toString());
+        }
+        s.append(" ] "); // no not use: ring.toString() );
+        return s.toString();
+    }
+
+
+    /**
+     * String representation of GenPolynomial.
+     * @param v names for variables.
+     * @see java.lang.Object#toString()
+     */
+    public String toString(String[] v) {
+        StringBuffer s = new StringBuffer();
+        if (PrettyPrint.isTrue()) {
+            if (val.isEmpty()) {
+                s.append("0");
+            } else {
+                // s.append( "( " );
+                boolean first = true;
+                for (Map.Entry<ExpVector, C> m : val.entrySet()) {
+                    C c = m.getValue();
+                    if (first) {
+                        first = false;
+                    } else {
+                        if (c.signum() < 0) {
+                            s.append(" - ");
+                            c = c.negate();
+                        } else {
+                            s.append(" + ");
+                        }
+                    }
+                    ExpVector e = m.getKey();
+                    if (!c.isONE() || e.isZERO()) {
+                        String cs = c.toString();
+                        //if (c instanceof GenPolynomial || c instanceof AlgebraicNumber) {
+                        if (cs.indexOf("-") >= 0 || cs.indexOf("+") >= 0) {
+                            s.append("( ");
+                            s.append(cs);
+                            s.append(" )");
+                        } else {
+                            s.append(cs);
+                        }
+                        s.append(" ");
+                    }
+                    if (e != null && v != null) {
+                        s.append(e.toString(v));
+                    } else {
+                        s.append(e);
+                    }
+                }
+                //s.append(" )");
+            }
+        } else {
+            s.append(this.getClass().getSimpleName() + "[ ");
+            if (val.isEmpty()) {
+                s.append("0");
+            } else {
+                boolean first = true;
+                for (Map.Entry<ExpVector, C> m : val.entrySet()) {
+                    C c = m.getValue();
+                    if (first) {
+                        first = false;
+                    } else {
+                        if (c.signum() < 0) {
+                            s.append(" - ");
+                            c = c.negate();
+                        } else {
+                            s.append(" + ");
+                        }
+                    }
+                    ExpVector e = m.getKey();
+                    if (!c.isONE() || e.isZERO()) {
+                        s.append(c.toString());
+                        s.append(" ");
+                    }
+                    s.append(e.toString(v));
+                }
+            }
+            s.append(" ] "); // no not use: ring.toString() );
+        }
+        return s.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        if (isZERO()) {
+            return "0";
+        }
+        StringBuffer s = new StringBuffer();
+        if (val.size() > 1) {
+            s.append("( ");
+        }
+        String[] v = ring.vars;
+        if (v == null) {
+            v = GenPolynomialRing.newVars("x", ring.nvar);
+        }
+        Pattern klammern = Pattern.compile("\\s*\\(.+\\)\\s*");
+        boolean first = true;
+        for (Map.Entry<ExpVector, C> m : val.entrySet()) {
+            C c = m.getValue();
+            if (first) {
+                first = false;
+            } else {
+                if (c.signum() < 0) {
+                    s.append(" - ");
+                    c = c.negate();
+                } else {
+                    s.append(" + ");
+                }
+            }
+            ExpVector e = m.getKey();
+            String cs = c.toScript();
+            boolean parenthesis = (cs.indexOf("-") >= 0 || cs.indexOf("+") >= 0)
+                            && !klammern.matcher(cs).matches();
+            if (!c.isONE() || e.isZERO()) {
+                if (parenthesis) {
+                    s.append("( ");
+                }
+                s.append(cs);
+                if (parenthesis) {
+                    s.append(" )");
+                }
+                if (!e.isZERO()) {
+                    s.append(" * ");
+                }
+            }
+            s.append(e.toScript(v));
+        }
+        if (val.size() > 1) {
+            s.append(" )");
+        }
+        return s.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python case
+        return factory().toScript();
+    }
+
+
+    /**
+     * Is GenPolynomial&lt;C&gt; zero.
+     * @return If this is 0 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isZERO()
+     */
+    public boolean isZERO() {
+        return val.isEmpty();
+    }
+
+
+    /**
+     * Is GenPolynomial&lt;C&gt; one.
+     * @return If this is 1 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isONE()
+     */
+    public boolean isONE() {
+        if (val.size() != 1) {
+            return false;
+        }
+        C c = val.get(ring.evzero);
+        if (c == null) {
+            return false;
+        }
+        return c.isONE();
+    }
+
+
+    /**
+     * Is GenPolynomial&lt;C&gt; a unit.
+     * @return If this is a unit then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isUnit()
+     */
+    public boolean isUnit() {
+        if (val.size() != 1) {
+            return false;
+        }
+        C c = val.get(ring.evzero);
+        if (c == null) {
+            return false;
+        }
+        return c.isUnit();
+    }
+
+
+    /**
+     * Is GenPolynomial&lt;C&gt; a constant.
+     * @return If this is a constant polynomial then true is returned, else
+     *         false.
+     */
+    public boolean isConstant() {
+        if (val.size() != 1) {
+            return false;
+        }
+        C c = val.get(ring.evzero);
+        if (c == null) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Is GenPolynomial&lt;C&gt; homogeneous.
+     * @return true, if this is homogeneous, else false.
+     */
+    public boolean isHomogeneous() {
+        if (val.size() <= 1) {
+            return true;
+        }
+        long deg = -1;
+        for (ExpVector e : val.keySet()) {
+            if (deg < 0) {
+                deg = e.totalDeg();
+            } else if (deg != e.totalDeg()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object B) {
+        if (B == null) {
+            return false;
+        }
+        if (!(B instanceof GenPolynomial)) {
+            return false;
+        }
+        GenPolynomial<C> a = (GenPolynomial<C>) B;
+        return this.compareTo(a) == 0;
+    }
+
+
+    /**
+     * Hash code for this polynomial.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h = hash;
+        if (h == -1) {
+            //not in sync with equals(): h = (ring.hashCode() << 27);
+            h = val.hashCode();
+            hash = h;
+            //System.out.println("GenPolynomial.hashCode: " + h);
+        }
+        return h;
+    }
+
+
+    /**
+     * GenPolynomial comparison.
+     * @param b GenPolynomial.
+     * @return sign(this-b).
+     */
+    public int compareTo(GenPolynomial<C> b) {
+        if (b == null) {
+            return 1;
+        }
+        SortedMap<ExpVector, C> av = this.val;
+        SortedMap<ExpVector, C> bv = b.val;
+        Iterator<Map.Entry<ExpVector, C>> ai = av.entrySet().iterator();
+        Iterator<Map.Entry<ExpVector, C>> bi = bv.entrySet().iterator();
+        int s = 0;
+        int c = 0;
+        while (ai.hasNext() && bi.hasNext()) {
+            Map.Entry<ExpVector, C> aie = ai.next();
+            Map.Entry<ExpVector, C> bie = bi.next();
+            ExpVector ae = aie.getKey();
+            ExpVector be = bie.getKey();
+            s = ae.compareTo(be);
+            if (s != 0) {
+                //System.out.println("s = " + s + ", " + ring.toScript(ae) + ", " + ring.toScript(be));
+                return s;
+            }
+            if (c == 0) {
+                C ac = aie.getValue(); //av.get(ae);
+                C bc = bie.getValue(); //bv.get(be);
+                c = ac.compareTo(bc);
+            }
+        }
+        if (ai.hasNext()) {
+            //System.out.println("ai = " + ai);
+            return 1;
+        }
+        if (bi.hasNext()) {
+            //System.out.println("bi = " + bi);
+            return -1;
+        }
+        //if (c != 0) {
+        //System.out.println("c = " + c);
+        //}
+        // now all keys are equal
+        return c;
+    }
+
+
+    /**
+     * GenPolynomial signum.
+     * @return sign(ldcf(this)).
+     */
+    public int signum() {
+        if (this.isZERO()) {
+            return 0;
+        }
+        ExpVector t = val.firstKey();
+        C c = val.get(t);
+        return c.signum();
+    }
+
+
+    /**
+     * Number of variables.
+     * @return ring.nvar.
+     */
+    public int numberOfVariables() {
+        return ring.nvar;
+    }
+
+
+    /**
+     * Leading monomial.
+     * @return first map entry.
+     */
+    public Map.Entry<ExpVector, C> leadingMonomial() {
+        if (val.isEmpty()) {
+            return null;
+        }
+        //Iterator<Map.Entry<ExpVector, C>> ai = val.entrySet().iterator();
+        //return ai.next();
+        ExpVector e = val.firstKey();
+        return new MapEntry<ExpVector, C>(e, val.get(e));
+    }
+
+
+    /**
+     * Leading exponent vector.
+     * @return first exponent.
+     */
+    public ExpVector leadingExpVector() {
+        if (val.isEmpty()) {
+            return null; // ring.evzero? needs many changes 
+        }
+        return val.firstKey();
+    }
+
+
+    /**
+     * Trailing exponent vector.
+     * @return last exponent.
+     */
+    public ExpVector trailingExpVector() {
+        if (val.isEmpty()) {
+            return null; //ring.evzero; // or null ?;
+        }
+        return val.lastKey();
+    }
+
+
+    /**
+     * Leading base coefficient.
+     * @return first coefficient.
+     */
+    public C leadingBaseCoefficient() {
+        if (val.isEmpty()) {
+            return ring.coFac.getZERO();
+        }
+        return val.get(val.firstKey());
+    }
+
+
+    /**
+     * Trailing base coefficient.
+     * @return coefficient of constant term.
+     */
+    public C trailingBaseCoefficient() {
+        C c = val.get(ring.evzero);
+        if (c == null) {
+            return ring.coFac.getZERO();
+        }
+        return c;
+    }
+
+
+    /**
+     * Coefficient.
+     * @param e exponent.
+     * @return coefficient for given exponent.
+     */
+    public C coefficient(ExpVector e) {
+        C c = val.get(e);
+        if (c == null) {
+            c = ring.coFac.getZERO();
+        }
+        return c;
+    }
+
+
+    /**
+     * Reductum.
+     * @return this - leading monomial.
+     */
+    public GenPolynomial<C> reductum() {
+        if (val.size() <= 1) {
+            return ring.getZERO();
+        }
+        Iterator<ExpVector> ai = val.keySet().iterator();
+        ExpVector lt = ai.next();
+        lt = ai.next(); // size > 1
+        SortedMap<ExpVector, C> red = val.tailMap(lt);
+        GenPolynomial<C> r = ring.getZERO().copy();
+        r.doPutToMap(red); //  new GenPolynomial<C>(ring, red);
+        return r;
+    }
+
+
+    /**
+     * Degree in variable i.
+     * @return maximal degree in the variable i.
+     */
+    public long degree(int i) {
+        if (val.isEmpty()) {
+            return -1L; // 0 or -1 ?;
+        }
+        int j;
+        if (i >= 0) {
+            j = ring.nvar - 1 - i;
+        } else { // python like -1 means main variable
+            j = ring.nvar + i;
+        }
+        long deg = 0;
+        if (j < 0) {
+            return deg;
+        }
+        for (ExpVector e : val.keySet()) {
+            long d = e.getVal(j);
+            if (d > deg) {
+                deg = d;
+            }
+        }
+        return deg;
+    }
+
+
+    /**
+     * Maximal degree.
+     * @return maximal degree in any variables.
+     */
+    public long degree() {
+        if (val.isEmpty()) {
+            return -1L; // 0 or -1 ?;
+        }
+        long deg = 0;
+        for (ExpVector e : val.keySet()) {
+            long d = e.maxDeg();
+            if (d > deg) {
+                deg = d;
+            }
+        }
+        return deg;
+    }
+
+
+    /**
+     * Minimal degree. <b>Author:</b> Youssef Elbarbary
+     * @return minimal degree in any variables.
+     */
+    public long degreeMin() {
+        if (val.isEmpty()) {
+            return -1L; // 0 or -1 ?;
+        }
+        long deg = Long.MAX_VALUE;
+        for (ExpVector e : val.keySet()) {
+            long d = e.minDeg();
+            if (d < deg) {
+                deg = d;
+            }
+        }
+        return deg;
+    }
+
+
+    /**
+     * Total degree.
+     * @return total degree in any variables.
+     */
+    public long totalDegree() {
+        if (val.isEmpty()) {
+            return -1L; // 0 or -1 ?;
+        }
+        long deg = 0;
+        for (ExpVector e : val.keySet()) {
+            long d = e.totalDeg();
+            if (d > deg) {
+                deg = d;
+            }
+        }
+        return deg;
+    }
+
+
+    /**
+     * Weight degree.
+     * @return weight degree in all variables.
+     */
+    public long weightDegree() {
+        long[][] w = ring.tord.getWeight();
+        if (w == null || w.length == 0) {
+            return totalDegree(); // assume weight 1 
+        }
+        if (val.isEmpty()) {
+            return -1L; // 0 or -1 ?;
+        }
+        long deg = 0;
+        for (ExpVector e : val.keySet()) {
+            long d = e.weightDeg(w);
+            if (d > deg) {
+                deg = d;
+            }
+        }
+        return deg;
+    }
+
+
+    /**
+     * Leading weight polynomial.
+     * @return polynomial with terms of maximal weight degree.
+     */
+    public GenPolynomial<C> leadingWeightPolynomial() {
+        if (val.isEmpty()) {
+            return ring.getZERO();
+        }
+        long[][] w = ring.tord.getWeight();
+        long maxw = weightDegree();
+        GenPolynomial<C> wp = ring.getZERO().copy();
+        for (Map.Entry<ExpVector, C> m : val.entrySet()) {
+            ExpVector e = m.getKey();
+            long d = e.weightDeg(w);
+            if (d >= maxw) {
+                wp.val.put(e, m.getValue());
+            }
+        }
+        return wp;
+    }
+
+
+    /**
+     * Leading facet normal polynomial.
+     * @param u leading exponent vector.
+     * @param uv exponent vector of facet normal.
+     * @return polynomial with terms of facet normal.
+     */
+    public GenPolynomial<C> leadingFacetPolynomial(ExpVector u, ExpVector uv) {
+        if (val.isEmpty()) {
+            return ring.getZERO();
+        }
+        long[] normal = uv.getVal();
+        GenPolynomial<C> fp = ring.getZERO().copy();
+        for (Map.Entry<ExpVector, C> m : val.entrySet()) {
+            ExpVector e = m.getKey();
+            if (u.equals(e)) {
+                fp.val.put(e, m.getValue());
+            } else {
+                ExpVector v = u.subtract(e);
+                if (v.compareTo(uv) == 0) { // || v.negate().compareTo(uv) == 0
+                    fp.val.put(e, m.getValue());
+                } else { // check for v parallel to uv
+                    long ab = v.weightDeg(normal); //scalarProduct(v, uv);
+                    long a = v.weightDeg(v.getVal()); //scalarProduct(v, v);
+                    long b = uv.weightDeg(normal); //scalarProduct(uv, uv);
+                    if (ab * ab == a * b) { // cos == 1
+                        fp.val.put(e, m.getValue());
+                        logger.info("ab = " + ab + ", a = " + a + ", b = " + b + ", u = " + u + ", e = " + e
+                                        + ", v = " + v);
+                    }
+                }
+            }
+        }
+        return fp;
+    }
+
+
+    /**
+     * Is GenPolynomial&lt;C&gt; homogeneous with respect to a weight.
+     * @return true, if this is weight homogeneous, else false.
+     */
+    public boolean isWeightHomogeneous() {
+        if (val.size() <= 1) {
+            return true;
+        }
+        long[][] w = ring.tord.getWeight();
+        if (w == null || w.length == 0) {
+            return isHomogeneous(); // assume weights = 1
+        }
+        long deg = -1;
+        for (ExpVector e : val.keySet()) {
+            if (deg < 0) {
+                deg = e.weightDeg(w);
+            } else if (deg != e.weightDeg(w)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Maximal degree vector.
+     * @return maximal degree vector of all variables.
+     */
+    public ExpVector degreeVector() {
+        if (val.isEmpty()) {
+            return null; //deg;
+        }
+        ExpVector deg = ring.evzero;
+        for (ExpVector e : val.keySet()) {
+            deg = deg.lcm(e);
+        }
+        return deg;
+    }
+
+
+    /**
+     * Delta of exponent vectors.
+     * @return list of u-v, where u = lt() and v != u in this.
+     */
+    public List<ExpVector> deltaExpVectors() {
+        List<ExpVector> de = new ArrayList<ExpVector>(val.size());
+        if (val.isEmpty()) {
+            return de;
+        }
+        ExpVector u = null;
+        for (ExpVector e : val.keySet()) {
+            if (u == null) {
+                u = e;
+            } else {
+                ExpVector v = u.subtract(e);
+                de.add(v);
+            }
+        }
+        return de;
+    }
+
+
+    /**
+     * Delta of exponent vectors.
+     * @param u marked ExpVector in this.expVectors
+     * @return list of u-v, where v != u in this.expVectors.
+     */
+    public List<ExpVector> deltaExpVectors(ExpVector u) {
+        List<ExpVector> de = new ArrayList<ExpVector>(val.size());
+        if (val.isEmpty()) {
+            return de;
+        }
+        for (ExpVector e : val.keySet()) {
+            ExpVector v = u.subtract(e);
+            if (v.isZERO()) {
+                continue;
+            }
+            de.add(v);
+        }
+        return de;
+    }
+
+
+    /**
+     * GenPolynomial maximum norm.
+     * @return ||this|| the maximum of all absolute values of coefficients.
+     */
+    public C maxNorm() {
+        C n = ring.getZEROCoefficient();
+        for (C c : val.values()) {
+            C x = c.abs();
+            if (n.compareTo(x) < 0) {
+                n = x;
+            }
+        }
+        return n;
+    }
+
+
+    /**
+     * GenPolynomial sum norm.
+     * @return sum of all absolute values of coefficients.
+     */
+    public C sumNorm() {
+        C n = ring.getZEROCoefficient();
+        for (C c : val.values()) {
+            C x = c.abs();
+            n = n.sum(x);
+        }
+        return n;
+    }
+
+
+    /**
+     * GenPolynomial square norm.
+     * @return the sum all squared values of coefficients.
+     */
+    public C squareNorm() {
+        C n = ring.getZEROCoefficient();
+        for (C c : val.values()) {
+            C x = c.abs();
+            x = x.multiply(x);
+            n = n.sum(x);
+        }
+        return n;
+    }
+
+
+    /**
+     * GenPolynomial summation.
+     * @param S GenPolynomial.
+     * @return this+S.
+     */
+    //public <T extends GenPolynomial<C>> T sum(T /*GenPolynomial<C>*/ S) {
+    public GenPolynomial<C> sum(GenPolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return S;
+        }
+        if (this.length() < (3 * S.length()) / 5) {
+            return S.sum(this); // performance
+        }
+        assert (ring.nvar == S.ring.nvar);
+        GenPolynomial<C> n = this.copy();
+        SortedMap<ExpVector, C> nv = n.val;
+        SortedMap<ExpVector, C> sv = S.val;
+        for (Map.Entry<ExpVector, C> me : sv.entrySet()) {
+            ExpVector e = me.getKey();
+            C y = me.getValue(); // assert y != null
+            C x = nv.get(e);
+            if (x != null) {
+                x = x.sum(y);
+                if (!x.isZERO()) {
+                    nv.put(e, x);
+                } else {
+                    nv.remove(e);
+                }
+            } else {
+                nv.put(e, y);
+            }
+        }
+        return n;
+    }
+
+
+    /**
+     * GenPolynomial addition. This method is not very efficient, since this is
+     * copied.
+     * @param a coefficient.
+     * @param e exponent.
+     * @return this + a x<sup>e</sup>.
+     */
+    public GenPolynomial<C> sum(C a, ExpVector e) {
+        if (a == null) {
+            return this;
+        }
+        if (a.isZERO()) {
+            return this;
+        }
+        GenPolynomial<C> n = this.copy();
+        SortedMap<ExpVector, C> nv = n.val;
+        //if ( nv.size() == 0 ) { nv.put(e,a); return n; }
+        C x = nv.get(e);
+        if (x != null) {
+            x = x.sum(a);
+            if (!x.isZERO()) {
+                nv.put(e, x);
+            } else {
+                nv.remove(e);
+            }
+        } else {
+            nv.put(e, a);
+        }
+        return n;
+    }
+
+
+    /**
+     * GenPolynomial addition. This method is not very efficient, since this is
+     * copied.
+     * @param m monomial.
+     * @return this + m.
+     */
+    public GenPolynomial<C> sum(Monomial<C> m) {
+        return sum(m.coefficient(), m.exponent());
+    }
+
+
+    /**
+     * GenPolynomial addition. This method is not very efficient, since this is
+     * copied.
+     * @param a coefficient.
+     * @return this + a x<sup>0</sup>.
+     */
+    public GenPolynomial<C> sum(C a) {
+        return sum(a, ring.evzero);
+    }
+
+
+    /**
+     * GenPolynomial destructive summation.
+     * @param S GenPolynomial.
+     */
+    public void doAddTo(GenPolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            return;
+        }
+        if (this.isZERO()) {
+            this.val.putAll(S.val);
+            return;
+        }
+        assert (ring.nvar == S.ring.nvar);
+        SortedMap<ExpVector, C> nv = this.val;
+        SortedMap<ExpVector, C> sv = S.val;
+        for (Map.Entry<ExpVector, C> me : sv.entrySet()) {
+            ExpVector e = me.getKey();
+            C y = me.getValue(); // assert y != null
+            C x = nv.get(e);
+            if (x != null) {
+                x = x.sum(y);
+                if (!x.isZERO()) {
+                    nv.put(e, x);
+                } else {
+                    nv.remove(e);
+                }
+            } else {
+                nv.put(e, y);
+            }
+        }
+        return;
+    }
+
+
+    /**
+     * GenPolynomial destructive summation.
+     * @param a coefficient.
+     * @param e exponent.
+     */
+    public void doAddTo(C a, ExpVector e) {
+        if (a == null || a.isZERO()) {
+            return;
+        }
+        SortedMap<ExpVector, C> nv = this.val;
+        C x = nv.get(e);
+        if (x != null) {
+            x = x.sum(a);
+            if (!x.isZERO()) {
+                nv.put(e, x);
+            } else {
+                nv.remove(e);
+            }
+        } else {
+            nv.put(e, a);
+        }
+        return;
+    }
+
+
+    /**
+     * GenPolynomial destructive summation.
+     * @param a coefficient.
+     */
+    public void doAddTo(C a) {
+        doAddTo(a, ring.evzero);
+    }
+
+
+    /**
+     * GenPolynomial subtraction.
+     * @param S GenPolynomial.
+     * @return this-S.
+     */
+    public GenPolynomial<C> subtract(GenPolynomial<C> S) {
+        if (S == null) {
+            return this;
+        }
+        if (S.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return S.negate();
+        }
+        assert (ring.nvar == S.ring.nvar);
+        GenPolynomial<C> n = this.copy();
+        SortedMap<ExpVector, C> nv = n.val;
+        SortedMap<ExpVector, C> sv = S.val;
+        for (Map.Entry<ExpVector, C> me : sv.entrySet()) {
+            ExpVector e = me.getKey();
+            C y = me.getValue(); // assert y != null
+            C x = nv.get(e);
+            if (x != null) {
+                x = x.subtract(y);
+                if (!x.isZERO()) {
+                    nv.put(e, x);
+                } else {
+                    nv.remove(e);
+                }
+            } else {
+                nv.put(e, y.negate());
+            }
+        }
+        return n;
+    }
+
+
+    /**
+     * GenPolynomial subtraction. This method is not very efficient, since this
+     * is copied.
+     * @param a coefficient.
+     * @param e exponent.
+     * @return this - a x<sup>e</sup>.
+     */
+    public GenPolynomial<C> subtract(C a, ExpVector e) {
+        if (a == null || a.isZERO()) {
+            return this;
+        }
+        GenPolynomial<C> n = this.copy();
+        SortedMap<ExpVector, C> nv = n.val;
+        C x = nv.get(e);
+        if (x != null) {
+            x = x.subtract(a);
+            if (!x.isZERO()) {
+                nv.put(e, x);
+            } else {
+                nv.remove(e);
+            }
+        } else {
+            nv.put(e, a.negate());
+        }
+        return n;
+    }
+
+
+    /**
+     * GenPolynomial subtraction. This method is not very efficient, since this
+     * is copied.
+     * @param m monomial.
+     * @return this - m.
+     */
+    public GenPolynomial<C> subtract(Monomial<C> m) {
+        return subtract(m.coefficient(), m.exponent());
+    }
+
+
+    /**
+     * GenPolynomial subtract. This method is not very efficient, since this is
+     * copied.
+     * @param a coefficient.
+     * @return this + a x<sup>0</sup>.
+     */
+    public GenPolynomial<C> subtract(C a) {
+        return subtract(a, ring.evzero);
+    }
+
+
+    /**
+     * GenPolynomial subtract a multiple.
+     * @param a coefficient.
+     * @param S GenPolynomial.
+     * @return this - a S.
+     */
+    public GenPolynomial<C> subtractMultiple(C a, GenPolynomial<C> S) {
+        if (a == null || a.isZERO()) {
+            return this;
+        }
+        if (S == null || S.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return S.multiply(a.negate());
+        }
+        assert (ring.nvar == S.ring.nvar);
+        GenPolynomial<C> n = this.copy();
+        SortedMap<ExpVector, C> nv = n.val;
+        SortedMap<ExpVector, C> sv = S.val;
+        for (Map.Entry<ExpVector, C> me : sv.entrySet()) {
+            ExpVector f = me.getKey();
+            C y = me.getValue(); // assert y != null
+            y = a.multiply(y);
+            C x = nv.get(f);
+            if (x != null) {
+                x = x.subtract(y);
+                if (!x.isZERO()) {
+                    nv.put(f, x);
+                } else {
+                    nv.remove(f);
+                }
+            } else if (!y.isZERO()) {
+                nv.put(f, y.negate());
+            }
+        }
+        return n;
+    }
+
+
+    /**
+     * GenPolynomial subtract a multiple.
+     * @param a coefficient.
+     * @param e exponent.
+     * @param S GenPolynomial.
+     * @return this - a x<sup>e</sup> S.
+     */
+    public GenPolynomial<C> subtractMultiple(C a, ExpVector e, GenPolynomial<C> S) {
+        if (a == null || a.isZERO()) {
+            return this;
+        }
+        if (S == null || S.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return S.multiply(a.negate(), e);
+        }
+        assert (ring.nvar == S.ring.nvar);
+        GenPolynomial<C> n = this.copy();
+        SortedMap<ExpVector, C> nv = n.val;
+        SortedMap<ExpVector, C> sv = S.val;
+        for (Map.Entry<ExpVector, C> me : sv.entrySet()) {
+            ExpVector f = me.getKey();
+            f = e.sum(f);
+            C y = me.getValue(); // assert y != null
+            y = a.multiply(y);
+            C x = nv.get(f);
+            if (x != null) {
+                x = x.subtract(y);
+                if (!x.isZERO()) {
+                    nv.put(f, x);
+                } else {
+                    nv.remove(f);
+                }
+            } else if (!y.isZERO()) {
+                nv.put(f, y.negate());
+            }
+        }
+        return n;
+    }
+
+
+    /**
+     * GenPolynomial scale and subtract a multiple.
+     * @param b scale factor.
+     * @param a coefficient.
+     * @param S GenPolynomial.
+     * @return this * b - a S.
+     */
+    public GenPolynomial<C> scaleSubtractMultiple(C b, C a, GenPolynomial<C> S) {
+        if (a == null || S == null) {
+            return this.multiply(b);
+        }
+        if (a.isZERO() || S.isZERO()) {
+            return this.multiply(b);
+        }
+        if (this.isZERO() || b == null || b.isZERO()) {
+            return S.multiply(a.negate()); //left?
+        }
+        if (b.isONE()) {
+            return subtractMultiple(a, S);
+        }
+        assert (ring.nvar == S.ring.nvar);
+        GenPolynomial<C> n = this.multiply(b);
+        SortedMap<ExpVector, C> nv = n.val;
+        SortedMap<ExpVector, C> sv = S.val;
+        for (Map.Entry<ExpVector, C> me : sv.entrySet()) {
+            ExpVector f = me.getKey();
+            //f = e.sum(f);
+            C y = me.getValue(); // assert y != null
+            y = a.multiply(y); // now y can be zero
+            C x = nv.get(f);
+            if (x != null) {
+                x = x.subtract(y);
+                if (!x.isZERO()) {
+                    nv.put(f, x);
+                } else {
+                    nv.remove(f);
+                }
+            } else if (!y.isZERO()) {
+                nv.put(f, y.negate());
+            }
+        }
+        return n;
+    }
+
+
+    /**
+     * GenPolynomial scale and subtract a multiple.
+     * @param b scale factor.
+     * @param a coefficient.
+     * @param e exponent.
+     * @param S GenPolynomial.
+     * @return this * b - a x<sup>e</sup> S.
+     */
+    public GenPolynomial<C> scaleSubtractMultiple(C b, C a, ExpVector e, GenPolynomial<C> S) {
+        if (a == null || S == null) {
+            return this.multiply(b);
+        }
+        if (a.isZERO() || S.isZERO()) {
+            return this.multiply(b);
+        }
+        if (this.isZERO() || b == null || b.isZERO()) {
+            return S.multiply(a.negate(), e);
+        }
+        if (b.isONE()) {
+            return subtractMultiple(a, e, S);
+        }
+        assert (ring.nvar == S.ring.nvar);
+        GenPolynomial<C> n = this.multiply(b);
+        SortedMap<ExpVector, C> nv = n.val;
+        SortedMap<ExpVector, C> sv = S.val;
+        for (Map.Entry<ExpVector, C> me : sv.entrySet()) {
+            ExpVector f = me.getKey();
+            f = e.sum(f);
+            C y = me.getValue(); // assert y != null
+            y = a.multiply(y); // now y can be zero
+            C x = nv.get(f);
+            if (x != null) {
+                x = x.subtract(y);
+                if (!x.isZERO()) {
+                    nv.put(f, x);
+                } else {
+                    nv.remove(f);
+                }
+            } else if (!y.isZERO()) {
+                nv.put(f, y.negate());
+            }
+        }
+        return n;
+    }
+
+
+    /**
+     * GenPolynomial scale and subtract a multiple.
+     * @param b scale factor.
+     * @param g scale exponent.
+     * @param a coefficient.
+     * @param e exponent.
+     * @param S GenPolynomial.
+     * @return this * a x<sup>g</sup> - a x<sup>e</sup> S.
+     */
+    public GenPolynomial<C> scaleSubtractMultiple(C b, ExpVector g, C a, ExpVector e, GenPolynomial<C> S) {
+        if (a == null || S == null) {
+            return this.multiply(b, g);
+        }
+        if (a.isZERO() || S.isZERO()) {
+            return this.multiply(b, g);
+        }
+        if (this.isZERO() || b == null || b.isZERO()) {
+            return S.multiply(a.negate(), e);
+        }
+        if (b.isONE() && g.isZERO()) {
+            return subtractMultiple(a, e, S);
+        }
+        assert (ring.nvar == S.ring.nvar);
+        GenPolynomial<C> n = this.multiply(b, g);
+        SortedMap<ExpVector, C> nv = n.val;
+        SortedMap<ExpVector, C> sv = S.val;
+        for (Map.Entry<ExpVector, C> me : sv.entrySet()) {
+            ExpVector f = me.getKey();
+            f = e.sum(f);
+            C y = me.getValue(); // assert y != null
+            y = a.multiply(y); // y can be zero now
+            C x = nv.get(f);
+            if (x != null) {
+                x = x.subtract(y);
+                if (!x.isZERO()) {
+                    nv.put(f, x);
+                } else {
+                    nv.remove(f);
+                }
+            } else if (!y.isZERO()) {
+                nv.put(f, y.negate());
+            }
+        }
+        return n;
+    }
+
+
+    /**
+     * GenPolynomial negation, alternative implementation.
+     * @return -this.
+     */
+    public GenPolynomial<C> negateAlt() {
+        GenPolynomial<C> n = ring.getZERO().copy();
+        SortedMap<ExpVector, C> v = n.val;
+        for (Map.Entry<ExpVector, C> m : val.entrySet()) {
+            C x = m.getValue(); // != null, 0
+            v.put(m.getKey(), x.negate());
+        }
+        return n;
+    }
+
+
+    /**
+     * GenPolynomial negation.
+     * @return -this.
+     */
+    public GenPolynomial<C> negate() {
+        GenPolynomial<C> n = this.copy();
+        SortedMap<ExpVector, C> v = n.val;
+        for (Map.Entry<ExpVector, C> m : v.entrySet()) {
+            C x = m.getValue(); // != null, 0
+            m.setValue(x.negate()); // okay
+        }
+        return n;
+    }
+
+
+    /**
+     * GenPolynomial absolute value, i.e. leadingCoefficient &gt; 0.
+     * @return abs(this).
+     */
+    public GenPolynomial<C> abs() {
+        if (leadingBaseCoefficient().signum() < 0) {
+            return this.negate();
+        }
+        return this;
+    }
+
+
+    /**
+     * GenPolynomial multiplication.
+     * @param S GenPolynomial.
+     * @return this*S.
+     */
+    public GenPolynomial<C> multiply(GenPolynomial<C> S) {
+        if (S == null) {
+            return ring.getZERO();
+        }
+        if (S.isZERO()) {
+            return ring.getZERO();
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        assert (ring.nvar == S.ring.nvar);
+        if (this instanceof GenSolvablePolynomial && S instanceof GenSolvablePolynomial) {
+            //throw new RuntimeException("wrong method dispatch in JRE ");
+            logger.debug("warn: wrong method dispatch in JRE multiply(S) - trying to fix");
+            GenSolvablePolynomial<C> T = (GenSolvablePolynomial<C>) this;
+            GenSolvablePolynomial<C> Sp = (GenSolvablePolynomial<C>) S;
+            return T.multiply(Sp);
+        }
+        GenPolynomial<C> p = ring.getZERO().copy();
+        SortedMap<ExpVector, C> pv = p.val;
+        for (Map.Entry<ExpVector, C> m1 : val.entrySet()) {
+            C c1 = m1.getValue();
+            ExpVector e1 = m1.getKey();
+            for (Map.Entry<ExpVector, C> m2 : S.val.entrySet()) {
+                C c2 = m2.getValue();
+                ExpVector e2 = m2.getKey();
+                C c = c1.multiply(c2); // check non zero if not domain
+                if (!c.isZERO()) {
+                    ExpVector e = e1.sum(e2);
+                    C c0 = pv.get(e);
+                    if (c0 == null) {
+                        pv.put(e, c);
+                    } else {
+                        c0 = c0.sum(c);
+                        if (!c0.isZERO()) {
+                            pv.put(e, c0);
+                        } else {
+                            pv.remove(e);
+                        }
+                    }
+                }
+            }
+        }
+        return p;
+    }
+
+
+    /**
+     * GenPolynomial multiplication. Product with coefficient ring element.
+     * @param s coefficient.
+     * @return this*s.
+     */
+    public GenPolynomial<C> multiply(C s) {
+        if (s == null || s.isZERO()) {
+            return ring.getZERO();
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        if (this instanceof GenSolvablePolynomial) {
+            //throw new RuntimeException("wrong method dispatch in JRE ");
+            logger.debug("warn: wrong method dispatch in JRE multiply(s) - trying to fix");
+            GenSolvablePolynomial<C> T = (GenSolvablePolynomial<C>) this;
+            return T.multiply(s);
+        }
+        GenPolynomial<C> p = ring.getZERO().copy();
+        SortedMap<ExpVector, C> pv = p.val;
+        for (Map.Entry<ExpVector, C> m : val.entrySet()) {
+            C a = m.getValue();
+            ExpVector e = m.getKey();
+            C c = a.multiply(s); // check non zero if not domain
+            if (!c.isZERO()) {
+                pv.put(e, c); // not m1.setValue( c )
+            }
+        }
+        return p;
+    }
+
+
+    /**
+     * GenPolynomial left multiplication. Left product with coefficient ring
+     * element.
+     * @param s coefficient.
+     * @return s*this.
+     */
+    public GenPolynomial<C> multiplyLeft(C s) {
+        if (s == null || s.isZERO()) {
+            return ring.getZERO();
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        if (this instanceof GenSolvablePolynomial) {
+            //throw new RuntimeException("wrong method dispatch in JRE ");
+            logger.debug("warn: wrong method dispatch in JRE multiply(s) - trying to fix");
+            GenSolvablePolynomial<C> T = (GenSolvablePolynomial<C>) this;
+            return T.multiplyLeft(s);
+        }
+        GenPolynomial<C> p = ring.getZERO().copy();
+        SortedMap<ExpVector, C> pv = p.val;
+        for (Map.Entry<ExpVector, C> m : val.entrySet()) {
+            C a = m.getValue();
+            ExpVector e = m.getKey();
+            C c = s.multiply(a);
+            if (!c.isZERO()) {
+                pv.put(e, c);
+            }
+        }
+        return p;
+    }
+
+
+    /**
+     * GenPolynomial monic, i.e. leadingCoefficient == 1. If leadingCoefficient
+     * is not invertible returns this unmodified.
+     * @return monic(this).
+     */
+    public GenPolynomial<C> monic() {
+        if (this.isZERO()) {
+            return this;
+        }
+        C lc = leadingBaseCoefficient();
+        if (!lc.isUnit()) {
+            //System.out.println("lc = "+lc);
+            return this;
+        }
+        C lm = lc.inverse();
+        return multiplyLeft(lm);
+    }
+
+
+    /**
+     * GenPolynomial multiplication. Product with ring element and exponent
+     * vector.
+     * @param s coefficient.
+     * @param e exponent.
+     * @return this * s x<sup>e</sup>.
+     */
+    public GenPolynomial<C> multiply(C s, ExpVector e) {
+        if (s == null) {
+            return ring.getZERO();
+        }
+        if (s.isZERO()) {
+            return ring.getZERO();
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        if (e == null) { // exp vector of zero polynomial
+            return ring.getZERO();
+        }
+        if (this instanceof GenSolvablePolynomial) {
+            //throw new RuntimeException("wrong method dispatch in JRE ");
+            logger.debug("warn: wrong method dispatch in JRE multiply(s,e) - trying to fix");
+            GenSolvablePolynomial<C> T = (GenSolvablePolynomial<C>) this;
+            return T.multiply(s, e);
+        }
+        GenPolynomial<C> p = ring.getZERO().copy();
+        SortedMap<ExpVector, C> pv = p.val;
+        for (Map.Entry<ExpVector, C> m1 : val.entrySet()) {
+            C c1 = m1.getValue();
+            ExpVector e1 = m1.getKey();
+            C c = c1.multiply(s); // check non zero if not domain
+            if (!c.isZERO()) {
+                ExpVector e2 = e1.sum(e);
+                pv.put(e2, c);
+            }
+        }
+        return p;
+    }
+
+
+    /**
+     * GenPolynomial multiplication. Product with exponent vector.
+     * @param e exponent (!= null).
+     * @return this * x<sup>e</sup>.
+     */
+    public GenPolynomial<C> multiply(ExpVector e) {
+        if (e == null) { // exp vector of zero polynomial
+            return ring.getZERO();
+        }
+        // assert e != null. This is seldom allowed.
+        if (this.isZERO()) {
+            return this;
+        }
+        if (this instanceof GenSolvablePolynomial) {
+            //throw new RuntimeException("wrong method dispatch in JRE ");
+            logger.debug("warn: wrong method dispatch in JRE multiply(e) - trying to fix");
+            GenSolvablePolynomial<C> T = (GenSolvablePolynomial<C>) this;
+            return T.multiply(e);
+        }
+        GenPolynomial<C> p = ring.getZERO().copy();
+        SortedMap<ExpVector, C> pv = p.val;
+        for (Map.Entry<ExpVector, C> m1 : val.entrySet()) {
+            C c1 = m1.getValue();
+            ExpVector e1 = m1.getKey();
+            ExpVector e2 = e1.sum(e);
+            pv.put(e2, c1);
+        }
+        return p;
+    }
+
+
+    /**
+     * GenPolynomial multiplication. Product with 'monomial'.
+     * @param m 'monomial'.
+     * @return this * m.
+     */
+    public GenPolynomial<C> multiply(Map.Entry<ExpVector, C> m) {
+        if (m == null) {
+            return ring.getZERO();
+        }
+        return multiply(m.getValue(), m.getKey());
+    }
+
+
+    /**
+     * GenPolynomial division. Division by coefficient ring element. Fails, if
+     * exact division is not possible.
+     * @param s coefficient.
+     * @return s**(-1) * this.
+     */
+    public GenPolynomial<C> divide(C s) {
+        if (s == null || s.isZERO()) {
+            throw new ArithmeticException("division by zero");
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        //C t = s.inverse();
+        //return multiply(t);
+        GenPolynomial<C> p = ring.getZERO().copy();
+        SortedMap<ExpVector, C> pv = p.val;
+        for (Map.Entry<ExpVector, C> m : val.entrySet()) {
+            ExpVector e = m.getKey();
+            C c1 = m.getValue();
+            C c = c1.divide(s);
+            if (debug) {
+                C x = c1.remainder(s);
+                if (!x.isZERO()) {
+                    logger.info("divide x = " + x);
+                    throw new ArithmeticException("no exact division: " + c1 + "/" + s);
+                }
+            }
+            if (c.isZERO()) {
+                throw new ArithmeticException("no exact division: " + c1 + "/" + s + ", in " + this);
+            }
+            pv.put(e, c); // not m1.setValue( c )
+        }
+        return p;
+    }
+
+
+    /**
+     * GenPolynomial right division. Right division by coefficient ring element.
+     * Fails, if exact division is not possible.
+     * @param s coefficient.
+     * @return this * s**(-1).
+     */
+    public GenPolynomial<C> rightDivideCoeff(C s) {
+        if (s == null || s.isZERO()) {
+            throw new ArithmeticException("division by zero");
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        //C t = s.inverse();
+        //return multiply(t);
+        GenPolynomial<C> p = ring.getZERO().copy();
+        SortedMap<ExpVector, C> pv = p.val;
+        for (Map.Entry<ExpVector, C> m : val.entrySet()) {
+            ExpVector e = m.getKey();
+            C c1 = m.getValue();
+            C c = c1.rightDivide(s);
+            if (debug) {
+                C x = c1.rightRemainder(s);
+                if (!x.isZERO()) {
+                    logger.info("divide x = " + x);
+                    throw new ArithmeticException("no exact division: " + c1 + "/" + s);
+                }
+            }
+            if (c.isZERO()) {
+                throw new ArithmeticException("no exact division: " + c1 + "/" + s + ", in " + this);
+            }
+            pv.put(e, c); // not m1.setValue( c )
+        }
+        return p;
+    }
+
+
+    /**
+     * GenPolynomial left division. Left division by coefficient ring element.
+     * Fails, if exact division is not possible.
+     * @param s coefficient.
+     * @return s**(-1) * this.
+     */
+    public GenPolynomial<C> leftDivideCoeff(C s) {
+        if (s == null || s.isZERO()) {
+            throw new ArithmeticException("division by zero");
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        //C t = s.inverse();
+        //return multiply(t);
+        GenPolynomial<C> p = ring.getZERO().copy();
+        SortedMap<ExpVector, C> pv = p.val;
+        for (Map.Entry<ExpVector, C> m : val.entrySet()) {
+            ExpVector e = m.getKey();
+            C c1 = m.getValue();
+            C c = c1.leftDivide(s);
+            if (debug) {
+                C x = c1.leftRemainder(s);
+                if (!x.isZERO()) {
+                    logger.info("divide x = " + x);
+                    throw new ArithmeticException("no exact division: " + c1 + "/" + s);
+                }
+            }
+            if (c.isZERO()) {
+                throw new ArithmeticException("no exact division: " + c1 + "/" + s + ", in " + this);
+            }
+            pv.put(e, c); // not m1.setValue( c )
+        }
+        return p;
+    }
+
+
+    /**
+     * GenPolynomial division with remainder. Fails, if exact division by
+     * leading base coefficient is not possible. Meaningful only for univariate
+     * polynomials over fields, but works in any case.
+     * @param S nonzero GenPolynomial with invertible leading coefficient.
+     * @return [ quotient , remainder ] with this = quotient * S + remainder and
+     *         deg(remainder) &lt; deg(S) or remiander = 0.
+     * @see edu.jas.poly.PolyUtil#baseSparsePseudoRemainder(edu.jas.poly.GenPolynomial,edu.jas.poly.GenPolynomial)
+     */
+    @SuppressWarnings("unchecked")
+    public GenPolynomial<C>[] quotientRemainder(GenPolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            throw new ArithmeticException("division by zero");
+        }
+        C c = S.leadingBaseCoefficient();
+        if (!c.isUnit()) {
+            throw new ArithmeticException("lbcf not invertible " + c);
+        }
+        C ci = c.inverse();
+        assert (ring.nvar == S.ring.nvar);
+        ExpVector e = S.leadingExpVector();
+        GenPolynomial<C> h;
+        GenPolynomial<C> q = ring.getZERO().copy();
+        GenPolynomial<C> r = this.copy();
+        while (!r.isZERO()) {
+            ExpVector f = r.leadingExpVector();
+            if (f.multipleOf(e)) {
+                C a = r.leadingBaseCoefficient();
+                ExpVector g = f.subtract(e);
+                a = a.multiply(ci);
+                q = q.sum(a, g);
+                h = S.multiply(a, g);
+                r = r.subtract(h);
+                assert (!f.equals(r.leadingExpVector())) : "leadingExpVector not descending: " + f;
+            } else {
+                break;
+            }
+        }
+        GenPolynomial<C>[] ret = new GenPolynomial[2];
+        ret[0] = q;
+        ret[1] = r;
+        return ret;
+    }
+
+
+    /**
+     * GenPolynomial division. Fails, if exact division by leading base
+     * coefficient is not possible. Meaningful only for univariate polynomials
+     * over fields, but works in any case.
+     * @param S nonzero GenPolynomial with invertible leading coefficient.
+     * @return quotient with this = quotient * S + remainder.
+     * @see edu.jas.poly.PolyUtil#baseSparsePseudoRemainder(edu.jas.poly.GenPolynomial,edu.jas.poly.GenPolynomial)
+     */
+    public GenPolynomial<C> divide(GenPolynomial<C> S) {
+        if (this instanceof GenSolvablePolynomial || S instanceof GenSolvablePolynomial) {
+            //throw new RuntimeException("wrong method dispatch in JRE ");
+            //logger.debug("warn: wrong method dispatch in JRE multiply(S) - trying to fix");
+            GenSolvablePolynomial<C> T = (GenSolvablePolynomial<C>) this;
+            GenSolvablePolynomial<C> Sp = (GenSolvablePolynomial<C>) S;
+            return T.quotientRemainder(Sp)[0];
+        }
+        return quotientRemainder(S)[0];
+    }
+
+
+    /**
+     * GenPolynomial remainder. Fails, if exact division by leading base
+     * coefficient is not possible. Meaningful only for univariate polynomials
+     * over fields, but works in any case.
+     * @param S nonzero GenPolynomial with invertible leading coefficient.
+     * @return remainder with this = quotient * S + remainder.
+     * @see edu.jas.poly.PolyUtil#baseSparsePseudoRemainder(edu.jas.poly.GenPolynomial,edu.jas.poly.GenPolynomial)
+     */
+    public GenPolynomial<C> remainder(GenPolynomial<C> S) {
+        if (this instanceof GenSolvablePolynomial || S instanceof GenSolvablePolynomial) {
+            //throw new RuntimeException("wrong method dispatch in JRE ");
+            //logger.debug("warn: wrong method dispatch in JRE multiply(S) - trying to fix");
+            GenSolvablePolynomial<C> T = (GenSolvablePolynomial<C>) this;
+            GenSolvablePolynomial<C> Sp = (GenSolvablePolynomial<C>) S;
+            return T.quotientRemainder(Sp)[1];
+        }
+        if (S == null || S.isZERO()) {
+            throw new ArithmeticException("division by zero");
+        }
+        C c = S.leadingBaseCoefficient();
+        if (!c.isUnit()) {
+            throw new ArithmeticException("lbc not invertible " + c);
+        }
+        C ci = c.inverse();
+        assert (ring.nvar == S.ring.nvar);
+        ExpVector e = S.leadingExpVector();
+        GenPolynomial<C> h;
+        GenPolynomial<C> r = this.copy();
+        while (!r.isZERO()) {
+            ExpVector f = r.leadingExpVector();
+            if (f.multipleOf(e)) {
+                C a = r.leadingBaseCoefficient();
+                ExpVector g = f.subtract(e);
+                //logger.info("red div = " + e);
+                a = a.multiply(ci);
+                h = S.multiply(a, g);
+                r = r.subtract(h);
+                assert (!f.equals(r.leadingExpVector())) : "leadingExpVector not descending: " + f;
+            } else {
+                break;
+            }
+        }
+        return r;
+    }
+
+
+    /**
+     * GenPolynomial greatest common divisor. Only for univariate polynomials
+     * over fields.
+     * @param S GenPolynomial.
+     * @return gcd(this,S).
+     */
+    public GenPolynomial<C> gcd(GenPolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return S;
+        }
+        if (ring.nvar != 1) {
+            throw new IllegalArgumentException("not univariate polynomials" + ring);
+        }
+        GenPolynomial<C> x;
+        GenPolynomial<C> q = this;
+        GenPolynomial<C> r = S;
+        while (!r.isZERO()) {
+            x = q.remainder(r);
+            q = r;
+            r = x;
+        }
+        return q.monic(); // normalize
+    }
+
+
+    /**
+     * GenPolynomial extended greatest comon divisor. Only for univariate
+     * polynomials over fields.
+     * @param S GenPolynomial.
+     * @return [ gcd(this,S), a, b ] with a*this + b*S = gcd(this,S).
+     */
+    @SuppressWarnings("unchecked")
+    public GenPolynomial<C>[] egcd(GenPolynomial<C> S) {
+        GenPolynomial<C>[] ret = new GenPolynomial[3];
+        ret[0] = null;
+        ret[1] = null;
+        ret[2] = null;
+        if (S == null || S.isZERO()) {
+            ret[0] = this;
+            ret[1] = this.ring.getONE();
+            ret[2] = this.ring.getZERO();
+            return ret;
+        }
+        if (this.isZERO()) {
+            ret[0] = S;
+            ret[1] = this.ring.getZERO();
+            ret[2] = this.ring.getONE();
+            return ret;
+        }
+        if (ring.nvar != 1) {
+            throw new IllegalArgumentException(
+                            this.getClass().getName() + " not univariate polynomials" + ring);
+        }
+        if (this.isConstant() && S.isConstant()) {
+            C t = this.leadingBaseCoefficient();
+            C s = S.leadingBaseCoefficient();
+            C[] gg = t.egcd(s);
+            //System.out.println("coeff gcd = " + Arrays.toString(gg));
+            GenPolynomial<C> z = this.ring.getZERO();
+            ret[0] = z.sum(gg[0]);
+            ret[1] = z.sum(gg[1]);
+            ret[2] = z.sum(gg[2]);
+            return ret;
+        }
+        GenPolynomial<C>[] qr;
+        GenPolynomial<C> q = this;
+        GenPolynomial<C> r = S;
+        GenPolynomial<C> c1 = ring.getONE().copy();
+        GenPolynomial<C> d1 = ring.getZERO().copy();
+        GenPolynomial<C> c2 = ring.getZERO().copy();
+        GenPolynomial<C> d2 = ring.getONE().copy();
+        GenPolynomial<C> x1;
+        GenPolynomial<C> x2;
+        while (!r.isZERO()) {
+            qr = q.quotientRemainder(r);
+            q = qr[0];
+            x1 = c1.subtract(q.multiply(d1));
+            x2 = c2.subtract(q.multiply(d2));
+            c1 = d1;
+            c2 = d2;
+            d1 = x1;
+            d2 = x2;
+            q = r;
+            r = qr[1];
+        }
+        // normalize ldcf(q) to 1, i.e. make monic
+        C g = q.leadingBaseCoefficient();
+        if (g.isUnit()) {
+            C h = g.inverse();
+            q = q.multiply(h);
+            c1 = c1.multiply(h);
+            c2 = c2.multiply(h);
+        }
+        //assert ( ((c1.multiply(this)).sum( c2.multiply(S)).equals(q) )); 
+        ret[0] = q;
+        ret[1] = c1;
+        ret[2] = c2;
+        return ret;
+    }
+
+
+    /**
+     * GenPolynomial half extended greatest comon divisor. Only for univariate
+     * polynomials over fields.
+     * @param S GenPolynomial.
+     * @return [ gcd(this,S), a ] with a*this + b*S = gcd(this,S).
+     */
+    @SuppressWarnings("unchecked")
+    public GenPolynomial<C>[] hegcd(GenPolynomial<C> S) {
+        GenPolynomial<C>[] ret = new GenPolynomial[2];
+        ret[0] = null;
+        ret[1] = null;
+        if (S == null || S.isZERO()) {
+            ret[0] = this;
+            ret[1] = this.ring.getONE();
+            return ret;
+        }
+        if (this.isZERO()) {
+            ret[0] = S;
+            return ret;
+        }
+        if (ring.nvar != 1) {
+            throw new IllegalArgumentException(
+                            this.getClass().getName() + " not univariate polynomials" + ring);
+        }
+        GenPolynomial<C>[] qr;
+        GenPolynomial<C> q = this;
+        GenPolynomial<C> r = S;
+        GenPolynomial<C> c1 = ring.getONE().copy();
+        GenPolynomial<C> d1 = ring.getZERO().copy();
+        GenPolynomial<C> x1;
+        while (!r.isZERO()) {
+            qr = q.quotientRemainder(r);
+            q = qr[0];
+            x1 = c1.subtract(q.multiply(d1));
+            c1 = d1;
+            d1 = x1;
+            q = r;
+            r = qr[1];
+        }
+        // normalize ldcf(q) to 1, i.e. make monic
+        C g = q.leadingBaseCoefficient();
+        if (g.isUnit()) {
+            C h = g.inverse();
+            q = q.multiply(h);
+            c1 = c1.multiply(h);
+        }
+        //assert ( ((c1.multiply(this)).remainder(S).equals(q) )); 
+        ret[0] = q;
+        ret[1] = c1;
+        return ret;
+    }
+
+
+    /**
+     * GenPolynomial inverse. Required by RingElem. Throws not invertible
+     * exception.
+     */
+    public GenPolynomial<C> inverse() {
+        if (isUnit()) { // only possible if ldbcf is unit
+            C c = leadingBaseCoefficient().inverse();
+            return ring.getONE().multiply(c);
+        }
+        throw new NotInvertibleException("element not invertible " + this + " :: " + ring);
+    }
+
+
+    /**
+     * GenPolynomial modular inverse. Only for univariate polynomials over
+     * fields.
+     * @param m GenPolynomial.
+     * @return a with with a*this = 1 mod m.
+     */
+    public GenPolynomial<C> modInverse(GenPolynomial<C> m) {
+        if (this.isZERO()) {
+            throw new NotInvertibleException("zero is not invertible");
+        }
+        GenPolynomial<C>[] hegcd = this.hegcd(m);
+        GenPolynomial<C> a = hegcd[0];
+        if (!a.isUnit()) { // gcd != 1
+            throw new AlgebraicNotInvertibleException("element not invertible, gcd != 1", m, a, m.divide(a));
+        }
+        GenPolynomial<C> b = hegcd[1];
+        if (b.isZERO()) { // when m divides this, e.g. m.isUnit()
+            throw new NotInvertibleException("element not invertible, divisible by modul");
+        }
+        return b;
+    }
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend all ExpVectors by
+     * i elements and multiply by x_j^k.
+     * @param pfac extended polynomial ring factory (by i variables).
+     * @param j index of variable to be used for multiplication.
+     * @param k exponent for x_j.
+     * @return extended polynomial.
+     */
+    public GenPolynomial<C> extend(GenPolynomialRing<C> pfac, int j, long k) {
+        if (ring.equals(pfac)) { // nothing to do
+            return this;
+        }
+        GenPolynomial<C> Cp = pfac.getZERO().copy();
+        if (this.isZERO()) {
+            return Cp;
+        }
+        int i = pfac.nvar - ring.nvar;
+        Map<ExpVector, C> C = Cp.val; //getMap();
+        Map<ExpVector, C> A = val;
+        for (Map.Entry<ExpVector, C> y : A.entrySet()) {
+            ExpVector e = y.getKey();
+            C a = y.getValue();
+            ExpVector f = e.extend(i, j, k);
+            C.put(f, a);
+        }
+        return Cp;
+    }
+
+
+    /**
+     * Extend lower variables. Used e.g. in module embedding. Extend all
+     * ExpVectors by i lower elements and multiply by x_j^k.
+     * @param pfac extended polynomial ring factory (by i variables).
+     * @param j index of variable to be used for multiplication.
+     * @param k exponent for x_j.
+     * @return extended polynomial.
+     */
+    public GenPolynomial<C> extendLower(GenPolynomialRing<C> pfac, int j, long k) {
+        if (ring.equals(pfac)) { // nothing to do
+            return this;
+        }
+        GenPolynomial<C> Cp = pfac.getZERO().copy();
+        if (this.isZERO()) {
+            return Cp;
+        }
+        int i = pfac.nvar - ring.nvar;
+        Map<ExpVector, C> C = Cp.val; //getMap();
+        Map<ExpVector, C> A = val;
+        for (Map.Entry<ExpVector, C> y : A.entrySet()) {
+            ExpVector e = y.getKey();
+            C a = y.getValue();
+            ExpVector f = e.extendLower(i, j, k);
+            C.put(f, a);
+        }
+        return Cp;
+    }
+
+
+    /**
+     * Contract variables. Used e.g. in module embedding. Remove i elements of
+     * each ExpVector.
+     * @param pfac contracted polynomial ring factory (by i variables).
+     * @return Map of exponents and contracted polynomials. <b>Note:</b> could
+     *         return SortedMap
+     */
+    public Map<ExpVector, GenPolynomial<C>> contract(GenPolynomialRing<C> pfac) {
+        GenPolynomial<C> zero = pfac.getZERO(); //not pfac.coFac;
+        TermOrder t = new TermOrder(TermOrder.INVLEX);
+        Map<ExpVector, GenPolynomial<C>> B = new TreeMap<ExpVector, GenPolynomial<C>>(
+                        t.getAscendComparator());
+        if (this.isZERO()) {
+            return B;
+        }
+        int i = ring.nvar - pfac.nvar;
+        Map<ExpVector, C> A = val;
+        for (Map.Entry<ExpVector, C> y : A.entrySet()) {
+            ExpVector e = y.getKey();
+            C a = y.getValue();
+            ExpVector f = e.contract(0, i);
+            ExpVector g = e.contract(i, e.length() - i);
+            GenPolynomial<C> p = B.get(f);
+            if (p == null) {
+                p = zero;
+            }
+            p = p.sum(a, g);
+            B.put(f, p);
+        }
+        return B;
+    }
+
+
+    /**
+     * Contract variables to coefficient polynomial. Remove i elements of each
+     * ExpVector, removed elements must be zero.
+     * @param pfac contracted polynomial ring factory (by i variables).
+     * @return contracted coefficient polynomial.
+     */
+    public GenPolynomial<C> contractCoeff(GenPolynomialRing<C> pfac) {
+        Map<ExpVector, GenPolynomial<C>> ms = contract(pfac);
+        GenPolynomial<C> c = pfac.getZERO();
+        for (Map.Entry<ExpVector, GenPolynomial<C>> m : ms.entrySet()) {
+            if (m.getKey().isZERO()) {
+                c = m.getValue();
+            } else {
+                throw new RuntimeException("wrong coefficient contraction " + m + ", pol =  " + c);
+            }
+        }
+        return c;
+    }
+
+
+    /**
+     * Extend univariate to multivariate polynomial. This is an univariate
+     * polynomial in variable i of the polynomial ring, it is extended to the
+     * given polynomial ring.
+     * @param pfac extended polynomial ring factory.
+     * @param i index of the variable of this polynomial in pfac.
+     * @return extended multivariate polynomial.
+     */
+    public GenPolynomial<C> extendUnivariate(GenPolynomialRing<C> pfac, int i) {
+        if (i < 0 || pfac.nvar < i) {
+            throw new IllegalArgumentException("index " + i + "out of range " + pfac.nvar);
+        }
+        if (ring.nvar != 1) {
+            throw new IllegalArgumentException("polynomial not univariate " + ring.nvar);
+        }
+        if (this.isONE()) {
+            return pfac.getONE();
+        }
+        int j = pfac.nvar - 1 - i;
+        GenPolynomial<C> Cp = pfac.getZERO().copy();
+        if (this.isZERO()) {
+            return Cp;
+        }
+        Map<ExpVector, C> C = Cp.val; //getMap();
+        Map<ExpVector, C> A = val;
+        for (Map.Entry<ExpVector, C> y : A.entrySet()) {
+            ExpVector e = y.getKey();
+            long n = e.getVal(0);
+            C a = y.getValue();
+            ExpVector f = ExpVector.create(pfac.nvar, j, n);
+            C.put(f, a); // assert not contained
+        }
+        return Cp;
+    }
+
+
+    /**
+     * Make homogeneous.
+     * @param pfac extended polynomial ring factory (by 1 variable).
+     * @return homogeneous polynomial.
+     */
+    public GenPolynomial<C> homogenize(GenPolynomialRing<C> pfac) {
+        if (ring.equals(pfac)) { // not implemented
+            throw new UnsupportedOperationException("case with same ring not implemented");
+        }
+        GenPolynomial<C> Cp = pfac.getZERO().copy();
+        if (this.isZERO()) {
+            return Cp;
+        }
+        long deg = totalDegree();
+        //int i = pfac.nvar - ring.nvar;
+        Map<ExpVector, C> C = Cp.val; //getMap();
+        Map<ExpVector, C> A = val;
+        for (Map.Entry<ExpVector, C> y : A.entrySet()) {
+            ExpVector e = y.getKey();
+            C a = y.getValue();
+            long d = deg - e.totalDeg();
+            ExpVector f = e.extend(1, 0, d);
+            C.put(f, a);
+        }
+        return Cp;
+    }
+
+
+    /**
+     * Dehomogenize.
+     * @param pfac contracted polynomial ring factory (by 1 variable).
+     * @return in homogeneous polynomial.
+     */
+    public GenPolynomial<C> deHomogenize(GenPolynomialRing<C> pfac) {
+        if (ring.equals(pfac)) { // not implemented
+            throw new UnsupportedOperationException("case with same ring not implemented");
+        }
+        GenPolynomial<C> Cp = pfac.getZERO().copy();
+        if (this.isZERO()) {
+            return Cp;
+        }
+        Map<ExpVector, C> C = Cp.val; //getMap();
+        Map<ExpVector, C> A = val;
+        for (Map.Entry<ExpVector, C> y : A.entrySet()) {
+            ExpVector e = y.getKey();
+            C a = y.getValue();
+            ExpVector f = e.contract(1, pfac.nvar);
+            C.put(f, a);
+        }
+        return Cp;
+    }
+
+
+    /**
+     * Reverse variables. Used e.g. in opposite rings.
+     * @return polynomial with reversed variables.
+     */
+    public GenPolynomial<C> reverse(GenPolynomialRing<C> oring) {
+        GenPolynomial<C> Cp = oring.getZERO().copy();
+        if (this.isZERO()) {
+            return Cp;
+        }
+        int k = -1;
+        if (oring.tord.getEvord2() != 0 && oring.partial) {
+            k = oring.tord.getSplit();
+        }
+
+        Map<ExpVector, C> C = Cp.val; //getMap();
+        Map<ExpVector, C> A = val;
+        ExpVector f;
+        for (Map.Entry<ExpVector, C> y : A.entrySet()) {
+            ExpVector e = y.getKey();
+            if (k >= 0) {
+                f = e.reverse(k);
+            } else {
+                f = e.reverse();
+            }
+            C a = y.getValue();
+            C.put(f, a);
+        }
+        return Cp;
+    }
+
+
+    /**
+     * GenPolynomial inflate. Only for univariate polynomials over fields.
+     * @param e exponent.
+     * @return this(x**e)
+     */
+    public GenPolynomial<C> inflate(long e) {
+        if (e == 1) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        if (ring.nvar != 1) {
+            throw new IllegalArgumentException(
+                            this.getClass().getName() + " not univariate polynomial" + ring);
+        }
+        GenPolynomial<C> Cp = ring.getZERO().copy();
+        Map<ExpVector, C> C = Cp.val; //getMap();
+        Map<ExpVector, C> A = val;
+        ExpVector f;
+        for (Map.Entry<ExpVector, C> y : A.entrySet()) {
+            ExpVector g = y.getKey();
+            f = g.scalarMultiply(e);
+            C a = y.getValue();
+            C.put(f, a);
+        }
+        return Cp;
+    }
+
+
+    /**
+     * Iterator over coefficients.
+     * @return val.values().iterator().
+     */
+    public Iterator<C> coefficientIterator() {
+        return val.values().iterator();
+    }
+
+
+    /**
+     * Iterator over exponents.
+     * @return val.keySet().iterator().
+     */
+    public Iterator<ExpVector> exponentIterator() {
+        return val.keySet().iterator();
+    }
+
+
+    /**
+     * Iterator over monomials.
+     * @return a PolyIterator.
+     */
+    public Iterator<Monomial<C>> iterator() {
+        return new PolyIterator<C>(val);
+    }
+
+
+    /**
+     * Spliterator over monomials.
+     * @return a PolySpliterator.
+     */
+    public Spliterator<Monomial<C>> spliterator() {
+        return new PolySpliterator<C>(val);
+    }
+
+
+    /**
+     * Map a unary function to the coefficients.
+     * @param f evaluation functor.
+     * @return new polynomial with coefficients f(this.coefficients).
+     */
+    public GenPolynomial<C> map(final UnaryFunctor<? super C, C> f) {
+        GenPolynomial<C> n = ring.getZERO().copy();
+        SortedMap<ExpVector, C> nv = n.val;
+        for (Map.Entry<ExpVector, C> m : this.val.entrySet()) {
+            //logger.info("m = " + m);
+            C c = f.eval(m.getValue());
+            if (c != null && !c.isZERO()) {
+                nv.put(m.getKey(), c);
+            }
+        }
+        return n;
+    }
+
+
+    /*
+     * Map a unary function to the coefficients.
+     * @param f evaluation functor.
+     * @return new polynomial with coefficients f(this.coefficients).
+     */
+    GenPolynomial<C> mapWrong(final UnaryFunctor<? super C, C> f) {
+        GenPolynomial<C> n = this.copy();
+        SortedMap<ExpVector, C> nv = n.val;
+        for (Map.Entry<ExpVector, C> m : nv.entrySet()) {
+            //logger.info("m = " + m);
+            C c = f.eval(m.getValue());
+            if (c != null && !c.isZERO()) {
+                m.setValue(c); // not okay
+            } else {
+                // not possible nv.remove(m.getKey());
+            }
+        }
+        return n;
+    }
+
+
+    /**
+     * Map a function to the polynomial stream entries.
+     * @param f evaluation functor.
+     * @return new polynomial with f(this.entries).
+     */
+    public GenPolynomial<C> mapOnStream(
+                    final Function<? super Map.Entry<ExpVector, C>, ? extends Map.Entry<ExpVector, C>> f) {
+        return mapOnStream(f, false);
+    }
+
+
+    /**
+     * Map a function to the polynomial stream entries.
+     * @param f evaluation functor.
+     * @return new polynomial with f(this.entries).
+     */
+    public GenPolynomial<C> mapOnStream(
+                    final Function<? super Map.Entry<ExpVector, C>, ? extends Map.Entry<ExpVector, C>> f,
+                    boolean parallel) {
+        Stream<Map.Entry<ExpVector, C>> st;
+        if (parallel) {
+            st = val.entrySet().parallelStream();
+        } else {
+            st = val.entrySet().stream();
+        }
+        Map<ExpVector, C> m = st.map(f).filter(me -> !me.getValue().isZERO())
+                        .collect(Collectors.toMap(me -> me.getKey(), me -> me.getValue()));
+        //Stream<Map.Entry<ExpVector,C>> stp = st.map(f);
+        //Stream<Map.Entry<ExpVector,C>> stf = stp.filter(me -> !me.getValue().isZERO());
+        //Map<ExpVector,C> m = stf.collect(Collectors.toMap(me -> me.getKey(), me -> me.getValue()));
+        return new GenPolynomial<C>(ring, m);
+    }
+
+
+    /**
+     * Returns the number of bits in the representation of this polynomial.
+     * @return number of bits in the representation of this polynomial,
+     *         including sign bits.
+     */
+    public long bitLength() {
+        if (blen < 0L) {
+            long n = 0L;
+            for (Monomial<C> m : this) {
+                n += m.e.bitLength();
+                //n += m.c.bitLength(); // todo add bitLength to Element
+                try { // hack
+                    Method method = m.c.getClass().getMethod("bitLength", (Class<?>[]) null);
+                    n += (Long) method.invoke(m.c, (Object[]) null);
+                } catch (NoSuchMethodException e) {
+                    logger.error("Exception, class: " + m.c.getClass());
+                    throw new RuntimeException(e);
+                } catch (IllegalAccessException e) {
+                    logger.error("Exception, class: " + m.c.getClass());
+                    throw new RuntimeException(e);
+                } catch (InvocationTargetException e) {
+                    logger.error("Exception, class: " + m.c.getClass());
+                    throw new RuntimeException(e);
+                }
+            }
+            blen = n;
+            //System.out.println("bitLength(poly) = " + blen);
+        }
+        return blen;
+    }
+
+    //private void writeObject(java.io.ObjectOutputStream out) throws IOException {
+    //    out.defaultWriteObject();
+    //}
+
+
+    private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        blen = -1;
+        hash = -1;
+    }
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/GenPolynomialRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/GenPolynomialRing.java
@@ -1,0 +1,1554 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.SortedMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.arith.ModIntegerRing;
+import edu.jas.kern.PreemptStatus;
+import edu.jas.kern.PrettyPrint;
+import edu.jas.kern.Scripting;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.util.CartesianProduct;
+import edu.jas.util.CartesianProductInfinite;
+import edu.jas.util.LongIterable;
+import edu.jas.vector.GenVector;
+
+
+/**
+ * GenPolynomialRing generic polynomial factory. It implements RingFactory for
+ * n-variate ordered polynomials over coefficients C. The variables commute with
+ * each other and with the coefficients. For non-commutative coefficients some
+ * care is taken to respect the multiplication order.
+ *
+ * Almost immutable object, except variable names.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class GenPolynomialRing<C extends RingElem<C>>
+                implements RingFactory<GenPolynomial<C>>, Iterable<GenPolynomial<C>> {
+
+
+    /**
+     * The factory for the coefficients.
+     */
+    public final RingFactory<C> coFac;
+
+
+    /**
+     * The number of variables.
+     */
+    public final int nvar;
+
+
+    /**
+     * The term order.
+     */
+    public final TermOrder tord;
+
+
+    /**
+     * True for partially reversed variables.
+     */
+    protected boolean partial;
+
+
+    /**
+     * The names of the variables. This value can be modified.
+     */
+    protected String[] vars;
+
+
+    /**
+     * Counter to distinguish new variables.
+     */
+    private static AtomicLong varCounter = new AtomicLong(0L);
+
+
+    /**
+     * The constant polynomial 0 for this ring.
+     */
+    public final GenPolynomial<C> ZERO;
+
+
+    /**
+     * The constant polynomial 1 for this ring.
+     */
+    public final GenPolynomial<C> ONE;
+
+
+    /**
+     * The constant exponent vector 0 for this ring.
+     */
+    public final ExpVector evzero;
+
+
+    /**
+     * A default random sequence generator.
+     */
+    protected final static Random random = new Random();
+
+
+    /**
+     * Indicator if this ring is a field.
+     */
+    protected int isField = -1; // initially unknown
+
+
+    /**
+     * Log4j logger object.
+     */
+    private static final Logger logger = LogManager.getLogger(GenPolynomialRing.class);
+
+
+    /**
+     * Count for number of polynomial creations.
+     */
+    static int creations = 0;
+
+
+    /**
+     * Flag to enable if preemptive interrrupt is checked.
+     */
+    final boolean checkPreempt = PreemptStatus.isAllowed();
+
+
+    /**
+     * The constructor creates a polynomial factory object with the default term
+     * order.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     */
+    public GenPolynomialRing(RingFactory<C> cf, int n) {
+        this(cf, n, new TermOrder(), null);
+    }
+
+
+    /**
+     * The constructor creates a polynomial factory object.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     */
+    public GenPolynomialRing(RingFactory<C> cf, int n, TermOrder t) {
+        this(cf, n, t, null);
+    }
+
+
+    /**
+     * The constructor creates a polynomial factory object.
+     * @param cf factory for coefficients of type C.
+     * @param v names for the variables.
+     */
+    public GenPolynomialRing(RingFactory<C> cf, String[] v) {
+        this(cf, v.length, v);
+    }
+
+
+    /**
+     * The constructor creates a polynomial factory object.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param v names for the variables.
+     */
+    public GenPolynomialRing(RingFactory<C> cf, int n, String[] v) {
+        this(cf, n, new TermOrder(), v);
+    }
+
+
+    /**
+     * The constructor creates a polynomial factory object.
+     * @param cf factory for coefficients of type C.
+     * @param t a term order.
+     * @param v names for the variables.
+     */
+    public GenPolynomialRing(RingFactory<C> cf, TermOrder t, String[] v) {
+        this(cf, v.length, t, v);
+    }
+
+
+    /**
+     * The constructor creates a polynomial factory object.
+     * @param cf factory for coefficients of type C.
+     * @param v names for the variables.
+     * @param t a term order.
+     */
+    public GenPolynomialRing(RingFactory<C> cf, String[] v, TermOrder t) {
+        this(cf, v.length, t, v);
+    }
+
+
+    /**
+     * The constructor creates a polynomial factory object.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     * @param v names for the variables.
+     */
+    public GenPolynomialRing(RingFactory<C> cf, int n, TermOrder t, String[] v) {
+        coFac = cf;
+        nvar = n;
+        tord = t;
+        partial = false;
+        if (v == null) {
+            vars = null;
+        } else {
+            vars = Arrays.copyOf(v, v.length); // > Java-5
+        }
+        ZERO = new GenPolynomial<C>(this);
+        C coeff = coFac.getONE();
+        evzero = ExpVector.create(nvar);
+        ONE = new GenPolynomial<C>(this, coeff, evzero);
+        if (vars == null) {
+            if (PrettyPrint.isTrue()) {
+                vars = newVars("x", nvar);
+            }
+        } else {
+            if (vars.length != nvar) {
+                throw new IllegalArgumentException("incompatible variable size " + vars.length + ", " + nvar);
+            }
+            // addVars(vars);
+        }
+    }
+
+
+    /**
+     * The constructor creates a polynomial factory object with the the same
+     * term order, number of variables and variable names as the given
+     * polynomial factory, only the coefficient factories differ.
+     * @param cf factory for coefficients of type C.
+     * @param o other polynomial ring.
+     */
+    public GenPolynomialRing(RingFactory<C> cf, GenPolynomialRing o) {
+        this(cf, o.nvar, o.tord, o.vars);
+    }
+
+
+    /**
+     * The constructor creates a polynomial factory object with the the same
+     * coefficient factory, number of variables and variable names as the given
+     * polynomial factory, only the term order differs.
+     * @param to term order.
+     * @param o other polynomial ring.
+     */
+    public GenPolynomialRing(GenPolynomialRing<C> o, TermOrder to) {
+        this(o.coFac, o.nvar, to, o.vars);
+    }
+
+
+    /**
+     * Copy this factory.
+     * @return a clone of this.
+     */
+    public GenPolynomialRing<C> copy() {
+        return new GenPolynomialRing<C>(coFac, this);
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @SuppressWarnings("cast")
+    @Override
+    public String toString() {
+        String res = null;
+        if (PrettyPrint.isTrue()) { // wrong: && coFac != null
+            String scf = coFac.getClass().getSimpleName();
+            if (coFac instanceof AlgebraicNumberRing) {
+                AlgebraicNumberRing an = (AlgebraicNumberRing) coFac;
+                res = "AN[ (" + an.ring.varsToString() + ") (" + an.toString() + ") ]";
+            }
+            if (coFac instanceof GenPolynomialRing) {
+                GenPolynomialRing rf = (GenPolynomialRing) coFac;
+                //String[] v = rf.vars;
+                //RingFactory cf = rf.coFac;
+                //String cs;
+                //if (cf instanceof ModIntegerRing) {
+                //    cs = cf.toString();
+                //} else {
+                //    cs = " " + cf.getClass().getSimpleName();
+                //}
+                //res = "IntFunc" + "{" + cs + "( " + rf.varsToString() + " )" + " } ";
+                res = "IntFunc" + "( " + rf.toString() + " )";
+            }
+            if (((Object) coFac) instanceof ModIntegerRing) {
+                ModIntegerRing mn = (ModIntegerRing) ((Object) coFac);
+                res = "Mod " + mn.getModul() + " ";
+            }
+            if (res == null) {
+                res = coFac.toString();
+                if (res.matches("[0-9].*")) {
+                    res = scf;
+                }
+            }
+            res += "( " + varsToString() + " ) " + tord.toString() + " ";
+        } else {
+            res = this.getClass().getSimpleName() + "[ " + coFac.toString() + " ";
+            if (coFac instanceof AlgebraicNumberRing) {
+                AlgebraicNumberRing an = (AlgebraicNumberRing) coFac;
+                res = "AN[ (" + an.ring.varsToString() + ") (" + an.modul + ") ]";
+            }
+            if (coFac instanceof GenPolynomialRing) {
+                GenPolynomialRing rf = (GenPolynomialRing) coFac;
+                //String[] v = rf.vars;
+                //RingFactory cf = rf.coFac;
+                //String cs;
+                //if (cf instanceof ModIntegerRing) {
+                //    cs = cf.toString();
+                //} else {
+                //    cs = " " + cf.getClass().getSimpleName();
+                //}
+                //res = "IntFunc{ " + cs + "( " + rf.varsToString() + " )" + " } ";
+                res = "IntFunc" + "( " + rf.toString() + " )";
+            }
+            if (((Object) coFac) instanceof ModIntegerRing) {
+                ModIntegerRing mn = (ModIntegerRing) ((Object) coFac);
+                res = "Mod " + mn.getModul() + " ";
+            }
+            //res += ", " + nvar + ", " + tord.toString() + ", " + varsToString() + ", " + partial + " ]";
+            res += "( " + varsToString() + " ) " + tord.toString() + " ]";
+        }
+        return res;
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        StringBuffer s = new StringBuffer();
+        switch (Scripting.getLang()) {
+        case Ruby:
+            s.append("PolyRing.new(");
+            break;
+        case Python:
+        default:
+            s.append("PolyRing(");
+        }
+        if (coFac instanceof RingElem) {
+            s.append(((RingElem<C>) coFac).toScriptFactory());
+        } else {
+            s.append(coFac.toScript().trim());
+        }
+        s.append(",\"" + varsToString() + "\"");
+        String to = tord.toScript();
+        s.append("," + to);
+        s.append(")");
+        return s.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of an ExpVector of this
+     * ring.
+     * @param e exponent vector
+     * @return script compatible representation for the ExpVector.
+     */
+    public String toScript(ExpVector e) {
+        if (e == null) {
+            return "null";
+        }
+        if (vars != null) {
+            return e.toScript(vars);
+        }
+        return e.toScript();
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        }
+        if (!(other instanceof GenPolynomialRing)) {
+            return false;
+        }
+        GenPolynomialRing<C> oring = (GenPolynomialRing<C>) other;
+        if (nvar != oring.nvar) {
+            return false;
+        }
+        if (!coFac.equals(oring.coFac)) {
+            return false;
+        }
+        if (!tord.equals(oring.tord)) {
+            return false;
+        }
+        // same variables required ?
+        if (!Arrays.deepEquals(vars, oring.vars)) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Hash code for this polynomial ring.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = (nvar << 27);
+        h += (coFac.hashCode() << 11);
+        h += (tord.hashCode() << 9);
+        h += Arrays.hashCode(vars);
+        //System.out.println("GenPolynomialRing.hashCode: " + h);
+        return h;
+    }
+
+
+    /**
+     * Get the number of polynomial creations.
+     * @return creations.
+     */
+    public int getCreations() {
+        return creations;
+    }
+
+
+    /**
+     * Get the variable names.
+     * @return vars.
+     */
+    public String[] getVars() {
+        return Arrays.copyOf(vars, vars.length); // > Java-5
+    }
+
+
+    /**
+     * Set the variable names.
+     * @return old vars.
+     */
+    public String[] setVars(String[] v) {
+        if (v.length != nvar) {
+            throw new IllegalArgumentException(
+                            "v not matching number of variables: " + Arrays.toString(v) + ", nvar " + nvar);
+        }
+        String[] t = vars;
+        vars = Arrays.copyOf(v, v.length); // > Java-5 
+        return t;
+    }
+
+
+    /**
+     * Get a String representation of the variable names.
+     * @return names seperated by commas.
+     */
+    public String varsToString() {
+        if (vars == null) {
+            return "#" + nvar;
+        }
+        //return Arrays.toString(vars);
+        return ExpVector.varsToString(vars);
+    }
+
+
+    /**
+     * Get the zero element from the coefficients.
+     * @return 0 as C.
+     */
+    public C getZEROCoefficient() {
+        return coFac.getZERO();
+    }
+
+
+    /**
+     * Get the one element from the coefficients.
+     * @return 1 as C.
+     */
+    public C getONECoefficient() {
+        return coFac.getONE();
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as GenPolynomial<C>.
+     */
+    public GenPolynomial<C> getZERO() {
+        return ZERO;
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as GenPolynomial<C>.
+     */
+    public GenPolynomial<C> getONE() {
+        return ONE;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true if this ring is commutative, else false.
+     */
+    public boolean isCommutative() {
+        return coFac.isCommutative();
+    }
+
+
+    /**
+     * Query if this ring is associative.
+     * @return true if this ring is associative, else false.
+     */
+    public boolean isAssociative() {
+        return coFac.isAssociative();
+    }
+
+
+    /**
+     * Query if this ring is a field.
+     * @return false.
+     */
+    public boolean isField() {
+        if (isField > 0) {
+            return true;
+        }
+        if (isField == 0) {
+            return false;
+        }
+        if (coFac.isField() && nvar == 0) {
+            isField = 1;
+            return true;
+        }
+        isField = 0;
+        return false;
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic() {
+        return coFac.characteristic();
+    }
+
+
+    /**
+     * Get a (constant) GenPolynomial&lt;C&gt; element from a coefficient value.
+     * @param a coefficient.
+     * @return a GenPolynomial&lt;C&gt;.
+     */
+    public GenPolynomial<C> valueOf(C a) {
+        return new GenPolynomial<C>(this, a);
+    }
+
+
+    /**
+     * Get a GenPolynomial&lt;C&gt; element from an exponent vector.
+     * @param e exponent vector.
+     * @return a GenPolynomial&lt;C&gt;.
+     */
+    public GenPolynomial<C> valueOf(ExpVector e) {
+        if (e == null) {
+            return getZERO();
+        }
+        return new GenPolynomial<C>(this, coFac.getONE(), e);
+    }
+
+
+    /**
+     * Get a GenPolynomial&lt;C&gt; element from a list of exponent vectors.
+     * @param E list of exponent vector.
+     * @return a GenPolynomial&lt;C&gt;.
+     */
+    public List<GenPolynomial<C>> valueOf(Iterable<ExpVector> E) {
+        if (E == null) {
+            return null;
+        }
+        List<GenPolynomial<C>> P = new ArrayList<GenPolynomial<C>>(); //E.size());
+        for (ExpVector e : E) {
+            GenPolynomial<C> p = valueOf(e);
+            P.add(p);
+        }
+        return P;
+    }
+
+
+    /**
+     * Get a GenPolynomial&lt;C&gt; element from a coeffcient and an exponent
+     * vector.
+     * @param a coefficient.
+     * @param e exponent vector.
+     * @return a GenPolynomial&lt;C&gt;.
+     */
+    public GenPolynomial<C> valueOf(C a, ExpVector e) {
+        return new GenPolynomial<C>(this, a, e);
+    }
+
+
+    /**
+     * Get a GenPolynomial&lt;C&gt; element from a monomial.
+     * @param m monomial.
+     * @return a GenPolynomial&lt;C&gt;.
+     */
+    public GenPolynomial<C> valueOf(Monomial<C> m) {
+        return new GenPolynomial<C>(this, m.c, m.e);
+    }
+
+
+    /**
+     * Get a (constant) GenPolynomial&lt;C&gt; element from a long value.
+     * @param a long.
+     * @return a GenPolynomial&lt;C&gt;.
+     */
+    public GenPolynomial<C> fromInteger(long a) {
+        return new GenPolynomial<C>(this, coFac.fromInteger(a), evzero);
+    }
+
+
+    /**
+     * Get a (constant) GenPolynomial&lt;C&gt; element from a BigInteger value.
+     * @param a BigInteger.
+     * @return a GenPolynomial&lt;C&gt;.
+     */
+    public GenPolynomial<C> fromInteger(BigInteger a) {
+        return new GenPolynomial<C>(this, coFac.fromInteger(a), evzero);
+    }
+
+
+    /**
+     * Get a GenPolynomial&lt;C&gt; from a GenVector&lt;C&gt;.
+     * @param a GenVector&lt;C&gt;.
+     * @return a GenPolynomial&lt;C&gt;.
+     */
+    public GenPolynomial<C> fromVector(GenVector<C> a) {
+        if (a == null || a.isZERO()) {
+            return ZERO;
+        }
+        if (nvar != 1) {
+            throw new IllegalArgumentException("no univariate polynomial ring");
+        }
+        GenPolynomial<C> ret = copy(ZERO);
+        SortedMap<ExpVector, C> tm = ret.val;
+        long i = -1;
+        for (C m : a.val) {
+            i++;
+            if (m.isZERO()) {
+                continue;
+            }
+            ExpVector e = ExpVector.create(1, 0, i);
+            tm.put(e, m);
+        }
+        return ret;
+    }
+
+
+    /**
+     * Random polynomial. Generates a random polynomial with k = 5, l = n, d =
+     * (nvar == 1) ? n : 3, q = (nvar == 1) ? 0.7 : 0.3.
+     * @param n number of terms.
+     * @return a random polynomial.
+     */
+    public GenPolynomial<C> random(int n) {
+        return random(n, random);
+    }
+
+
+    /**
+     * Random polynomial. Generates a random polynomial with k = 5, l = n, d =
+     * n, q = (nvar == 1) ? 0.5 : 0.3.
+     * @param n number of terms.
+     * @param rnd is a source for random bits.
+     * @return a random polynomial.
+     */
+    public GenPolynomial<C> random(int n, Random rnd) {
+        if (nvar == 1) {
+            return random(3, n, n, 0.5f, rnd);
+        }
+        return random(3, n, n, 0.3f, rnd);
+    }
+
+
+    /**
+     * Generate a random polynomial.
+     * @param k bitsize of random coefficients.
+     * @param l number of terms.
+     * @param d maximal degree in each variable.
+     * @param q density of nozero exponents.
+     * @return a random polynomial.
+     */
+    public GenPolynomial<C> random(int k, int l, int d, float q) {
+        return random(k, l, d, q, random);
+    }
+
+
+    /**
+     * Generate a random polynomial.
+     * @param k bitsize of random coefficients.
+     * @param l number of terms.
+     * @param d maximal degree in each variable.
+     * @param q density of nozero exponents.
+     * @param rnd is a source for random bits.
+     * @return a random polynomial.
+     */
+    public GenPolynomial<C> random(int k, int l, int d, float q, Random rnd) {
+        GenPolynomial<C> r = getZERO(); //.clone() or copy( ZERO ); 
+        ExpVector e;
+        C a;
+        // add l random coeffs and exponents
+        for (int i = 0; i < l; i++) {
+            e = ExpVector.random(nvar, d, q, rnd);
+            a = coFac.random(k, rnd);
+            r = r.sum(a, e); // somewhat inefficient but clean
+            //System.out.println("e = " + e + " a = " + a);
+        }
+        // System.out.println("r = " + r);
+        return r;
+    }
+
+
+    /**
+     * Copy polynomial c.
+     * @param c
+     * @return a copy of c.
+     */
+    public GenPolynomial<C> copy(GenPolynomial<C> c) {
+        //System.out.println("GP copy = " + this);
+        return new GenPolynomial<C>(this, c.val);
+    }
+
+
+    /**
+     * Copy polynomial list.
+     * @param L polynomial list
+     * @return a copy of L in this ring.
+     */
+    public List<GenPolynomial<C>> copy(List<GenPolynomial<C>> L) {
+        if (L == null) {
+            return L;
+        }
+        List<GenPolynomial<C>> R = new ArrayList<GenPolynomial<C>>(L.size());
+        for (GenPolynomial<C> a : L) {
+            R.add(copy(a));
+        }
+        return R;
+    }
+
+
+    /**
+     * Parse a polynomial with the use of GenPolynomialTokenizer.
+     * @param s String.
+     * @return GenPolynomial from s.
+     */
+    public GenPolynomial<C> parse(String s) {
+        String val = s;
+        if (!s.contains("|")) {
+            val = val.replace("{", "").replace("}", "");
+        }
+        return parse(new StringReader(val));
+    }
+
+
+    /**
+     * Parse a polynomial with the use of GenPolynomialTokenizer.
+     * @param r Reader.
+     * @return next GenPolynomial from r.
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    public GenPolynomial<C> parse(Reader r) {
+        GenPolynomialTokenizer pt = new GenPolynomialTokenizer(this, r);
+        GenPolynomial<C> p = null;
+        try {
+            p = (GenPolynomial<C>) pt.nextPolynomial();
+        } catch (IOException e) {
+            logger.error(e.toString() + " parse " + this);
+            p = ZERO;
+        }
+        return p;
+    }
+
+
+    /**
+     * Generate univariate polynomial in a given variable with given exponent.
+     * @param x the name of a variable.
+     * @return x as univariate polynomial.
+     */
+    public GenPolynomial<C> univariate(String x) {
+        return univariate(x, 1L);
+    }
+
+
+    /**
+     * Generate univariate polynomial in a given variable with given exponent.
+     * @param x the name of the variable.
+     * @param e the exponent of the variable.
+     * @return x^e as univariate polynomial.
+     */
+    public GenPolynomial<C> univariate(String x, long e) {
+        if (vars == null) { // should not happen
+            throw new IllegalArgumentException("no variables defined for polynomial ring");
+        }
+        if (x == null || x.isEmpty()) {
+            throw new IllegalArgumentException("no variable name given");
+        }
+        int i;
+        for (i = 0; i < vars.length; i++) {
+            if (x.equals(vars[i])) { // use HashMap or TreeMap
+                break;
+            }
+        }
+        if (i >= vars.length) {
+            throw new IllegalArgumentException("variable '" + x + "' not defined in polynomial ring");
+        }
+        return univariate(0, nvar - i - 1, e);
+    }
+
+
+    /**
+     * Generate univariate polynomial in a given variable.
+     * @param i the index of the variable.
+     * @return X_i as univariate polynomial.
+     */
+    public GenPolynomial<C> univariate(int i) {
+        return univariate(0, i, 1L);
+    }
+
+
+    /**
+     * Generate univariate polynomial in a given variable with given exponent.
+     * @param i the index of the variable.
+     * @param e the exponent of the variable.
+     * @return X_i^e as univariate polynomial.
+     */
+    public GenPolynomial<C> univariate(int i, long e) {
+        return univariate(0, i, e);
+    }
+
+
+    /**
+     * Generate univariate polynomial in a given variable with given exponent.
+     * @param modv number of module variables.
+     * @param i the index of the variable.
+     * @param e the exponent of the variable.
+     * @return X_i^e as univariate polynomial.
+     */
+    public GenPolynomial<C> univariate(int modv, int i, long e) {
+        GenPolynomial<C> p = getZERO();
+        int r = nvar - modv;
+        if (0 <= i && i < r) {
+            C one = coFac.getONE();
+            ExpVector f = ExpVector.create(r, i, e);
+            if (modv > 0) {
+                f = f.extend(modv, 0, 0l);
+            }
+            p = p.sum(one, f);
+        }
+        return p;
+    }
+
+
+    /**
+     * Get the generating elements excluding the generators for the coefficient
+     * ring.
+     * @return a list of generating elements for this ring.
+     */
+    public List<GenPolynomial<C>> getGenerators() {
+        List<? extends GenPolynomial<C>> univs = univariateList();
+        List<GenPolynomial<C>> gens = new ArrayList<GenPolynomial<C>>(univs.size() + 1);
+        gens.add(getONE());
+        gens.addAll(univs);
+        return gens;
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     * @see edu.jas.structure.ElemFactory#generators()
+     */
+    public List<GenPolynomial<C>> generators() {
+        List<? extends C> cogens = coFac.generators();
+        List<? extends GenPolynomial<C>> univs = univariateList();
+        List<GenPolynomial<C>> gens = new ArrayList<GenPolynomial<C>>(univs.size() + cogens.size());
+        for (C c : cogens) {
+            gens.add(getONE().multiply(c));
+        }
+        gens.addAll(univs);
+        return gens;
+    }
+
+
+    /**
+     * Get a list of the generating elements excluding the module variables.
+     * @param modv number of module variables
+     * @return list of generators for the polynomial ring.
+     */
+    public List<GenPolynomial<C>> generators(int modv) {
+        List<? extends C> cogens = coFac.generators();
+        List<? extends GenPolynomial<C>> univs = univariateList(modv);
+        List<GenPolynomial<C>> gens = new ArrayList<GenPolynomial<C>>(univs.size() + cogens.size());
+        for (C c : cogens) {
+            gens.add(getONE().multiply(c));
+        }
+        gens.addAll(univs);
+        return gens;
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite()
+     */
+    public boolean isFinite() {
+        return (nvar == 0) && coFac.isFinite();
+    }
+
+
+    /**
+     * Generate list of univariate polynomials in all variables.
+     * @return List(X_1,...,X_n) a list of univariate polynomials.
+     */
+    public List<? extends GenPolynomial<C>> univariateList() {
+        return univariateList(0, 1L);
+    }
+
+
+    /**
+     * Generate list of univariate polynomials in all variables.
+     * @param modv number of module variables.
+     * @return List(X_1,...,X_n) a list of univariate polynomials.
+     */
+    public List<? extends GenPolynomial<C>> univariateList(int modv) {
+        return univariateList(modv, 1L);
+    }
+
+
+    /**
+     * Generate list of univariate polynomials in all variables with given
+     * exponent.
+     * @param modv number of module variables.
+     * @param e the exponent of the variables.
+     * @return List(X_1^e,...,X_n^e) a list of univariate polynomials.
+     */
+    public List<? extends GenPolynomial<C>> univariateList(int modv, long e) {
+        List<GenPolynomial<C>> pols = new ArrayList<GenPolynomial<C>>(nvar);
+        int nm = nvar - modv;
+        for (int i = 0; i < nm; i++) {
+            GenPolynomial<C> p = univariate(modv, nm - 1 - i, e);
+            pols.add(p);
+        }
+        return pols;
+    }
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by i.
+     * @param i number of variables to extend.
+     * @return extended polynomial ring factory.
+     */
+    public GenPolynomialRing<C> extend(int i) {
+        return extend(i, false);
+    }
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by i.
+     * @param i number of variables to extend.
+     * @param top true for TOP term order, false for POT term order.
+     * @return extended polynomial ring factory.
+     */
+    public GenPolynomialRing<C> extend(int i, boolean top) {
+        // add module variable names
+        String[] v = newVars("e", i);
+        return extend(v, top);
+    }
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by length(vn).
+     * @param vn names for extended variables.
+     * @return extended polynomial ring factory.
+     */
+    public GenPolynomialRing<C> extend(String[] vn) {
+        return extend(vn, false);
+    }
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by length(vn).
+     * @param vn names for extended variables.
+     * @param top true for TOP term order, false for POT term order.
+     * @return extended polynomial ring factory.
+     */
+    public GenPolynomialRing<C> extend(String[] vn, boolean top) {
+        if (vn == null || vars == null) {
+            throw new IllegalArgumentException("vn and vars may not be null");
+        }
+        int i = vn.length;
+        String[] v = new String[vars.length + i];
+        for (int k = 0; k < vars.length; k++) {
+            v[k] = vars[k];
+        }
+        for (int k = 0; k < vn.length; k++) {
+            v[vars.length + k] = vn[k];
+        }
+        TermOrder to = tord.extend(nvar, i, top);
+        GenPolynomialRing<C> pfac = new GenPolynomialRing<C>(coFac, nvar + i, to, v);
+        return pfac;
+    }
+
+
+    /**
+     * Extend lower variables. Extend number of variables by i.
+     * @param i number of variables to extend.
+     * @return extended polynomial ring factory.
+     */
+    public GenPolynomialRing<C> extendLower(int i) {
+        String[] v = newVars("e", i);
+        return extendLower(v);
+    }
+
+
+    /**
+     * Extend lower variables. Extend number of variables by length(vn).
+     * @param vn names for extended lower variables.
+     * @return extended polynomial ring factory.
+     */
+    public GenPolynomialRing<C> extendLower(String[] vn) {
+        return extendLower(vn, false);
+    }
+
+
+    /**
+     * Extend lower variables. Extend number of variables by length(vn).
+     * @param vn names for extended lower variables.
+     * @param top true for TOP term order, false for POT term order.
+     * @return extended polynomial ring factory.
+     */
+    public GenPolynomialRing<C> extendLower(String[] vn, boolean top) {
+        if (vn == null || vars == null) {
+            throw new IllegalArgumentException("vn and vars may not be null");
+        }
+        int i = vn.length;
+        String[] v = new String[vars.length + i];
+        for (int k = 0; k < vn.length; k++) {
+            v[k] = vn[k];
+        }
+        for (int k = 0; k < vars.length; k++) {
+            v[vn.length + k] = vars[k];
+        }
+        TermOrder to = tord.extendLower(nvar, i, top);
+        GenPolynomialRing<C> pfac = new GenPolynomialRing<C>(coFac, nvar + i, to, v);
+        return pfac;
+    }
+
+
+    /**
+     * Contract variables. Used e.g. in module embedding. Contract number of
+     * variables by i.
+     * @param i number of variables to remove.
+     * @return contracted polynomial ring factory.
+     */
+    public GenPolynomialRing<C> contract(int i) {
+        String[] v = null;
+        if (vars != null) {
+            v = new String[vars.length - i];
+            for (int j = 0; j < vars.length - i; j++) {
+                v[j] = vars[j];
+            }
+        }
+        TermOrder to = tord.contract(i, nvar - i);
+        GenPolynomialRing<C> pfac = new GenPolynomialRing<C>(coFac, nvar - i, to, v);
+        return pfac;
+    }
+
+
+    /**
+     * Recursive representation as polynomial with i main variables.
+     * @param i number of main variables.
+     * @return recursive polynomial ring factory.
+     */
+    public GenPolynomialRing<GenPolynomial<C>> recursive(int i) {
+        if (i <= 0 || i >= nvar) {
+            throw new IllegalArgumentException("wrong: 0 < " + i + " < " + nvar);
+        }
+        GenPolynomialRing<C> cfac = contract(i);
+        String[] v = null;
+        if (vars != null) {
+            v = new String[i];
+            int k = 0;
+            for (int j = nvar - i; j < nvar; j++) {
+                v[k++] = vars[j];
+            }
+        }
+        TermOrder to = tord.contract(0, i); // ??
+        GenPolynomialRing<GenPolynomial<C>> pfac = new GenPolynomialRing<GenPolynomial<C>>(cfac, i, to, v);
+        return pfac;
+    }
+
+
+    /**
+     * Distributive representation as polynomial with all main variables.
+     * @return distributive polynomial ring factory.
+     */
+    @SuppressWarnings("unchecked")
+    public GenPolynomialRing<C> distribute() {
+        if (!(coFac instanceof GenPolynomialRing)) {
+            return this;
+        }
+        RingFactory cf = coFac;
+        RingFactory<GenPolynomial<C>> cfp = (RingFactory<GenPolynomial<C>>) cf;
+        GenPolynomialRing cr = (GenPolynomialRing) cfp;
+        GenPolynomialRing<C> pfac;
+        if (cr.vars != null) {
+            pfac = extend(cr.vars);
+        } else {
+            pfac = extend(cr.nvar);
+        }
+        return pfac;
+    }
+
+
+    /**
+     * Reverse variables. Used e.g. in opposite rings.
+     * @return polynomial ring factory with reversed variables.
+     */
+    public GenPolynomialRing<C> reverse() {
+        return reverse(false);
+    }
+
+
+    /**
+     * Reverse variables. Used e.g. in opposite rings.
+     * @param partial true for partialy reversed term orders.
+     * @return polynomial ring factory with reversed variables.
+     */
+    public GenPolynomialRing<C> reverse(boolean partial) {
+        String[] v = null;
+        if (vars != null) { // vars are not inversed
+            v = new String[vars.length];
+            int k = tord.getSplit();
+            if (partial && k < vars.length) {
+                // copy upper
+                for (int j = 0; j < k; j++) {
+                    //v[vars.length - k + j] = vars[vars.length - 1 - j]; // reverse upper
+                    v[vars.length - k + j] = vars[vars.length - k + j];
+                }
+                // reverse lower
+                for (int j = 0; j < vars.length - k; j++) {
+                    //v[j] = vars[j]; // copy upper
+                    v[j] = vars[vars.length - k - j - 1];
+                }
+            } else {
+                for (int j = 0; j < vars.length; j++) {
+                    v[j] = vars[vars.length - 1 - j];
+                }
+            }
+            //System.out.println("vars = " + Arrays.toString(vars));
+            //System.out.println("v    = " + Arrays.toString(v));
+        }
+        TermOrder to = tord.reverse(partial);
+        GenPolynomialRing<C> pfac = new GenPolynomialRing<C>(coFac, nvar, to, v);
+        pfac.partial = partial;
+        return pfac;
+    }
+
+
+    /**
+     * Get PolynomialComparator.
+     * @return polynomial comparator.
+     */
+    public PolynomialComparator<C> getComparator() {
+        return new PolynomialComparator<C>(tord, false);
+    }
+
+
+    /**
+     * Get PolynomialComparator.
+     * @param rev for reverse comparator.
+     * @return polynomial comparator.
+     */
+    public PolynomialComparator<C> getComparator(boolean rev) {
+        return new PolynomialComparator<C>(tord, rev);
+    }
+
+
+    /**
+     * New variable names. Generate new names for variables,
+     * @param prefix name prefix.
+     * @param n number of variables.
+     * @return new variable names.
+     */
+    public static String[] newVars(String prefix, int n) {
+        String[] vars = new String[n];
+        for (int i = 0; i < n; i++) {
+            long m = varCounter.getAndIncrement();
+            vars[i] = prefix + m;
+        }
+        return vars;
+    }
+
+
+    /**
+     * New variable names. Generate new names for variables,
+     * @param prefix name prefix.
+     * @return new variable names.
+     */
+    public String[] newVars(String prefix) {
+        return newVars(prefix, nvar);
+    }
+
+
+    /**
+     * New variable names. Generate new names for variables,
+     * @param n number of variables.
+     * @return new variable names.
+     */
+    public static String[] newVars(int n) {
+        return newVars("x", n);
+    }
+
+
+    /**
+     * New variable names. Generate new names for variables,
+     * @return new variable names.
+     */
+    public String[] newVars() {
+        return newVars(nvar);
+    }
+
+
+    /*
+     * Add variable names.
+     * @param vars variable names to be recorded.
+    public static void addVars(String[] vars) {
+        if (vars == null) {
+            return;
+        }
+        // synchronized (knownVars) {
+        //   for (int i = 0; i < vars.length; i++) {
+        //      knownVars.add(vars[i]); // eventualy names 'overwritten'
+        //   }
+        // }
+    }
+     */
+
+
+    /**
+     * Permute variable names.
+     * @param vars variable names.
+     * @param P permutation.
+     * @return P(vars).
+     */
+    public static String[] permuteVars(List<Integer> P, String[] vars) {
+        if (vars == null || vars.length <= 1) {
+            return vars;
+        }
+        String[] b = new String[vars.length];
+        int j = 0;
+        for (Integer i : P) {
+            b[j++] = vars[i];
+        }
+        return b;
+    }
+
+
+    /**
+     * Permutation of polynomial ring variables.
+     * @param P permutation.
+     * @return P(this).
+     */
+    public GenPolynomialRing<C> permutation(List<Integer> P) {
+        if (nvar <= 1) {
+            return this;
+        }
+        TermOrder tp = tord.permutation(P);
+        if (vars == null) {
+            return new GenPolynomialRing<C>(coFac, nvar, tp);
+        }
+        String[] v1 = new String[vars.length];
+        for (int i = 0; i < v1.length; i++) {
+            v1[i] = vars[v1.length - 1 - i];
+        }
+        String[] vp = permuteVars(P, v1);
+        String[] v2 = new String[vp.length];
+        for (int i = 0; i < vp.length; i++) {
+            v2[i] = vp[vp.length - 1 - i];
+        }
+        return new GenPolynomialRing<C>(coFac, nvar, tp, v2);
+    }
+
+
+    /**
+     * Get a GenPolynomial iterator.
+     * @return an iterator over all polynomials.
+     */
+    public Iterator<GenPolynomial<C>> iterator() {
+        if (coFac.isFinite()) {
+            return new GenPolynomialIterator<C>(this);
+        }
+        logger.warn("ring of coefficients " + coFac
+                        + " is infinite, constructing iterator only over monomials");
+        return new GenPolynomialMonomialIterator<C>(this);
+        //throw new IllegalArgumentException("only for finite iterable coefficients implemented");
+    }
+
+}
+
+
+/**
+ * Polynomial iterator.
+ * @author Heinz Kredel
+ */
+class GenPolynomialIterator<C extends RingElem<C>> implements Iterator<GenPolynomial<C>> {
+
+
+    /**
+     * data structure.
+     */
+    final GenPolynomialRing<C> ring;
+
+
+    final Iterator<List<Long>> eviter;
+
+
+    final List<ExpVector> powers;
+
+
+    final List<Iterable<C>> coeffiter;
+
+
+    Iterator<List<C>> itercoeff;
+
+
+    GenPolynomial<C> current;
+
+
+    /**
+     * Polynomial iterator constructor.
+     */
+    @SuppressWarnings("unchecked")
+    public GenPolynomialIterator(GenPolynomialRing<C> fac) {
+        ring = fac;
+        LongIterable li = new LongIterable();
+        li.setNonNegativeIterator();
+        List<Iterable<Long>> tlist = new ArrayList<Iterable<Long>>(ring.nvar);
+        for (int i = 0; i < ring.nvar; i++) {
+            tlist.add(li);
+        }
+        CartesianProductInfinite<Long> ei = new CartesianProductInfinite<Long>(tlist);
+        eviter = ei.iterator();
+        RingFactory<C> cf = ring.coFac;
+        coeffiter = new ArrayList<Iterable<C>>();
+        if (cf instanceof Iterable && cf.isFinite()) {
+            Iterable<C> cfi = (Iterable<C>) cf;
+            coeffiter.add(cfi);
+        } else {
+            throw new IllegalArgumentException("only for finite iterable coefficients implemented");
+        }
+        CartesianProduct<C> tuples = new CartesianProduct<C>(coeffiter);
+        itercoeff = tuples.iterator();
+        powers = new ArrayList<ExpVector>();
+        ExpVector e = ExpVector.create(eviter.next());
+        powers.add(e);
+        //System.out.println("new e = " + e);
+        //System.out.println("powers = " + powers);
+        List<C> c = itercoeff.next();
+        //System.out.println("coeffs = " + c);
+        current = new GenPolynomial<C>(ring, c.get(0), e);
+    }
+
+
+    /**
+     * Test for availability of a next element.
+     * @return true if the iteration has more elements, else false.
+     */
+    public boolean hasNext() {
+        return true;
+    }
+
+
+    /**
+     * Get next polynomial.
+     * @return next polynomial.
+     */
+    public synchronized GenPolynomial<C> next() {
+        GenPolynomial<C> res = current;
+        if (!itercoeff.hasNext()) {
+            ExpVector e = ExpVector.create(eviter.next());
+            powers.add(0, e); // add new ev at beginning
+            //System.out.println("new e = " + e);
+            //System.out.println("powers = " + powers);
+            if (coeffiter.size() == 1) { // shorten frist iterator by one element
+                coeffiter.add(coeffiter.get(0));
+                Iterable<C> it = coeffiter.get(0);
+                List<C> elms = new ArrayList<C>();
+                for (C elm : it) {
+                    elms.add(elm);
+                }
+                elms.remove(0);
+                coeffiter.set(0, elms);
+            } else {
+                coeffiter.add(coeffiter.get(1));
+            }
+            CartesianProduct<C> tuples = new CartesianProduct<C>(coeffiter);
+            itercoeff = tuples.iterator();
+        }
+        List<C> coeffs = itercoeff.next();
+        //      while ( coeffs.get(0).isZERO() ) {
+        //             System.out.println(" skip zero ");
+        //          coeffs = itercoeff.next(); // skip tuples with zero in first component
+        //      }
+        //System.out.println("coeffs = " + coeffs);
+        GenPolynomial<C> pol = ring.getZERO().copy();
+        int i = 0;
+        for (ExpVector f : powers) {
+            C c = coeffs.get(i++);
+            if (c.isZERO()) {
+                continue;
+            }
+            if (pol.val.get(f) != null) {
+                System.out.println("error f in pol = " + f + ", " + pol.getMap().get(f));
+                throw new RuntimeException("error in iterator");
+            }
+            pol.doPutToMap(f, c);
+        }
+        current = pol;
+        return res;
+    }
+
+
+    /**
+     * Remove an element if allowed.
+     */
+    public void remove() {
+        throw new UnsupportedOperationException("cannnot remove elements");
+    }
+}
+
+
+/**
+ * Polynomial monomial iterator.
+ * @author Heinz Kredel
+ */
+class GenPolynomialMonomialIterator<C extends RingElem<C>> implements Iterator<GenPolynomial<C>> {
+
+
+    /**
+     * data structure.
+     */
+    final GenPolynomialRing<C> ring;
+
+
+    final Iterator<List> iter;
+
+
+    GenPolynomial<C> current;
+
+
+    /**
+     * Polynomial iterator constructor.
+     */
+    @SuppressWarnings("unchecked")
+    public GenPolynomialMonomialIterator(GenPolynomialRing<C> fac) {
+        ring = fac;
+        LongIterable li = new LongIterable();
+        li.setNonNegativeIterator();
+        List<Iterable<Long>> tlist = new ArrayList<Iterable<Long>>(ring.nvar);
+        for (int i = 0; i < ring.nvar; i++) {
+            tlist.add(li);
+        }
+        CartesianProductInfinite<Long> ei = new CartesianProductInfinite<Long>(tlist);
+        //Iterator<List<Long>> eviter = ei.iterator();
+
+        RingFactory<C> cf = ring.coFac;
+        Iterable<C> coeffiter;
+        if (cf instanceof Iterable && !cf.isFinite()) {
+            Iterable<C> cfi = (Iterable<C>) cf;
+            coeffiter = cfi;
+        } else {
+            throw new IllegalArgumentException("only for infinite iterable coefficients implemented");
+        }
+
+        // Cantor iterator for exponents and coeffcients
+        List<Iterable> eci = new ArrayList<Iterable>(2); // no type parameter
+        eci.add(ei);
+        eci.add(coeffiter);
+        CartesianProductInfinite ecp = new CartesianProductInfinite(eci);
+        iter = ecp.iterator();
+
+        List ec = iter.next();
+        List<Long> ecl = (List<Long>) ec.get(0);
+        C c = (C) ec.get(1); // zero
+        ExpVector e = ExpVector.create(ecl);
+        //System.out.println("exp    = " + e);
+        //System.out.println("coeffs = " + c);
+        current = new GenPolynomial<C>(ring, c, e);
+    }
+
+
+    /**
+     * Test for availability of a next element.
+     * @return true if the iteration has more elements, else false.
+     */
+    public boolean hasNext() {
+        return true;
+    }
+
+
+    /**
+     * Get next polynomial.
+     * @return next polynomial.
+     */
+    @SuppressWarnings("unchecked")
+    public synchronized GenPolynomial<C> next() {
+        GenPolynomial<C> res = current;
+
+        List ec = iter.next();
+        C c = (C) ec.get(1);
+        while (c.isZERO()) { // zero already done in first next
+            ec = iter.next();
+            c = (C) ec.get(1);
+        }
+        List<Long> ecl = (List<Long>) ec.get(0);
+        ExpVector e = ExpVector.create(ecl);
+        //System.out.println("exp    = " + e);
+        //System.out.println("coeffs = " + c);
+        current = new GenPolynomial<C>(ring, c, e);
+
+        return res;
+    }
+
+
+    /**
+     * Remove an element if allowed.
+     */
+    public void remove() {
+        throw new UnsupportedOperationException("cannnot remove elements");
+    }
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/GenPolynomialTokenizer.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/GenPolynomialTokenizer.java
@@ -1,0 +1,2017 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.StreamTokenizer;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Scanner;
+import java.util.Set;
+import java.util.TreeSet;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.arith.BigComplex;
+import edu.jas.arith.BigDecimal;
+import edu.jas.arith.BigInteger;
+import edu.jas.arith.BigOctonion;
+import edu.jas.arith.BigQuaternion;
+import edu.jas.arith.BigQuaternionRing;
+import edu.jas.arith.BigRational;
+import edu.jas.arith.ModIntRing;
+import edu.jas.arith.ModInteger;
+import edu.jas.arith.ModIntegerRing;
+import edu.jas.arith.ModLongRing;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * GenPolynomial Tokenizer. Used to read rational polynomials and lists of
+ * polynomials from input streams. Arbitrary polynomial rings and coefficient
+ * rings can be read with RingFactoryTokenizer. <b>Note:</b> Can no more read
+ * QuotientRing since end of 2010, revision 3441. Quotient coefficients and
+ * others can still be read if the respective factory is provided via the
+ * constructor.
+ * @see edu.jas.application.RingFactoryTokenizer
+ * @author Heinz Kredel
+ */
+public class GenPolynomialTokenizer {
+
+
+    private static final Logger logger = LogManager.getLogger(GenPolynomialTokenizer.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    private String[] vars;
+
+
+    private int nvars = 1;
+
+
+    private TermOrder tord;
+
+
+    private RelationTable table;
+
+
+    private final StreamTokenizer tok;
+
+
+    private final Reader reader;
+
+
+    private RingFactory fac;
+
+
+    private static enum coeffType {
+        BigRat, BigInt, ModInt, BigC, BigQ, BigO, BigD, ANrat, ANmod, IntFunc
+    };
+
+
+    private coeffType parsedCoeff = coeffType.BigRat;
+
+
+    private GenPolynomialRing pfac;
+
+
+    private static enum polyType {
+        PolBigRat, PolBigInt, PolModInt, PolBigC, PolBigD, PolBigQ, PolBigO, PolANrat, PolANmod, PolIntFunc
+    };
+
+
+    @SuppressWarnings("unused")
+    private polyType parsedPoly = polyType.PolBigRat;
+
+
+    private GenSolvablePolynomialRing spfac;
+
+
+    /**
+     * No-args constructor reads from System.in.
+     */
+    public GenPolynomialTokenizer() {
+        this(new BufferedReader(new InputStreamReader(System.in, Charset.forName("UTF8"))));
+    }
+
+
+    /**
+     * Constructor with Ring and Reader.
+     * @param rf ring factory.
+     * @param r reader stream.
+     */
+    public GenPolynomialTokenizer(GenPolynomialRing rf, Reader r) {
+        this(r);
+        if (rf == null) {
+            return;
+        }
+        if (rf instanceof GenSolvablePolynomialRing) {
+            pfac = rf;
+            spfac = (GenSolvablePolynomialRing) rf;
+        } else {
+            pfac = rf;
+            spfac = null;
+        }
+        fac = rf.coFac;
+        vars = rf.vars;
+        if (vars != null) {
+            nvars = vars.length;
+        }
+        tord = rf.tord;
+        // relation table
+        if (spfac != null) {
+            table = spfac.table;
+        } else {
+            table = null;
+        }
+    }
+
+
+    /**
+     * Constructor with Reader.
+     * @param r reader stream.
+     */
+    @SuppressWarnings("unchecked")
+    public GenPolynomialTokenizer(Reader r) {
+        vars = null;
+        tord = new TermOrder();
+        nvars = 1;
+        fac = new BigRational(1);
+
+        pfac = new GenPolynomialRing<BigRational>(fac, nvars, tord, vars);
+        spfac = new GenSolvablePolynomialRing<BigRational>(fac, nvars, tord, vars);
+
+        reader = r;
+        tok = new StreamTokenizer(reader);
+        tok.resetSyntax();
+        // tok.eolIsSignificant(true); no more
+        tok.eolIsSignificant(false);
+        tok.wordChars('0', '9');
+        tok.wordChars('a', 'z');
+        tok.wordChars('A', 'Z');
+        tok.wordChars('_', '_'); // for subscripts x_i
+        tok.wordChars('/', '/'); // wg. rational numbers
+        tok.wordChars('.', '.'); // wg. floats
+        tok.wordChars('~', '~'); // wg. quaternions
+        tok.wordChars(128 + 32, 255);
+        tok.whitespaceChars(0, ' ');
+        tok.commentChar('#');
+        tok.quoteChar('"');
+        tok.quoteChar('\'');
+        //tok.slashStarComments(true); does not work
+
+    }
+
+
+    /**
+     * Initialize coefficient and polynomial factories.
+     * @param rf ring factory.
+     * @param ct coefficient type.
+     */
+    @SuppressWarnings("unchecked")
+    public void initFactory(RingFactory rf, coeffType ct) {
+        fac = rf;
+        parsedCoeff = ct;
+
+        switch (ct) {
+        case BigRat:
+            pfac = new GenPolynomialRing<BigRational>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolBigRat;
+            break;
+        case BigInt:
+            pfac = new GenPolynomialRing<BigInteger>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolBigInt;
+            break;
+        case ModInt:
+            pfac = new GenPolynomialRing<ModInteger>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolModInt;
+            break;
+        case BigC:
+            pfac = new GenPolynomialRing<BigComplex>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolBigC;
+            break;
+        case BigQ:
+            pfac = new GenPolynomialRing<BigQuaternion>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolBigQ;
+            break;
+        case BigO:
+            pfac = new GenPolynomialRing<BigOctonion>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolBigO;
+            break;
+        case BigD:
+            pfac = new GenPolynomialRing<BigDecimal>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolBigD;
+            break;
+        case IntFunc:
+            pfac = new GenPolynomialRing<GenPolynomial<BigRational>>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolIntFunc;
+            break;
+        default:
+            pfac = new GenPolynomialRing<BigRational>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolBigRat;
+        }
+    }
+
+
+    /**
+     * Initialize coefficient and solvable polynomial factories.
+     * @param rf ring factory.
+     * @param ct coefficient type.
+     */
+    @SuppressWarnings("unchecked")
+    public void initSolvableFactory(RingFactory rf, coeffType ct) {
+        fac = rf;
+        parsedCoeff = ct;
+
+        switch (ct) {
+        case BigRat:
+            spfac = new GenSolvablePolynomialRing<BigRational>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolBigRat;
+            break;
+        case BigInt:
+            spfac = new GenSolvablePolynomialRing<BigInteger>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolBigInt;
+            break;
+        case ModInt:
+            spfac = new GenSolvablePolynomialRing<ModInteger>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolModInt;
+            break;
+        case BigC:
+            spfac = new GenSolvablePolynomialRing<BigComplex>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolBigC;
+            break;
+        case BigQ:
+            spfac = new GenSolvablePolynomialRing<BigQuaternion>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolBigQ;
+            break;
+        case BigO:
+            spfac = new GenSolvablePolynomialRing<BigOctonion>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolBigO;
+            break;
+        case BigD:
+            spfac = new GenSolvablePolynomialRing<BigDecimal>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolBigD;
+            break;
+        case IntFunc:
+            spfac = new GenSolvablePolynomialRing<GenPolynomial<BigRational>>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolIntFunc;
+            break;
+        default:
+            spfac = new GenSolvablePolynomialRing<BigRational>(fac, nvars, tord, vars);
+            parsedPoly = polyType.PolBigRat;
+        }
+    }
+
+
+    /**
+     * Parsing method for GenPolynomial. Syntax depends also on the syntax of
+     * the coefficients, as the respective parser is used. Basic term/monomial
+     * syntax:
+     * 
+     * <pre>
+     ... coefficient variable**exponent ... variable^exponent + ... - ....
+     * </pre>
+     * 
+     * Juxtaposition means multiplication <code>*</code>. Then terms/monomials
+     * can be added or subtracted <code>+, -</code> and grouped by parenthesis
+     * <code>()</code>. There are some heuristics to detect when a coefficient
+     * should be parsed. To force parsing of a coefficient enclose it in braces
+     * <code>{}</code>.
+     * @return the next polynomial.
+     * @throws IOException
+     */
+    @SuppressWarnings("unchecked")
+    public GenPolynomial nextPolynomial() throws IOException {
+        if (debug) {
+            logger.debug("torder = " + tord);
+        }
+        GenPolynomial a = pfac.getZERO();
+        GenPolynomial a1 = pfac.getONE();
+        ExpVector leer = pfac.evzero;
+
+        if (debug) {
+            logger.debug("a = " + a);
+            logger.debug("a1 = " + a1);
+        }
+        GenPolynomial b = a1;
+        GenPolynomial c;
+        int tt; //, oldtt;
+        //String rat = "";
+        char first;
+        RingElem r;
+        ExpVector e;
+        int ix;
+        long ie;
+        while (true) {
+            // next input. determine next action
+            tt = tok.nextToken();
+            //System.out.println("while tt = " + tok);
+            logger.debug("while tt = " + tok);
+            if (tt == StreamTokenizer.TT_EOF)
+                break;
+            switch (tt) {
+            case ')':
+            case ',':
+                return a; // do not change or remove
+            case '-':
+                b = b.negate();
+            case '+':
+            case '*':
+                tt = tok.nextToken();
+                break;
+            default: // skip
+            }
+            // read coefficient, monic monomial and polynomial
+            if (tt == StreamTokenizer.TT_EOF)
+                break;
+            switch (tt) {
+            // case '_': removed 
+            case '}':
+                throw new InvalidExpressionException("mismatch of braces after " + a + ", error at " + b);
+            case '{': // recursion
+                StringBuffer rf = new StringBuffer();
+                int level = 0;
+                do {
+                    tt = tok.nextToken();
+                    //System.out.println("token { = " + ((char)tt) + ", " + tt + ", level = " + level);
+                    if (tt == StreamTokenizer.TT_EOF) {
+                        throw new InvalidExpressionException(
+                                        "mismatch of braces after " + a + ", error at " + b);
+                    }
+                    if (tt == '{') {
+                        level++;
+                    }
+                    if (tt == '}') {
+                        level--;
+                        if (level < 0) {
+                            continue; // skip last closing brace 
+                        }
+                    }
+                    if (tok.sval != null) {
+                        if (rf.length() > 0 && rf.charAt(rf.length() - 1) != '.') {
+                            rf.append(" ");
+                        }
+                        rf.append(tok.sval); // " " + 
+                    } else {
+                        rf.append((char) tt);
+                    }
+                } while (level >= 0);
+                //System.out.println("coeff{} = " + rf.toString() );
+                try {
+                    r = (RingElem) fac.parse(rf.toString());
+                } catch (NumberFormatException re) {
+                    throw new InvalidExpressionException("not a number " + rf, re);
+                }
+                if (debug)
+                    logger.debug("coeff " + r);
+                ie = nextExponent();
+                if (debug)
+                    logger.debug("ie " + ie);
+                r = (RingElem) r.power(ie); //Power.<RingElem> positivePower(r, ie);
+                if (debug)
+                    logger.debug("coeff^ie " + r);
+                b = b.multiply(r, leer);
+                tt = tok.nextToken();
+                if (debug)
+                    logger.debug("tt,digit = " + tok);
+                //no break;
+                break;
+
+            //case '.': // eventually a float
+            //System.out.println("start . = " + reader);
+            //throw new InvalidExpressionException("float must start with a digit ");
+
+            case StreamTokenizer.TT_WORD:
+                //System.out.println("TT_WORD: " + tok.sval);
+                if (tok.sval == null || tok.sval.length() == 0)
+                    break;
+                // read coefficient
+                first = tok.sval.charAt(0);
+                if (digit(first) || first == '/' || first == '.' || first == '~') {
+                    //System.out.println("coeff 0 = " + tok.sval );
+                    StringBuffer df = new StringBuffer();
+                    df.append(tok.sval);
+                    if (tok.sval.length() > 1 && digit(tok.sval.charAt(1))) {
+                        //System.out.println("start / or . = " + tok.sval);
+                        if (first == '/') { // let x/2 be x 1/2
+                            df.insert(0, "1");
+                        }
+                        if (first == '.') { // let x.2 be x 0.2
+                            df.insert(0, "0");
+                        }
+                    }
+                    if (tok.sval.charAt(tok.sval.length() - 1) == 'i') { // complex number
+                        tt = tok.nextToken();
+                        if (debug)
+                            logger.debug("tt,im = " + tok);
+                        if (tok.sval != null || tt == '-') {
+                            if (tok.sval != null) {
+                                df.append(tok.sval);
+                            } else {
+                                df.append("-");
+                            }
+                            if (tt == '-') {
+                                tt = tok.nextToken(); // todo: decimal number
+                                if (tok.sval != null && digit(tok.sval.charAt(0))) {
+                                    df.append(tok.sval);
+
+                                } else {
+                                    tok.pushBack();
+                                }
+                            }
+                        } else {
+                            tok.pushBack();
+                        }
+                    }
+                    tt = tok.nextToken();
+                    if (tt == '.') { // decimal number, obsolete by word char?
+                        tt = tok.nextToken();
+                        if (debug)
+                            logger.debug("tt,dot = " + tok);
+                        if (tok.sval != null) {
+                            df.append(".");
+                            df.append(tok.sval);
+                        } else {
+                            tok.pushBack();
+                            tok.pushBack();
+                        }
+                    } else {
+                        tok.pushBack();
+                    }
+                    try {
+                        //System.out.println("df = " + df + ", fac = " + fac.getClass());
+                        r = (RingElem) fac.parse(df.toString());
+                        //System.out.println("r = " + r);
+                    } catch (NumberFormatException re) {
+                        //System.out.println("re = " + re);
+                        throw new InvalidExpressionException("not a number " + df, re);
+                    }
+                    if (debug)
+                        logger.debug("coeff " + r);
+                    //System.out.println("r = " + r.toScriptFactory());
+                    ie = nextExponent();
+                    if (debug)
+                        logger.debug("ie " + ie);
+                    // r = r^ie;
+                    r = (RingElem) r.power(ie); //Power.<RingElem> positivePower(r, ie);
+                    if (debug)
+                        logger.debug("coeff^ie " + r);
+                    b = b.multiply(r, leer);
+                    tt = tok.nextToken();
+                    if (debug)
+                        logger.debug("tt,digit = " + tok);
+                }
+                if (tt == StreamTokenizer.TT_EOF)
+                    break;
+                if (tok.sval == null)
+                    break;
+                // read monomial or recursion 
+                first = tok.sval.charAt(0);
+                if (letter(first)) {
+                    ix = leer.indexVar(tok.sval, vars); //indexVar( tok.sval );
+                    if (ix < 0) { // not found
+                        try {
+                            r = (RingElem) fac.parse(tok.sval);
+                        } catch (NumberFormatException re) {
+                            throw new InvalidExpressionException("recursively unknown variable " + tok.sval);
+                        }
+                        if (debug)
+                            logger.info("coeff " + r);
+                        //if (r.isONE() || r.isZERO()) {
+                        //logger.error("Unknown varibable " + tok.sval);
+                        //break;
+                        //throw new InvalidExpressionException("recursively unknown variable " + tok.sval);
+                        //}
+                        ie = nextExponent();
+                        //  System.out.println("ie: " + ie);
+                        r = (RingElem) r.power(ie); //Power.<RingElem> positivePower(r, ie);
+                        b = b.multiply(r);
+                    } else { // found
+                        //  System.out.println("ix: " + ix);
+                        ie = nextExponent();
+                        //  System.out.println("ie: " + ie);
+                        e = ExpVector.create(vars.length, ix, ie);
+                        b = b.multiply(e);
+                    }
+                    tt = tok.nextToken();
+                    if (debug)
+                        logger.debug("tt,letter = " + tok);
+                }
+                break;
+
+            case '(':
+                c = nextPolynomial();
+                if (debug)
+                    logger.debug("factor " + c);
+                ie = nextExponent();
+                if (debug)
+                    logger.debug("ie " + ie);
+                c = (GenPolynomial) c.power(ie); //Power.<GenPolynomial> positivePower(c, ie);
+                if (debug)
+                    logger.debug("factor^ie " + c);
+                b = b.multiply(c);
+                tt = tok.nextToken();
+                if (debug)
+                    logger.debug("tt,digit = " + tok);
+                //no break;
+                break;
+
+            default: //skip 
+            }
+            if (tt == StreamTokenizer.TT_EOF)
+                break;
+            // complete polynomial
+            tok.pushBack();
+            switch (tt) {
+            case '-':
+            case '+':
+            case ')':
+            case ',':
+                logger.debug("b, = " + b);
+                a = a.sum(b);
+                b = a1;
+                break;
+            case '*':
+                logger.debug("b, = " + b);
+                //a = a.sum(b); 
+                //b = a1;
+                break;
+            case '\n':
+                tt = tok.nextToken();
+                if (debug)
+                    logger.debug("tt,nl = " + tt);
+                break;
+            default: // skip or finish ?
+                if (debug)
+                    logger.debug("default: " + tok);
+            }
+        }
+        if (debug)
+            logger.debug("b = " + b);
+        a = a.sum(b);
+        if (debug)
+            logger.debug("a = " + a);
+        // b = a1;
+        return a;
+    }
+
+
+    /**
+     * Parsing method for exponent (of variable). Syntax:
+     * 
+     * <pre>
+     * ^long | **long
+     * </pre>
+     * 
+     * @return the next exponent or 1.
+     * @throws IOException
+     */
+    public long nextExponent() throws IOException {
+        long e = 1;
+        char first;
+        int tt;
+        tt = tok.nextToken();
+        if (tt == '^') {
+            if (debug)
+                logger.debug("exponent ^");
+            tt = tok.nextToken();
+            if (tok.sval != null) {
+                first = tok.sval.charAt(0);
+                if (digit(first)) {
+                    e = Long.parseLong(tok.sval);
+                    return e;
+                }
+            }
+        }
+        if (tt == '*') {
+            tt = tok.nextToken();
+            if (tt == '*') {
+                if (debug)
+                    logger.debug("exponent **");
+                tt = tok.nextToken();
+                if (tok.sval != null) {
+                    first = tok.sval.charAt(0);
+                    if (digit(first)) {
+                        e = Long.parseLong(tok.sval);
+                        return e;
+                    }
+                }
+            }
+            tok.pushBack();
+        }
+        tok.pushBack();
+        return e;
+    }
+
+
+    /**
+     * Parsing method for comments. Syntax:
+     * 
+     * <pre>
+     * (* comment *) | /_* comment *_/
+     * </pre>
+     * 
+     * without <code>_</code>. Unused, as it does not work with this pushBack().
+     */
+    public String nextComment() throws IOException {
+        // syntax: (* comment *) | /* comment */ 
+        StringBuffer c = new StringBuffer();
+        int tt;
+        if (debug)
+            logger.debug("comment: " + tok);
+        tt = tok.nextToken();
+        if (debug)
+            logger.debug("comment: " + tok);
+        if (tt == '(') {
+            tt = tok.nextToken();
+            if (debug)
+                logger.debug("comment: " + tok);
+            if (tt == '*') {
+                if (debug)
+                    logger.debug("comment: ");
+                while (true) {
+                    tt = tok.nextToken();
+                    if (tt == '*') {
+                        tt = tok.nextToken();
+                        if (tt == ')') {
+                            return c.toString();
+                        }
+                        tok.pushBack();
+                    }
+                    c.append(tok.sval);
+                }
+            }
+            tok.pushBack();
+            if (debug)
+                logger.debug("comment: " + tok);
+        }
+        tok.pushBack();
+        if (debug)
+            logger.debug("comment: " + tok);
+        return c.toString();
+    }
+
+
+    /**
+     * Parsing method for variable list. Syntax:
+     * 
+     * <pre>
+     * (a, b c, de)
+     * </pre>
+     * 
+     * gives <code>[ "a", "b", "c", "de" ]</code>
+     * @return the next variable list.
+     * @throws IOException
+     */
+    public String[] nextVariableList() throws IOException {
+        List<String> l = new ArrayList<String>();
+        int tt;
+        tt = tok.nextToken();
+        //System.out.println("vList tok = " + tok);
+        if (tt == '(' || tt == '{') {
+            logger.debug("variable list");
+            tt = tok.nextToken();
+            while (true) {
+                if (tt == StreamTokenizer.TT_EOF)
+                    break;
+                if (tt == ')' || tt == '}')
+                    break;
+                if (tt == StreamTokenizer.TT_WORD) {
+                    //System.out.println("TT_WORD: " + tok.sval);
+                    l.add(tok.sval);
+                }
+                tt = tok.nextToken();
+            }
+        } else {
+            tok.pushBack();
+        }
+        Object[] ol = l.toArray();
+        String[] v = new String[ol.length];
+        for (int i = 0; i < v.length; i++) {
+            v[i] = (String) ol[i];
+        }
+        return v;
+    }
+
+
+    /**
+     * Parsing method for coefficient ring. Syntax:
+     * 
+     * <pre>
+     * Rat | Q | Int | Z | Mod modul | Complex | C | D | Quat | AN[ (var) ( poly ) ] | AN[ modul (var) ( poly ) ] | IntFunc (var_list)
+     * </pre>
+     * 
+     * @return the next coefficient factory.
+     * @throws IOException
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    public RingFactory nextCoefficientRing() throws IOException {
+        RingFactory coeff = null;
+        coeffType ct = null;
+        int tt;
+        tt = tok.nextToken();
+        if (tok.sval != null) {
+            if (tok.sval.equalsIgnoreCase("Q")) {
+                coeff = new BigRational(0);
+                ct = coeffType.BigRat;
+            } else if (tok.sval.equalsIgnoreCase("Rat")) {
+                coeff = new BigRational(0);
+                ct = coeffType.BigRat;
+            } else if (tok.sval.equalsIgnoreCase("D")) {
+                coeff = new BigDecimal(0);
+                ct = coeffType.BigD;
+            } else if (tok.sval.equalsIgnoreCase("Z")) {
+                coeff = new BigInteger(0);
+                ct = coeffType.BigInt;
+            } else if (tok.sval.equalsIgnoreCase("Int")) {
+                coeff = new BigInteger(0);
+                ct = coeffType.BigInt;
+            } else if (tok.sval.equalsIgnoreCase("C")) {
+                coeff = new BigComplex(0);
+                ct = coeffType.BigC;
+            } else if (tok.sval.equalsIgnoreCase("Complex")) {
+                coeff = new BigComplex(0);
+                ct = coeffType.BigC;
+            } else if (tok.sval.equalsIgnoreCase("Quat")) {
+                logger.warn("parse of quaternion coefficients may fail for negative components (use ~ for -)");
+                coeff = new BigQuaternionRing();
+                ct = coeffType.BigQ;
+            } else if (tok.sval.equalsIgnoreCase("Oct")) {
+                logger.warn("parse of octonion coefficients may fail for negative components (use ~ for -)");
+                coeff = new BigOctonion(new BigQuaternionRing());
+                ct = coeffType.BigO;
+            } else if (tok.sval.equalsIgnoreCase("Mod")) {
+                tt = tok.nextToken();
+                boolean openb = false;
+                if (tt == '[') { // optional
+                    openb = true;
+                    tt = tok.nextToken();
+                }
+                if (tok.sval != null && tok.sval.length() > 0) {
+                    if (digit(tok.sval.charAt(0))) {
+                        BigInteger mo = new BigInteger(tok.sval);
+                        BigInteger lm = new BigInteger(ModLongRing.MAX_LONG); //wrong: Long.MAX_VALUE);
+                        if (mo.compareTo(lm) < 0) {
+                            if (mo.compareTo(new BigInteger(ModIntRing.MAX_INT)) < 0) {
+                                coeff = new ModIntRing(mo.getVal());
+                            } else {
+                                coeff = new ModLongRing(mo.getVal());
+                            }
+                        } else {
+                            coeff = new ModIntegerRing(mo.getVal());
+                        }
+                        //System.out.println("coeff = " + coeff + " :: " + coeff.getClass());
+                        ct = coeffType.ModInt;
+                    } else {
+                        tok.pushBack();
+                    }
+                } else {
+                    tok.pushBack();
+                }
+                if (tt == ']' && openb) { // optional
+                    tt = tok.nextToken();
+                }
+            } else if (tok.sval.equalsIgnoreCase("RatFunc") || tok.sval.equalsIgnoreCase("ModFunc")) {
+                //logger.error("RatFunc and ModFunc can no more be read, see edu.jas.application.RingFactoryTokenizer.");
+                throw new InvalidExpressionException(
+                                "RatFunc and ModFunc can no more be read, see edu.jas.application.RingFactoryTokenizer.");
+            } else if (tok.sval.equalsIgnoreCase("IntFunc")) {
+                String[] rfv = nextVariableList();
+                //System.out.println("rfv = " + rfv.length + " " + rfv[0]);
+                int vr = rfv.length;
+                BigRational bi = new BigRational();
+                TermOrder to = new TermOrder(TermOrder.INVLEX);
+                GenPolynomialRing<BigRational> pcf = new GenPolynomialRing<BigRational>(bi, vr, to, rfv);
+                coeff = pcf;
+                ct = coeffType.IntFunc;
+            } else if (tok.sval.equalsIgnoreCase("AN")) {
+                tt = tok.nextToken();
+                if (tt == '[') {
+                    tt = tok.nextToken();
+                    RingFactory tcfac = new ModIntegerRing("19");
+                    if (tok.sval != null && tok.sval.length() > 0) {
+                        if (digit(tok.sval.charAt(0))) {
+                            tcfac = new ModIntegerRing(tok.sval);
+                        } else {
+                            tcfac = new BigRational();
+                            tok.pushBack();
+                        }
+                    } else {
+                        tcfac = new BigRational();
+                        tok.pushBack();
+                    }
+                    String[] anv = nextVariableList();
+                    //System.out.println("anv = " + anv.length + " " + anv[0]);
+                    int vs = anv.length;
+                    if (vs != 1) {
+                        throw new InvalidExpressionException(
+                                        "AlgebraicNumber only for univariate polynomials "
+                                                        + Arrays.toString(anv));
+                    }
+                    String[] ovars = vars;
+                    vars = anv;
+                    GenPolynomialRing tpfac = pfac;
+                    RingFactory tfac = fac;
+                    fac = tcfac;
+                    // pfac and fac used in nextPolynomial()
+                    if (tcfac instanceof ModIntegerRing) {
+                        pfac = new GenPolynomialRing<ModInteger>(tcfac, vs, new TermOrder(), anv);
+                    } else {
+                        pfac = new GenPolynomialRing<BigRational>(tcfac, vs, new TermOrder(), anv);
+                    }
+                    if (debug) {
+                        logger.debug("pfac = " + pfac);
+                    }
+                    tt = tok.nextToken();
+                    GenPolynomial mod;
+                    if (tt == '(') {
+                        mod = nextPolynomial();
+                        tt = tok.nextToken();
+                        if (tok.ttype != ')')
+                            tok.pushBack();
+                    } else {
+                        tok.pushBack();
+                        mod = nextPolynomial();
+                    }
+                    if (debug) {
+                        logger.debug("mod = " + mod);
+                    }
+                    pfac = tpfac;
+                    fac = tfac;
+                    vars = ovars;
+                    if (tcfac instanceof ModIntegerRing) {
+                        GenPolynomial<ModInteger> gfmod;
+                        gfmod = (GenPolynomial<ModInteger>) mod;
+                        coeff = new AlgebraicNumberRing<ModInteger>(gfmod);
+                        ct = coeffType.ANmod;
+                    } else {
+                        GenPolynomial<BigRational> anmod;
+                        anmod = (GenPolynomial<BigRational>) mod;
+                        coeff = new AlgebraicNumberRing<BigRational>(anmod);
+                        ct = coeffType.ANrat;
+                    }
+                    if (debug) {
+                        logger.debug("coeff = " + coeff);
+                    }
+                    tt = tok.nextToken();
+                    if (tt == ']') {
+                        //ok, no nextToken();
+                    } else {
+                        tok.pushBack();
+                    }
+                } else {
+                    tok.pushBack();
+                }
+            }
+        }
+        if (coeff == null) {
+            tok.pushBack();
+            coeff = new BigRational();
+            ct = coeffType.BigRat;
+        }
+        parsedCoeff = ct;
+        return coeff;
+    }
+
+
+    /**
+     * Parsing method for weight list. Syntax:
+     * 
+     * <pre>
+     * (w1, w2, w3, ..., wn)
+     * </pre>
+     * 
+     * @return the next weight list.
+     * @throws IOException
+     */
+    public long[] nextWeightList() throws IOException {
+        List<Long> l = new ArrayList<Long>();
+        long e;
+        char first;
+        int tt;
+        tt = tok.nextToken();
+        if (tt == '(') {
+            logger.debug("weight list");
+            tt = tok.nextToken();
+            while (true) {
+                if (tt == StreamTokenizer.TT_EOF)
+                    break;
+                if (tt == ')')
+                    break;
+                if (tok.sval != null) {
+                    first = tok.sval.charAt(0);
+                    if (digit(first)) {
+                        e = Long.parseLong(tok.sval);
+                        l.add(Long.valueOf(e));
+                        //System.out.println("w: " + e);
+                    }
+                }
+                tt = tok.nextToken(); // also comma
+            }
+        } else {
+            tok.pushBack();
+        }
+        Long[] ol = new Long[1];
+        ol = l.toArray(ol);
+        long[] w = new long[ol.length];
+        for (int i = 0; i < w.length; i++) {
+            w[i] = ol[ol.length - i - 1].longValue();
+        }
+        return w;
+    }
+
+
+    /**
+     * Parsing method for weight array. Syntax:
+     * 
+     * <pre>
+     * ( (w11, ...,w1n), ..., (wm1, ..., wmn) )
+     * </pre>
+     * 
+     * @return the next weight array.
+     * @throws IOException
+     */
+    public long[][] nextWeightArray() throws IOException {
+        List<long[]> l = new ArrayList<long[]>();
+        long[] e;
+        char first;
+        int tt;
+        tt = tok.nextToken();
+        if (tt == '(') {
+            logger.debug("weight array");
+            tt = tok.nextToken();
+            while (true) {
+                if (tt == StreamTokenizer.TT_EOF)
+                    break;
+                if (tt == ')')
+                    break;
+                if (tt == '(') {
+                    tok.pushBack();
+                    e = nextWeightList();
+                    l.add(e);
+                    //System.out.println("wa: " + e);
+                } else if (tok.sval != null) {
+                    first = tok.sval.charAt(0);
+                    if (digit(first)) {
+                        tok.pushBack();
+                        tok.pushBack();
+                        e = nextWeightList();
+                        l.add(e);
+                        break;
+                        //System.out.println("w: " + e);
+                    }
+                }
+                tt = tok.nextToken(); // also comma
+            }
+        } else {
+            tok.pushBack();
+        }
+        Object[] ol = l.toArray();
+        long[][] w = new long[ol.length][];
+        for (int i = 0; i < w.length; i++) {
+            w[i] = (long[]) ol[i];
+        }
+        return w;
+    }
+
+
+    /**
+     * Parsing method for split index. Syntax:
+     * 
+     * <pre>
+     * |i|
+     * </pre>
+     * 
+     * @return the next split index.
+     * @throws IOException
+     */
+    public int nextSplitIndex() throws IOException {
+        int e = -1; // =unknown
+        int e0 = -1; // =unknown
+        char first;
+        int tt;
+        tt = tok.nextToken();
+        if (tt == '|') {
+            if (debug) {
+                logger.debug("split index");
+            }
+            tt = tok.nextToken();
+            if (tt == StreamTokenizer.TT_EOF) {
+                return e;
+            }
+            if (tok.sval != null) {
+                first = tok.sval.charAt(0);
+                if (digit(first)) {
+                    e = Integer.parseInt(tok.sval);
+                    //System.out.println("w: " + i);
+                }
+                tt = tok.nextToken();
+                if (tt != '|') {
+                    tok.pushBack();
+                }
+            }
+        } else if (tt == '[') {
+            if (debug) {
+                logger.debug("split index");
+            }
+            tt = tok.nextToken();
+            if (tt == StreamTokenizer.TT_EOF) {
+                return e;
+            }
+            if (tok.sval != null) {
+                first = tok.sval.charAt(0);
+                if (digit(first)) {
+                    e0 = Integer.parseInt(tok.sval);
+                    //System.out.println("w: " + i);
+                }
+                tt = tok.nextToken();
+                if (tt == ',') {
+                    tt = tok.nextToken();
+                    if (tt == StreamTokenizer.TT_EOF) {
+                        return e0;
+                    }
+                    if (tok.sval != null) {
+                        first = tok.sval.charAt(0);
+                        if (digit(first)) {
+                            e = Integer.parseInt(tok.sval);
+                            //System.out.println("w: " + i);
+                        }
+                    }
+                    if (tt != ']') {
+                        tok.pushBack();
+                    }
+                }
+            }
+        } else {
+            tok.pushBack();
+        }
+        return e;
+    }
+
+
+    /**
+     * Parsing method for term order name. Syntax:
+     * 
+     * <pre>
+     * L | IL | LEX | G | IG | GRLEX | W(weights) | '|'split index'|'
+     * </pre>
+     * 
+     * @return the next term order.
+     * @throws IOException
+     */
+    public TermOrder nextTermOrder() throws IOException {
+        int evord = TermOrder.DEFAULT_EVORD;
+        int tt;
+        tt = tok.nextToken();
+        if (tt == StreamTokenizer.TT_EOF) { /* nop */
+        } else if (tt == StreamTokenizer.TT_WORD) {
+            // System.out.println("TT_WORD: " + tok.sval);
+            if (tok.sval != null) {
+                if (tok.sval.equalsIgnoreCase("L")) {
+                    evord = TermOrder.INVLEX;
+                } else if (tok.sval.equalsIgnoreCase("IL")) {
+                    evord = TermOrder.INVLEX;
+                } else if (tok.sval.equalsIgnoreCase("INVLEX")) {
+                    evord = TermOrder.INVLEX;
+                } else if (tok.sval.equalsIgnoreCase("LEX")) {
+                    evord = TermOrder.LEX;
+                } else if (tok.sval.equalsIgnoreCase("G")) {
+                    evord = TermOrder.IGRLEX;
+                } else if (tok.sval.equalsIgnoreCase("IG")) {
+                    evord = TermOrder.IGRLEX;
+                } else if (tok.sval.equalsIgnoreCase("IGRLEX")) {
+                    evord = TermOrder.IGRLEX;
+                } else if (tok.sval.equalsIgnoreCase("GRLEX")) {
+                    evord = TermOrder.GRLEX;
+                } else if (tok.sval.equalsIgnoreCase("REVITDG")) {
+                    evord = TermOrder.REVITDG;
+                } else if (tok.sval.equalsIgnoreCase("REVILEX")) {
+                    evord = TermOrder.REVILEX;
+                } else if (tok.sval.equalsIgnoreCase("W")) {
+                    long[][] w = nextWeightArray();
+                    return new TermOrder(w);
+                }
+            }
+        } else {
+            tok.pushBack();
+        }
+        int s = nextSplitIndex();
+        if (s <= 0) {
+            return new TermOrder(evord);
+        }
+        return new TermOrder(evord, evord, nvars, s);
+    }
+
+
+    /**
+     * Parsing method for polynomial list. Syntax:
+     * 
+     * <pre>
+     * ( p1, p2, p3, ..., pn )
+     * </pre>
+     * 
+     * @return the next polynomial list.
+     * @throws IOException
+     */
+    public List<GenPolynomial> nextPolynomialList() throws IOException {
+        GenPolynomial a;
+        List<GenPolynomial> L = new ArrayList<GenPolynomial>();
+        int tt;
+        tt = tok.nextToken();
+        if (tt == StreamTokenizer.TT_EOF)
+            return L;
+        if (tt != '(')
+            return L;
+        logger.debug("polynomial list");
+        while (true) {
+            tt = tok.nextToken();
+            if (tok.ttype == ',')
+                continue;
+            if (tt == '(') {
+                a = nextPolynomial();
+                tt = tok.nextToken();
+                if (tok.ttype != ')')
+                    tok.pushBack();
+            } else {
+                tok.pushBack();
+                a = nextPolynomial();
+            }
+            logger.info("next pol = " + a);
+            L.add(a);
+            if (tok.ttype == StreamTokenizer.TT_EOF)
+                break;
+            if (tok.ttype == ')')
+                break;
+        }
+        return L;
+    }
+
+
+    /**
+     * Parsing method for submodule list. Syntax:
+     * 
+     * <pre>
+     * ( ( p11, p12, p13, ..., p1n ), ..., ( pm1, pm2, pm3, ..., pmn ) )
+     * </pre>
+     * 
+     * @return the next list of polynomial lists.
+     * @throws IOException
+     */
+    public List<List<GenPolynomial>> nextSubModuleList() throws IOException {
+        List<List<GenPolynomial>> L = new ArrayList<List<GenPolynomial>>();
+        int tt;
+        tt = tok.nextToken();
+        if (tt == StreamTokenizer.TT_EOF)
+            return L;
+        if (tt != '(')
+            return L;
+        logger.debug("module list");
+        List<GenPolynomial> v = null;
+        while (true) {
+            tt = tok.nextToken();
+            if (tok.ttype == ',')
+                continue;
+            if (tok.ttype == ')')
+                break;
+            if (tok.ttype == StreamTokenizer.TT_EOF)
+                break;
+            if (tt == '(') {
+                tok.pushBack();
+                v = nextPolynomialList();
+                logger.info("next vect = " + v);
+                L.add(v);
+            }
+        }
+        return L;
+    }
+
+
+    /**
+     * Parsing method for solvable polynomial relation table. Syntax:
+     * 
+     * <pre>
+     * ( p_1, p_2, p_3, ..., p_{n+1}, p_{n+2}, p_{n+3} )
+     * </pre>
+     * 
+     * semantics: <code>p_{n+1} * p_{n+2} = p_{n+3}</code>. The next relation
+     * table is stored into the solvable polynomial factory.
+     * @throws IOException
+     */
+    @SuppressWarnings("unchecked")
+    public void nextRelationTable() throws IOException {
+        if (spfac == null) {
+            return;
+        }
+        RelationTable table = spfac.table;
+        List<GenPolynomial> rels = null;
+        GenPolynomial p;
+        GenSolvablePolynomial sp;
+        int tt;
+        tt = tok.nextToken();
+        if (debug) {
+            logger.debug("start relation table: " + tt);
+        }
+        if (tok.sval != null) {
+            if (tok.sval.equalsIgnoreCase("RelationTable")) {
+                rels = nextPolynomialList();
+            }
+        }
+        if (rels == null) {
+            tok.pushBack();
+            return;
+        }
+        for (Iterator<GenPolynomial> it = rels.iterator(); it.hasNext();) {
+            p = it.next();
+            ExpVector e = p.leadingExpVector();
+            if (it.hasNext()) {
+                p = it.next();
+                ExpVector f = p.leadingExpVector();
+                if (it.hasNext()) {
+                    p = it.next();
+                    sp = new GenSolvablePolynomial(spfac, p.val);
+                    table.update(e, f, sp);
+                }
+            }
+        }
+        if (debug) {
+            logger.info("table = " + table);
+        }
+        return;
+    }
+
+
+    /**
+     * Parsing method for polynomial set. Syntax:
+     * 
+     * <pre>
+     * coeffRing varList termOrderName polyList
+     * </pre>
+     * 
+     * @return the next polynomial set.
+     * @throws IOException
+     */
+    @SuppressWarnings("unchecked")
+    public PolynomialList nextPolynomialSet() throws IOException {
+        //String comments = "";
+        //comments += nextComment();
+        //if (debug) logger.debug("comment = " + comments);
+
+        RingFactory coeff = nextCoefficientRing();
+        logger.info("coeff = " + coeff.getClass().getSimpleName());
+
+        vars = nextVariableList();
+        logger.info("vars = " + Arrays.toString(vars));
+        if (vars != null) {
+            nvars = vars.length;
+        }
+
+        tord = nextTermOrder();
+        logger.info("tord = " + tord);
+        // check more TOs
+
+        initFactory(coeff, parsedCoeff); // global: nvars, tord, vars
+        List<GenPolynomial> s = null;
+        s = nextPolynomialList();
+        logger.info("s = " + s);
+        // comments += nextComment();
+        return new PolynomialList(pfac, s);
+    }
+
+
+    /**
+     * Parsing method for module set. Syntax:
+     * 
+     * <pre>
+     * coeffRing varList termOrderName moduleList
+     * </pre>
+     * 
+     * @return the next module set.
+     * @throws IOException
+     */
+    @SuppressWarnings("unchecked")
+    public ModuleList nextSubModuleSet() throws IOException {
+        //String comments = "";
+        //comments += nextComment();
+        //if (debug) logger.debug("comment = " + comments);
+
+        RingFactory coeff = nextCoefficientRing();
+        logger.info("coeff = " + coeff.getClass().getSimpleName());
+
+        vars = nextVariableList();
+        logger.info("vars = " + Arrays.toString(vars));
+        if (vars != null) {
+            nvars = vars.length;
+        }
+
+        tord = nextTermOrder();
+        logger.info("tord = " + tord);
+        // check more TOs
+
+        initFactory(coeff, parsedCoeff); // global: nvars, tord, vars
+        List<List<GenPolynomial>> m = null;
+        m = nextSubModuleList();
+        logger.info("m = " + m);
+        // comments += nextComment();
+
+        return new ModuleList(pfac, m);
+    }
+
+
+    /**
+     * Parsing method for solvable polynomial list. Syntax:
+     * 
+     * <pre>
+     * ( p1, p2, p3, ..., pn )
+     * </pre>
+     * 
+     * @return the next solvable polynomial list.
+     * @throws IOException
+     */
+    @SuppressWarnings("unchecked")
+    public List<GenSolvablePolynomial> nextSolvablePolynomialList() throws IOException {
+        List<GenPolynomial> s = nextPolynomialList();
+        logger.info("s = " + s);
+        // comments += nextComment();
+
+        GenPolynomial p;
+        GenSolvablePolynomial ps;
+        List<GenSolvablePolynomial> sp = new ArrayList<GenSolvablePolynomial>(s.size());
+        for (Iterator<GenPolynomial> it = s.iterator(); it.hasNext();) {
+            p = it.next();
+            ps = new GenSolvablePolynomial(spfac, p.val);
+            //System.out.println("ps = " + ps);
+            sp.add(ps);
+        }
+        return sp;
+    }
+
+
+    /**
+     * Parsing method for solvable polynomial. Syntax: same as for polynomial.
+     * If the relation table is set-up, then multiplication will mean
+     * solvable-multiplication.
+     * @return the next polynomial.
+     * @throws IOException
+     */
+    @SuppressWarnings("unchecked")
+    public GenSolvablePolynomial nextSolvablePolynomial() throws IOException {
+        GenPolynomial p = nextPolynomial();
+        logger.info("nextSolvablePolynomial = " + p);
+        // comments += nextComment();
+
+        GenSolvablePolynomial ps = new GenSolvablePolynomial(spfac, p.val);
+        //System.out.println("ps = " + ps);
+        return ps;
+    }
+
+
+    /**
+     * Parsing method for solvable polynomial set. Syntax:
+     * 
+     * <pre>
+     * varList termOrderName relationTable polyList
+     * </pre>
+     * 
+     * @return the next solvable polynomial set.
+     * @throws IOException
+     */
+    @SuppressWarnings("unchecked")
+    public PolynomialList nextSolvablePolynomialSet() throws IOException {
+        //String comments = "";
+        //comments += nextComment();
+        //if (debug) logger.debug("comment = " + comments);
+
+        RingFactory coeff = nextCoefficientRing();
+        logger.info("coeff = " + coeff.getClass().getSimpleName());
+
+        vars = nextVariableList();
+        logger.info("vars = " + Arrays.toString(vars));
+        if (vars != null) {
+            nvars = vars.length;
+        }
+
+        tord = nextTermOrder();
+        logger.info("tord = " + tord);
+        // check more TOs
+
+        initFactory(coeff, parsedCoeff); // must be because of symmetric read
+        initSolvableFactory(coeff, parsedCoeff); // global: nvars, tord, vars
+        //System.out.println("pfac = " + pfac);
+        //System.out.println("spfac = " + spfac);
+
+        nextRelationTable();
+        if (logger.isInfoEnabled()) {
+            logger.info("table = " + table);
+        }
+
+        List<GenSolvablePolynomial> s = null;
+        s = nextSolvablePolynomialList();
+        logger.info("s = " + s);
+        // comments += nextComment();
+        return new PolynomialList(spfac, s); // Ordered ?
+    }
+
+
+    /**
+     * Parsing method for solvable submodule list. Syntax:
+     * 
+     * <pre>
+     * ( ( p11, p12, p13, ..., p1n ), ..., ( pm1, pm2, pm3, ..., pmn ) )
+     * </pre>
+     * 
+     * @return the next list of solvable polynomial lists.
+     * @throws IOException
+     */
+    public List<List<GenSolvablePolynomial>> nextSolvableSubModuleList() throws IOException {
+        List<List<GenSolvablePolynomial>> L = new ArrayList<List<GenSolvablePolynomial>>();
+        int tt;
+        tt = tok.nextToken();
+        if (tt == StreamTokenizer.TT_EOF)
+            return L;
+        if (tt != '(')
+            return L;
+        logger.debug("module list");
+        List<GenSolvablePolynomial> v = null;
+        while (true) {
+            tt = tok.nextToken();
+            if (tok.ttype == ',')
+                continue;
+            if (tok.ttype == ')')
+                break;
+            if (tok.ttype == StreamTokenizer.TT_EOF)
+                break;
+            if (tt == '(') {
+                tok.pushBack();
+                v = nextSolvablePolynomialList();
+                logger.info("next vect = " + v);
+                L.add(v);
+            }
+        }
+        return L;
+    }
+
+
+    /**
+     * Parsing method for solvable module set. Syntax:
+     * 
+     * <pre>
+     * varList termOrderName relationTable moduleList
+     * </pre>
+     * 
+     * @return the next solvable module set.
+     * @throws IOException
+     */
+    @SuppressWarnings("unchecked")
+    public ModuleList nextSolvableSubModuleSet() throws IOException {
+        //String comments = "";
+        //comments += nextComment();
+        //if (debug) logger.debug("comment = " + comments);
+
+        RingFactory coeff = nextCoefficientRing();
+        logger.info("coeff = " + coeff.getClass().getSimpleName());
+
+        vars = nextVariableList();
+        logger.info("vars = " + Arrays.toString(vars));
+        if (vars != null) {
+            nvars = vars.length;
+        }
+
+        tord = nextTermOrder();
+        logger.info("tord = " + tord);
+        // check more TOs
+
+        initFactory(coeff, parsedCoeff); // must be because of symmetric read
+        initSolvableFactory(coeff, parsedCoeff); // global: nvars, tord, vars
+
+        //System.out.println("spfac = " + spfac);
+
+        nextRelationTable();
+        if (logger.isInfoEnabled()) {
+            logger.info("table = " + table);
+        }
+
+        List<List<GenSolvablePolynomial>> s = null;
+        s = nextSolvableSubModuleList();
+        logger.info("s = " + s);
+        // comments += nextComment();
+
+        return new OrderedModuleList(spfac, s); // Ordered
+    }
+
+
+    /**
+     * Parsing method for word polynomial. Syntax: same as for polynomial.
+     * Multiplication will be non commutative.
+     * @return the next polynomial.
+     * @throws IOException
+     */
+    @SuppressWarnings("unchecked")
+    public GenWordPolynomial nextWordPolynomial() throws IOException {
+        GenWordPolynomialRing wfac = new GenWordPolynomialRing(pfac);
+        return nextWordPolynomial(wfac);
+    }
+
+
+    /**
+     * Parsing method for word polynomial. Syntax: same as for polynomial.
+     * Multiplication will be non commutative.
+     * @param wfac word polynomial ring.
+     * @return the next polynomial.
+     * @throws IOException
+     */
+    @SuppressWarnings("unchecked")
+    public GenWordPolynomial nextWordPolynomial(GenWordPolynomialRing wfac) throws IOException {
+        //logger.info("wfac = " + wfac);
+        WordFactory wf = wfac.alphabet;
+
+        GenWordPolynomial a = wfac.getZERO();
+        GenWordPolynomial a1 = wfac.getONE();
+        Word leer = wfac.wone;
+        RingFactory fac = wfac.coFac;
+        if (debug) {
+            logger.debug("a = " + a);
+            logger.debug("a1 = " + a1);
+        }
+        GenWordPolynomial b = a1;
+        GenWordPolynomial c;
+        int tt;
+        char first;
+        RingElem r;
+        Word e;
+        //int ix;
+        long ie;
+        while (true) {
+            // next input. determine next action
+            tt = tok.nextToken();
+            //System.out.println("while tt = " + tok);
+            logger.debug("while tt = " + tok);
+            if (tt == StreamTokenizer.TT_EOF)
+                break;
+            switch (tt) {
+            case ')':
+            case ',':
+                if (logger.isInfoEnabled())
+                    logger.info("nextWordPolynomial = " + a);
+                return a; // do not change or remove
+            case '-':
+                b = b.negate();
+            case '+':
+            case '*':
+                tt = tok.nextToken();
+                break;
+            default: // skip
+            }
+            // read coefficient, monic monomial and polynomial
+            if (tt == StreamTokenizer.TT_EOF)
+                break;
+            switch (tt) {
+            // case '_': removed 
+            case '}':
+                throw new InvalidExpressionException("mismatch of braces after " + a + ", error at " + b);
+            case '{': // recursion
+                StringBuffer rf = new StringBuffer();
+                int level = 0;
+                do {
+                    tt = tok.nextToken();
+                    //System.out.println("token { = " + ((char)tt) + ", " + tt + ", level = " + level);
+                    if (tt == StreamTokenizer.TT_EOF) {
+                        throw new InvalidExpressionException(
+                                        "mismatch of braces after " + a + ", error at " + b);
+                    }
+                    if (tt == '{') {
+                        level++;
+                    }
+                    if (tt == '}') {
+                        level--;
+                        if (level < 0) {
+                            continue; // skip last closing brace 
+                        }
+                    }
+                    if (tok.sval != null) {
+                        if (rf.length() > 0 && rf.charAt(rf.length() - 1) != '.') {
+                            rf.append(" ");
+                        }
+                        rf.append(tok.sval); // " " + 
+                    } else {
+                        rf.append((char) tt);
+                    }
+                } while (level >= 0);
+                //System.out.println("coeff{} = " + rf.toString() );
+                try {
+                    r = (RingElem) fac.parse(rf.toString());
+                } catch (NumberFormatException re) {
+                    throw new InvalidExpressionException("not a number " + rf, re);
+                }
+                if (debug)
+                    logger.debug("coeff " + r);
+                ie = nextExponent();
+                if (debug)
+                    logger.debug("ie " + ie);
+                r = (RingElem) r.power(ie);
+                if (debug)
+                    logger.debug("coeff^ie " + r);
+                b = b.multiply(r, leer);
+                tt = tok.nextToken();
+                if (debug)
+                    logger.debug("tt,digit = " + tok);
+                //no break;
+                break;
+
+            //case '.': // eventually a float
+            //System.out.println("start . = " + reader);
+            //throw new InvalidExpressionException("float must start with a digit ");
+
+            case StreamTokenizer.TT_WORD:
+                //System.out.println("TT_WORD: " + tok.sval);
+                if (tok.sval == null || tok.sval.length() == 0)
+                    break;
+                // read coefficient
+                first = tok.sval.charAt(0);
+                if (digit(first) || first == '/' || first == '.' || first == '~') {
+                    //System.out.println("coeff 0 = " + tok.sval );
+                    StringBuffer df = new StringBuffer();
+                    df.append(tok.sval);
+                    if (tok.sval.length() > 1 && digit(tok.sval.charAt(1))) {
+                        //System.out.println("start / or . = " + tok.sval);
+                        if (first == '/') { // let x/2 be x 1/2
+                            df.insert(0, "1");
+                        }
+                        if (first == '.') { // let x.2 be x 0.2
+                            df.insert(0, "0");
+                        }
+                    }
+                    if (tok.sval.charAt(tok.sval.length() - 1) == 'i') { // complex number
+                        tt = tok.nextToken();
+                        if (debug)
+                            logger.debug("tt,im = " + tok);
+                        if (tok.sval != null || tt == '-') {
+                            if (tok.sval != null) {
+                                df.append(tok.sval);
+                            } else {
+                                df.append("-");
+                            }
+                            if (tt == '-') {
+                                tt = tok.nextToken(); // todo: decimal number
+                                if (tok.sval != null && digit(tok.sval.charAt(0))) {
+                                    df.append(tok.sval);
+
+                                } else {
+                                    tok.pushBack();
+                                }
+                            }
+                        } else {
+                            tok.pushBack();
+                        }
+                    }
+                    tt = tok.nextToken();
+                    if (tt == '.') { // decimal number, obsolete by word char?
+                        tt = tok.nextToken();
+                        if (debug)
+                            logger.debug("tt,dot = " + tok);
+                        if (tok.sval != null) {
+                            df.append(".");
+                            df.append(tok.sval);
+                        } else {
+                            tok.pushBack();
+                            tok.pushBack();
+                        }
+                    } else {
+                        tok.pushBack();
+                    }
+                    try {
+                        //System.out.println("df = " + df + ", fac = " + fac.getClass());
+                        r = (RingElem) fac.parse(df.toString());
+                        //System.out.println("r = " + r);
+                    } catch (NumberFormatException re) {
+                        //System.out.println("re = " + re);
+                        throw new InvalidExpressionException("not a number " + df, re);
+                    }
+                    if (debug)
+                        logger.debug("coeff " + r);
+                    //System.out.println("r = " + r.toScriptFactory());
+                    ie = nextExponent();
+                    if (debug)
+                        logger.debug("ie " + ie);
+                    // r = r^ie;
+                    r = (RingElem) r.power(ie); //Power.<RingElem> positivePower(r, ie);
+                    if (debug)
+                        logger.debug("coeff^ie " + r);
+                    b = b.multiply(r, leer);
+                    tt = tok.nextToken();
+                    if (debug)
+                        logger.debug("tt,digit = " + tok);
+                }
+                if (tt == StreamTokenizer.TT_EOF)
+                    break;
+                if (tok.sval == null)
+                    break;
+                // read monomial or recursion 
+                first = tok.sval.charAt(0);
+                if (letter(first)) {
+                    //ix = leer.indexVar(tok.sval, vars); 
+                    try {
+                        e = wf.parse(tok.sval);
+                    } catch (IllegalArgumentException ee) {
+                        e = null;
+                    }
+                    if (debug)
+                        logger.info("monom " + e);
+                    if (e == null) { // not found, look for coeff var
+                        try {
+                            r = (RingElem) fac.parse(tok.sval);
+                        } catch (NumberFormatException re) {
+                            throw new InvalidExpressionException("recursively unknown variable " + tok.sval);
+                        }
+                        ie = nextExponent();
+                        //  System.out.println("ie: " + ie);
+                        r = (RingElem) r.power(ie);
+                        //  System.out.println("re:  " + r);
+                        b = b.multiply(r, leer);
+                    } else { // found
+                        ie = nextExponent();
+                        //  System.out.println("ie: " + ie);
+                        e = e.power(ie);
+                        //  System.out.println("e:  " + e);
+                        b = b.multiply(e);
+                    }
+                    tt = tok.nextToken();
+                    if (debug)
+                        logger.debug("tt,letter = " + tok);
+                }
+                break;
+
+            case '(':
+                c = nextWordPolynomial(wfac);
+                if (debug)
+                    logger.debug("factor " + c);
+                ie = nextExponent();
+                if (debug)
+                    logger.debug("ie " + ie);
+                c = (GenWordPolynomial) c.power(ie); //Power.<GenPolynomial> positivePower(c, ie);
+                if (debug)
+                    logger.debug("factor^ie " + c);
+                b = b.multiply(c);
+                tt = tok.nextToken();
+                if (debug)
+                    logger.debug("tt,digit = " + tok);
+                //no break;
+                break;
+
+            default: //skip 
+            }
+            if (tt == StreamTokenizer.TT_EOF)
+                break;
+            // complete polynomial
+            tok.pushBack();
+            switch (tt) {
+            case '-':
+            case '+':
+            case ')':
+            case ',':
+                logger.debug("b, = " + b);
+                a = a.sum(b);
+                b = a1;
+                break;
+            case '*':
+                logger.debug("b, = " + b);
+                //a = a.sum(b); 
+                //b = a1;
+                break;
+            case '\n':
+                tt = tok.nextToken();
+                if (debug)
+                    logger.debug("tt,nl = " + tt);
+                break;
+            default: // skip or finish ?
+                if (debug)
+                    logger.debug("default: " + tok);
+            }
+        }
+        if (debug)
+            logger.debug("b = " + b);
+        a = a.sum(b);
+        if (logger.isInfoEnabled())
+            logger.info("nextWordPolynomial = " + a);
+        // b = a1;
+        return a;
+    }
+
+
+    /**
+     * Parsing method for word polynomial list. Syntax:
+     *
+     * <pre>
+     * ( p1, p2, p3, ..., pn )
+     * </pre>
+     *
+     * @return the next word polynomial list.
+     * @throws IOException
+     */
+    @SuppressWarnings("unchecked")
+    public List<GenWordPolynomial> nextWordPolynomialList() throws IOException {
+        GenWordPolynomialRing wfac = new GenWordPolynomialRing(pfac);
+        return nextWordPolynomialList(wfac);
+    }
+
+
+    /**
+     * Parsing method for word polynomial list. Syntax:
+     *
+     * <pre>
+     * ( p1, p2, p3, ..., pn )
+     * </pre>
+     *
+     * @param wfac word polynomial ring.
+     * @return the next word polynomial list.
+     * @throws IOException
+     */
+    public List<GenWordPolynomial> nextWordPolynomialList(GenWordPolynomialRing wfac) throws IOException {
+        GenWordPolynomial a;
+        List<GenWordPolynomial> L = new ArrayList<GenWordPolynomial>();
+        int tt;
+        tt = tok.nextToken();
+        if (tt == StreamTokenizer.TT_EOF)
+            return L;
+        if (tt != '(')
+            return L;
+        logger.debug("word polynomial list");
+        while (true) {
+            tt = tok.nextToken();
+            if (tok.ttype == ',')
+                continue;
+            if (tt == '(') {
+                a = nextWordPolynomial(wfac);
+                tt = tok.nextToken();
+                if (tok.ttype != ')')
+                    tok.pushBack();
+            } else {
+                tok.pushBack();
+                a = nextWordPolynomial(wfac);
+            }
+            logger.info("next pol = " + a);
+            L.add(a);
+            if (tok.ttype == StreamTokenizer.TT_EOF)
+                break;
+            if (tok.ttype == ')')
+                break;
+        }
+        return L;
+    }
+
+
+    // must also allow +/- // does not work with tokenizer
+    //private static boolean number(char x) {
+    //    return digit(x) || x == '-' || x == '+';
+    //}
+
+
+    static boolean digit(char x) {
+        return '0' <= x && x <= '9';
+    }
+
+
+    static boolean letter(char x) {
+        return ('a' <= x && x <= 'z') || ('A' <= x && x <= 'Z');
+    }
+
+
+    // unused
+    public void nextComma() throws IOException {
+        int tt;
+        if (tok.ttype == ',') {
+            tt = tok.nextToken();
+            if (debug) {
+                logger.debug("after comma: " + tt);
+            }
+        }
+    }
+
+
+    /**
+     * Parse variable list from String.
+     * @param s String. Syntax:
+     * 
+     *            <pre>
+     * (n1,...,nk)
+     *            </pre>
+     * 
+     *            or
+     * 
+     *            <pre>
+     * (n1 ... nk)
+     *            </pre>
+     * 
+     *            parenthesis are optional.
+     * @return array of variable names found in s.
+     */
+    public static String[] variableList(String s) {
+        String[] vl = null;
+        if (s == null) {
+            return vl;
+        }
+        String st = s.trim();
+        if (st.length() == 0) {
+            return new String[0];
+        }
+        if (st.charAt(0) == '(') {
+            st = st.substring(1);
+        }
+        if (st.charAt(st.length() - 1) == ')') {
+            st = st.substring(0, st.length() - 1);
+        }
+        st = st.replaceAll(",", " ");
+        List<String> sl = new ArrayList<String>();
+        Scanner sc = new Scanner(st);
+        while (sc.hasNext()) {
+            String sn = sc.next();
+            sl.add(sn);
+        }
+        sc.close();
+        vl = new String[sl.size()];
+        int i = 0;
+        for (String si : sl) {
+            vl[i] = si;
+            i++;
+        }
+        return vl;
+    }
+
+
+    /**
+     * Extract variable list from expression.
+     * @param s String. Syntax: any polynomial expression.
+     * @return array of variable names found in s.
+     */
+    public static String[] expressionVariables(String s) {
+        String[] vl = null;
+        if (s == null) {
+            return vl;
+        }
+        String st = s.trim();
+        if (st.length() == 0) {
+            return new String[0];
+        }
+        st = st.replaceAll(",", " ");
+        st = st.replaceAll("\\+", " ");
+        st = st.replaceAll("-", " ");
+        st = st.replaceAll("\\*", " ");
+        st = st.replaceAll("/", " ");
+        st = st.replaceAll("\\(", " ");
+        st = st.replaceAll("\\)", " ");
+        st = st.replaceAll("\\{", " ");
+        st = st.replaceAll("\\}", " ");
+        st = st.replaceAll("\\[", " ");
+        st = st.replaceAll("\\]", " ");
+        st = st.replaceAll("\\^", " ");
+        //System.out.println("st = " + st);
+
+        Set<String> sl = new TreeSet<String>();
+        Scanner sc = new Scanner(st);
+        while (sc.hasNext()) {
+            String sn = sc.next();
+            if (sn == null || sn.length() == 0) {
+                continue;
+            }
+            //System.out.println("sn = " + sn);
+            int i = 0;
+            while (digit(sn.charAt(i)) && i < sn.length() - 1) {
+                i++;
+            }
+            //System.out.println("sn = " + sn + ", i = " + i);
+            if (i > 0) {
+                sn = sn.substring(i, sn.length());
+            }
+            //System.out.println("sn = " + sn);
+            if (sn.length() == 0) {
+                continue;
+            }
+            if (!letter(sn.charAt(0))) {
+                continue;
+            }
+            //System.out.println("sn = " + sn);
+            sl.add(sn);
+        }
+        sc.close();
+        vl = new String[sl.size()];
+        int i = 0;
+        for (String si : sl) {
+            vl[i] = si;
+            i++;
+        }
+        return vl;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/GenSolvablePolynomial.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/GenSolvablePolynomial.java
@@ -1,0 +1,1039 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.structure.NotInvertibleException;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * GenSolvablePolynomial generic solvable polynomials implementing RingElem.
+ * n-variate ordered solvable polynomials over C. Objects of this class are
+ * intended to be immutable. The implementation is based on TreeMap respectively
+ * SortedMap from exponents to coefficients by extension of GenPolybomial. Only
+ * the coefficients are modeled with generic types, the exponents are fixed to
+ * ExpVector with long, int, short entries (@see edu.jas.poly.ExpVector
+ * StorUnit).
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class GenSolvablePolynomial<C extends RingElem<C>> extends GenPolynomial<C> {
+
+
+    //not possible: implements RingElem< GenSolvablePolynomial<C> > {
+
+
+    private static final Logger logger = LogManager.getLogger(GenSolvablePolynomial.class);
+
+
+    private static final boolean debug = false; //logger.isDebugEnabled();
+
+
+    /**
+     * The factory for the solvable polynomial ring. Hides super.ring.
+     */
+    public final GenSolvablePolynomialRing<C> ring;
+
+
+    /**
+     * Constructor for zero GenSolvablePolynomial.
+     * @param r solvable polynomial ring factory.
+     */
+    public GenSolvablePolynomial(GenSolvablePolynomialRing<C> r) {
+        super(r);
+        ring = r;
+    }
+
+
+    /**
+     * Constructor for GenSolvablePolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param c coefficient.
+     * @param e exponent.
+     */
+    public GenSolvablePolynomial(GenSolvablePolynomialRing<C> r, C c, ExpVector e) {
+        this(r);
+        if (c != null && !c.isZERO()) {
+            val.put(e, c);
+        }
+    }
+
+
+    /**
+     * Constructor for GenSolvablePolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param c coefficient.
+     */
+    public GenSolvablePolynomial(GenSolvablePolynomialRing<C> r, C c) {
+        this(r, c, r.evzero);
+    }
+
+
+    /**
+     * Constructor for GenSolvablePolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param v the SortedMap of some other (solvable) polynomial.
+     */
+    protected GenSolvablePolynomial(GenSolvablePolynomialRing<C> r, SortedMap<ExpVector, C> v) {
+        this(r);
+        if (v.size() > 0) {
+            GenPolynomialRing.creations++;
+            val.putAll(v); // assume val is empty and no zero coefficients in v
+        }
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    @Override
+    public GenSolvablePolynomialRing<C> factory() {
+        return ring;
+    }
+
+
+    /**
+     * Clone this GenSolvablePolynomial.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public GenSolvablePolynomial<C> copy() {
+        return new GenSolvablePolynomial<C>(ring, this.val);
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object B) {
+        if (!(B instanceof GenSolvablePolynomial)) {
+            return false;
+        }
+        return super.equals(B);
+    }
+
+
+    /**
+     * Hash code for this polynomial.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+
+    /**
+     * GenSolvablePolynomial multiplication.
+     * @param Bp GenSolvablePolynomial.
+     * @return this*Bp, where * denotes solvable multiplication.
+     */
+    // cannot @Override
+    @SuppressWarnings("unchecked")
+    public GenSolvablePolynomial<C> multiply(GenSolvablePolynomial<C> Bp) {
+        if (Bp == null || Bp.isZERO()) {
+            return ring.getZERO();
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        assert (ring.nvar == Bp.ring.nvar);
+        if (debug) {
+            logger.debug("ring = " + ring);
+        }
+        if (this instanceof RecSolvablePolynomial && Bp instanceof RecSolvablePolynomial) {
+            //throw new RuntimeException("wrong method dispatch in JRE ");
+            logger.info("warn: wrong method dispatch in JRE Rec.multiply(Rec Bp) - trying to fix");
+            RecSolvablePolynomial T = (RecSolvablePolynomial) this; // no <C>
+            RecSolvablePolynomial Sp = (RecSolvablePolynomial) Bp;
+            return T.multiply(Sp);
+        }
+        if (this instanceof QLRSolvablePolynomial && Bp instanceof QLRSolvablePolynomial) {
+            //throw new RuntimeException("wrong method dispatch in JRE ");
+            logger.info("warn: wrong method dispatch in JRE QLR.multiply(QLR Bp) - trying to fix");
+            QLRSolvablePolynomial T = (QLRSolvablePolynomial) this; // no <C>
+            QLRSolvablePolynomial Sp = (QLRSolvablePolynomial) Bp;
+            return T.multiply(Sp);
+        }
+        final boolean commute = ring.table.isEmpty();
+        GenSolvablePolynomial<C> Cp = ring.getZERO().copy(); // needed for doPutToMap and doAddTo
+        ExpVector Z = ring.evzero;
+
+        GenSolvablePolynomial<C> C1 = null;
+        GenSolvablePolynomial<C> C2 = null;
+        Map<ExpVector, C> A = val;
+        Map<ExpVector, C> B = Bp.val;
+        Set<Map.Entry<ExpVector, C>> Bk = B.entrySet();
+        for (Map.Entry<ExpVector, C> y : A.entrySet()) {
+            C a = y.getValue();
+            ExpVector e = y.getKey();
+            if (debug)
+                logger.debug("e = " + e);
+            int[] ep = e.dependencyOnVariables();
+            int el1 = ring.nvar + 1;
+            if (ep.length > 0) {
+                el1 = ep[0];
+            }
+            int el1s = ring.nvar + 1 - el1;
+            for (Map.Entry<ExpVector, C> x : Bk) {
+                C b = x.getValue();
+                ExpVector f = x.getKey();
+                if (debug)
+                    logger.debug("f = " + f);
+                int[] fp = f.dependencyOnVariables();
+                int fl1 = 0;
+                if (fp.length > 0) {
+                    fl1 = fp[fp.length - 1];
+                }
+                int fl1s = ring.nvar + 1 - fl1;
+                if (debug) {
+                    logger.debug("el1s = " + el1s + " fl1s = " + fl1s);
+                }
+                GenSolvablePolynomial<C> Cs = null;
+                if (commute || el1s <= fl1s) { // symmetric
+                    ExpVector g = e.sum(f);
+                    Cs = ring.valueOf(g); // symmetric! 
+                    //no: Cs = new GenSolvablePolynomial<C>(ring, one, g); 
+                    //System.out.println("Cs(sym) = " + Cs + ", g = " + g);
+                } else { // unsymmetric
+                    // split e = e1 * e2, f = f1 * f2
+                    ExpVector e1 = e.subst(el1, 0);
+                    ExpVector e2 = Z.subst(el1, e.getVal(el1));
+                    ExpVector e4;
+                    ExpVector f1 = f.subst(fl1, 0);
+                    ExpVector f2 = Z.subst(fl1, f.getVal(fl1));
+                    TableRelation<C> rel = ring.table.lookup(e2, f2);
+                    //logger.info("relation = " + rel);
+                    Cs = rel.p; // do not clone() 
+                    if (rel.f != null) {
+                        C2 = ring.valueOf(rel.f);
+                        Cs = Cs.multiply(C2);
+                        if (rel.e == null) {
+                            e4 = e2;
+                        } else {
+                            e4 = e2.subtract(rel.e);
+                        }
+                        ring.table.update(e4, f2, Cs);
+                    }
+                    if (rel.e != null) {
+                        C1 = ring.valueOf(rel.e);
+                        Cs = C1.multiply(Cs);
+                        ring.table.update(e2, f2, Cs);
+                    }
+                    if (!f1.isZERO()) {
+                        C2 = ring.valueOf(f1);
+                        Cs = Cs.multiply(C2);
+                        //ring.table.update(?,f1,Cs)
+                    }
+                    if (!e1.isZERO()) {
+                        C1 = ring.valueOf(e1);
+                        Cs = C1.multiply(Cs);
+                        //ring.table.update(e1,?,Cs)
+                    }
+                }
+                //System.out.println("Cs = " + Cs + ", a = " + a + ", b = " + b);
+                Cs = Cs.multiply(a, b); // now non-symmetric // Cs.multiply(c); is symmetric!
+                Cp.doAddTo(Cs);
+            }
+        }
+        return Cp;
+    }
+
+
+    /**
+     * GenSolvablePolynomial left and right multiplication. Product with two
+     * polynomials.
+     * @param S GenSolvablePolynomial.
+     * @param T GenSolvablePolynomial.
+     * @return S*this*T.
+     */
+    // new method, @NoOverride
+    public GenSolvablePolynomial<C> multiply(GenSolvablePolynomial<C> S, GenSolvablePolynomial<C> T) {
+        if (S.isZERO() || T.isZERO() || this.isZERO()) {
+            return ring.getZERO();
+        }
+        if (S.isONE()) {
+            return multiply(T);
+        }
+        if (T.isONE()) {
+            return S.multiply(this);
+        }
+        return S.multiply(this).multiply(T);
+    }
+
+
+    /**
+     * GenSolvablePolynomial multiplication. Product with coefficient ring
+     * element.
+     * @param b coefficient.
+     * @return this*b, where * is coefficient multiplication.
+     */
+    @Override
+    @SuppressWarnings({ "cast", "unchecked" })
+    public GenSolvablePolynomial<C> multiply(C b) {
+        GenSolvablePolynomial<C> Cp = ring.getZERO();
+        if (b == null || b.isZERO()) {
+            return Cp;
+        }
+        if (this instanceof RecSolvablePolynomial && b instanceof GenSolvablePolynomial) {
+            //throw new RuntimeException("wrong method dispatch in JRE ");
+            logger.info("warn: wrong method dispatch in JRE Rec.multiply(b) - trying to fix");
+            RecSolvablePolynomial T = (RecSolvablePolynomial) this; // no <C>
+            GenSolvablePolynomial Sp = (GenSolvablePolynomial) b;
+            return (GenSolvablePolynomial<C>) T.recMultiply(Sp);
+        }
+        if (this instanceof QLRSolvablePolynomial && b instanceof GenSolvablePolynomial) {
+            //throw new RuntimeException("wrong method dispatch in JRE ");
+            logger.info("warn: wrong method dispatch in JRE QLR.multiply(Bp) - trying to fix");
+            QLRSolvablePolynomial T = (QLRSolvablePolynomial) this; // no <C>
+            GenSolvablePolynomial Sp = (GenSolvablePolynomial) b;
+            return (GenSolvablePolynomial<C>) T.multiply(Sp);
+        }
+        Cp = Cp.copy();
+        Map<ExpVector, C> Cm = Cp.val;
+        Map<ExpVector, C> Am = val;
+        for (Map.Entry<ExpVector, C> y : Am.entrySet()) {
+            ExpVector e = y.getKey();
+            C a = y.getValue();
+            C c = a.multiply(b);
+            if (!c.isZERO()) {
+                Cm.put(e, c);
+            }
+        }
+        return Cp;
+    }
+
+
+    /**
+     * GenSolvablePolynomial left and right multiplication. Product with
+     * coefficient ring element.
+     * @param b coefficient.
+     * @param c coefficient.
+     * @return b*this*c, where * is coefficient multiplication.
+     */
+    // new method, @NoOverride
+    @SuppressWarnings({ "cast", "unchecked" })
+    public GenSolvablePolynomial<C> multiply(C b, C c) {
+        GenSolvablePolynomial<C> Cp = ring.getZERO();
+        if (b == null || b.isZERO()) {
+            return Cp;
+        }
+        if (c == null || c.isZERO()) {
+            return Cp;
+        }
+        if (this instanceof RecSolvablePolynomial && b instanceof GenSolvablePolynomial
+                        && c instanceof GenSolvablePolynomial) {
+            //throw new RuntimeException("wrong method dispatch in JRE ");
+            logger.info("warn: wrong method dispatch in JRE Rec.multiply(b,c) - trying to fix");
+            RecSolvablePolynomial T = (RecSolvablePolynomial) this; // no <C>
+            GenSolvablePolynomial Bp = (GenSolvablePolynomial) b;
+            GenSolvablePolynomial Dp = (GenSolvablePolynomial) c;
+            return (GenSolvablePolynomial<C>) T.multiply(Bp, Dp);
+        }
+        if (this instanceof QLRSolvablePolynomial && b instanceof GenSolvablePolynomial
+                        && c instanceof GenSolvablePolynomial) {
+            //throw new RuntimeException("wrong method dispatch in JRE ");
+            logger.info("warn: wrong method dispatch in JRE QLR.multiply(b,c) - trying to fix");
+            QLRSolvablePolynomial T = (QLRSolvablePolynomial) this; // no <C>
+            GenSolvablePolynomial Bp = (GenSolvablePolynomial) b;
+            GenSolvablePolynomial Dp = (GenSolvablePolynomial) c;
+            return (GenSolvablePolynomial<C>) T.multiply(Bp, Dp);
+        }
+        Cp = Cp.copy();
+        Map<ExpVector, C> Cm = Cp.val;
+        Map<ExpVector, C> Am = val;
+        for (Map.Entry<ExpVector, C> y : Am.entrySet()) {
+            ExpVector e = y.getKey();
+            C a = y.getValue();
+            C d = b.multiply(a).multiply(c);
+            if (!d.isZERO()) {
+                Cm.put(e, d);
+            }
+        }
+        return Cp;
+    }
+
+
+    /**
+     * GenSolvablePolynomial multiplication. Product with exponent vector.
+     * @param e exponent.
+     * @return this * x<sup>e</sup>, where * denotes solvable multiplication.
+     */
+    @Override
+    public GenSolvablePolynomial<C> multiply(ExpVector e) {
+        if (e == null || e.isZERO()) {
+            return this;
+        }
+        C b = ring.getONECoefficient();
+        return multiply(b, e);
+    }
+
+
+    /**
+     * GenSolvablePolynomial left and right multiplication. Product with
+     * exponent vector.
+     * @param e exponent.
+     * @param f exponent.
+     * @return x<sup>e</sup> * this * x<sup>f</sup>, where * denotes solvable
+     *         multiplication.
+     */
+    // new method, @NoOverride
+    public GenSolvablePolynomial<C> multiply(ExpVector e, ExpVector f) {
+        if (e == null || e.isZERO()) {
+            return this;
+        }
+        if (f == null || f.isZERO()) {
+            return this;
+        }
+        C b = ring.getONECoefficient();
+        return multiply(b, e, b, f);
+    }
+
+
+    /**
+     * GenSolvablePolynomial multiplication. Product with ring element and
+     * exponent vector.
+     * @param b coefficient.
+     * @param e exponent.
+     * @return this * b x<sup>e</sup>, where * denotes solvable multiplication.
+     */
+    @Override
+    public GenSolvablePolynomial<C> multiply(C b, ExpVector e) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        GenSolvablePolynomial<C> Cp = ring.valueOf(b, e); //new GenSolvablePolynomial<C>(ring, b, e);
+        return multiply(Cp);
+    }
+
+
+    /**
+     * GenSolvablePolynomial left and right multiplication. Product with ring
+     * element and exponent vector.
+     * @param b coefficient.
+     * @param e exponent.
+     * @param c coefficient.
+     * @param f exponent.
+     * @return b x<sup>e</sup> * this * c x<sup>f</sup>, where * denotes
+     *         solvable multiplication.
+     */
+    // new method, @NoOverride
+    public GenSolvablePolynomial<C> multiply(C b, ExpVector e, C c, ExpVector f) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        if (c == null || c.isZERO()) {
+            return ring.getZERO();
+        }
+        GenSolvablePolynomial<C> Cp = ring.valueOf(b, e); //new GenSolvablePolynomial<C>(ring, b, e);
+        GenSolvablePolynomial<C> Dp = ring.valueOf(c, f); //new GenSolvablePolynomial<C>(ring, c, f);
+        return multiply(Cp, Dp);
+    }
+
+
+    /**
+     * GenSolvablePolynomial multiplication. Left product with ring element and
+     * exponent vector.
+     * @param b coefficient.
+     * @param e exponent.
+     * @return b x<sup>e</sup> * this, where * denotes solvable multiplication.
+     */
+    public GenSolvablePolynomial<C> multiplyLeft(C b, ExpVector e) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        GenSolvablePolynomial<C> Cp = ring.valueOf(b, e);
+        return Cp.multiply(this);
+    }
+
+
+    /**
+     * GenSolvablePolynomial multiplication. Left product with exponent vector.
+     * @param e exponent.
+     * @return x<sup>e</sup> * this, where * denotes solvable multiplication.
+     */
+    public GenSolvablePolynomial<C> multiplyLeft(ExpVector e) {
+        if (e == null || e.isZERO()) {
+            return this;
+        }
+        C b = ring.getONECoefficient();
+        return multiplyLeft(b, e);
+    }
+
+
+    /**
+     * GenSolvablePolynomial multiplication. Left product with coefficient ring
+     * element.
+     * @param b coefficient.
+     * @return b*this, where * is coefficient multiplication.
+     */
+    @Override
+    public GenSolvablePolynomial<C> multiplyLeft(C b) {
+        GenSolvablePolynomial<C> Cp = ring.getZERO();
+        if (b == null || b.isZERO()) {
+            return Cp;
+        }
+        Cp = Cp.copy();
+        Map<ExpVector, C> Cm = Cp.val; //getMap();
+        Map<ExpVector, C> Am = val;
+        for (Map.Entry<ExpVector, C> y : Am.entrySet()) {
+            ExpVector e = y.getKey();
+            C a = y.getValue();
+            C c = b.multiply(a);
+            if (!c.isZERO()) {
+                Cm.put(e, c);
+            }
+        }
+        return Cp;
+    }
+
+
+    /**
+     * GenSolvablePolynomial multiplication. Left product with 'monomial'.
+     * @param m 'monomial'.
+     * @return m * this, where * denotes solvable multiplication.
+     */
+    // new method, @NoOverride
+    public GenSolvablePolynomial<C> multiplyLeft(Map.Entry<ExpVector, C> m) {
+        if (m == null) {
+            return ring.getZERO();
+        }
+        return multiplyLeft(m.getValue(), m.getKey());
+    }
+
+
+    /**
+     * GenSolvablePolynomial multiplication. Product with 'monomial'.
+     * @param m 'monomial'.
+     * @return this * m, where * denotes solvable multiplication.
+     */
+    @Override
+    public GenSolvablePolynomial<C> multiply(Map.Entry<ExpVector, C> m) {
+        if (m == null) {
+            return ring.getZERO();
+        }
+        return multiply(m.getValue(), m.getKey());
+    }
+
+
+    /**
+     * GenSolvablePolynomial subtract a multiple.
+     * @param a coefficient.
+     * @param S GenSolvablePolynomial.
+     * @return this - a * S.
+     */
+    public GenSolvablePolynomial<C> subtractMultiple(C a, GenSolvablePolynomial<C> S) {
+        if (a == null || a.isZERO()) {
+            return this;
+        }
+        if (S == null || S.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return S.multiplyLeft(a.negate());
+        }
+        assert (ring.nvar == S.ring.nvar);
+        GenSolvablePolynomial<C> n = this.copy();
+        SortedMap<ExpVector, C> nv = n.val;
+        SortedMap<ExpVector, C> sv = S.val;
+        for (Map.Entry<ExpVector, C> me : sv.entrySet()) {
+            ExpVector f = me.getKey();
+            C y = me.getValue(); // assert y != null
+            y = a.multiply(y);
+            C x = nv.get(f);
+            if (x != null) {
+                x = x.subtract(y);
+                if (!x.isZERO()) {
+                    nv.put(f, x);
+                } else {
+                    nv.remove(f);
+                }
+            } else if (!y.isZERO()) {
+                nv.put(f, y.negate());
+            }
+        }
+        return n;
+    }
+
+
+    /**
+     * GenSolvablePolynomial subtract a multiple.
+     * @param a coefficient.
+     * @param e exponent.
+     * @param S GenSolvablePolynomial.
+     * @return this - a * x<sup>e</sup> * S.
+     */
+    public GenSolvablePolynomial<C> subtractMultiple(C a, ExpVector e, GenSolvablePolynomial<C> S) {
+        if (a == null || a.isZERO()) {
+            return this;
+        }
+        if (S == null || S.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return S.multiplyLeft(a.negate(), e);
+        }
+        assert (ring.nvar == S.ring.nvar);
+        GenSolvablePolynomial<C> n = this.copy();
+        SortedMap<ExpVector, C> nv = n.val;
+        GenSolvablePolynomial<C> s = S.multiplyLeft(e);
+        SortedMap<ExpVector, C> sv = s.val;
+        for (Map.Entry<ExpVector, C> me : sv.entrySet()) {
+            ExpVector f = me.getKey();
+            //f = e.sum(f);
+            C y = me.getValue(); // assert y != null
+            y = a.multiply(y);
+            C x = nv.get(f);
+            if (x != null) {
+                x = x.subtract(y);
+                if (!x.isZERO()) {
+                    nv.put(f, x);
+                } else {
+                    nv.remove(f);
+                }
+            } else if (!y.isZERO()) {
+                nv.put(f, y.negate());
+            }
+        }
+        return n;
+    }
+
+
+    /**
+     * GenSolvablePolynomial scale and subtract a multiple.
+     * @param b scale factor.
+     * @param a coefficient.
+     * @param S GenSolvablePolynomial.
+     * @return b * this - a * S.
+     */
+    public GenSolvablePolynomial<C> scaleSubtractMultiple(C b, C a, GenSolvablePolynomial<C> S) {
+        if (a == null || S == null) {
+            return this.multiplyLeft(b);
+        }
+        if (a.isZERO() || S.isZERO()) {
+            return this.multiplyLeft(b);
+        }
+        if (this.isZERO() || b == null || b.isZERO()) {
+            return S.multiplyLeft(a.negate());
+        }
+        if (b.isONE()) {
+            return subtractMultiple(a, S);
+        }
+        assert (ring.nvar == S.ring.nvar);
+        GenSolvablePolynomial<C> n = this.multiplyLeft(b);
+        SortedMap<ExpVector, C> nv = n.val;
+        SortedMap<ExpVector, C> sv = S.val;
+        for (Map.Entry<ExpVector, C> me : sv.entrySet()) {
+            ExpVector f = me.getKey();
+            //f = e.sum(f);
+            C y = me.getValue(); // assert y != null
+            y = a.multiply(y); // now y can be zero
+            C x = nv.get(f);
+            if (x != null) {
+                x = x.subtract(y);
+                if (!x.isZERO()) {
+                    nv.put(f, x);
+                } else {
+                    nv.remove(f);
+                }
+            } else if (!y.isZERO()) {
+                nv.put(f, y.negate());
+            }
+        }
+        return n;
+    }
+
+
+    /**
+     * GenSolvablePolynomial scale and subtract a multiple.
+     * @param b scale factor.
+     * @param a coefficient.
+     * @param e exponent.
+     * @param S GenSolvablePolynomial.
+     * @return b * this - a * x<sup>e</sup> * S.
+     */
+    public GenSolvablePolynomial<C> scaleSubtractMultiple(C b, C a, ExpVector e, GenSolvablePolynomial<C> S) {
+        if (a == null || S == null) {
+            return this.multiplyLeft(b);
+        }
+        if (a.isZERO() || S.isZERO()) {
+            return this.multiplyLeft(b);
+        }
+        if (this.isZERO() || b == null || b.isZERO()) {
+            return S.multiplyLeft(a.negate(), e);
+        }
+        if (b.isONE()) {
+            return subtractMultiple(a, e, S);
+        }
+        assert (ring.nvar == S.ring.nvar);
+        GenSolvablePolynomial<C> n = this.multiplyLeft(b);
+        SortedMap<ExpVector, C> nv = n.val;
+        GenSolvablePolynomial<C> s = S.multiplyLeft(e);
+        SortedMap<ExpVector, C> sv = s.val;
+        for (Map.Entry<ExpVector, C> me : sv.entrySet()) {
+            ExpVector f = me.getKey();
+            //f = e.sum(f);
+            C y = me.getValue(); // assert y != null
+            y = a.multiply(y); // now y can be zero
+            C x = nv.get(f);
+            if (x != null) {
+                x = x.subtract(y);
+                if (!x.isZERO()) {
+                    nv.put(f, x);
+                } else {
+                    nv.remove(f);
+                }
+            } else if (!y.isZERO()) {
+                nv.put(f, y.negate());
+            }
+        }
+        return n;
+    }
+
+
+    /**
+     * GenSolvablePolynomial scale and subtract a multiple.
+     * @param b scale factor.
+     * @param g scale exponent.
+     * @param a coefficient.
+     * @param e exponent.
+     * @param S GenSolvablePolynomial.
+     * @return a * x<sup>g</sup> * this - a * x<sup>e</sup> * S.
+     */
+    public GenSolvablePolynomial<C> scaleSubtractMultiple(C b, ExpVector g, C a, ExpVector e,
+                    GenSolvablePolynomial<C> S) {
+        if (a == null || S == null) {
+            return this.multiplyLeft(b, g);
+        }
+        if (a.isZERO() || S.isZERO()) {
+            return this.multiplyLeft(b, g);
+        }
+        if (this.isZERO() || b == null || b.isZERO()) {
+            return S.multiplyLeft(a.negate(), e);
+        }
+        if (b.isONE() && g.isZERO()) {
+            return subtractMultiple(a, e, S);
+        }
+        assert (ring.nvar == S.ring.nvar);
+        GenSolvablePolynomial<C> n = this.multiplyLeft(b, g);
+        SortedMap<ExpVector, C> nv = n.val;
+        GenSolvablePolynomial<C> s = S.multiplyLeft(e);
+        SortedMap<ExpVector, C> sv = s.val;
+        for (Map.Entry<ExpVector, C> me : sv.entrySet()) {
+            ExpVector f = me.getKey();
+            //f = e.sum(f);
+            C y = me.getValue(); // assert y != null
+            y = a.multiply(y); // y can be zero now
+            C x = nv.get(f);
+            if (x != null) {
+                x = x.subtract(y);
+                if (!x.isZERO()) {
+                    nv.put(f, x);
+                } else {
+                    nv.remove(f);
+                }
+            } else if (!y.isZERO()) {
+                nv.put(f, y.negate());
+            }
+        }
+        return n;
+    }
+
+
+    /**
+     * GenSolvablePolynomial left monic, i.e. leadingCoefficient == 1. If
+     * leadingCoefficient is not invertible returns this abs value.
+     * @return monic(this).
+     */
+    @Override
+    public GenSolvablePolynomial<C> monic() {
+        if (this.isZERO()) {
+            return this;
+        }
+        C lc = leadingBaseCoefficient();
+        if (!lc.isUnit()) {
+            return (GenSolvablePolynomial<C>) this.abs();
+        }
+        try {
+            C lm = lc.inverse();
+            //System.out.println("lm = "+lm);
+            return (GenSolvablePolynomial<C>) multiplyLeft(lm).abs();
+        } catch (NotInvertibleException e) {
+            logger.info("monic not invertible " + lc);
+            //e.printStackTrace();
+        }
+        return this;
+    }
+
+
+    /**
+     * GenSolvablePolynomial left division. Fails, if exact division by leading
+     * base coefficient is not possible. Meaningful only for univariate
+     * polynomials over fields, but works in any case.
+     * @param S nonzero GenSolvablePolynomial with invertible leading
+     *            coefficient.
+     * @return quotient with this = quotient * S + remainder and deg(remainder)
+     *         &lt; deg(S) or remiander = 0.
+     * @see edu.jas.poly.PolyUtil#baseSparsePseudoRemainder(edu.jas.poly.GenPolynomial,edu.jas.poly.GenPolynomial)
+     */
+    // cannot @Override
+    @SuppressWarnings({ "unchecked" })
+    public GenSolvablePolynomial<C> divide(GenSolvablePolynomial<C> S) {
+        return quotientRemainder(S)[0];
+    }
+
+
+    /**
+     * GenSolvablePolynomial remainder by left division. Fails, if exact
+     * division by leading base coefficient is not possible. Meaningful only for
+     * univariate polynomials over fields, but works in any case.
+     * @param S nonzero GenSolvablePolynomial with invertible leading
+     *            coefficient.
+     * @return remainder with this = quotient * S + remainder and deg(remainder)
+     *         &lt; deg(S) or remiander = 0.
+     * @see edu.jas.poly.PolyUtil#baseSparsePseudoRemainder(edu.jas.poly.GenPolynomial,edu.jas.poly.GenPolynomial)
+     */
+    // cannot @Override
+    @SuppressWarnings({ "unchecked" })
+    public GenSolvablePolynomial<C> remainder(GenSolvablePolynomial<C> S) {
+        return quotientRemainder(S)[1];
+    }
+
+
+    /**
+     * GenSolvablePolynomial left division with remainder. Fails, if exact
+     * division by leading base coefficient is not possible. Meaningful only for
+     * univariate polynomials over fields, but works in any case.
+     * @param S nonzero GenSolvablePolynomial with invertible leading
+     *            coefficient.
+     * @return [ quotient , remainder ] with this = quotient * S + remainder and
+     *         deg(remainder) &lt; deg(S) or remiander = 0.
+     * @see edu.jas.poly.PolyUtil#baseSparsePseudoRemainder(edu.jas.poly.GenPolynomial,edu.jas.poly.GenPolynomial)
+     */
+    // cannot @Override
+    @SuppressWarnings({ "unchecked" })
+    public GenSolvablePolynomial<C>[] quotientRemainder(GenSolvablePolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            throw new ArithmeticException("division by zero");
+        }
+        C c = S.leadingBaseCoefficient();
+        if (!c.isUnit()) {
+            throw new ArithmeticException("lbcf not invertible " + c);
+        }
+        C ci = c.inverse();
+        assert (ring.nvar == S.ring.nvar);
+        ExpVector e = S.leadingExpVector();
+        GenSolvablePolynomial<C> h;
+        GenSolvablePolynomial<C> q = ring.getZERO().copy();
+        GenSolvablePolynomial<C> r = this.copy();
+        while (!r.isZERO()) {
+            ExpVector f = r.leadingExpVector();
+            if (f.multipleOf(e)) {
+                C a = r.leadingBaseCoefficient();
+                //System.out.println("FDQR: f = " + f + ", a = " + a);
+                f = f.subtract(e);
+                //a = ci.multiply(a); // multiplyLeft
+                a = a.multiply(ci); // this is correct!
+                q = (GenSolvablePolynomial<C>) q.sum(a, f);
+                h = S.multiplyLeft(a, f);
+                if (!h.leadingBaseCoefficient().equals(r.leadingBaseCoefficient())) {
+                    throw new RuntimeException("something is wrong: r = " + r + ", h = " + h);
+                }
+                r = (GenSolvablePolynomial<C>) r.subtract(h);
+            } else {
+                break;
+            }
+        }
+        GenSolvablePolynomial<C>[] ret = new GenSolvablePolynomial[2];
+        ret[0] = q;
+        ret[1] = r;
+        return ret;
+    }
+
+
+    /**
+     * GenSolvablePolynomial right division. Fails, if exact division by leading
+     * base coefficient is not possible. Meaningful only for univariate
+     * polynomials over fields, but works in any case.
+     * @param S nonzero GenSolvablePolynomial with invertible leading
+     *            coefficient.
+     * @return quotient with this = S * quotient + remainder and deg(remainder)
+     *         &lt; deg(S) or remiander = 0.
+     * @see edu.jas.poly.PolyUtil#baseSparsePseudoRemainder(edu.jas.poly.GenPolynomial,edu.jas.poly.GenPolynomial)
+     */
+    @SuppressWarnings({ "unchecked" })
+    public GenSolvablePolynomial<C> rightDivide(GenSolvablePolynomial<C> S) {
+        return rightQuotientRemainder(S)[0];
+    }
+
+
+    /**
+     * GenSolvablePolynomial remainder by right division. Fails, if exact
+     * division by leading base coefficient is not possible. Meaningful only for
+     * univariate polynomials over fields, but works in any case.
+     * @param S nonzero GenSolvablePolynomial with invertible leading
+     *            coefficient.
+     * @return remainder with this = S * quotient + remainder and deg(remainder)
+     *         &lt; deg(S) or remiander = 0.
+     * @see edu.jas.poly.PolyUtil#baseSparsePseudoRemainder(edu.jas.poly.GenPolynomial,edu.jas.poly.GenPolynomial)
+     */
+    @SuppressWarnings({ "unchecked" })
+    public GenSolvablePolynomial<C> rightRemainder(GenSolvablePolynomial<C> S) {
+        return rightQuotientRemainder(S)[1];
+    }
+
+
+    /**
+     * GenSolvablePolynomial right division with remainder. Fails, if exact
+     * division by leading base coefficient is not possible. Meaningful only for
+     * univariate polynomials over fields, but works in any case.
+     * @param S nonzero GenSolvablePolynomial with invertible leading
+     *            coefficient.
+     * @return [ quotient , remainder ] with this = S * quotient + remainder and
+     *         deg(remainder) &lt; deg(S) or remainder = 0.
+     * @see edu.jas.poly.PolyUtil#baseSparsePseudoRemainder(edu.jas.poly.GenPolynomial,edu.jas.poly.GenPolynomial)
+     */
+    @SuppressWarnings({ "unchecked" })
+    public GenSolvablePolynomial<C>[] rightQuotientRemainder(GenSolvablePolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            throw new ArithmeticException("division by zero");
+        }
+        C c = S.leadingBaseCoefficient();
+        if (!c.isUnit()) {
+            throw new ArithmeticException("lbcf not invertible " + c);
+        }
+        C ci = c.inverse();
+        assert (ring.nvar == S.ring.nvar);
+        ExpVector e = S.leadingExpVector();
+        GenSolvablePolynomial<C> h;
+        GenSolvablePolynomial<C> q = ring.getZERO().copy();
+        GenSolvablePolynomial<C> r = this.copy();
+        while (!r.isZERO()) {
+            ExpVector f = r.leadingExpVector();
+            if (f.multipleOf(e)) {
+                C a = r.leadingBaseCoefficient();
+                //System.out.println("FDQR: f = " + f + ", a = " + a);
+                f = f.subtract(e);
+                //a = a.multiplyLeft(ci); // not existing
+                a = ci.multiply(a); // this is correct!
+                q = (GenSolvablePolynomial<C>) q.sum(a, f);
+                h = S.multiply(a, f);
+                if (!h.leadingBaseCoefficient().equals(r.leadingBaseCoefficient())) {
+                    throw new RuntimeException("something is wrong: r = " + r + ", h = " + h);
+                }
+                r = (GenSolvablePolynomial<C>) r.subtract(h);
+            } else {
+                break;
+            }
+        }
+        GenSolvablePolynomial<C>[] ret = new GenSolvablePolynomial[2];
+        ret[0] = q;
+        ret[1] = r;
+        return ret;
+    }
+
+
+    /**
+     * RecSolvablePolynomial right coefficients from left coefficients.
+     * <b>Note:</b> R is represented as a polynomial with left coefficients, the
+     * implementation can at the moment not distinguish between left and right
+     * coefficients.
+     * @return R = sum( X<sup>i</sup> b<sub>i</sub> ), with P =
+     *         sum(a<sub>i</sub> X<sup>i</sup> ) and eval(sum(X<sup>i</sup>
+     *         b<sub>i</sub>)) == sum(a<sub>i</sub> X<sup>i</sup>)
+     */
+    @SuppressWarnings({ "unchecked" })
+    public GenSolvablePolynomial<C> rightRecursivePolynomial() {
+        if (this.isONE() || this.isZERO()) {
+            return this;
+        }
+        if (!(this instanceof RecSolvablePolynomial)) {
+            return this;
+        }
+        RecSolvablePolynomialRing<C> rfac = (RecSolvablePolynomialRing<C>) ring;
+        if (rfac.coeffTable.isEmpty()) {
+            return this;
+        }
+        RecSolvablePolynomial<C> p = (RecSolvablePolynomial<C>) this;
+        RecSolvablePolynomial<C> R = (RecSolvablePolynomial<C>) p.rightRecursivePolynomial();
+        return (GenSolvablePolynomial<C>) R;
+    }
+
+
+    /**
+     * Evaluate RecSolvablePolynomial as right coefficients polynomial.
+     * <b>Note:</b> R is represented as a polynomial with left coefficients, the
+     * implementation can at the moment not distinguish between left and right
+     * coefficients.
+     * @return this as evaluated polynomial R. R = sum( X<sup>i</sup>
+     *         b<sub>i</sub> ), this = sum(a<sub>i</sub> X<sup>i</sup> ) =
+     *         eval(sum(X<sup>i</sup> b<sub>i</sub>))
+     */
+    @SuppressWarnings({ "unchecked" })
+    public GenSolvablePolynomial<C> evalAsRightRecursivePolynomial() {
+        if (this.isONE() || this.isZERO()) {
+            return this;
+        }
+        if (!(this instanceof RecSolvablePolynomial)) {
+            return this;
+        }
+        RecSolvablePolynomialRing<C> rfac = (RecSolvablePolynomialRing<C>) ring;
+        if (rfac.coeffTable.isEmpty()) {
+            return this;
+        }
+        RecSolvablePolynomial<C> p = (RecSolvablePolynomial<C>) this;
+        RecSolvablePolynomial<C> R = (RecSolvablePolynomial<C>) p.evalAsRightRecursivePolynomial();
+        return (GenSolvablePolynomial<C>) R;
+    }
+
+
+    /**
+     * Test RecSolvablePolynomial right coefficients polynomial. <b>Note:</b> R
+     * is represented as a polynomial with left coefficients, the implementation
+     * can at the moment not distinguish between left and right coefficients.
+     * @param R GenSolvablePolynomial with right coefficients.
+     * @return true, if R is polynomial with right coefficients of this. R =
+     *         sum( X<sup>i</sup> b<sub>i</sub> ), with this = sum(a<sub>i</sub>
+     *         X<sup>i</sup> ) and eval(sum(X<sup>i</sup> b<sub>i</sub>)) ==
+     *         sum(a<sub>i</sub> X<sup>i</sup>)
+     */
+    @SuppressWarnings({ "unchecked" })
+    public boolean isRightRecursivePolynomial(GenSolvablePolynomial<C> R) {
+        if (this.isZERO()) {
+            return R.isZERO();
+        }
+        if (this.isONE()) {
+            return R.isONE();
+        }
+        if (!(this instanceof RecSolvablePolynomial)) {
+            return !(R instanceof RecSolvablePolynomial);
+        }
+        if (!(R instanceof RecSolvablePolynomial)) {
+            return false;
+        }
+        RecSolvablePolynomialRing<C> rfac = (RecSolvablePolynomialRing<C>) ring;
+        if (rfac.coeffTable.isEmpty()) {
+            RecSolvablePolynomialRing<C> rf = (RecSolvablePolynomialRing<C>) R.ring;
+            return rf.coeffTable.isEmpty();
+        }
+        RecSolvablePolynomial<C> p = (RecSolvablePolynomial<C>) this;
+        RecSolvablePolynomial<C> q = (RecSolvablePolynomial<C>) R;
+        return p.isRightRecursivePolynomial(q);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/GenSolvablePolynomialRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/GenSolvablePolynomialRing.java
@@ -1,0 +1,814 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.kern.PrettyPrint;
+import edu.jas.kern.Scripting;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * GenSolvablePolynomialRing generic solvable polynomial factory implementing
+ * RingFactory and extending GenPolynomialRing factory. Factory for n-variate
+ * ordered solvable polynomials over C. The non-commutative multiplication
+ * relations are maintained in a relation table. Almost immutable object, except
+ * variable names and relation table contents.
+ * @param <C> coefficient type.
+ * @author Heinz Kredel
+ */
+
+public class GenSolvablePolynomialRing<C extends RingElem<C>> extends GenPolynomialRing<C> {
+
+
+    //  implements RingFactory< GenSolvablePolynomial<C> > {
+
+
+    /**
+     * The solvable multiplication relations.
+     */
+    public final RelationTable<C> table;
+
+
+    /**
+     * The constant polynomial 0 for this ring. Hides super ZERO.
+     */
+    public final GenSolvablePolynomial<C> ZERO;
+
+
+    /**
+     * The constant polynomial 1 for this ring. Hides super ONE.
+     */
+    public final GenSolvablePolynomial<C> ONE;
+
+
+    private static final Logger logger = LogManager.getLogger(GenSolvablePolynomialRing.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * default term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     */
+    public GenSolvablePolynomialRing(RingFactory<C> cf, int n) {
+        this(cf, n, new TermOrder(), null, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * default term order.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param rt solvable multiplication relations.
+     */
+    public GenSolvablePolynomialRing(RingFactory<C> cf, int n, RelationTable<C> rt) {
+        this(cf, n, new TermOrder(), null, rt);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     */
+    public GenSolvablePolynomialRing(RingFactory<C> cf, int n, TermOrder t) {
+        this(cf, n, t, null, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     * @param rt solvable multiplication relations.
+     */
+    public GenSolvablePolynomialRing(RingFactory<C> cf, int n, TermOrder t, RelationTable<C> rt) {
+        this(cf, n, t, null, rt);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     * @param v names for the variables.
+     */
+    public GenSolvablePolynomialRing(RingFactory<C> cf, int n, TermOrder t, String[] v) {
+        this(cf, n, t, v, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param t a term order.
+     * @param v names for the variables.
+     */
+    public GenSolvablePolynomialRing(RingFactory<C> cf, TermOrder t, String[] v) {
+        this(cf, v.length, t, v, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * default term order.
+     * @param cf factory for coefficients of type C.
+     * @param v names for the variables.
+     */
+    public GenSolvablePolynomialRing(RingFactory<C> cf, String[] v) {
+        this(cf, v.length, new TermOrder(), v, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     * @param v names for the variables.
+     * @param rt solvable multiplication relations.
+     */
+    public GenSolvablePolynomialRing(RingFactory<C> cf, int n, TermOrder t, String[] v, RelationTable<C> rt) {
+        super(cf, n, t, v);
+        if (rt == null) {
+            table = new RelationTable<C>(this);
+        } else {
+            table = rt;
+        }
+        ZERO = new GenSolvablePolynomial<C>(this);
+        C coeff = coFac.getONE();
+        //evzero = ExpVector.create(nvar); // from super
+        ONE = new GenSolvablePolynomial<C>(this, coeff, evzero);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the the
+     * same term order, number of variables and variable names as the given
+     * polynomial factory, only the coefficient factories differ and the
+     * solvable multiplication relations are <b>empty</b>.
+     * @param cf factory for coefficients of type C.
+     * @param o other (solvable) polynomial ring.
+     */
+    public GenSolvablePolynomialRing(RingFactory<C> cf, GenPolynomialRing o) {
+        this(cf, o.nvar, o.tord, o.getVars(), null);
+    }
+
+
+    /**
+     * Generate the relation table of the solvable polynomial ring from a
+     * relation generator.
+     * @param rg relation generator.
+     */
+    public void addRelations(RelationGenerator<C> rg) {
+        rg.generate(this);
+    }
+
+
+    /**
+     * Generate the relation table of the solvable polynomial ring from a
+     * polynomial list of relations.
+     * @param rel polynomial list of relations [..., ei, fj, pij, ... ] with ei
+     *            * fj = pij.
+     */
+    public void addRelations(List<GenPolynomial<C>> rel) {
+        table.addRelations(rel);
+    }
+
+
+    /**
+     * Generate the relation table of the solvable polynomial ring from a
+     * solvable polynomial list of relations.
+     * @param rel solvable polynomial list of relations [..., ei, fj, pij, ... ]
+     *            with ei * fj = pij.
+     */
+    public void addSolvRelations(List<GenSolvablePolynomial<C>> rel) {
+        table.addSolvRelations(rel);
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        String res = super.toString();
+        if (PrettyPrint.isTrue()) {
+            res += "\n" + table.toString(vars);
+        } else {
+            res += ", #rel = " + table.size();
+        }
+        return res;
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        StringBuffer s = new StringBuffer();
+        switch (Scripting.getLang()) {
+        case Ruby:
+            s.append("SolvPolyRing.new(");
+            break;
+        case Python:
+        default:
+            s.append("SolvPolyRing(");
+        }
+        if (coFac instanceof RingElem) {
+            s.append(((RingElem<C>) coFac).toScriptFactory());
+        } else {
+            s.append(coFac.toScript().trim());
+        }
+        s.append(",\"" + varsToString() + "\",");
+        String to = tord.toScript();
+        s.append(to);
+        if (table.size() > 0) {
+            String rel = table.toScript();
+            s.append(",rel=");
+            s.append(rel);
+        }
+        s.append(")");
+        return s.toString();
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        }
+        if (!(other instanceof GenSolvablePolynomialRing)) {
+            return false;
+        }
+        GenSolvablePolynomialRing<C> oring = (GenSolvablePolynomialRing<C>) other;
+        if (!super.equals(other)) {
+            return false;
+        }
+        // check same base relations
+        if (!table.equals(oring.table)) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Hash code for this polynomial ring.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = super.hashCode();
+        h = 37 * h + table.hashCode();
+        //System.out.println("GenSolvablePolynomialRing.hashCode: " + h);
+        return h;
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as GenSolvablePolynomial<C>.
+     */
+    @Override
+    public GenSolvablePolynomial<C> getZERO() {
+        return ZERO;
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as GenSolvablePolynomial<C>.
+     */
+    @Override
+    public GenSolvablePolynomial<C> getONE() {
+        return ONE;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true if this ring is commutative, else false.
+     */
+    @Override
+    public boolean isCommutative() {
+        if (table.isEmpty()) {
+            return super.isCommutative();
+        }
+        return false;
+    }
+
+
+    /**
+     * Query if this ring is associative. Test if the relations define an
+     * associative solvable ring.
+     * @return true, if this ring is associative, else false.
+     */
+    @SuppressWarnings("unused")
+    @Override
+    public boolean isAssociative() {
+        GenSolvablePolynomial<C> Xi, Xj, Xk, p, q;
+        for (int i = 0; i < nvar; i++) {
+            Xi = univariate(i);
+            for (int j = i + 1; j < nvar; j++) {
+                Xj = univariate(j);
+                for (int k = j + 1; k < nvar; k++) {
+                    Xk = univariate(k);
+                    p = Xk.multiply(Xj).multiply(Xi);
+                    q = Xk.multiply(Xj.multiply(Xi));
+                    if (!p.equals(q)) {
+                        if (logger.isInfoEnabled()) {
+                            logger.info("Xi = " + Xi + ", Xj = " + Xj + ", Xk = " + Xk);
+                            logger.info("p = ( Xk * Xj ) * Xi = " + p);
+                            logger.info("q = Xk * ( Xj * Xi ) = " + q);
+                        }
+                        return false;
+                    }
+                }
+            }
+        }
+        return coFac.isAssociative();
+    }
+
+
+    /**
+     * Get a (constant) GenPolynomial&lt;C&gt; element from a coefficient value.
+     * @param a coefficient.
+     * @return a GenPolynomial&lt;C&gt;.
+     */
+    @Override
+    public GenSolvablePolynomial<C> valueOf(C a) {
+        return new GenSolvablePolynomial<C>(this, a);
+    }
+
+
+    /**
+     * Get a GenPolynomial&lt;C&gt; element from an exponent vector.
+     * @param e exponent vector.
+     * @return a GenPolynomial&lt;C&gt;.
+     */
+    @Override
+    public GenSolvablePolynomial<C> valueOf(ExpVector e) {
+        return new GenSolvablePolynomial<C>(this, coFac.getONE(), e);
+    }
+
+
+    /**
+     * Get a GenPolynomial&lt;C&gt; element from a coeffcient and an exponent
+     * vector.
+     * @param a coefficient.
+     * @param e exponent vector.
+     * @return a GenPolynomial&lt;C&gt;.
+     */
+    @Override
+    public GenSolvablePolynomial<C> valueOf(C a, ExpVector e) {
+        return new GenSolvablePolynomial<C>(this, a, e);
+    }
+
+
+    /**
+     * Get a (constant) GenSolvablePolynomial&lt;C&gt; element from a long
+     * value.
+     * @param a long.
+     * @return a GenSolvablePolynomial&lt;C&gt;.
+     */
+    @Override
+    public GenSolvablePolynomial<C> fromInteger(long a) {
+        return new GenSolvablePolynomial<C>(this, coFac.fromInteger(a), evzero);
+    }
+
+
+    /**
+     * Get a (constant) GenSolvablePolynomial&lt;C&gt; element from a BigInteger
+     * value.
+     * @param a BigInteger.
+     * @return a GenSolvablePolynomial&lt;C&gt;.
+     */
+    @Override
+    public GenSolvablePolynomial<C> fromInteger(BigInteger a) {
+        return new GenSolvablePolynomial<C>(this, coFac.fromInteger(a), evzero);
+    }
+
+
+    /**
+     * Random solvable polynomial. Generates a random solvable polynomial with k
+     * = 5, l = n, d = (nvar == 1) ? n : 3, q = (nvar == 1) ? 0.7 : 0.3.
+     * @param n number of terms.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    public GenSolvablePolynomial<C> random(int n) {
+        return random(n, random);
+    }
+
+
+    /**
+     * Random solvable polynomial. Generates a random solvable polynomial with k
+     * = 5, l = n, d = (nvar == 1) ? n : 3, q = (nvar == 1) ? 0.7 : 0.3.
+     * @param n number of terms.
+     * @param rnd is a source for random bits.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    public GenSolvablePolynomial<C> random(int n, Random rnd) {
+        if (nvar == 1) {
+            return random(5, n, n, 0.7f, rnd);
+        }
+        return random(5, n, 3, 0.3f, rnd);
+    }
+
+
+    /**
+     * Generate a random solvable polynomial.
+     * @param k bitsize of random coefficients.
+     * @param l number of terms.
+     * @param d maximal degree in each variable.
+     * @param q density of nozero exponents.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    public GenSolvablePolynomial<C> random(int k, int l, int d, float q) {
+        return random(k, l, d, q, random);
+    }
+
+
+    /**
+     * Random solvable polynomial.
+     * @param k size of random coefficients.
+     * @param l number of terms.
+     * @param d maximal degree in each variable.
+     * @param q density of nozero exponents.
+     * @param rnd is a source for random bits.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    public GenSolvablePolynomial<C> random(int k, int l, int d, float q, Random rnd) {
+        GenSolvablePolynomial<C> r = getZERO(); //.clone();
+        // copy( ZERO ); 
+        // new GenPolynomial<C>( this, getZERO().val );
+        ExpVector e;
+        C a;
+        // add random coeffs and exponents
+        for (int i = 0; i < l; i++) {
+            e = ExpVector.random(nvar, d, q, rnd);
+            a = coFac.random(k, rnd);
+            r = (GenSolvablePolynomial<C>) r.sum(a, e);
+            // somewhat inefficient but clean
+        }
+        return r;
+    }
+
+
+    /**
+     * Copy polynomial c.
+     * @param c
+     * @return a copy of c.
+     */
+    public GenSolvablePolynomial<C> copy(GenSolvablePolynomial<C> c) {
+        return new GenSolvablePolynomial<C>(this, c.val);
+    }
+
+
+    /**
+     * Parse a solvable polynomial with the use of GenPolynomialTokenizer
+     * @param s String.
+     * @return GenSolvablePolynomial from s.
+     */
+    @Override
+    public GenSolvablePolynomial<C> parse(String s) {
+        //return getZERO();
+        return parse(new StringReader(s));
+    }
+
+
+    /**
+     * Parse a solvable polynomial with the use of GenPolynomialTokenizer
+     * @param r Reader.
+     * @return next GenSolvablePolynomial from r.
+     */
+    @Override
+    @SuppressWarnings({ "unchecked", "cast" })
+    public GenSolvablePolynomial<C> parse(Reader r) {
+        GenPolynomialTokenizer pt = new GenPolynomialTokenizer(this, r);
+        GenSolvablePolynomial<C> p = null;
+        try {
+            p = (GenSolvablePolynomial<C>) pt.nextSolvablePolynomial();
+        } catch (IOException e) {
+            logger.error(e.toString() + " parse " + this);
+            p = ZERO;
+        }
+        return p;
+    }
+
+
+    /**
+     * Generate univariate solvable polynomial in a given variable.
+     * @param i the index of the variable.
+     * @return X_i as solvable univariate polynomial.
+     */
+    @Override
+    public GenSolvablePolynomial<C> univariate(int i) {
+        return (GenSolvablePolynomial<C>) super.univariate(i);
+    }
+
+
+    /**
+     * Generate univariate solvable polynomial in a given variable with given
+     * exponent.
+     * @param i the index of the variable.
+     * @param e the exponent of the variable.
+     * @return X_i^e as solvable univariate polynomial.
+     */
+    @Override
+    public GenSolvablePolynomial<C> univariate(int i, long e) {
+        return (GenSolvablePolynomial<C>) super.univariate(i, e);
+    }
+
+
+    /**
+     * Generate univariate solvable polynomial in a given variable with given
+     * exponent.
+     * @param modv number of module variables.
+     * @param i the index of the variable.
+     * @param e the exponent of the variable.
+     * @return X_i^e as solvable univariate polynomial.
+     */
+    @Override
+    public GenSolvablePolynomial<C> univariate(int modv, int i, long e) {
+        return (GenSolvablePolynomial<C>) super.univariate(modv, i, e);
+    }
+
+
+    /**
+     * Generate list of univariate polynomials in all variables.
+     * @return List(X_1,...,X_n) a list of univariate polynomials.
+     */
+    @Override
+    public List<? extends GenSolvablePolynomial<C>> univariateList() {
+        //return castToSolvableList( super.univariateList() );
+        return univariateList(0, 1L);
+    }
+
+
+    /**
+     * Generate list of univariate polynomials in all variables.
+     * @param modv number of module variables.
+     * @return List(X_1,...,X_n) a list of univariate polynomials.
+     */
+    @Override
+    public List<? extends GenSolvablePolynomial<C>> univariateList(int modv) {
+        return univariateList(modv, 1L);
+    }
+
+
+    /**
+     * Generate list of univariate polynomials in all variables with given
+     * exponent.
+     * @param modv number of module variables.
+     * @param e the exponent of the variables.
+     * @return List(X_1^e,...,X_n^e) a list of univariate polynomials.
+     */
+    @Override
+    public List<? extends GenSolvablePolynomial<C>> univariateList(int modv, long e) {
+        List<GenSolvablePolynomial<C>> pols = new ArrayList<GenSolvablePolynomial<C>>(nvar);
+        int nm = nvar - modv;
+        for (int i = 0; i < nm; i++) {
+            GenSolvablePolynomial<C> p = univariate(modv, nm - 1 - i, e);
+            pols.add(p);
+        }
+        return pols;
+    }
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by i. New variables commute with the exiting variables.
+     * @param i number of variables to extend.
+     * @return extended solvable polynomial ring factory.
+     */
+    @Override
+    public GenSolvablePolynomialRing<C> extend(int i) {
+        return extend(i,false);
+    }
+
+    
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by i. New variables commute with the exiting variables.
+     * @param i number of variables to extend.
+     * @param top true for TOP term order, false for POT term order.
+     * @return extended solvable polynomial ring factory.
+     */
+    @Override
+    public GenSolvablePolynomialRing<C> extend(int i, boolean top) {
+        GenPolynomialRing<C> pfac = super.extend(i, top);
+        GenSolvablePolynomialRing<C> spfac = new GenSolvablePolynomialRing<C>(pfac.coFac, pfac.nvar,
+                        pfac.tord, pfac.vars);
+        spfac.table.extend(this.table);
+        return spfac;
+    }
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by length(vn). New variables commute with the exiting
+     * variables.
+     * @param vn names for extended variables.
+     * @return extended polynomial ring factory.
+     */
+    @Override
+    public GenSolvablePolynomialRing<C> extend(String[] vn) {
+        return extend(vn, false);
+    }
+
+    
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by length(vn). New variables commute with the exiting
+     * variables.
+     * @param vn names for extended variables.
+     * @param top true for TOP term order, false for POT term order.
+     * @return extended polynomial ring factory.
+     */
+    @Override
+    public GenSolvablePolynomialRing<C> extend(String[] vn, boolean top) {
+        GenPolynomialRing<C> pfac = super.extend(vn, top);
+        GenSolvablePolynomialRing<C> spfac = new GenSolvablePolynomialRing<C>(pfac.coFac, pfac.nvar,
+                        pfac.tord, pfac.vars);
+        //GenSolvablePolynomialRing<C> spfac = new GenSolvablePolynomialRing<C>(pfac.coFac, pfac);
+        spfac.table.extend(this.table);
+        return spfac;
+    }
+
+
+    /**
+     * Contract variables. Used e.g. in module embedding. Contract number of
+     * variables by i.
+     * @param i number of variables to remove.
+     * @return contracted solvable polynomial ring factory.
+     */
+    @Override
+    public GenSolvablePolynomialRing<C> contract(int i) {
+        GenPolynomialRing<C> pfac = super.contract(i);
+        GenSolvablePolynomialRing<C> spfac = new GenSolvablePolynomialRing<C>(pfac.coFac, pfac.nvar,
+                        pfac.tord, pfac.vars);
+        spfac.table.contract(this.table);
+        return spfac;
+    }
+
+
+    /**
+     * Reverse variables. Used e.g. in opposite rings.
+     * @return solvable polynomial ring factory with reversed variables.
+     */
+    @Override
+    public GenSolvablePolynomialRing<C> reverse() {
+        return reverse(false);
+    }
+
+
+    /**
+     * Reverse variables. Used e.g. in opposite rings.
+     * @param partial true for partialy reversed term orders.
+     * @return solvable polynomial ring factory with reversed variables.
+     */
+    @Override
+    public GenSolvablePolynomialRing<C> reverse(boolean partial) {
+        GenPolynomialRing<C> pfac = super.reverse(partial);
+        GenSolvablePolynomialRing<C> spfac = new GenSolvablePolynomialRing<C>(pfac.coFac, pfac.nvar,
+                        pfac.tord, pfac.vars);
+        spfac.partial = partial;
+        spfac.table.reverse(this.table);
+        return spfac;
+    }
+
+
+    /**
+     * Recursive representation as polynomial ring with i main variables.
+     * @param i number of main variables.
+     * @return recursive polynomial ring factory.
+     */
+    @Override
+    public GenSolvablePolynomialRing<GenPolynomial<C>> recursive(int i) {
+        if (i <= 0 || i >= nvar) {
+            throw new IllegalArgumentException("wrong: 0 < " + i + " < " + nvar);
+        }
+        GenSolvablePolynomialRing<C> cfac = contract(i);
+        //System.out.println("cvars = " + Arrays.toString(cfac.vars));
+        //System.out.println("vars = " + Arrays.toString(vars));
+        String[] v = null;
+        if (vars != null) {
+            v = new String[i];
+            int k = 0;
+            for (int j = nvar - i; j < nvar; j++) {
+                v[k++] = vars[j];
+            }
+        }
+        //System.out.println("v = " + Arrays.toString(v));
+        TermOrder to = tord.contract(0, i); // ??
+        RecSolvablePolynomialRing<C> pfac = new RecSolvablePolynomialRing<C>(cfac, i, to, v);
+        //System.out.println("pfac = " + pfac.toScript());
+        pfac.table.recursive(table);
+        pfac.coeffTable.recursive(table);
+        return pfac;
+    }
+
+
+    /**
+     * Distributive representation as polynomial with all main variables.
+     * @return distributive polynomial ring factory.
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    @Override
+    public GenSolvablePolynomialRing<C> distribute() {
+        if (!(coFac instanceof GenPolynomialRing)) {
+            return this;
+        }
+        RingFactory cf = coFac;
+        RingFactory<GenPolynomial<C>> cfp = (RingFactory<GenPolynomial<C>>) cf;
+        GenPolynomialRing cr = (GenPolynomialRing) cfp;
+        //System.out.println("cr = " + cr.toScript());
+        GenPolynomialRing<C> fac;
+        if (cr.vars != null) {
+            fac = cr.extend(vars);
+        } else {
+            fac = cr.extend(nvar);
+        }
+        //System.out.println("fac = " + fac.toScript());
+        // fac could be a commutative polynomial ring, coefficient relations
+        GenSolvablePolynomialRing<C> pfac = new GenSolvablePolynomialRing<C>(fac.coFac, fac.nvar, this.tord,
+                        fac.vars);
+        //System.out.println("pfac = " + pfac.toScript());
+        if (fac instanceof GenSolvablePolynomialRing) {
+            GenSolvablePolynomialRing<C> sfac = (GenSolvablePolynomialRing<C>) fac;
+            List<GenSolvablePolynomial<C>> rlc = sfac.table.relationList();
+            pfac.table.addSolvRelations(rlc);
+            //System.out.println("pfac = " + pfac.toScript());
+        }
+        // main relations
+        List<GenPolynomial<GenPolynomial<C>>> rl = (List<GenPolynomial<GenPolynomial<C>>>) (List) PolynomialList
+                        .castToList(table.relationList());
+        List<GenPolynomial<C>> rld = PolyUtil.<C> distribute(pfac, rl);
+        pfac.table.addRelations(rld);
+        //System.out.println("pfac = " + pfac.toScript());
+        // coeffTable not avaliable here
+        return pfac;
+    }
+
+
+    /**
+     * Permutation of polynomial ring variables.
+     * @param P permutation, must be compatible with the commutator relations.
+     * @return P(this).
+     */
+    @Override
+    public GenPolynomialRing<C> permutation(List<Integer> P) {
+        GenPolynomialRing<C> pfac = super.permutation(P);
+        GenSolvablePolynomialRing<C> spfac;
+        spfac = new GenSolvablePolynomialRing<C>(pfac.coFac, pfac.nvar, pfac.tord, pfac.vars);
+        List<GenSolvablePolynomial<C>> rl = this.table.relationList();
+        PolynomialList<C> prl = new PolynomialList<C>(spfac,rl);
+        List<GenPolynomial<C>> pl = prl.getList();
+        pl = TermOrderOptimization.permutation(P, spfac, pl);
+        spfac.table.addRelations(pl);
+        return spfac;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/GenWordPolynomial.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/GenWordPolynomial.java
@@ -1,0 +1,1601 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.kern.PreemptingException;
+import edu.jas.structure.NotInvertibleException;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.UnaryFunctor;
+
+
+/**
+ * GenWordPolynomial generic polynomials implementing RingElem. Non-commutative
+ * string polynomials over C. Objects of this class are intended to be
+ * immutable. The implementation is based on TreeMap respectively SortedMap from
+ * words to coefficients. Only the coefficients are modeled with generic types,
+ * the "exponents" are fixed to Word. C can also be a non integral domain, e.g.
+ * a ModInteger, i.e. it may contain zero divisors, since multiply() does check
+ * for zeros.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+public final class GenWordPolynomial<C extends RingElem<C>>
+                implements RingElem<GenWordPolynomial<C>>, Iterable<WordMonomial<C>> {
+
+
+    /**
+     * The factory for the polynomial ring.
+     */
+    public final GenWordPolynomialRing<C> ring;
+
+
+    /**
+     * The data structure for polynomials.
+     */
+    final SortedMap<Word, C> val; // do not change to TreeMap
+
+
+    private static final Logger logger = LogManager.getLogger(GenWordPolynomial.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    // protected GenWordPolynomial() { ring = null; val = null; } // don't use
+
+
+    /**
+     * Private constructor for GenWordPolynomial.
+     * @param r polynomial ring factory.
+     * @param t TreeMap with correct ordering.
+     */
+    private GenWordPolynomial(GenWordPolynomialRing<C> r, TreeMap<Word, C> t) {
+        ring = r;
+        val = t;
+        if (ring.checkPreempt) {
+            if (Thread.currentThread().isInterrupted()) {
+                logger.debug("throw PreemptingException");
+                throw new PreemptingException();
+            }
+        }
+    }
+
+
+    /**
+     * Constructor for zero GenWordPolynomial.
+     * @param r polynomial ring factory.
+     */
+    public GenWordPolynomial(GenWordPolynomialRing<C> r) {
+        this(r, new TreeMap<Word, C>(r.alphabet.getDescendComparator()));
+    }
+
+
+    /**
+     * Constructor for GenWordPolynomial c * x<sup>e</sup>.
+     * @param r polynomial ring factory.
+     * @param c coefficient.
+     * @param e word.
+     */
+    public GenWordPolynomial(GenWordPolynomialRing<C> r, C c, Word e) {
+        this(r);
+        if (!c.isZERO()) {
+            val.put(e, c);
+        }
+    }
+
+
+    /**
+     * Constructor for GenWordPolynomial c * x<sup>0</sup>.
+     * @param r polynomial ring factory.
+     * @param c coefficient.
+     */
+    public GenWordPolynomial(GenWordPolynomialRing<C> r, C c) {
+        this(r, c, r.wone);
+    }
+
+
+    /**
+     * Constructor for GenWordPolynomial x<sup>e</sup>.
+     * @param r polynomial ring factory.
+     * @param e word.
+     */
+    public GenWordPolynomial(GenWordPolynomialRing<C> r, Word e) {
+        this(r, r.coFac.getONE(), e);
+    }
+
+
+    /**
+     * Constructor for GenWordPolynomial x<sup>e</sup>.
+     * @param r polynomial ring factory.
+     * @param e exponent vector.
+     */
+    public GenWordPolynomial(GenWordPolynomialRing<C> r, ExpVector e) {
+        this(r, r.coFac.getONE(), r.alphabet.valueOf(e));
+    }
+
+
+    /**
+     * Constructor for GenWordPolynomial c * x<sup>e</sup>.
+     * @param r polynomial ring factory.
+     * @param c coefficient.
+     * @param e exponent vector.
+     */
+    public GenWordPolynomial(GenWordPolynomialRing<C> r, C c, ExpVector e) {
+        this(r, c, r.alphabet.valueOf(e));
+    }
+
+
+    /**
+     * Constructor for GenWordPolynomial.
+     * @param r polynomial ring factory.
+     * @param v the SortedMap of some other polynomial.
+     */
+    protected GenWordPolynomial(GenWordPolynomialRing<C> r, SortedMap<Word, C> v) {
+        this(r);
+        val.putAll(v); // assume no zero coefficients
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public GenWordPolynomialRing<C> factory() {
+        return ring;
+    }
+
+
+    /**
+     * Copy this GenWordPolynomial.
+     * @return copy of this.
+     */
+    public GenWordPolynomial<C> copy() {
+        return new GenWordPolynomial<C>(ring, this.val);
+    }
+
+
+    /**
+     * Length of GenWordPolynomial.
+     * @return number of coefficients of this GenWordPolynomial.
+     */
+    public int length() {
+        return val.size();
+    }
+
+
+    /**
+     * Word to coefficient map of GenWordPolynomial.
+     * @return val as unmodifiable SortedMap.
+     */
+    public SortedMap<Word, C> getMap() {
+        // return val;
+        return Collections.<Word, C> unmodifiableSortedMap(val);
+    }
+
+
+    /**
+     * Put a Word to coefficient entry into the internal map of this
+     * GenWordPolynomial. <b>Note:</b> Do not use this method unless you are
+     * constructing a new polynomial. this is modified and breaks the
+     * immutability promise of this class.
+     * @param c coefficient.
+     * @param e word.
+     */
+    public void doPutToMap(Word e, C c) {
+        if (debug) {
+            C a = val.get(e);
+            if (a != null) {
+                logger.error("map entry exists " + e + " to " + a + " new " + c);
+            }
+        }
+        if (!c.isZERO()) {
+            val.put(e, c);
+        }
+    }
+
+
+    /**
+     * Remove a Word to coefficient entry from the internal map of this
+     * GenWordPolynomial. <b>Note:</b> Do not use this method unless you are
+     * constructing a new polynomial. this is modified and breaks the
+     * immutability promise of this class.
+     * @param e Word.
+     * @param c expected coefficient, null for ignore.
+     */
+    public void doRemoveFromMap(Word e, C c) {
+        C b = val.remove(e);
+        if (debug) {
+            if (c == null) { // ignore b
+                return;
+            }
+            if (!c.equals(b)) {
+                logger.error("map entry wrong " + e + " to " + c + " old " + b);
+            }
+        }
+    }
+
+
+    /**
+     * Put an a sorted map of words to coefficients into the internal map of
+     * this GenWordPolynomial. <b>Note:</b> Do not use this method unless you
+     * are constructing a new polynomial. this is modified and breaks the
+     * immutability promise of this class.
+     * @param vals sorted map of wordss and coefficients.
+     */
+    public void doPutToMap(SortedMap<Word, C> vals) {
+        for (Map.Entry<Word, C> me : vals.entrySet()) {
+            Word e = me.getKey();
+            if (debug) {
+                C a = val.get(e);
+                if (a != null) {
+                    logger.error("map entry exists " + e + " to " + a + " new " + me.getValue());
+                }
+            }
+            C c = me.getValue();
+            if (!c.isZERO()) {
+                val.put(e, c);
+            }
+        }
+    }
+
+
+    /**
+     * String representation of GenWordPolynomial.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        if (isZERO()) {
+            return "0";
+        }
+        if (isONE()) {
+            return "1";
+        }
+        StringBuffer s = new StringBuffer();
+        if (val.size() > 1) {
+            s.append("( ");
+        }
+        boolean parenthesis = false;
+        boolean first = true;
+        for (Map.Entry<Word, C> m : val.entrySet()) {
+            C c = m.getValue();
+            if (first) {
+                first = false;
+            } else {
+                if (c.signum() < 0) {
+                    s.append(" - ");
+                    c = c.negate();
+                } else {
+                    s.append(" + ");
+                }
+            }
+            Word e = m.getKey();
+            if (!c.isONE() || e.isONE()) {
+                if (parenthesis) {
+                    s.append("( ");
+                }
+                String cs = c.toString();
+                if (cs.indexOf("+") >= 0 || cs.indexOf("-") >= 0) {
+                    s.append("( " + cs + " )");
+                } else {
+                    s.append(cs);
+                }
+                if (parenthesis) {
+                    s.append(" )");
+                }
+                if (!e.isONE()) {
+                    s.append(" ");
+                }
+            }
+            s.append(e.toString());
+        }
+        if (val.size() > 1) {
+            s.append(" )");
+        }
+        return s.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        if (isZERO()) {
+            return "0";
+        }
+        if (isONE()) {
+            return "1";
+        }
+        StringBuffer s = new StringBuffer();
+        if (val.size() > 1) {
+            s.append("( ");
+        }
+        final boolean parenthesis = false;
+        boolean first = true;
+        for (Map.Entry<Word, C> m : val.entrySet()) {
+            C c = m.getValue();
+            if (first) {
+                first = false;
+            } else {
+                if (c.signum() < 0) {
+                    s.append(" - ");
+                    c = c.negate();
+                } else {
+                    s.append(" + ");
+                }
+            }
+            Word e = m.getKey();
+            if (!c.isONE() || e.isONE()) {
+                if (parenthesis) {
+                    s.append("( ");
+                }
+                String cs = c.toScript();
+                if (cs.indexOf("+") >= 0 || cs.indexOf("-") >= 0) {
+                    s.append("( " + cs + " )");
+                } else {
+                    s.append(cs);
+                }
+                if (parenthesis) {
+                    s.append(" )");
+                }
+                if (!e.isONE()) {
+                    s.append(" * ");
+                }
+            }
+            s.append(e.toScript());
+        }
+        if (val.size() > 1) {
+            s.append(" )");
+        }
+        return s.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python case
+        return factory().toScript();
+    }
+
+
+    /**
+     * Is GenWordPolynomial&lt;C&gt; zero.
+     * @return If this is 0 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isZERO()
+     */
+    public boolean isZERO() {
+        return (val.size() == 0);
+    }
+
+
+    /**
+     * Is GenWordPolynomial&lt;C&gt; one.
+     * @return If this is 1 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isONE()
+     */
+    public boolean isONE() {
+        if (val.size() != 1) {
+            return false;
+        }
+        C c = val.get(ring.wone);
+        if (c == null) {
+            return false;
+        }
+        return c.isONE();
+    }
+
+
+    /**
+     * Is GenWordPolynomial&lt;C&gt; a unit.
+     * @return If this is a unit then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isUnit()
+     */
+    public boolean isUnit() {
+        if (val.size() != 1) {
+            return false;
+        }
+        C c = val.get(ring.wone);
+        if (c == null) {
+            return false;
+        }
+        return c.isUnit();
+    }
+
+
+    /**
+     * Is GenWordPolynomial&lt;C&gt; a constant.
+     * @return If this is a constant polynomial then true is returned, else
+     *         false.
+     */
+    public boolean isConstant() {
+        if (val.size() != 1) {
+            return false;
+        }
+        C c = val.get(ring.wone);
+        if (c == null) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Is GenWordPolynomial&lt;C&gt; homogeneous.
+     * @return true, if this is homogeneous, else false.
+     */
+    public boolean isHomogeneous() {
+        if (val.size() <= 1) {
+            return true;
+        }
+        long deg = -1;
+        for (Word e : val.keySet()) {
+            if (deg < 0) {
+                deg = e.degree();
+            } else if (deg != e.degree()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object B) {
+        if (B == null) {
+            return false;
+        }
+        if (!(B instanceof GenWordPolynomial)) {
+            return false;
+        }
+        GenWordPolynomial<C> a = (GenWordPolynomial<C>) B;
+        return this.compareTo(a) == 0;
+    }
+
+
+    /**
+     * Hash code for this polynomial.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = (ring.hashCode() << 27);
+        h += val.hashCode();
+        return h;
+    }
+
+
+    /**
+     * GenWordPolynomial comparison.
+     * @param b GenWordPolynomial.
+     * @return sign(this-b).
+     */
+    public int compareTo(GenWordPolynomial<C> b) {
+        if (b == null) {
+            return 1;
+        }
+        SortedMap<Word, C> av = this.val;
+        SortedMap<Word, C> bv = b.val;
+        Iterator<Map.Entry<Word, C>> ai = av.entrySet().iterator();
+        Iterator<Map.Entry<Word, C>> bi = bv.entrySet().iterator();
+        int s = 0;
+        int c = 0;
+        while (ai.hasNext() && bi.hasNext()) {
+            Map.Entry<Word, C> aie = ai.next();
+            Map.Entry<Word, C> bie = bi.next();
+            Word ae = aie.getKey();
+            Word be = bie.getKey();
+            s = ae.compareTo(be);
+            //System.out.println("s = " + s + ", " + ae + ", " +be);
+            if (s != 0) {
+                return s;
+            }
+            if (c == 0) {
+                C ac = aie.getValue(); //av.get(ae);
+                C bc = bie.getValue(); //bv.get(be);
+                c = ac.compareTo(bc);
+            }
+        }
+        if (ai.hasNext()) {
+            return 1;
+        }
+        if (bi.hasNext()) {
+            return -1;
+        }
+        // now all keys are equal
+        return c;
+    }
+
+
+    /**
+     * GenWordPolynomial signum.
+     * @return sign(ldcf(this)).
+     */
+    public int signum() {
+        if (this.isZERO()) {
+            return 0;
+        }
+        Word t = val.firstKey();
+        C c = val.get(t);
+        return c.signum();
+    }
+
+
+    /**
+     * Number of variables.
+     * @return ring.alphabet.length().
+     */
+    public int numberOfVariables() {
+        return ring.alphabet.length();
+    }
+
+
+    /**
+     * Leading monomial.
+     * @return first map entry.
+     */
+    public Map.Entry<Word, C> leadingMonomial() {
+        if (val.size() == 0)
+            return null;
+        Iterator<Map.Entry<Word, C>> ai = val.entrySet().iterator();
+        return ai.next();
+    }
+
+
+    /**
+     * Leading word.
+     * @return first highest word.
+     */
+    public Word leadingWord() {
+        if (val.size() == 0) {
+            return ring.wone; // null? needs changes? 
+        }
+        return val.firstKey();
+    }
+
+
+    /**
+     * Trailing word.
+     * @return last lowest word.
+     */
+    public Word trailingWord() {
+        if (val.size() == 0) {
+            return ring.wone; // or null ?;
+        }
+        return val.lastKey();
+    }
+
+
+    /**
+     * Leading base coefficient.
+     * @return first coefficient.
+     */
+    public C leadingBaseCoefficient() {
+        if (val.size() == 0) {
+            return ring.coFac.getZERO();
+        }
+        return val.get(val.firstKey());
+    }
+
+
+    /**
+     * Trailing base coefficient.
+     * @return coefficient of constant term.
+     */
+    public C trailingBaseCoefficient() {
+        C c = val.get(ring.wone);
+        if (c == null) {
+            return ring.coFac.getZERO();
+        }
+        return c;
+    }
+
+
+    /**
+     * Coefficient.
+     * @param e word.
+     * @return coefficient for given word.
+     */
+    public C coefficient(Word e) {
+        C c = val.get(e);
+        if (c == null) {
+            c = ring.coFac.getZERO();
+        }
+        return c;
+    }
+
+
+    /**
+     * Reductum.
+     * @return this - leading monomial.
+     */
+    public GenWordPolynomial<C> reductum() {
+        if (val.size() <= 1) {
+            return ring.getZERO();
+        }
+        Iterator<Word> ai = val.keySet().iterator();
+        Word lt = ai.next();
+        lt = ai.next(); // size > 1
+        SortedMap<Word, C> red = val.tailMap(lt);
+        return new GenWordPolynomial<C>(ring, red);
+    }
+
+
+    /**
+     * Maximal degree.
+     * @return maximal degree in any variables.
+     */
+    public long degree() {
+        if (val.size() == 0) {
+            return 0; // 0 or -1 ?;
+        }
+        long deg = 0;
+        for (Word e : val.keySet()) {
+            long d = e.degree();
+            if (d > deg) {
+                deg = d;
+            }
+        }
+        return deg;
+    }
+
+
+    /**
+     * GenWordPolynomial maximum norm.
+     * @return ||this||.
+     */
+    public C maxNorm() {
+        C n = ring.getZEROCoefficient();
+        for (C c : val.values()) {
+            C x = c.abs();
+            if (n.compareTo(x) < 0) {
+                n = x;
+            }
+        }
+        return n;
+    }
+
+
+    /**
+     * GenWordPolynomial sum norm.
+     * @return sum of all absolute values of coefficients.
+     */
+    public C sumNorm() {
+        C n = ring.getZEROCoefficient();
+        for (C c : val.values()) {
+            C x = c.abs();
+            n = n.sum(x);
+        }
+        return n;
+    }
+
+
+    /**
+     * GenWordPolynomial summation.
+     * @param S GenWordPolynomial.
+     * @return this+S.
+     */
+    public GenWordPolynomial<C> sum(GenWordPolynomial<C> S) {
+        if (S == null) {
+            return this;
+        }
+        if (S.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return S;
+        }
+        assert (ring.alphabet == S.ring.alphabet);
+        GenWordPolynomial<C> n = this.copy(); //new GenWordPolynomial<C>(ring, val); 
+        SortedMap<Word, C> nv = n.val;
+        SortedMap<Word, C> sv = S.val;
+        for (Map.Entry<Word, C> me : sv.entrySet()) {
+            Word e = me.getKey();
+            C y = me.getValue(); //sv.get(e); // assert y != null
+            C x = nv.get(e);
+            if (x != null) {
+                x = x.sum(y);
+                if (!x.isZERO()) {
+                    nv.put(e, x);
+                } else {
+                    nv.remove(e);
+                }
+            } else {
+                nv.put(e, y);
+            }
+        }
+        return n;
+    }
+
+
+    /**
+     * GenWordPolynomial addition. This method is not very efficient, since this
+     * is copied.
+     * @param a coefficient.
+     * @param e word.
+     * @return this + a e.
+     */
+    public GenWordPolynomial<C> sum(C a, Word e) {
+        if (a == null) {
+            return this;
+        }
+        if (a.isZERO()) {
+            return this;
+        }
+        GenWordPolynomial<C> n = this.copy(); //new GenWordPolynomial<C>(ring, val); 
+        SortedMap<Word, C> nv = n.val;
+        C x = nv.get(e);
+        if (x != null) {
+            x = x.sum(a);
+            if (!x.isZERO()) {
+                nv.put(e, x);
+            } else {
+                nv.remove(e);
+            }
+        } else {
+            nv.put(e, a);
+        }
+        return n;
+    }
+
+
+    /**
+     * GenWordPolynomial addition. This method is not very efficient, since this
+     * is copied.
+     * @param a coefficient.
+     * @return this + a x<sup>0</sup>.
+     */
+    public GenWordPolynomial<C> sum(C a) {
+        return sum(a, ring.wone);
+    }
+
+
+    /**
+     * GenWordPolynomial subtraction.
+     * @param S GenWordPolynomial.
+     * @return this-S.
+     */
+    public GenWordPolynomial<C> subtract(GenWordPolynomial<C> S) {
+        if (S == null) {
+            return this;
+        }
+        if (S.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return S.negate();
+        }
+        assert (ring.alphabet == S.ring.alphabet);
+        GenWordPolynomial<C> n = this.copy(); //new GenWordPolynomial<C>(ring, val); 
+        SortedMap<Word, C> nv = n.val;
+        SortedMap<Word, C> sv = S.val;
+        for (Map.Entry<Word, C> me : sv.entrySet()) {
+            Word e = me.getKey();
+            C y = me.getValue(); //sv.get(e); // assert y != null
+            C x = nv.get(e);
+            if (x != null) {
+                x = x.subtract(y);
+                if (!x.isZERO()) {
+                    nv.put(e, x);
+                } else {
+                    nv.remove(e);
+                }
+            } else {
+                nv.put(e, y.negate());
+            }
+        }
+        return n;
+    }
+
+
+    /**
+     * GenWordPolynomial subtraction. This method is not very efficient, since
+     * this is copied.
+     * @param a coefficient.
+     * @param e word.
+     * @return this - a e.
+     */
+    public GenWordPolynomial<C> subtract(C a, Word e) {
+        if (a == null) {
+            return this;
+        }
+        if (a.isZERO()) {
+            return this;
+        }
+        GenWordPolynomial<C> n = this.copy(); //new GenWordPolynomial<C>(ring, val); 
+        SortedMap<Word, C> nv = n.val;
+        C x = nv.get(e);
+        if (x != null) {
+            x = x.subtract(a);
+            if (!x.isZERO()) {
+                nv.put(e, x);
+            } else {
+                nv.remove(e);
+            }
+        } else {
+            nv.put(e, a.negate());
+        }
+        return n;
+    }
+
+
+    /**
+     * GenWordPolynomial subtract. This method is not very efficient, since this
+     * is copied.
+     * @param a coefficient.
+     * @return this + a x<sup>0</sup>.
+     */
+    public GenWordPolynomial<C> subtract(C a) {
+        return subtract(a, ring.wone);
+    }
+
+
+    /**
+     * GenWordPolynomial negation.
+     * @return -this.
+     */
+    public GenWordPolynomial<C> negate() {
+        GenWordPolynomial<C> n = ring.getZERO().copy();
+        SortedMap<Word, C> v = n.val;
+        for (Map.Entry<Word, C> m : val.entrySet()) {
+            C x = m.getValue(); // != null, 0
+            v.put(m.getKey(), x.negate());
+        }
+        return n;
+    }
+
+
+    /**
+     * GenWordPolynomial absolute value, i.e. leadingCoefficient &gt; 0.
+     * @return abs(this).
+     */
+    public GenWordPolynomial<C> abs() {
+        if (leadingBaseCoefficient().signum() < 0) {
+            return this.negate();
+        }
+        return this;
+    }
+
+
+    /**
+     * GenWordPolynomial multiplication.
+     * @param S GenWordPolynomial.
+     * @return this*S.
+     */
+    public GenWordPolynomial<C> multiply(GenWordPolynomial<C> S) {
+        if (S == null) {
+            return ring.getZERO();
+        }
+        if (S.isZERO()) {
+            return ring.getZERO();
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        assert (ring.alphabet == S.ring.alphabet) : " " + ring + " != " + S.ring;
+        GenWordPolynomial<C> p = ring.getZERO().copy();
+        SortedMap<Word, C> pv = p.val;
+        for (Map.Entry<Word, C> m1 : val.entrySet()) {
+            C c1 = m1.getValue();
+            Word e1 = m1.getKey();
+            for (Map.Entry<Word, C> m2 : S.val.entrySet()) {
+                C c2 = m2.getValue();
+                Word e2 = m2.getKey();
+                C c = c1.multiply(c2); // check non zero if not domain
+                if (!c.isZERO()) {
+                    Word e = e1.multiply(e2);
+                    C c0 = pv.get(e);
+                    if (c0 == null) {
+                        pv.put(e, c);
+                    } else {
+                        c0 = c0.sum(c);
+                        if (!c0.isZERO()) {
+                            pv.put(e, c0);
+                        } else {
+                            pv.remove(e);
+                        }
+                    }
+                }
+            }
+        }
+        return p;
+    }
+
+
+    /**
+     * GenWordPolynomial left and right multiplication. Product with two
+     * polynomials.
+     * @param S GenWordPolynomial.
+     * @param T GenWordPolynomial.
+     * @return S*this*T.
+     */
+    public GenWordPolynomial<C> multiply(GenWordPolynomial<C> S, GenWordPolynomial<C> T) {
+        if (S.isZERO() || T.isZERO()) {
+            return ring.getZERO();
+        }
+        if (S.isONE()) {
+            return multiply(T);
+        }
+        if (T.isONE()) {
+            return S.multiply(this);
+        }
+        return S.multiply(this).multiply(T);
+    }
+
+
+    /**
+     * GenWordPolynomial multiplication. Product with coefficient ring element.
+     * @param s coefficient.
+     * @return this*s.
+     */
+    public GenWordPolynomial<C> multiply(C s) {
+        if (s == null) {
+            return ring.getZERO();
+        }
+        if (s.isZERO()) {
+            return ring.getZERO();
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        GenWordPolynomial<C> p = ring.getZERO().copy();
+        SortedMap<Word, C> pv = p.val;
+        for (Map.Entry<Word, C> m1 : val.entrySet()) {
+            C c1 = m1.getValue();
+            Word e1 = m1.getKey();
+            C c = c1.multiply(s); // check non zero if not domain
+            if (!c.isZERO()) {
+                pv.put(e1, c); // or m1.setValue( c )
+            }
+        }
+        return p;
+    }
+
+
+    /**
+     * GenWordPolynomial multiplication. Product with coefficient ring element.
+     * @param s coefficient.
+     * @param t coefficient.
+     * @return s*this*t.
+     */
+    public GenWordPolynomial<C> multiply(C s, C t) {
+        if (s == null || t == null) {
+            return ring.getZERO();
+        }
+        if (s.isZERO() || t.isZERO()) {
+            return ring.getZERO();
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        GenWordPolynomial<C> p = ring.getZERO().copy();
+        SortedMap<Word, C> pv = p.val;
+        for (Map.Entry<Word, C> m1 : val.entrySet()) {
+            C c1 = m1.getValue();
+            Word e = m1.getKey();
+            C c = s.multiply(c1).multiply(t); // check non zero if not domain
+            if (!c.isZERO()) {
+                pv.put(e, c); // or m1.setValue( c )
+            }
+        }
+        return p;
+    }
+
+
+    /**
+     * GenWordPolynomial monic, i.e. leadingCoefficient == 1. If
+     * leadingCoefficient is not invertible returns this unmodified.
+     * @return monic(this).
+     */
+    public GenWordPolynomial<C> monic() {
+        if (this.isZERO()) {
+            return this;
+        }
+        C lc = leadingBaseCoefficient();
+        if (!lc.isUnit()) {
+            //System.out.println("lc = "+lc);
+            return this;
+        }
+        C lm = lc.inverse();
+        return multiply(lm);
+    }
+
+
+    /**
+     * GenWordPolynomial multiplication. Product with ring element and word.
+     * @param s coefficient.
+     * @param e left word.
+     * @return this * s e.
+     */
+    public GenWordPolynomial<C> multiply(C s, Word e) {
+        if (s == null) {
+            return ring.getZERO();
+        }
+        if (s.isZERO()) {
+            return ring.getZERO();
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        GenWordPolynomial<C> p = ring.getZERO().copy();
+        SortedMap<Word, C> pv = p.val;
+        for (Map.Entry<Word, C> m1 : val.entrySet()) {
+            C c1 = m1.getValue();
+            Word e1 = m1.getKey();
+            C c = c1.multiply(s); // check non zero if not domain
+            if (!c.isZERO()) {
+                Word e2 = e1.multiply(e);
+                pv.put(e2, c);
+            }
+        }
+        return p;
+    }
+
+
+    /**
+     * GenWordPolynomial left and right multiplication. Product with ring
+     * element and two words.
+     * @param e left word.
+     * @param f right word.
+     * @return e * this * f.
+     */
+    public GenWordPolynomial<C> multiply(Word e, Word f) {
+        if (this.isZERO()) {
+            return this;
+        }
+        if (e.isONE()) {
+            return multiply(f);
+        }
+        GenWordPolynomial<C> p = ring.getZERO().copy();
+        SortedMap<Word, C> pv = p.val;
+        for (Map.Entry<Word, C> m1 : val.entrySet()) {
+            C c = m1.getValue();
+            Word e1 = m1.getKey();
+            Word e2 = e.multiply(e1.multiply(f));
+            pv.put(e2, c);
+        }
+        return p;
+    }
+
+
+    /**
+     * GenWordPolynomial left and right multiplication. Product with ring
+     * element and two words.
+     * @param s coefficient.
+     * @param e left word.
+     * @param f right word.
+     * @return e * this * s * f.
+     */
+    public GenWordPolynomial<C> multiply(C s, Word e, Word f) {
+        if (s == null) {
+            return ring.getZERO();
+        }
+        if (s.isZERO()) {
+            return ring.getZERO();
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        if (e.isONE()) {
+            return multiply(s, f);
+        }
+        C c = ring.coFac.getONE();
+        return multiply(c, e, s, f); // sic, history
+    }
+
+
+    /**
+     * GenWordPolynomial left and right multiplication. Product with ring
+     * element and two words.
+     * @param s coefficient.
+     * @param e left word.
+     * @param t coefficient.
+     * @param f right word.
+     * @return s * e * this * t * f.
+     */
+    public GenWordPolynomial<C> multiply(C s, Word e, C t, Word f) {
+        if (s == null) {
+            return ring.getZERO();
+        }
+        if (s.isZERO()) {
+            return ring.getZERO();
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        GenWordPolynomial<C> p = ring.getZERO().copy();
+        SortedMap<Word, C> pv = p.val;
+        for (Map.Entry<Word, C> m1 : val.entrySet()) {
+            C c1 = m1.getValue();
+            C c = s.multiply(c1).multiply(t); // check non zero if not domain
+            if (!c.isZERO()) {
+                Word e1 = m1.getKey();
+                Word e2 = e.multiply(e1).multiply(f);
+                pv.put(e2, c);
+            }
+        }
+        return p;
+    }
+
+
+    /**
+     * GenWordPolynomial multiplication. Product with word.
+     * @param e word (!= null).
+     * @return this * e.
+     */
+    public GenWordPolynomial<C> multiply(Word e) {
+        if (this.isZERO()) {
+            return this;
+        }
+        GenWordPolynomial<C> p = ring.getZERO().copy();
+        SortedMap<Word, C> pv = p.val;
+        for (Map.Entry<Word, C> m1 : val.entrySet()) {
+            C c1 = m1.getValue();
+            Word e1 = m1.getKey();
+            Word e2 = e1.multiply(e);
+            pv.put(e2, c1);
+        }
+        return p;
+    }
+
+
+    /**
+     * GenWordPolynomial multiplication. Product with 'monomial'.
+     * @param m 'monomial'.
+     * @return this * m.
+     */
+    public GenWordPolynomial<C> multiply(Map.Entry<Word, C> m) {
+        if (m == null) {
+            return ring.getZERO();
+        }
+        return multiply(m.getValue(), m.getKey());
+    }
+
+
+    /**
+     * GenWordPolynomial division. Division by coefficient ring element. Fails,
+     * if exact division is not possible.
+     * @param s coefficient.
+     * @return this/s.
+     */
+    public GenWordPolynomial<C> divide(C s) {
+        if (s == null || s.isZERO()) {
+            throw new ArithmeticException(this.getClass().getName() + " division by zero");
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        //C t = s.inverse();
+        //return multiply(t);
+        GenWordPolynomial<C> p = ring.getZERO().copy();
+        SortedMap<Word, C> pv = p.val;
+        for (Map.Entry<Word, C> m : val.entrySet()) {
+            Word e = m.getKey();
+            C c1 = m.getValue();
+            C c = c1.divide(s); // is divideLeft
+            if (debug) {
+                C x = c1.remainder(s);
+                if (!x.isZERO()) {
+                    logger.info("divide x = " + x);
+                    throw new ArithmeticException(
+                                    this.getClass().getName() + " no exact division: " + c1 + "/" + s);
+                }
+            }
+            if (c.isZERO()) {
+                throw new ArithmeticException(this.getClass().getName() + " no exact division: " + c1 + "/"
+                                + s + ", in " + this);
+            }
+            pv.put(e, c); // or m1.setValue( c )
+        }
+        return p;
+    }
+
+
+    /**
+     * GenWordPolynomial division with remainder. Fails, if exact division by
+     * leading base coefficient is not possible. Meaningful only for univariate
+     * polynomials over fields, but works in any case.
+     * @param S nonzero GenWordPolynomial with invertible leading coefficient.
+     * @return [ quotient , remainder ] with this = quotient * S + remainder and
+     *         deg(remainder) &lt; deg(S) or remiander = 0.
+     * @see edu.jas.poly.PolyUtil#baseSparsePseudoRemainder(edu.jas.poly.GenPolynomial,edu.jas.poly.GenPolynomial)
+     *      .
+     */
+    @SuppressWarnings("unchecked")
+    public GenWordPolynomial<C>[] quotientRemainder(GenWordPolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            throw new ArithmeticException(this.getClass().getName() + " division by zero");
+        }
+        C c = S.leadingBaseCoefficient();
+        if (!c.isUnit()) {
+            throw new ArithmeticException(this.getClass().getName() + " lbcf not invertible " + c);
+        }
+        C ci = c.inverse();
+        C one = ring.coFac.getONE();
+        assert (ring.alphabet == S.ring.alphabet);
+        WordFactory.WordComparator cmp = ring.alphabet.getDescendComparator();
+        Word e = S.leadingWord();
+        GenWordPolynomial<C> h;
+        GenWordPolynomial<C> q = ring.getZERO().copy();
+        GenWordPolynomial<C> r = this.copy();
+        while (!r.isZERO()) {
+            Word f = r.leadingWord();
+            if (f.multipleOf(e)) {
+                C a = r.leadingBaseCoefficient();
+                Word[] g = f.divideWord(e); // divide not sufficient
+                //logger.info("div: f = " + f + ", e = " + e + ", g = " + g[0] + ", " + g[1]);
+                a = a.multiply(ci);
+                q = q.sum(a, g[0].multiply(g[1]));
+                h = S.multiply(a, g[0], one, g[1]);
+                r = r.subtract(h);
+                Word fr = r.leadingWord();
+                if (cmp.compare(f, fr) > 0) { // non noetherian reduction
+                    throw new RuntimeException("possible infinite loop: f = " + f + ", fr = " + fr);
+                }
+            } else {
+                break;
+            }
+        }
+        GenWordPolynomial<C>[] ret = new GenWordPolynomial[2];
+        ret[0] = q;
+        ret[1] = r;
+        return ret;
+    }
+
+
+    /**
+     * GenWordPolynomial division. Fails, if exact division by leading base
+     * coefficient is not possible. Meaningful only for univariate polynomials
+     * over fields, but works in any case.
+     * @param S nonzero GenWordPolynomial with invertible leading coefficient.
+     * @return quotient with this = quotient * S + remainder.
+     * @see edu.jas.poly.PolyUtil#baseSparsePseudoRemainder(edu.jas.poly.GenPolynomial,edu.jas.poly.GenPolynomial)
+     *      .
+     */
+    public GenWordPolynomial<C> divide(GenWordPolynomial<C> S) {
+        return quotientRemainder(S)[0];
+    }
+
+
+    /**
+     * GenWordPolynomial remainder. Fails, if exact division by leading base
+     * coefficient is not possible. Meaningful only for univariate polynomials
+     * over fields, but works in any case.
+     * @param S nonzero GenWordPolynomial with invertible leading coefficient.
+     * @return remainder with this = quotient * S + remainder.
+     * @see edu.jas.poly.PolyUtil#baseSparsePseudoRemainder(edu.jas.poly.GenPolynomial,edu.jas.poly.GenPolynomial)
+     *      .
+     */
+    public GenWordPolynomial<C> remainder(GenWordPolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            throw new ArithmeticException(this.getClass().getName() + " division by zero");
+        }
+        C c = S.leadingBaseCoefficient();
+        if (!c.isUnit()) {
+            throw new ArithmeticException(this.getClass().getName() + " lbc not invertible " + c);
+        }
+        C ci = c.inverse();
+        C one = ring.coFac.getONE();
+        assert (ring.alphabet == S.ring.alphabet);
+        WordFactory.WordComparator cmp = ring.alphabet.getDescendComparator();
+        Word e = S.leadingWord();
+        GenWordPolynomial<C> h;
+        GenWordPolynomial<C> r = this.copy();
+        while (!r.isZERO()) {
+            Word f = r.leadingWord();
+            if (f.multipleOf(e)) {
+                C a = r.leadingBaseCoefficient();
+                Word[] g = f.divideWord(e); // divide not sufficient
+                //logger.info("rem: f = " + f + ", e = " + e + ", g = " + g[0] + ", " + g[1]);
+                a = a.multiply(ci);
+                h = S.multiply(a, g[0], one, g[1]);
+                r = r.subtract(h);
+                Word fr = r.leadingWord();
+                if (cmp.compare(f, fr) > 0) { // non noetherian reduction
+                    throw new RuntimeException("possible infinite loop: f = " + f + ", fr = " + fr);
+                }
+            } else {
+                break;
+            }
+        }
+        return r;
+    }
+
+
+    /**
+     * GenWordPolynomial greatest common divisor. Only for univariate
+     * polynomials over fields.
+     * @param S GenWordPolynomial.
+     * @return gcd(this,S).
+     */
+    public GenWordPolynomial<C> gcd(GenWordPolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return S;
+        }
+        if (ring.alphabet.length() != 1) {
+            throw new IllegalArgumentException("no univariate polynomial " + ring);
+        }
+        GenWordPolynomial<C> x;
+        GenWordPolynomial<C> q = this;
+        GenWordPolynomial<C> r = S;
+        while (!r.isZERO()) {
+            x = q.remainder(r);
+            q = r;
+            r = x;
+        }
+        return q.monic(); // normalize
+    }
+
+
+    /**
+     * GenWordPolynomial extended greatest comon divisor. Only for univariate
+     * polynomials over fields.
+     * @param S GenWordPolynomial.
+     * @return [ gcd(this,S), a, b ] with a*this + b*S = gcd(this,S).
+     */
+    @SuppressWarnings("unchecked")
+    public GenWordPolynomial<C>[] egcd(GenWordPolynomial<C> S) {
+        GenWordPolynomial<C>[] ret = new GenWordPolynomial[3];
+        ret[0] = null;
+        ret[1] = null;
+        ret[2] = null;
+        if (S == null || S.isZERO()) {
+            ret[0] = this;
+            ret[1] = this.ring.getONE();
+            ret[2] = this.ring.getZERO();
+            return ret;
+        }
+        if (this.isZERO()) {
+            ret[0] = S;
+            ret[1] = this.ring.getZERO();
+            ret[2] = this.ring.getONE();
+            return ret;
+        }
+        if (ring.alphabet.length() != 1) {
+            throw new IllegalArgumentException("no univariate polynomial " + ring);
+        }
+        if (this.isConstant() && S.isConstant()) {
+            C t = this.leadingBaseCoefficient();
+            C s = S.leadingBaseCoefficient();
+            C[] gg = t.egcd(s);
+            //System.out.println("coeff gcd = " + Arrays.toString(gg));
+            GenWordPolynomial<C> z = this.ring.getZERO();
+            ret[0] = z.sum(gg[0]);
+            ret[1] = z.sum(gg[1]);
+            ret[2] = z.sum(gg[2]);
+            return ret;
+        }
+        GenWordPolynomial<C>[] qr;
+        GenWordPolynomial<C> q = this;
+        GenWordPolynomial<C> r = S;
+        GenWordPolynomial<C> c1 = ring.getONE().copy();
+        GenWordPolynomial<C> d1 = ring.getZERO().copy();
+        GenWordPolynomial<C> c2 = ring.getZERO().copy();
+        GenWordPolynomial<C> d2 = ring.getONE().copy();
+        GenWordPolynomial<C> x1;
+        GenWordPolynomial<C> x2;
+        while (!r.isZERO()) {
+            qr = q.quotientRemainder(r);
+            q = qr[0];
+            x1 = c1.subtract(q.multiply(d1));
+            x2 = c2.subtract(q.multiply(d2));
+            c1 = d1;
+            c2 = d2;
+            d1 = x1;
+            d2 = x2;
+            q = r;
+            r = qr[1];
+        }
+        // normalize ldcf(q) to 1, i.e. make monic
+        C g = q.leadingBaseCoefficient();
+        if (g.isUnit()) {
+            C h = g.inverse();
+            q = q.multiply(h);
+            c1 = c1.multiply(h);
+            c2 = c2.multiply(h);
+        }
+        //assert ( ((c1.multiply(this)).sum( c2.multiply(S)).equals(q) )); 
+        ret[0] = q;
+        ret[1] = c1;
+        ret[2] = c2;
+        return ret;
+    }
+
+
+    /**
+     * GenWordPolynomial half extended greatest comon divisor. Only for
+     * univariate polynomials over fields.
+     * @param S GenWordPolynomial.
+     * @return [ gcd(this,S), a ] with a*this + b*S = gcd(this,S).
+     */
+    @SuppressWarnings("unchecked")
+    public GenWordPolynomial<C>[] hegcd(GenWordPolynomial<C> S) {
+        GenWordPolynomial<C>[] ret = new GenWordPolynomial[2];
+        ret[0] = null;
+        ret[1] = null;
+        if (S == null || S.isZERO()) {
+            ret[0] = this;
+            ret[1] = this.ring.getONE();
+            return ret;
+        }
+        if (this.isZERO()) {
+            ret[0] = S;
+            return ret;
+        }
+        if (ring.alphabet.length() != 1) {
+            throw new IllegalArgumentException("no univariate polynomial " + ring);
+        }
+        GenWordPolynomial<C>[] qr;
+        GenWordPolynomial<C> q = this;
+        GenWordPolynomial<C> r = S;
+        GenWordPolynomial<C> c1 = ring.getONE().copy();
+        GenWordPolynomial<C> d1 = ring.getZERO().copy();
+        GenWordPolynomial<C> x1;
+        while (!r.isZERO()) {
+            qr = q.quotientRemainder(r);
+            q = qr[0];
+            x1 = c1.subtract(q.multiply(d1));
+            c1 = d1;
+            d1 = x1;
+            q = r;
+            r = qr[1];
+        }
+        // normalize ldcf(q) to 1, i.e. make monic
+        C g = q.leadingBaseCoefficient();
+        if (g.isUnit()) {
+            C h = g.inverse();
+            q = q.multiply(h);
+            c1 = c1.multiply(h);
+        }
+        //assert ( ((c1.multiply(this)).remainder(S).equals(q) )); 
+        ret[0] = q;
+        ret[1] = c1;
+        return ret;
+    }
+
+
+    /**
+     * GenWordPolynomial inverse. Required by RingElem. Throws not invertible
+     * exception.
+     */
+    public GenWordPolynomial<C> inverse() {
+        if (isUnit()) { // only possible if ldbcf is unit
+            C c = leadingBaseCoefficient().inverse();
+            return ring.getONE().multiply(c);
+        }
+        throw new NotInvertibleException("element not invertible " + this + " :: " + ring);
+    }
+
+
+    /**
+     * GenWordPolynomial modular inverse. Only for univariate polynomials over
+     * fields.
+     * @param m GenWordPolynomial.
+     * @return a with with a*this = 1 mod m.
+     */
+    public GenWordPolynomial<C> modInverse(GenWordPolynomial<C> m) {
+        if (this.isZERO()) {
+            throw new NotInvertibleException("zero is not invertible");
+        }
+        GenWordPolynomial<C>[] hegcd = this.hegcd(m);
+        GenWordPolynomial<C> a = hegcd[0];
+        if (!a.isUnit()) { // gcd != 1
+            throw new NotInvertibleException("element not invertible, gcd != 1");
+        }
+        GenWordPolynomial<C> b = hegcd[1];
+        if (b.isZERO()) { // when m divides this, e.g. m.isUnit()
+            throw new NotInvertibleException("element not invertible, divisible by modul");
+        }
+        return b;
+    }
+
+
+    /**
+     * Iterator over coefficients.
+     * @return val.values().iterator().
+     */
+    public Iterator<C> coefficientIterator() {
+        return val.values().iterator();
+    }
+
+
+    /**
+     * Iterator over words.
+     * @return val.keySet().iterator().
+     */
+    public Iterator<Word> wordIterator() {
+        return val.keySet().iterator();
+    }
+
+
+    /**
+     * Iterator over monomials.
+     * @return a PolyIterator.
+     */
+    public Iterator<WordMonomial<C>> iterator() {
+        return new WordPolyIterator<C>(val);
+    }
+
+
+    /**
+     * Map a unary function to the coefficients.
+     * @param f evaluation functor.
+     * @return new polynomial with coefficients f(this(e)).
+     */
+    public GenWordPolynomial<C> map(final UnaryFunctor<? super C, C> f) {
+        GenWordPolynomial<C> n = ring.getZERO().copy();
+        SortedMap<Word, C> nv = n.val;
+        for (WordMonomial<C> m : this) {
+            //logger.info("m = " + m);
+            C c = f.eval(m.c);
+            if (c != null && !c.isZERO()) {
+                nv.put(m.e, c);
+            }
+        }
+        return n;
+    }
+
+
+    /**
+     * GenWordPolynomial contraction.
+     * @param fac GenWordPolynomialRing.
+     * @return this contracted to fac ring, if this in fac ring, null else.
+     */
+    public GenWordPolynomial<C> contract(GenWordPolynomialRing<C> fac) {
+        if (fac == null) {
+            throw new IllegalArgumentException("fac ring may not be null");
+        }
+        GenWordPolynomial<C> S = fac.getZERO();
+        if (this.isZERO()) {
+            return S;
+        }
+        WordFactory wfac = fac.alphabet;
+        //eventually: assert (ring.alphabet.isSubFactory(fac.alphabet));
+        S = S.copy();
+        SortedMap<Word, C> sv = S.val;
+        SortedMap<Word, C> nv = this.val;
+        for (Map.Entry<Word, C> me : nv.entrySet()) {
+            Word e = me.getKey();
+            Word ec = wfac.contract(e);
+            if (ec == null) { // not contractable
+                return fac.getZERO(); // or null?
+            }
+            C y = me.getValue();
+            if (sv.get(ec) != null) { // eventualy need sum
+                throw new RuntimeException("x != null: need sum " + sv.get(ec) + " + " + y);
+            }
+            sv.put(ec, y);
+        }
+        return S;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/GenWordPolynomialRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/GenWordPolynomialRing.java
@@ -1,0 +1,737 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.kern.PreemptStatus;
+import edu.jas.kern.Scripting;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * GenWordPolynomialRing generic polynomial factory implementing RingFactory;
+ * Factory for non-commutative string polynomials over C.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public final class GenWordPolynomialRing<C extends RingElem<C>> implements RingFactory<GenWordPolynomial<C>>
+/*, Iterable<GenWordPolynomial<C>>*/ {
+
+
+    /**
+     * The factory for the coefficients.
+     */
+    public final RingFactory<C> coFac;
+
+
+    /**
+     * The factory for the alphabet.
+     */
+    public final WordFactory alphabet;
+
+
+    /**
+     * The constant polynomial 0 for this ring.
+     */
+    public final GenWordPolynomial<C> ZERO;
+
+
+    /**
+     * The constant polynomial 1 for this ring.
+     */
+    public final GenWordPolynomial<C> ONE;
+
+
+    /**
+     * The constant empty word exponent for this ring.
+     */
+    public final Word wone;
+
+
+    /**
+     * A default random sequence generator.
+     */
+    final static Random random = new Random();
+
+
+    /**
+     * Indicator if this ring is a field.
+     */
+    private int isField = -1; // initially unknown
+
+
+    /**
+     * Log4j logger object.
+     */
+    private static final Logger logger = LogManager.getLogger(GenWordPolynomialRing.class);
+
+
+    /**
+     * Flag to enable if preemptive interrrupt is checked.
+     */
+    final boolean checkPreempt = PreemptStatus.isAllowed();
+
+
+    /**
+     * The constructor creates a polynomial factory object with the default term
+     * order.
+     * @param cf factory for coefficients of type C.
+     * @param wf factory for strings.
+     */
+    public GenWordPolynomialRing(RingFactory<C> cf, WordFactory wf) {
+        coFac = cf;
+        alphabet = wf;
+        ZERO = new GenWordPolynomial<C>(this);
+        C coeff = coFac.getONE();
+        wone = wf.getONE();
+        ONE = new GenWordPolynomial<C>(this, coeff, wone);
+    }
+
+
+    /**
+     * The constructor creates a polynomial factory object.
+     * @param cf factory for coefficients of type C.
+     * @param s array of variable names.
+     */
+    public GenWordPolynomialRing(RingFactory<C> cf, String[] s) {
+        this(cf, new WordFactory(s));
+    }
+
+
+    /**
+     * The constructor creates a polynomial factory object.
+     * @param cf factory for coefficients of type C.
+     * @param s string of single letter variable names.
+     */
+    public GenWordPolynomialRing(RingFactory<C> cf, String s) {
+        this(cf, new WordFactory(s));
+    }
+
+
+    /**
+     * The constructor creates a polynomial factory object.
+     * @param cf factory for coefficients of type C.
+     * @param o other polynomial ring.
+     */
+    public GenWordPolynomialRing(RingFactory<C> cf, GenWordPolynomialRing o) {
+        this(cf, o.alphabet);
+    }
+
+
+    /**
+     * The constructor creates a polynomial factory object.
+     * @param fac polynomial ring.
+     */
+    public GenWordPolynomialRing(GenPolynomialRing<C> fac) {
+        this(fac.coFac, new WordFactory(fac.vars));
+    }
+
+
+    /**
+     * Copy this factory.
+     * @return a clone of this.
+     */
+    public GenWordPolynomialRing<C> copy() {
+        return new GenWordPolynomialRing<C>(coFac, this);
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer s = new StringBuffer();
+        s.append("WordPolyRing(");
+        if (coFac instanceof RingElem) {
+            s.append(((RingElem<C>) coFac).toScriptFactory());
+        } else {
+            s.append(coFac.toString().trim());
+        }
+        s.append(",");
+        s.append(alphabet.toString());
+        s.append(")");
+        return s.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        StringBuffer s = new StringBuffer();
+        switch (Scripting.getLang()) {
+        case Ruby:
+            s.append("WordPolyRing.new(");
+            break;
+        case Python:
+        default:
+            s.append("WordPolyRing(");
+        }
+        if (coFac instanceof RingElem) {
+            s.append(((RingElem<C>) coFac).toScriptFactory());
+        } else {
+            s.append(coFac.toScript().trim());
+        }
+        s.append(",");
+        s.append(alphabet.toScript());
+        s.append(")");
+        return s.toString();
+    }
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by i.
+     * @param i number of variables to extend.
+     * @return extended word polynomial ring factory.
+     */
+    public GenWordPolynomialRing<C> extend(int i) {
+        // add module variable names
+        String[] v = GenPolynomialRing.newVars("t", i);
+        return extend(v);
+    }
+
+
+    /**
+     * Extend variables. Extend number of variables by length(vn).
+     * @param vn names for extended variables.
+     * @return extended polynomial ring factory.
+     */
+    public GenWordPolynomialRing<C> extend(String[] vn) {
+        WordFactory wfe = alphabet.extend(vn);
+        return new GenWordPolynomialRing<C>(coFac, wfe);
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        }
+        if (!(other instanceof GenWordPolynomialRing)) {
+            return false;
+        }
+        GenWordPolynomialRing<C> oring = (GenWordPolynomialRing<C>) other;
+        if (!coFac.equals(oring.coFac)) {
+            return false;
+        }
+        if (!alphabet.equals(oring.alphabet)) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Hash code for this polynomial ring.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = (coFac.hashCode() << 11);
+        h += alphabet.hashCode();
+        return h;
+    }
+
+
+    /**
+     * Get the variable names.
+     * @return vars.
+     */
+    public String[] getVars() {
+        return alphabet.getVars(); // Java-5: Arrays.copyOf(vars,vars.length);
+    }
+
+
+    /**
+     * Get the zero element from the coefficients.
+     * @return 0 as C.
+     */
+    public C getZEROCoefficient() {
+        return coFac.getZERO();
+    }
+
+
+    /**
+     * Get the one element from the coefficients.
+     * @return 1 as C.
+     */
+    public C getONECoefficient() {
+        return coFac.getONE();
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as GenWordPolynomial<C>.
+     */
+    public GenWordPolynomial<C> getZERO() {
+        return ZERO;
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as GenWordPolynomial<C>.
+     */
+    public GenWordPolynomial<C> getONE() {
+        return ONE;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true if this ring is commutative, else false.
+     */
+    public boolean isCommutative() {
+        return coFac.isCommutative() && alphabet.isFinite();
+    }
+
+
+    /**
+     * Query if this ring is associative.
+     * @return true if this ring is associative, else false.
+     */
+    public boolean isAssociative() {
+        return coFac.isAssociative();
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite()
+     */
+    public boolean isFinite() {
+        return alphabet.isFinite() && coFac.isFinite();
+    }
+
+
+    /**
+     * Query if this ring is a field.
+     * @return false.
+     */
+    public boolean isField() {
+        if (isField > 0) {
+            return true;
+        }
+        if (isField == 0) {
+            return false;
+        }
+        if (coFac.isField() && alphabet.isFinite()) {
+            isField = 1;
+            return true;
+        }
+        isField = 0;
+        return false;
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic() {
+        return coFac.characteristic();
+    }
+
+
+    /**
+     * Get a (constant) GenWordPolynomial&lt;C&gt; element from a coefficient
+     * value.
+     * @param a coefficient.
+     * @return a GenWordPolynomial&lt;C&gt;.
+     */
+    public GenWordPolynomial<C> valueOf(C a) {
+        return new GenWordPolynomial<C>(this, a);
+    }
+
+
+    /**
+     * Get a GenWordPolynomial&lt;C&gt; element from a word.
+     * @param e word.
+     * @return a GenWordPolynomial&lt;C&gt;.
+     */
+    public GenWordPolynomial<C> valueOf(Word e) {
+        return valueOf(coFac.getONE(), e);
+    }
+
+
+    /**
+     * Get a GenWordPolynomial&lt;C&gt; element from an ExpVector.
+     * @param e exponent vector.
+     * @return a GenWordPolynomial&lt;C&gt;.
+     */
+    public GenWordPolynomial<C> valueOf(ExpVector e) {
+        return valueOf(coFac.getONE(), e);
+    }
+
+
+    /**
+     * Get a GenWordPolynomial&lt;C&gt; element from a coeffcient and a word.
+     * @param a coefficient.
+     * @param e word.
+     * @return a GenWordPolynomial&lt;C&gt;.
+     */
+    public GenWordPolynomial<C> valueOf(C a, Word e) {
+        return new GenWordPolynomial<C>(this, a, e);
+    }
+
+
+    /**
+     * Get a GenWordPolynomial&lt;C&gt; element from a coeffcient and an
+     * ExpVector.
+     * @param a coefficient.
+     * @param e exponent vector.
+     * @return a GenWordPolynomial&lt;C&gt;.
+     */
+    public GenWordPolynomial<C> valueOf(C a, ExpVector e) {
+        return new GenWordPolynomial<C>(this, a, alphabet.valueOf(e));
+    }
+
+
+    /**
+     * Get a GenWordPolynomial&lt;C&gt; element from a GenPolynomial&lt;C&gt;.
+     * @param a GenPolynomial.
+     * @return a GenWordPolynomial&lt;C&gt;.
+     */
+    public GenWordPolynomial<C> valueOf(GenPolynomial<C> a) {
+        if (a.isZERO()) {
+            return getZERO();
+        }
+        if (a.isONE()) {
+            return getONE();
+        }
+        GenWordPolynomial<C> p = this.getZERO().copy();
+        for (Map.Entry<ExpVector, C> m : a.val.entrySet()) {
+            C c = m.getValue();
+            ExpVector e = m.getKey();
+            Word w = alphabet.valueOf(e);
+            p.doPutToMap(w, c);
+        }
+        return p;
+    }
+
+
+    /**
+     * Get a GenWordPolynomial&lt;C&gt; element from a
+     * GenWordPolynomial&lt;C&gt;.
+     * @param a GenWordPolynomial.
+     * @return a GenWordPolynomial&lt;C&gt;.
+     */
+    public GenWordPolynomial<C> valueOf(GenWordPolynomial<C> a) {
+        if (a.isZERO()) {
+            return getZERO();
+        }
+        if (a.isONE()) {
+            return getONE();
+        }
+        GenWordPolynomial<C> p = this.getZERO().copy();
+        for (Map.Entry<Word, C> m : a.val.entrySet()) {
+            C c = m.getValue();
+            Word e = m.getKey();
+            Word w = alphabet.valueOf(e);
+            p.doPutToMap(w, c);
+        }
+        return p;
+    }
+
+
+    /**
+     * Get a list of GenWordPolynomial&lt;C&gt; element from a list of
+     * GenPolynomial&lt;C&gt;.
+     * @param A GenPolynomial list.
+     * @return a GenWordPolynomial&lt;C&gt; list.
+     */
+    public List<GenWordPolynomial<C>> valueOf(List<GenPolynomial<C>> A) {
+        List<GenWordPolynomial<C>> B = new ArrayList<GenWordPolynomial<C>>(A.size());
+        if (A.isEmpty()) {
+            return B;
+        }
+        for (GenPolynomial<C> a : A) {
+            GenWordPolynomial<C> b = valueOf(a);
+            B.add(b);
+        }
+        return B;
+    }
+
+
+    /**
+     * Get a (constant) GenWordPolynomial&lt;C&gt; element from a long value.
+     * @param a long.
+     * @return a GenWordPolynomial&lt;C&gt;.
+     */
+    public GenWordPolynomial<C> fromInteger(long a) {
+        return new GenWordPolynomial<C>(this, coFac.fromInteger(a), wone);
+    }
+
+
+    /**
+     * Get a (constant) GenWordPolynomial&lt;C&gt; element from a BigInteger
+     * value.
+     * @param a BigInteger.
+     * @return a GenWordPolynomial&lt;C&gt;.
+     */
+    public GenWordPolynomial<C> fromInteger(BigInteger a) {
+        return new GenWordPolynomial<C>(this, coFac.fromInteger(a), wone);
+    }
+
+
+    /**
+     * Random polynomial. Generates a random polynomial.
+     * @param n number of terms.
+     * @return a random polynomial.
+     */
+    public GenWordPolynomial<C> random(int n) {
+        return random(n, random);
+    }
+
+
+    /**
+     * Random polynomial. Generates a random polynomial with k = 5, l = n, d =
+     * 3.
+     * @param n number of terms.
+     * @param rnd is a source for random bits.
+     * @return a random polynomial.
+     */
+    public GenWordPolynomial<C> random(int n, Random rnd) {
+        return random(5, n, 3, rnd);
+    }
+
+
+    /**
+     * Generate a random polynomial.
+     * @param k bitsize of random coefficients.
+     * @param l number of terms.
+     * @param d maximal length of a random word.
+     * @return a random polynomial.
+     */
+    public GenWordPolynomial<C> random(int k, int l, int d) {
+        return random(k, l, d, random);
+    }
+
+
+    /**
+     * Generate a random polynomial.
+     * @param k bitsize of random coefficients.
+     * @param l number of terms.
+     * @param d maximal length of a random word.
+     * @param rnd is a source for random bits.
+     * @return a random polynomial.
+     */
+    public GenWordPolynomial<C> random(int k, int l, int d, Random rnd) {
+        GenWordPolynomial<C> r = getZERO(); //.clone() or copy( ZERO ); 
+        // add l random coeffs and words of maximal length d
+        for (int i = 0; i < l; i++) {
+            int di = Math.abs(rnd.nextInt() % d);
+            Word e = alphabet.random(di, rnd);
+            C a = coFac.random(k, rnd);
+            r = r.sum(a, e); // somewhat inefficient but clean
+            //System.out.println("e = " + e + " a = " + a);
+        }
+        return r;
+    }
+
+
+    /**
+     * Copy polynomial c.
+     * @param c polynomial to copy.
+     * @return a copy of c.
+     */
+    public GenWordPolynomial<C> copy(GenWordPolynomial<C> c) {
+        return new GenWordPolynomial<C>(this, c.val);
+    }
+
+
+    /**
+     * Parse a polynomial with the use of GenWordPolynomialTokenizer.
+     * @param s String.
+     * @return GenWordPolynomial from s.
+     */
+    public GenWordPolynomial<C> parse(String s) {
+        String val = s;
+        if (!s.contains("|")) {
+            val = val.replace("{", "").replace("}", "");
+        }
+        return parse(new StringReader(val));
+    }
+
+
+    /**
+     * Parse a polynomial with the use of GenWordPolynomialTokenizer.
+     * @param r Reader.
+     * @return next GenWordPolynomial from r.
+     */
+    @SuppressWarnings("unchecked")
+    public GenWordPolynomial<C> parse(Reader r) {
+        if (alphabet.length() <= 1) { // hack for univariate = commuative like cases
+            // obsolete case
+            GenPolynomialRing<C> cr = new GenPolynomialRing<C>(coFac, alphabet.getVars());
+            GenPolynomialTokenizer pt = new GenPolynomialTokenizer(cr, r);
+            GenPolynomial<C> p = cr.getZERO();
+            try {
+                p = pt.nextPolynomial();
+            } catch (IOException e) {
+                logger.error(e.toString() + " parse " + this);
+            }
+            GenWordPolynomial<C> wp = this.valueOf(p);
+            return wp;
+        }
+        GenPolynomialTokenizer tok = new GenPolynomialTokenizer(r);
+        GenWordPolynomial<C> a;
+        try {
+            a = tok.nextWordPolynomial(this);
+        } catch (IOException e) {
+            a = null;
+            e.printStackTrace();
+            logger.error(e.toString() + " parse " + this);
+        }
+        return a;
+        //throw new UnsupportedOperationException("not implemented");
+    }
+
+
+    /**
+     * Generate univariate polynomial in a given variable.
+     * @param i the index of the variable.
+     * @return X_i as univariate polynomial.
+     */
+    public GenWordPolynomial<C> univariate(int i) {
+        GenWordPolynomial<C> p = getZERO();
+        List<Word> wgen = alphabet.generators();
+        if (0 <= i && i < wgen.size()) {
+            C one = coFac.getONE();
+            Word f = wgen.get(i);
+            p = p.sum(one, f);
+        }
+        return p;
+    }
+
+
+    /**
+     * Generate commute polynomial in two variables.
+     * @param i the index of the first variable.
+     * @param j the index of the second variable.
+     * @return X_i * x_j - X_j * X_i as polynomial.
+     */
+    public GenWordPolynomial<C> commute(int i, int j) {
+        GenWordPolynomial<C> p = getZERO();
+        List<Word> wgen = alphabet.generators();
+        if (0 <= i && i < wgen.size() && 0 <= j && j < wgen.size()) {
+            C one = coFac.getONE();
+            Word f = wgen.get(i);
+            Word e = wgen.get(j);
+            p = p.sum(one, e.multiply(f));
+            p = p.subtract(one, f.multiply(e));
+            if (i > j) {
+                p = p.negate();
+            }
+        }
+        return p;
+    }
+
+
+    /**
+     * Generate commute polynomials for given variable.
+     * @param i the index of the variable.
+     * @return [X_i * x_j - X_j * X_i, i != j] as list of polynomials.
+     */
+    public List<GenWordPolynomial<C>> commute(int i) {
+        int n = alphabet.length();
+        List<GenWordPolynomial<C>> pols = new ArrayList<GenWordPolynomial<C>>(n - 1);
+        for (int j = 0; j < n; j++) {
+            if (i != j) {
+                pols.add(commute(i, j));
+            }
+        }
+        return pols;
+    }
+
+
+    /**
+     * Generate commute polynomials for all variables.
+     * @return [X_i * x_j - X_j * X_i, i != j] as list of polynomials.
+     */
+    public List<GenWordPolynomial<C>> commute() {
+        int n = alphabet.length();
+        List<GenWordPolynomial<C>> pols = new ArrayList<GenWordPolynomial<C>>(n * (n - 1));
+        for (int i = 0; i < n; i++) {
+            pols.addAll(commute(i));
+        }
+        return pols;
+    }
+
+
+    /**
+     * Generate list of univariate polynomials in all variables.
+     * @return List(X_1,...,X_n) a list of univariate polynomials.
+     */
+    public List<GenWordPolynomial<C>> univariateList() {
+        int n = alphabet.length();
+        List<GenWordPolynomial<C>> pols = new ArrayList<GenWordPolynomial<C>>(n);
+        for (int i = 0; i < n; i++) {
+            GenWordPolynomial<C> p = univariate(i);
+            pols.add(p);
+        }
+        return pols;
+    }
+
+
+    /**
+     * Get the generating elements <b>excluding</b> the generators for the
+     * coefficient ring.
+     * @return a list of generating elements for this ring.
+     */
+    public List<GenWordPolynomial<C>> getGenerators() {
+        List<GenWordPolynomial<C>> univs = univariateList();
+        List<GenWordPolynomial<C>> gens = new ArrayList<GenWordPolynomial<C>>(univs.size() + 1);
+        gens.add(getONE());
+        gens.addAll(univs);
+        return gens;
+    }
+
+
+    /**
+     * Get a list of all generating elements.
+     * @return list of generators for the algebraic structure.
+     * @see edu.jas.structure.ElemFactory#generators()
+     */
+    public List<GenWordPolynomial<C>> generators() {
+        List<C> cogens = coFac.generators();
+        List<GenWordPolynomial<C>> univs = univariateList();
+        List<GenWordPolynomial<C>> gens = new ArrayList<GenWordPolynomial<C>>(univs.size() + cogens.size());
+        for (C c : cogens) {
+            gens.add(getONE().multiply(c));
+        }
+        gens.addAll(univs);
+        return gens;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/InvalidExpressionException.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/InvalidExpressionException.java
@@ -1,0 +1,36 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+
+/**
+ * Invalid expression exception class.
+ * Runtime Exception to be thrown for invalid algebraic / polynomial expressions.
+ * @author Heinz Kredel
+ */
+public class InvalidExpressionException extends RuntimeException {
+
+
+    public InvalidExpressionException() {
+        super("InvalidExpressionException");
+    }
+
+
+    public InvalidExpressionException(String c) {
+        super(c);
+    }
+
+
+    public InvalidExpressionException(String c, Throwable t) {
+        super(c, t);
+    }
+
+
+    public InvalidExpressionException(Throwable t) {
+        super("InvalidExpressionException", t);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/Local.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/Local.java
@@ -1,0 +1,477 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.QuotPair;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Local element based on RingElem pairs. Objects of this class are (nearly)
+ * immutable.
+ * @author Heinz Kredel
+ */
+public class Local<C extends RingElem<C>> implements RingElem<Local<C>>, QuotPair<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(Local.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Local class factory data structure.
+     */
+    protected final LocalRing<C> ring;
+
+
+    /**
+     * Numerator part of the element data structure.
+     */
+    protected final C num;
+
+
+    /**
+     * Denominator part of the element data structure.
+     */
+    protected final C den;
+
+
+    /**
+     * Flag to remember if this local element is a unit. -1 is unknown, 1 is
+     * unit, 0 not a unit.
+     */
+    protected int isunit = -1; // initially unknown
+
+
+    /**
+     * The constructor creates a Local object from a ring factory.
+     * @param r ring factory.
+     */
+    public Local(LocalRing<C> r) {
+        this(r, r.ring.getZERO());
+    }
+
+
+    /**
+     * The constructor creates a Local object from a ring factory and a
+     * numerator element. The denominator is assumed to be 1.
+     * @param r ring factory.
+     * @param n numerator.
+     */
+    public Local(LocalRing<C> r, C n) {
+        this(r, n, r.ring.getONE(), true);
+    }
+
+
+    /**
+     * The constructor creates a Local object from a ring factory and a
+     * numerator and denominator element.
+     * @param r ring factory.
+     * @param n numerator.
+     * @param d denominator.
+     */
+    public Local(LocalRing<C> r, C n, C d) {
+        this(r, n, d, false);
+    }
+
+
+    /**
+     * The constructor creates a Local object from a ring factory and a
+     * numerator and denominator element.
+     * @param r ring factory.
+     * @param n numerator.
+     * @param d denominator.
+     * @param isred true if gcd(n,d) == 1, else false.
+     */
+    @SuppressWarnings("unchecked")
+    protected Local(LocalRing<C> r, C n, C d, boolean isred) {
+        if (d == null || d.isZERO()) {
+            throw new IllegalArgumentException("denominator may not be zero");
+        }
+        ring = r;
+        if (d.signum() < 0) {
+            n = n.negate();
+            d = d.negate();
+        }
+        if (isred) {
+            num = n;
+            den = d;
+            return;
+        }
+        C p = d.remainder(ring.ideal);
+        if (p == null || p.isZERO()) {
+            throw new IllegalArgumentException("denominator may not be in ideal");
+        }
+        // must reduce to lowest terms
+        if (n instanceof GcdRingElem && d instanceof GcdRingElem) {
+            GcdRingElem ng = (GcdRingElem) n;
+            GcdRingElem dg = (GcdRingElem) d;
+            C gcd = (C) ng.gcd(dg);
+            if (debug) {
+                logger.info("gcd = " + gcd);
+            }
+            //RingElem<C> gcd = ring.ring.getONE();
+            if (gcd.isONE()) {
+                num = n;
+                den = d;
+            } else {
+                num = n.divide(gcd);
+                den = d.divide(gcd);
+            }
+            // } else { // univariate polynomial?
+        } else {
+            logger.warn("gcd = ????: " + n.getClass() + ", " + d.getClass());
+            num = n;
+            den = d;
+        }
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public LocalRing<C> factory() {
+        return ring;
+    }
+
+
+    /**
+     * Numerator.
+     * @see edu.jas.structure.QuotPair#numerator()
+     */
+    public C numerator() {
+        return num;
+    }
+
+
+    /**
+     * Denominator.
+     * @see edu.jas.structure.QuotPair#denominator()
+     */
+    public C denominator() {
+        return den;
+    }
+
+
+    /**
+     * Is Local a constant. Not implemented.
+     * @throws UnsupportedOperationException.
+     */
+    public boolean isConstant() {
+        throw new UnsupportedOperationException("isConstant not implemented");
+    }
+
+
+    /**
+     * Clone this.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public Local<C> copy() {
+        return new Local<C>(ring, num, den, true);
+    }
+
+
+    /**
+     * Is Local zero.
+     * @return If this is 0 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isZERO()
+     */
+    public boolean isZERO() {
+        return num.isZERO();
+    }
+
+
+    /**
+     * Is Local one.
+     * @return If this is 1 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isONE()
+     */
+    public boolean isONE() {
+        return num.equals(den);
+    }
+
+
+    /**
+     * Is Local unit.
+     * @return If this is a unit then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isUnit()
+     */
+    public boolean isUnit() {
+        if (isunit > 0) {
+            return true;
+        }
+        if (isunit == 0) {
+            return false;
+        }
+        // not jet known
+        if (num.isZERO()) {
+            isunit = 0;
+            return false;
+        }
+        C p = num.remainder(ring.ideal);
+        boolean u = (p != null && !p.isZERO());
+        if (u) {
+            isunit = 1;
+        } else {
+            isunit = 0;
+        }
+        return (u);
+    }
+
+
+    /**
+     * Get the String representation as RingElem.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "Local[ " + num.toString() + " / " + den.toString() + " ]";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        return "Local( " + num.toScript() + " , " + den.toScript() + " )";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python case
+        return factory().toScript();
+    }
+
+
+    /**
+     * Local comparison.
+     * @param b Local.
+     * @return sign(this-b).
+     */
+    @Override
+    public int compareTo(Local<C> b) {
+        if (b == null || b.isZERO()) {
+            return this.signum();
+        }
+        C r = num.multiply(b.den);
+        C s = den.multiply(b.num);
+        C x = r.subtract(s);
+        return x.signum();
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (b == null) {
+            return false;
+        }
+        if (!(b instanceof Local)) {
+            return false;
+        }
+        Local<C> a = (Local<C>) b;
+        return (0 == compareTo(a));
+    }
+
+
+    /**
+     * Hash code for this local.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = ring.hashCode();
+        h = 37 * h + num.hashCode();
+        h = 37 * h + den.hashCode();
+        return h;
+    }
+
+
+    /**
+     * Local absolute value.
+     * @return the absolute value of this.
+     * @see edu.jas.structure.RingElem#abs()
+     */
+    public Local<C> abs() {
+        return new Local<C>(ring, num.abs(), den, true);
+    }
+
+
+    /**
+     * Local summation.
+     * @param S Local.
+     * @return this+S.
+     */
+    public Local<C> sum(Local<C> S) {
+        if (S == null || S.isZERO()) {
+            return this;
+        }
+        C n = num.multiply(S.den);
+        n = n.sum(den.multiply(S.num));
+        C d = den.multiply(S.den);
+        return new Local<C>(ring, n, d, false);
+    }
+
+
+    /**
+     * Local negate.
+     * @return -this.
+     * @see edu.jas.structure.RingElem#negate()
+     */
+    public Local<C> negate() {
+        return new Local<C>(ring, num.negate(), den, true);
+    }
+
+
+    /**
+     * Local signum.
+     * @see edu.jas.structure.RingElem#signum()
+     * @return signum(this).
+     */
+    public int signum() {
+        return num.signum();
+    }
+
+
+    /**
+     * Local subtraction.
+     * @param S Local.
+     * @return this-S.
+     */
+    public Local<C> subtract(Local<C> S) {
+        if (S == null || S.isZERO()) {
+            return this;
+        }
+        C n = num.multiply(S.den);
+        n = n.subtract(den.multiply(S.num));
+        C d = den.multiply(S.den);
+        return new Local<C>(ring, n, d, false);
+    }
+
+
+    /**
+     * Local division.
+     * @param S Local.
+     * @return this/S.
+     */
+    public Local<C> divide(Local<C> S) {
+        return multiply(S.inverse());
+    }
+
+
+    /**
+     * Local inverse.
+     * @see edu.jas.structure.RingElem#inverse()
+     * @return S with S = 1/this if defined.
+     */
+    public Local<C> inverse() {
+        if (isONE()) {
+            return this;
+        }
+        if (isUnit()) {
+            return new Local<C>(ring, den, num, true);
+        }
+        throw new ArithmeticException("element not invertible " + this);
+    }
+
+
+    /**
+     * Local remainder.
+     * @param S Local.
+     * @return this - (this/S)*S.
+     */
+    public Local<C> remainder(Local<C> S) {
+        if (num.isZERO()) {
+            throw new ArithmeticException("element not invertible " + this);
+        }
+        if (S.isUnit()) {
+            return ring.getZERO();
+        }
+        throw new UnsupportedOperationException("remainder not implemented" + S);
+    }
+
+
+    /**
+     * Quotient and remainder by division of this by S.
+     * @param S a Local
+     * @return [this/S, this - (this/S)*S].
+     */
+    @SuppressWarnings("unchecked")
+    public Local<C>[] quotientRemainder(Local<C> S) {
+        return new Local[] { divide(S), remainder(S) };
+    }
+
+
+    /**
+     * Local multiplication.
+     * @param S Local.
+     * @return this*S.
+     */
+    public Local<C> multiply(Local<C> S) {
+        if (S == null || S.isZERO()) {
+            return S;
+        }
+        if (num.isZERO()) {
+            return this;
+        }
+        if (S.isONE()) {
+            return this;
+        }
+        if (this.isONE()) {
+            return S;
+        }
+        C n = num.multiply(S.num);
+        C d = den.multiply(S.den);
+        return new Local<C>(ring, n, d, false);
+    }
+
+
+    /**
+     * Greatest common divisor. <b>Note: </b>Not implemented, throws
+     * UnsupportedOperationException.
+     * @param b other element.
+     * @return gcd(this,b).
+     */
+    public Local<C> gcd(Local<C> b) {
+        throw new UnsupportedOperationException("gcd not implemented " + this.getClass().getName());
+    }
+
+
+    /**
+     * Extended greatest common divisor. <b>Note: </b>Not implemented, throws
+     * UnsupportedOperationException.
+     * @param b other element.
+     * @return [ gcd(this,b), c1, c2 ] with c1*this + c2*b = gcd(this,b).
+     */
+    public Local<C>[] egcd(Local<C> b) {
+        throw new UnsupportedOperationException("egcd not implemented " + this.getClass().getName());
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/LocalRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/LocalRing.java
@@ -1,0 +1,327 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.structure.QuotPairFactory;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Local ring factory based on RingElem principal ideal. Objects of this class
+ * are immutable.
+ * @author Heinz Kredel
+ */
+public class LocalRing<C extends RingElem<C>> implements RingFactory<Local<C>>, QuotPairFactory<C, Local<C>> {
+
+
+    private static final Logger logger = LogManager.getLogger(LocalRing.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Ideal generator for localization.
+     */
+    protected final C ideal;
+
+
+    /**
+     * Ring factory.
+     */
+    protected final RingFactory<C> ring;
+
+
+    /**
+     * Indicator if this ring is a field.
+     */
+    protected int isField = -1; // initially unknown
+
+
+    /**
+     * The constructor creates a LocalRing object from a RingFactory and a
+     * RingElem.
+     * @param i localization ideal generator.
+     */
+    public LocalRing(RingFactory<C> r, C i) {
+        ring = r;
+        if (i == null) {
+            throw new IllegalArgumentException("ideal may not be null");
+        }
+        ideal = i;
+        if (ideal.isONE()) {
+            throw new IllegalArgumentException("ideal may not be 1");
+        }
+    }
+
+
+    /**
+     * Factory for base elements.
+     */
+    public RingFactory<C> pairFactory() {
+        return ring;
+    }
+
+
+    /**
+     * Create from numerator.
+     */
+    public Local<C> create(C n) {
+        return new Local<C>(this, n);
+    }
+
+
+    /**
+     * Create from numerator, denominator pair.
+     */
+    public Local<C> create(C n, C d) {
+        return new Local<C>(this, n, d);
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite()
+     */
+    public boolean isFinite() {
+        return ring.isFinite();
+    }
+
+
+    /**
+     * Copy Local element c.
+     * @param c
+     * @return a copy of c.
+     */
+    public Local<C> copy(Local<C> c) {
+        return new Local<C>(c.ring, c.num, c.den, true);
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as Local.
+     */
+    public Local<C> getZERO() {
+        return new Local<C>(this, ring.getZERO());
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as Local.
+     */
+    public Local<C> getONE() {
+        return new Local<C>(this, ring.getONE());
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     * @see edu.jas.structure.ElemFactory#generators()
+     */
+    public List<Local<C>> generators() {
+        List<? extends C> rgens = ring.generators();
+        List<Local<C>> gens = new ArrayList<Local<C>>(rgens.size() - 1);
+        for (C c : rgens) {
+            if (!c.isONE()) {
+                gens.add(new Local<C>(this, c));
+            }
+        }
+        return gens;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true if this ring is commutative, else false.
+     */
+    public boolean isCommutative() {
+        return ring.isCommutative();
+    }
+
+
+    /**
+     * Query if this ring is associative.
+     * @return true if this ring is associative, else false.
+     */
+    public boolean isAssociative() {
+        return ring.isAssociative();
+    }
+
+
+    /**
+     * Query if this ring is a field.
+     * @return false.
+     */
+    public boolean isField() {
+        if (isField > 0) {
+            return true;
+        }
+        if (isField == 0) {
+            return false;
+        }
+        // ??
+        return false;
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic() {
+        return ring.characteristic();
+    }
+
+
+    /**
+     * Get a Local element from a BigInteger value.
+     * @param a BigInteger.
+     * @return a Local.
+     */
+    public Local<C> fromInteger(java.math.BigInteger a) {
+        return new Local<C>(this, ring.fromInteger(a));
+    }
+
+
+    /**
+     * Get a Local element from a long value.
+     * @param a long.
+     * @return a Local.
+     */
+    public Local<C> fromInteger(long a) {
+        return new Local<C>(this, ring.fromInteger(a));
+    }
+
+
+    /**
+     * Get the String representation as RingFactory.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "Local[ " + ideal.toString() + " ]";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.ElemFactory#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        return "LocalRing(" + ideal.toScript() + ")";
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    // not jet working
+    public boolean equals(Object b) {
+        if (b == null) {
+            return false;
+        }
+        if (!(b instanceof LocalRing)) {
+            return false;
+        }
+        LocalRing<C> a = (LocalRing<C>) b;
+        if (!ring.equals(a.ring)) {
+            return false;
+        }
+        return ideal.equals(a.ideal);
+    }
+
+
+    /**
+     * Hash code for this local ring.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = ring.hashCode();
+        h = 37 * h + ideal.hashCode();
+        return h;
+    }
+
+
+    /**
+     * Local random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @return a random residue element.
+     */
+    public Local<C> random(int n) {
+        C r = ring.random(n);
+        C s = ring.random(n);
+        s = s.remainder(ideal);
+        while (s.isZERO()) {
+            logger.debug("zero was in ideal");
+            s = ring.random(n);
+            s = s.remainder(ideal);
+        }
+        return new Local<C>(this, r, s, false);
+    }
+
+
+    /**
+     * Local random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @param rnd is a source for random bits.
+     * @return a random residue element.
+     */
+    public Local<C> random(int n, Random rnd) {
+        C r = ring.random(n, rnd);
+        C s = ring.random(n, rnd);
+        s = s.remainder(ideal);
+        while (s.isZERO()) {
+            logger.debug("zero was in ideal");
+            s = ring.random(n, rnd);
+            s = s.remainder(ideal);
+        }
+        return new Local<C>(this, r, s, false);
+    }
+
+
+    /**
+     * Parse Local from String.
+     * @param s String.
+     * @return Local from s.
+     */
+    public Local<C> parse(String s) {
+        C x = ring.parse(s);
+        return new Local<C>(this, x);
+    }
+
+
+    /**
+     * Parse Local from Reader.
+     * @param r Reader.
+     * @return next Local from r.
+     */
+    public Local<C> parse(Reader r) {
+        C x = ring.parse(r);
+        return new Local<C>(this, x);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/ModuleList.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/ModuleList.java
@@ -1,0 +1,468 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.kern.Scripting;
+import edu.jas.structure.RingElem;
+import edu.jas.vector.GenVector;
+import edu.jas.vector.GenVectorModul;
+
+
+/**
+ * List of vectors of polynomials. Mainly for storage and printing / toString
+ * and conversions to other representations.
+ * @author Heinz Kredel
+ */
+
+public class ModuleList<C extends RingElem<C>> implements Serializable {
+
+
+    /**
+     * The factory for the solvable polynomial ring.
+     */
+    public final GenPolynomialRing<C> ring;
+
+
+    /**
+     * The data structure is a List of Lists of polynomials.
+     */
+    public final List<List<GenPolynomial<C>>> list;
+
+
+    /**
+     * Number of rows in the data structure.
+     */
+    public final int rows; // -1 is undefined
+
+
+    /**
+     * Number of columns in the data structure.
+     */
+    public final int cols; // -1 is undefined
+
+
+    private static final Logger logger = LogManager.getLogger(ModuleList.class);
+
+
+    /**
+     * Constructor.
+     * @param r polynomial ring factory.
+     * @param l list of list of polynomials.
+     */
+    public ModuleList(GenPolynomialRing<C> r, List<List<GenPolynomial<C>>> l) {
+        ring = r;
+        list = ModuleList.<C> padCols(r, l);
+        if (list == null) {
+            rows = -1;
+            cols = -1;
+        } else {
+            rows = list.size();
+            if (rows > 0) {
+                cols = list.get(0).size();
+            } else {
+                cols = -1;
+            }
+        }
+    }
+
+
+    /**
+     * Constructor.
+     * @param r solvable polynomial ring factory.
+     * @param l list of list of solvable polynomials.
+     */
+    public ModuleList(GenSolvablePolynomialRing<C> r, List<List<GenSolvablePolynomial<C>>> l) {
+        this(r, ModuleList.<C> castToList(l));
+    }
+
+
+    /**
+     * Constructor.
+     * @param r polynomial ring factory.
+     * @param l list of vectors of polynomials.
+     */
+    public ModuleList(GenVectorModul<GenPolynomial<C>> r, List<GenVector<GenPolynomial<C>>> l) {
+        this((GenPolynomialRing<C>) r.coFac, ModuleList.<C> vecToList(l));
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    // not jet working
+    public boolean equals(Object m) {
+        if (m == null) {
+            return false;
+        }
+        if (!(m instanceof ModuleList)) {
+            //System.out.println("ModuleList");
+            return false;
+        }
+        ModuleList<C> ml = (ModuleList<C>) m;
+        if (!ring.equals(ml.ring)) {
+            //System.out.println("Ring");
+            return false;
+        }
+        if (list == ml.list) {
+            return true;
+        }
+        if (list == null || ml.list == null) {
+            //System.out.println("List, null");
+            return false;
+        }
+        if (list.size() != ml.list.size()) {
+            //System.out.println("List, size");
+            return false;
+        }
+        // compare sorted lists
+        List otl = OrderedModuleList.sort(ring, list);
+        List oml = OrderedModuleList.sort(ring, ml.list);
+        if (!otl.equals(oml)) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Hash code for this module list.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = ring.hashCode();
+        h = 37 * h + (list == null ? 0 : list.hashCode());
+        return h;
+    }
+
+
+    /**
+     * Test if list is empty.
+     * @return true if this is empty, alse false.
+     */
+    public boolean isEmpty() {
+        if (list == null) {
+            return true;
+        }
+        if (rows <= 0) {
+            return true;
+        }
+        return false;
+    }
+
+
+    /**
+     * Test all elements are zero.
+     * @return true if all elements are zero, alse false.
+     */
+    public boolean isZERO() {
+        if (list == null) {
+            return true;
+        }
+        if (rows <= 0) {
+            return true;
+        }
+        for (List<GenPolynomial<C>> row : list) {
+            for (GenPolynomial<C> oa : row) {
+                if (!oa.isZERO()) {
+                    return false;
+                }
+            }
+        }       
+        return true;
+    }
+
+
+    /**
+     * String representation of the module list.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    //@SuppressWarnings("unchecked") 
+    public String toString() {
+        StringBuffer erg = new StringBuffer();
+        String[] vars = null;
+        if (ring != null) {
+            erg.append(ring.toString());
+            vars = ring.getVars();
+        }
+        if (list == null) {
+            erg.append(")");
+            return erg.toString();
+        }
+        boolean first = true;
+        erg.append("(\n");
+        for (List<GenPolynomial<C>> row : list) {
+            if (first) {
+                first = false;
+            } else {
+                erg.append(",\n");
+            }
+            boolean ifirst = true;
+            erg.append(" ( ");
+            String os;
+            for (GenPolynomial<C> oa : row) {
+                if (oa == null) {
+                    os = "0";
+                } else if (vars != null) {
+                    os = oa.toString(vars);
+                } else {
+                    os = oa.toString();
+                }
+                if (ifirst) {
+                    ifirst = false;
+                } else {
+                    erg.append(", ");
+                    if (os.length() > 100) {
+                        erg.append("\n");
+                    }
+                }
+                erg.append(os);
+            }
+            erg.append(" )");
+        }
+        erg.append("\n)");
+        return erg.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this ModuleList.
+     */
+    public String toScript() {
+        StringBuffer s = new StringBuffer();
+        if (ring instanceof GenSolvablePolynomialRing) {
+            s.append("Solvable");
+        }
+        switch (Scripting.getLang()) {
+        case Ruby:
+            s.append("SubModule.new(");
+            break;
+        case Python:
+        default:
+            s.append("SubModule(");
+        }
+        if (ring != null) {
+            s.append(ring.toScript());
+        }
+        if (list == null) {
+            s.append(")");
+            return s.toString();
+        }
+        switch (Scripting.getLang()) {
+        case Ruby:
+            s.append(",\"\",[");
+            break;
+        case Python:
+        default:
+            s.append(",list=[");
+        }
+        boolean first = true;
+        for (List<GenPolynomial<C>> row : list) {
+            if (first) {
+                first = false;
+            } else {
+                s.append(",");
+            }
+            boolean ifirst = true;
+            s.append(" ( ");
+            String os;
+            for (GenPolynomial<C> oa : row) {
+                if (oa == null) {
+                    os = "0";
+                } else {
+                    os = oa.toScript();
+                }
+                if (ifirst) {
+                    ifirst = false;
+                } else {
+                    s.append(", ");
+                }
+                s.append(os);
+            }
+            s.append(" )");
+        }
+        s.append(" ])");
+        return s.toString();
+    }
+
+
+    /**
+     * Pad columns and remove zero rows. Make all rows have the same number of
+     * columns.
+     * @param ring polynomial ring factory.
+     * @param l list of list of polynomials.
+     * @return list of list of polynomials with same number of colums.
+     */
+    public static <C extends RingElem<C>> List<List<GenPolynomial<C>>> padCols(GenPolynomialRing<C> ring,
+                    List<List<GenPolynomial<C>>> l) {
+        if (l == null) {
+            return l;
+        }
+        int mcols = 0;
+        int rs = 0;
+        for (List<GenPolynomial<C>> row : l) {
+            if (row != null) {
+                rs++;
+                if (row.size() > mcols) {
+                    mcols = row.size();
+                }
+            }
+        }
+        List<List<GenPolynomial<C>>> norm = new ArrayList<List<GenPolynomial<C>>>(rs);
+        for (List<GenPolynomial<C>> row : l) {
+            if (row != null) {
+                List<GenPolynomial<C>> rn = new ArrayList<GenPolynomial<C>>(row);
+                while (rn.size() < mcols) {
+                    rn.add(ring.getZERO());
+                }
+                norm.add(rn);
+            }
+        }
+        return norm;
+    }
+
+
+    /**
+     * Get PolynomialList. Embed module in a polynomial ring.
+     * @see edu.jas.poly.PolynomialList
+     * @return polynomial list corresponding to this.
+     */
+    public PolynomialList<C> getPolynomialList() {
+        return getPolynomialList(false);
+    }
+
+    
+    /**
+     * Get PolynomialList. Embed module in a polynomial ring.
+     * @see edu.jas.poly.PolynomialList
+     * @param top true for TOP term order, false for POT term order.
+     * @return polynomial list corresponding to this.
+     */
+    public PolynomialList<C> getPolynomialList(boolean top) {
+        GenPolynomialRing<C> pfac = ring.extend(cols, top);
+        logger.debug("extended ring = " + pfac);
+        //System.out.println("extended ring = " + pfac);
+        return getPolynomialList(pfac);
+    }
+
+
+    /**
+     * Get PolynomialList. Embed module in a polynomial ring.
+     * @see edu.jas.poly.PolynomialList
+     * @param pfac polynomial ring.
+     * @return polynomial list corresponding to pfac and this.
+     */
+    public PolynomialList<C> getPolynomialList(GenPolynomialRing<C> pfac) {
+        List<GenPolynomial<C>> pols = null;
+        if (list == null) { // rows < 0
+            return new PolynomialList<C>(pfac, pols);
+        }
+        pols = new ArrayList<GenPolynomial<C>>(rows);
+        if (rows == 0) { // nothing to do
+            return new PolynomialList<C>(pfac, pols);
+        }
+        GenPolynomial<C> zero = pfac.getZERO();
+        GenPolynomial<C> d = null;
+        for (List<GenPolynomial<C>> r : list) {
+            GenPolynomial<C> ext = zero;
+            //int m = cols-1;
+            int m = 0;
+            for (GenPolynomial<C> c : r) {
+                d = c.extend(pfac, m, 1l);
+                ext = ext.sum(d);
+                m++;
+            }
+            pols.add(ext);
+        }
+        return new PolynomialList<C>(pfac, pols);
+    }
+
+
+    /**
+     * Get list as List of GenSolvablePolynomials. Required because no List
+     * casts allowed. Equivalent to cast
+     * (List&lt;List&lt;GenSolvablePolynomial&lt;C&gt;&gt;&gt;) list.
+     * @return list of solvable polynomial lists from this.
+     */
+    public List<List<GenSolvablePolynomial<C>>> castToSolvableList() {
+        List<List<GenSolvablePolynomial<C>>> slist = null;
+        if (list == null) {
+            return slist;
+        }
+        slist = new ArrayList<List<GenSolvablePolynomial<C>>>(list.size());
+        for (List<GenPolynomial<C>> row : list) {
+            List<GenSolvablePolynomial<C>> srow = new ArrayList<GenSolvablePolynomial<C>>(row.size());
+            for (GenPolynomial<C> p : row) {
+                if (!(p instanceof GenSolvablePolynomial)) {
+                    throw new RuntimeException("no solvable polynomial " + p);
+                }
+                GenSolvablePolynomial<C> s = (GenSolvablePolynomial<C>) p;
+                srow.add(s);
+            }
+            slist.add(srow);
+        }
+        return slist;
+    }
+
+
+    /**
+     * Get a solvable polynomials list as List of GenPolynomials. Required
+     * because no List casts allowed. Equivalent to cast
+     * (List&lt;List&lt;GenPolynomial&lt;C&gt;&gt;&gt;) list.
+     * @param slist list of solvable polynomial lists.
+     * @return list of polynomial lists from slist.
+     */
+    public static <C extends RingElem<C>> List<List<GenPolynomial<C>>> castToList(
+                    List<List<GenSolvablePolynomial<C>>> slist) {
+        List<List<GenPolynomial<C>>> list = null;
+        if (slist == null) {
+            return list;
+        }
+        list = new ArrayList<List<GenPolynomial<C>>>(slist.size());
+        for (List<GenSolvablePolynomial<C>> srow : slist) {
+            List<GenPolynomial<C>> row = new ArrayList<GenPolynomial<C>>(srow.size());
+            for (GenSolvablePolynomial<C> s : srow) {
+                row.add(s);
+            }
+            list.add(row);
+        }
+        return list;
+    }
+
+
+    /**
+     * Get a list of vectors as List of list of GenPolynomials.
+     * @param vlist list of vectors of polynomials.
+     * @return list of polynomial lists from vlist.
+     */
+    public static <C extends RingElem<C>> List<List<GenPolynomial<C>>> vecToList(
+                    List<GenVector<GenPolynomial<C>>> vlist) {
+        List<List<GenPolynomial<C>>> list = null;
+        if (vlist == null) {
+            return list;
+        }
+        list = new ArrayList<List<GenPolynomial<C>>>(vlist.size());
+        for (GenVector<GenPolynomial<C>> srow : vlist) {
+            List<GenPolynomial<C>> row = srow.val;
+            list.add(row);
+        }
+        return list;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/Monomial.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/Monomial.java
@@ -1,0 +1,182 @@
+
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.util.Map;
+
+import edu.jas.structure.ElemFactory;
+// import edu.jas.structure.RingFactory;
+import edu.jas.structure.Element;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Monomial class. Represents pairs of exponent vectors and coefficients.
+ * Adaptor for Map.Entry.
+ * @author Heinz Kredel
+ */
+public final class Monomial<C extends RingElem<C>> implements Element<Monomial<C>> {
+
+
+    /**
+     * Exponent of monomial.
+     */
+    public final ExpVector e;
+
+
+    /**
+     * Coefficient of monomial.
+     */
+    public final C c;
+
+
+    /**
+     * Constructor of monomial.
+     * @param me a MapEntry.
+     */
+    public Monomial(Map.Entry<ExpVector, C> me) {
+        this(me.getKey(), me.getValue());
+    }
+
+
+    /**
+     * Constructor of monomial.
+     * @param e exponent.
+     * @param c coefficient.
+     */
+    public Monomial(ExpVector e, C c) {
+        this.e = e;
+        this.c = c;
+    }
+
+
+    /**
+     * Getter for exponent.
+     * @return exponent.
+     */
+    public ExpVector exponent() {
+        return e;
+    }
+
+
+    /**
+     * Getter for coefficient.
+     * @return coefficient.
+     */
+    public C coefficient() {
+        return c;
+    }
+
+
+    /**
+     * Clone this Element.
+     * @return Creates and returns a copy of this Element.
+     */
+    public Monomial<C> copy() {
+        return new Monomial<C>(e, c);
+    }
+
+
+    /**
+     * String representation of Monomial.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return c.toString() + " " + e.toString();
+    }
+
+
+    /**
+     * Script representation of Monomial.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        if (c.isZERO()) {
+            return "0";
+        }
+        StringBuffer sb = new StringBuffer();
+        if (!c.isONE()) {
+            sb.append(c.toScript());
+            if (e.signum() != 0) {
+                sb.append(" * ");
+            }
+        }
+        sb.append(e.toScript());
+        return sb.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python and Ruby case
+        throw new UnsupportedOperationException("no factory for Monomial");
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return null, factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public ElemFactory<Monomial<C>> factory() {
+        //return new GenPolynomialRing<C>((RingFactory<C>)c.factory(), e.length());
+        throw new UnsupportedOperationException("no factory for Monomial");
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object B) {
+        if (!(B instanceof Monomial)) {
+            return false;
+        }
+        Monomial<C> b = (Monomial<C>) B;
+        return (compareTo(b) == 0);
+    }
+
+
+    /**
+     * hashCode.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h = e.hashCode();
+        h = (h << 4) + c.hashCode();
+        return h;
+    }
+
+
+    /**
+     * Monomial comparison.
+     * @param S Monomial.
+     * @return SIGN(this-S).
+     */
+    @Override
+    public int compareTo(Monomial<C> S) {
+        if (S == null) {
+            return 1;
+        }
+        int s = e.compareTo(S.e);
+        if (s != 0) {
+            return s;
+        }
+        return c.compareTo(S.c);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/OptimizedModuleList.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/OptimizedModuleList.java
@@ -1,0 +1,66 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.util.List;
+
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Container for optimization results.
+ * @author Heinz Kredel
+ */
+
+public class OptimizedModuleList<C extends RingElem<C>> extends ModuleList<C> {
+
+
+    /**
+     * Permutation vector used to optimize term order.
+     */
+    public final List<Integer> perm;
+
+
+    /**
+     * Constructor.
+     */
+    public OptimizedModuleList(List<Integer> P, GenPolynomialRing<C> R, List<List<GenPolynomial<C>>> L) {
+        super(R, L);
+        perm = P;
+    }
+
+
+    /**
+     * String representation.
+     */
+    @Override
+    public String toString() {
+        return "permutation = " + perm + "\n" + super.toString();
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object B) {
+        if (!(B instanceof OptimizedModuleList)) {
+            return false;
+        }
+        return super.equals(B);
+    }
+
+
+    /**
+     * Hash code for this module list.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/OptimizedPolynomialList.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/OptimizedPolynomialList.java
@@ -1,0 +1,67 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.util.List;
+
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Container for optimization results.
+ * @author Heinz Kredel
+ */
+
+public class OptimizedPolynomialList<C extends RingElem<C>> extends PolynomialList<C> {
+
+
+    /**
+     * Permutation vector used to optimize term order.
+     */
+    public final List<Integer> perm;
+
+
+    /**
+     * Constructor.
+     */
+    public OptimizedPolynomialList(List<Integer> P, GenPolynomialRing<C> R, List<GenPolynomial<C>> L) {
+        super(R, L);
+        perm = P;
+    }
+
+
+    /**
+     * String representation.
+     */
+    @Override
+    public String toString() {
+        return "permutation = " + perm + "\n" + super.toString();
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object B) {
+        if (!(B instanceof OptimizedPolynomialList)) {
+            return false;
+        }
+        return super.equals(B);
+    }
+
+
+    /**
+     * Hash code for this polynomial list.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/OrderedModuleList.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/OrderedModuleList.java
@@ -1,0 +1,145 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Ordered list of vectors of polynomials. Mainly for storage and printing /
+ * toString and conversions to other representations. Lists of polynomials in
+ * this list are sorted according to the head terms of the first column.
+ * @author Heinz Kredel
+ */
+
+public class OrderedModuleList<C extends RingElem<C>> extends ModuleList<C> {
+
+
+    /**
+     * Constructor.
+     * @param r polynomial ring factory.
+     * @param l list of list of polynomials.
+     */
+    public OrderedModuleList(GenPolynomialRing<C> r, List<List<GenPolynomial<C>>> l) {
+        super(r, sort(r, ModuleList.padCols(r, l)));
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    // not jet working
+    public boolean equals(Object m) {
+        if (!super.equals(m)) {
+            return false;
+        }
+        OrderedModuleList<C> ml = null;
+        try {
+            ml = (OrderedModuleList<C>) m;
+        } catch (ClassCastException ignored) {
+        }
+        if (ml == null) {
+            return false;
+        }
+        // compare sorted lists, done already in super.equals()
+        return true;
+    }
+
+
+    /**
+     * Hash code for OrderedModuleList.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+
+    /**
+     * Sort a list of vectors of polynomials with respect to the ascending order
+     * of the leading Exponent vectors of the first column. The term order is
+     * taken from the ring.
+     * @param r polynomial ring factory.
+     * @param l list of polynomial lists.
+     * @return sorted list of polynomial lists from l.
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    public static <C extends RingElem<C>> List<List<GenPolynomial<C>>> sort(GenPolynomialRing<C> r,
+                    List<List<GenPolynomial<C>>> l) {
+        if (l == null) {
+            return l;
+        }
+        if (l.size() <= 1) { // nothing to sort
+            return l;
+        }
+        final Comparator<ExpVector> evc = r.tord.getAscendComparator();
+        Comparator<List<GenPolynomial<C>>> cmp = new Comparator<List<GenPolynomial<C>>>() {
+
+
+            public int compare(List<GenPolynomial<C>> l1, List<GenPolynomial<C>> l2) {
+                int c = 0;
+                for (int i = 0; i < l1.size(); i++) {
+                    GenPolynomial<C> p1 = l1.get(i);
+                    GenPolynomial<C> p2 = l2.get(i);
+                    ExpVector e1 = p1.leadingExpVector();
+                    ExpVector e2 = p2.leadingExpVector();
+                    if (e1 == e2) {
+                        continue;
+                    }
+                    if (e1 == null && e2 != null) {
+                        return -1;
+                    }
+                    if (e1 != null && e2 == null) {
+                        return 1;
+                    }
+                    if (e1 == null || e2 == null) { // for findbugs
+                        continue; // cannot happen
+                    }
+                    if (e1.length() != e2.length()) {
+                        if (e1.length() > e2.length()) {
+                            return 1;
+                        }
+                        return -1;
+                    }
+                    c = evc.compare(e1, e2);
+                    if (c != 0) {
+                        return c;
+                    }
+                }
+                return c;
+            }
+        };
+
+        List<GenPolynomial<C>>[] s = null;
+        try {
+            s = (List<GenPolynomial<C>>[]) new List[l.size()];
+            //System.out.println("s.length = " + s.length );
+            //s = l.toArray(s); does not work
+            //for ( int i = 0; i < l.size(); i++ ) {
+            //    s[i] = l.get(i);
+            //}
+            int i = 0;
+            for (List<GenPolynomial<C>> p : l) {
+                s[i++] = p;
+            }
+            Arrays.<List<GenPolynomial<C>>> sort(s, cmp);
+            return new ArrayList<List<GenPolynomial<C>>>(Arrays.<List<GenPolynomial<C>>> asList(s));
+        } catch (ClassCastException ok) {
+            System.out.println("Warning: polynomials not sorted");
+        }
+        return l; // unsorted
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/OrderedPolynomialList.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/OrderedPolynomialList.java
@@ -1,0 +1,184 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Ordered list of polynomials. Mainly for storage and printing / toString and
+ * conversions to other representations. Polynomials in this list are sorted
+ * according to their head terms.
+ * @author Heinz Kredel
+ */
+
+public class OrderedPolynomialList<C extends RingElem<C>> extends PolynomialList<C> {
+
+
+    /**
+     * Constructor.
+     * @param r polynomial ring factory.
+     * @param l list of polynomials.
+     */
+    public OrderedPolynomialList(GenPolynomialRing<C> r, List<GenPolynomial<C>> l) {
+        super(r, sort(r, l));
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object p) {
+        if (!super.equals(p)) {
+            return false;
+        }
+        OrderedPolynomialList<C> pl = null;
+        try {
+            pl = (OrderedPolynomialList<C>) p;
+        } catch (ClassCastException ignored) {
+        }
+        if (pl == null) {
+            return false;
+        }
+        // compare sorted lists
+        // done already in super.equals()
+        return true;
+    }
+
+
+    /**
+     * Hash code for OrderedPolynomialList.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+
+    /**
+     * Sort a list of polynomials with respect to the ascending order of the
+     * leading Exponent vectors. The term order is taken from the ring.
+     * @param L polynomial list.
+     * @return sorted polynomial list from L.
+     */
+    public static <C extends RingElem<C>> List<GenPolynomial<C>> sort(List<GenPolynomial<C>> L) {
+        if (L == null) {
+            return L;
+        }
+        if (L.size() <= 1) { // nothing to sort
+            return L;
+        }
+        GenPolynomialRing<C> r = L.get(0).ring;
+        return sort(r,L);
+    }
+
+
+    /**
+     * Sort a list of polynomials with respect to the ascending order of the
+     * leading Exponent vectors. The term order is taken from the ring.
+     * @param r polynomial ring factory.
+     * @param L polynomial list.
+     * @return sorted polynomial list from L.
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    public static <C extends RingElem<C>> List<GenPolynomial<C>> sort(GenPolynomialRing<C> r,
+                    List<GenPolynomial<C>> L) {
+        if (L == null) {
+            return L;
+        }
+        if (L.size() <= 1) { // nothing to sort
+            return L;
+        }
+        final Comparator<ExpVector> evc = r.tord.getAscendComparator();
+        Comparator<GenPolynomial<C>> cmp = new Comparator<GenPolynomial<C>>() {
+
+
+            public int compare(GenPolynomial<C> p1, GenPolynomial<C> p2) {
+                ExpVector e1 = p1.leadingExpVector();
+                ExpVector e2 = p2.leadingExpVector();
+                if (e1 == null) {
+                    return -1; // dont care
+                }
+                if (e2 == null) {
+                    return 1; // dont care
+                }
+                if (e1.length() != e2.length()) {
+                    if (e1.length() > e2.length()) {
+                        return 1; // dont care
+                    }
+                    return -1; // dont care
+                }
+                return evc.compare(e1, e2);
+            }
+        };
+        GenPolynomial<C>[] s = null;
+        try {
+            s = (GenPolynomial<C>[]) new GenPolynomial[L.size()];
+            int i = 0;
+            for (GenPolynomial<C> p : L) {
+                s[i++] = p;
+            }
+            Arrays.<GenPolynomial<C>> sort(s, cmp);
+            return new ArrayList<GenPolynomial<C>>(Arrays.<GenPolynomial<C>> asList(s));
+        } catch (ClassCastException ok) {
+            System.out.println("Warning: polynomials not sorted");
+        }
+        return L; // unsorted
+    }
+
+
+    /**
+     * Sort a list of polynomials with respect to the ascending order of the
+     * degree. 
+     * @param L polynomial list.
+     * @return sorted polynomial list from L.
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    public static <C extends RingElem<C>> List<GenPolynomial<C>> sortDegree(List<GenPolynomial<C>> L) {
+        if (L == null) {
+            return L;
+        }
+        if (L.size() <= 1) { // nothing to sort
+            return L;
+        }
+        Comparator<GenPolynomial<C>> cmp = new Comparator<GenPolynomial<C>>() {
+
+            public int compare(GenPolynomial<C> p1, GenPolynomial<C> p2) {
+                long d1 = p1.degree();
+                long d2 = p2.degree();
+                if (d1 > d2) {
+                    return -1;
+                } else if (d1 < d2) {
+                    return 1;
+                }
+                return 0;
+            }
+        };
+        GenPolynomial<C>[] s = null;
+        try {
+            s = (GenPolynomial<C>[]) new GenPolynomial[L.size()];
+            int i = 0;
+            for (GenPolynomial<C> p : L) {
+                s[i++] = p;
+            }
+            Arrays.<GenPolynomial<C>> sort(s, cmp);
+            return new ArrayList<GenPolynomial<C>>(Arrays.<GenPolynomial<C>> asList(s));
+        } catch (ClassCastException ok) {
+            System.out.println("Warning: polynomials not sorted");
+        }
+        return L; // unsorted
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/Overlap.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/Overlap.java
@@ -1,0 +1,71 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.io.Serializable;
+
+
+/**
+ * Container for overlap words.
+ * A container of four words l1, r1, l2, r2. 
+ * @author Heinz Kredel
+ */
+
+public class Overlap implements Serializable {
+
+    public final Word l1;
+    public final Word r1;
+    public final Word l2;
+    public final Word r2;
+
+
+    /**
+     * Constructor.
+     */
+    public Overlap(Word l1, Word r1, Word l2, Word r2) {
+        this.l1 = l1;
+        this.r1 = r1;
+        this.l2 = l2;
+        this.r2 = r2;
+    }
+
+
+    /**
+     * Is word overlap.
+     * @param u word
+     * @param v word
+     * @return true if l1 * u * r1 = l2 * v * r2, else false.
+     */
+    public boolean isOverlap(Word u, Word v) {
+        Word a = l1.multiply(u).multiply(r1);
+        Word b = l2.multiply(v).multiply(r2);
+        boolean t = a.equals(b);
+        if ( !t ) {
+            System.out.println("a = " + a + " !=  b = " + b);
+        }
+        return t;
+    }
+
+
+    /**
+     * Get the string representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer s = new StringBuffer("Overlap[");
+        s.append(l1);
+        s.append(", ");
+        s.append(r1);
+        s.append(", ");
+        s.append(l2);
+        s.append(", ");
+        s.append(r2);
+        s.append("]");
+        return s.toString();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/OverlapList.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/OverlapList.java
@@ -1,0 +1,65 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.ArrayList;
+
+
+/**
+ * Container for lists of overlap words.
+ * List of Overlaps.
+ * @author Heinz Kredel
+ */
+
+public class OverlapList implements Serializable {
+
+    public final List<Overlap> ols;
+
+
+    /**
+     * Constructor.
+     */
+    public OverlapList() {
+        ols = new ArrayList<Overlap>();
+    }
+
+
+    /**
+     * Add to list.
+     */
+    public void add(Overlap ol) {
+        ols.add(ol);
+    }
+
+
+    /**
+     * Get the string representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return ols.toString();
+    }
+
+
+    /**
+     * Is word overlap list.
+     * @param u word
+     * @param v word
+     * @return true if l1 * u * r1 = l2 * v * r2 for all overlaps, else false.
+     */
+    public boolean isOverlap(Word u, Word v) {
+        for (Overlap ol : ols ) {
+            if ( !ol.isOverlap(u,v) ) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/PolyIterator.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/PolyIterator.java
@@ -1,0 +1,67 @@
+
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.Iterator;
+
+import edu.jas.structure.RingElem;
+
+import edu.jas.poly.ExpVector;
+
+
+/**
+ * Iterator over monomials of a polynomial. 
+ * Adaptor for val.entrySet().iterator().
+ * @author Heinz Kredel
+ */
+
+public class PolyIterator<C extends RingElem<C> > 
+             implements Iterator< Monomial<C> > {
+
+
+    /** 
+     * Internal iterator over polynomial map.
+     */
+    protected final Iterator< Map.Entry<ExpVector,C> > ms;
+
+
+    /** 
+     * Constructor of polynomial iterator.
+     * @param m SortetMap of a polynomial.
+     */
+    public PolyIterator( SortedMap<ExpVector,C> m ) {
+        ms = m.entrySet().iterator();
+    }
+
+
+    /** 
+     * Test for availability of a next monomial.
+     * @return true if the iteration has more monomials, else false.
+     */
+    public boolean hasNext() {
+        return ms.hasNext();
+    }
+
+
+    /** 
+     * Get next monomial element.
+     * @return next monomial.
+     */
+    public Monomial<C> next() {
+        return new Monomial<C>( ms.next() );
+    }
+
+
+    /** 
+     * Remove the last monomial returned from underlying set if allowed.
+     */
+    public void remove() {
+        ms.remove();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/PolySpliterator.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/PolySpliterator.java
@@ -1,0 +1,138 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.Consumer;
+
+import edu.jas.structure.RingElem;
+
+import edu.jas.poly.ExpVector;
+
+
+/**
+ * Spliterator over monomials of a polynomial. 
+ * Adaptor for val.entrySet().spliterator().
+ * @author Heinz Kredel
+ */
+
+public class PolySpliterator<C extends RingElem<C> > 
+    implements Spliterator< Monomial<C> > {
+
+
+    /** 
+     * Internal spliterator over polynomial map.
+     */
+    protected Spliterator< Map.Entry<ExpVector,C> > ms;
+
+
+    /** 
+     * Polynomial sorted map.
+     */
+    protected SortedMap<ExpVector,C> sm;
+
+    
+    /** 
+     * Constructor of polynomial spliterator.
+     * @param m SortedMap of a polynomial.
+     */
+    public PolySpliterator( SortedMap<ExpVector,C> m ) {
+        //this(Spliterators.spliterator(m.entrySet(), Spliterator.NONNULL), m);
+        this(m.entrySet().spliterator(), m);
+    }
+
+
+    /** 
+     * Constructor of polynomial spliterator.
+     * @param mse Spliterator a polynomial.
+     * @param m SortedMap of a polynomial.
+     */
+    protected PolySpliterator( Spliterator<Map.Entry<ExpVector,C>> mse, SortedMap<ExpVector,C> m ) {
+        sm = m;
+        ms = mse;
+    }
+
+    
+    /**
+     * String representation of PolySpliterator.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "PolySpliterator(" + estimateSize() + ", " + characteristics() + ")";
+    }
+
+    
+    /** 
+     * Returns a set of characteristics of this Spliterator and its
+     * elements.
+     * @return ORed value of the characteristics.
+     */
+    public int characteristics() {
+        return ms.characteristics();
+    }
+
+    
+    /** 
+     * Returns an estimate of the number of elements of this Spliterator.
+     * @return size of the sorted map.
+     */
+    public long estimateSize() {
+        return ms.estimateSize();
+    }
+
+    
+    /** 
+     * Get the monomial comparator.
+     * @return monomial comparator.
+     */
+    public Comparator<Monomial<C>> getComparator() {
+        return new Comparator<Monomial<C>>() {
+            @Override
+            public int compare(Monomial<C> a, Monomial<C> b) {
+                if (sm == null) {
+                    throw new RuntimeException("sm == null");
+                }
+                int s = sm.comparator().compare(a.e, b.e);
+                if (s != 0) { // always true
+                    return s;
+                }
+                return a.c.compareTo(b.c);
+            }
+        };
+    }
+
+
+    /** 
+     * Try to split this spliterator.
+     * @return polynomial spliterator or null.
+     */
+    public PolySpliterator<C> trySplit() {
+        Spliterator< Map.Entry<ExpVector,C> > part = ms.trySplit();
+        //System.out.println("PolySplit(" + part.characteristics() + ")");
+        return new PolySpliterator<C>(part, sm);
+    }
+
+
+    /** 
+     * If a remaining element exists perform the action on it.
+     * @return true if the polynomial spliterator could be advanced, else false.
+     */
+    public boolean tryAdvance(Consumer<? super Monomial<C>> action) {
+        Consumer<Map.Entry<ExpVector,C>> mact =
+            new Consumer<Map.Entry<ExpVector,C>>() {
+                public void accept(Map.Entry<ExpVector,C> me) {
+                    action.accept( new Monomial<C>(me.getKey(), me.getValue()) );
+                }
+            };
+        return ms.tryAdvance(mact);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/PolyUtil.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/PolyUtil.java
@@ -1,0 +1,3584 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.arith.BigComplex;
+import edu.jas.arith.BigDecimal;
+import edu.jas.arith.BigDecimalComplex;
+import edu.jas.arith.BigInteger;
+import edu.jas.arith.BigRational;
+import edu.jas.arith.ModInteger;
+import edu.jas.arith.ModIntegerRing;
+import edu.jas.arith.Modular;
+import edu.jas.arith.ModularRingFactory;
+import edu.jas.arith.Product;
+import edu.jas.arith.ProductRing;
+import edu.jas.arith.Rational;
+import edu.jas.arith.Roots;
+import edu.jas.structure.Element;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.structure.StarRingElem;
+import edu.jas.structure.UnaryFunctor;
+import edu.jas.util.ListUtil;
+
+
+/**
+ * Polynomial utilities, for example conversion between different
+ * representations, evaluation and interpolation.
+ * @author Heinz Kredel
+ */
+
+public class PolyUtil {
+
+
+    private static final Logger logger = LogManager.getLogger(PolyUtil.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Recursive representation. Represent as polynomial in i variables with
+     * coefficients in n-i variables. Works for arbitrary term orders.
+     * @param <C> coefficient type.
+     * @param rfac recursive polynomial ring factory.
+     * @param A polynomial to be converted.
+     * @return Recursive represenations of this in the ring rfac.
+     */
+    public static <C extends RingElem<C>> GenPolynomial<GenPolynomial<C>> recursive(
+                    GenPolynomialRing<GenPolynomial<C>> rfac, GenPolynomial<C> A) {
+
+        GenPolynomial<GenPolynomial<C>> B = rfac.getZERO().copy();
+        if (A.isZERO()) {
+            return B;
+        }
+        int i = rfac.nvar;
+        GenPolynomial<C> zero = rfac.getZEROCoefficient();
+        Map<ExpVector, GenPolynomial<C>> Bv = B.val; //getMap();
+        for (Map.Entry<ExpVector, C> y : A.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            C a = y.getValue();
+            ExpVector f = e.contract(0, i);
+            ExpVector g = e.contract(i, e.length() - i);
+            GenPolynomial<C> p = Bv.get(f);
+            if (p == null) {
+                p = zero;
+            }
+            p = p.sum(a, g);
+            Bv.put(f, p);
+        }
+        return B;
+    }
+
+
+    /**
+     * Distribute a recursive polynomial to a generic polynomial. Works for
+     * arbitrary term orders.
+     * @param <C> coefficient type.
+     * @param dfac combined polynomial ring factory of coefficients and this.
+     * @param B polynomial to be converted.
+     * @return distributed polynomial.
+     */
+    public static <C extends RingElem<C>> GenPolynomial<C> distribute(GenPolynomialRing<C> dfac,
+                    GenPolynomial<GenPolynomial<C>> B) {
+        GenPolynomial<C> C = dfac.getZERO().copy();
+        if (B.isZERO()) {
+            return C;
+        }
+        Map<ExpVector, C> Cm = C.val; //getMap();
+        for (Map.Entry<ExpVector, GenPolynomial<C>> y : B.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            GenPolynomial<C> A = y.getValue();
+            for (Map.Entry<ExpVector, C> x : A.val.entrySet()) {
+                ExpVector f = x.getKey();
+                C b = x.getValue();
+                ExpVector g = e.combine(f);
+                assert (Cm.get(g) == null);
+                Cm.put(g, b);
+            }
+        }
+        return C;
+    }
+
+
+    /**
+     * Recursive representation. Represent as polynomials in i variables with
+     * coefficients in n-i variables. Works for arbitrary term orders.
+     * @param <C> coefficient type.
+     * @param rfac recursive polynomial ring factory.
+     * @param L list of polynomials to be converted.
+     * @return Recursive represenations of the list in the ring rfac.
+     */
+    public static <C extends RingElem<C>> List<GenPolynomial<GenPolynomial<C>>> recursive(
+                    GenPolynomialRing<GenPolynomial<C>> rfac, List<GenPolynomial<C>> L) {
+        return ListUtil.<GenPolynomial<C>, GenPolynomial<GenPolynomial<C>>> map(L, new DistToRec<C>(rfac));
+    }
+
+
+    /**
+     * Distribute a recursive polynomial list to a generic polynomial list.
+     * Works for arbitrary term orders.
+     * @param <C> coefficient type.
+     * @param dfac combined polynomial ring factory of coefficients and this.
+     * @param L list of polynomials to be converted.
+     * @return distributed polynomial list.
+     */
+    public static <C extends RingElem<C>> List<GenPolynomial<C>> distribute(GenPolynomialRing<C> dfac,
+                    List<GenPolynomial<GenPolynomial<C>>> L) {
+        return ListUtil.<GenPolynomial<GenPolynomial<C>>, GenPolynomial<C>> map(L, new RecToDist<C>(dfac));
+    }
+
+
+    /**
+     * BigInteger from ModInteger coefficients, symmetric. Represent as
+     * polynomial with BigInteger coefficients by removing the modules and
+     * making coefficients symmetric to 0.
+     * @param fac result polynomial factory.
+     * @param A polynomial with ModInteger coefficients to be converted.
+     * @return polynomial with BigInteger coefficients.
+     */
+    public static <C extends RingElem<C> & Modular> GenPolynomial<BigInteger> integerFromModularCoefficients(
+                    GenPolynomialRing<BigInteger> fac, GenPolynomial<C> A) {
+        return PolyUtil.<C, BigInteger> map(fac, A, new ModSymToInt<C>());
+    }
+
+
+    /**
+     * BigInteger from ModInteger coefficients, symmetric. Represent as
+     * polynomial with BigInteger coefficients by removing the modules and
+     * making coefficients symmetric to 0.
+     * @param fac result polynomial factory.
+     * @param L list of polynomials with ModInteger coefficients to be
+     *            converted.
+     * @return list of polynomials with BigInteger coefficients.
+     */
+    public static <C extends RingElem<C> & Modular> List<GenPolynomial<BigInteger>> integerFromModularCoefficients(
+                    final GenPolynomialRing<BigInteger> fac, List<GenPolynomial<C>> L) {
+        return ListUtil.<GenPolynomial<C>, GenPolynomial<BigInteger>> map(L,
+                        new UnaryFunctor<GenPolynomial<C>, GenPolynomial<BigInteger>>() {
+
+
+                            public GenPolynomial<BigInteger> eval(GenPolynomial<C> c) {
+                                return PolyUtil.<C> integerFromModularCoefficients(fac, c);
+                            }
+                        });
+    }
+
+
+    /**
+     * BigInteger from ModInteger coefficients, positive. Represent as
+     * polynomial with BigInteger coefficients by removing the modules.
+     * @param fac result polynomial factory.
+     * @param A polynomial with ModInteger coefficients to be converted.
+     * @return polynomial with BigInteger coefficients.
+     */
+    public static <C extends RingElem<C> & Modular> GenPolynomial<BigInteger> integerFromModularCoefficientsPositive(
+                    GenPolynomialRing<BigInteger> fac, GenPolynomial<C> A) {
+        return PolyUtil.<C, BigInteger> map(fac, A, new ModToInt<C>());
+    }
+
+
+    /**
+     * BigInteger from BigRational coefficients. Represent as polynomial with
+     * BigInteger coefficients by multiplication with the lcm of the numerators
+     * of the BigRational coefficients.
+     * @param fac result polynomial factory.
+     * @param A polynomial with BigRational coefficients to be converted.
+     * @return polynomial with BigInteger coefficients.
+     */
+    public static GenPolynomial<BigInteger> integerFromRationalCoefficients(GenPolynomialRing<BigInteger> fac,
+                    GenPolynomial<BigRational> A) {
+        if (A == null || A.isZERO()) {
+            return fac.getZERO();
+        }
+        java.math.BigInteger c = null;
+        int s = 0;
+        // lcm of denominators
+        for (BigRational y : A.val.values()) {
+            java.math.BigInteger x = y.denominator();
+            // c = lcm(c,x)
+            if (c == null) {
+                c = x;
+                s = x.signum();
+            } else {
+                java.math.BigInteger d = c.gcd(x);
+                c = c.multiply(x.divide(d));
+            }
+        }
+        if (s < 0) {
+            c = c.negate();
+        }
+        return PolyUtil.<BigRational, BigInteger> map(fac, A, new RatToInt(c));
+    }
+
+
+    /**
+     * BigInteger from BigRational coefficients. Represent as polynomial with
+     * BigInteger coefficients by multiplication with the gcd of the numerators
+     * and the lcm of the denominators of the BigRational coefficients. <br />
+     * <b>Author:</b> Axel Kramer
+     * @param fac result polynomial factory.
+     * @param A polynomial with BigRational coefficients to be converted.
+     * @return Object[] with 3 entries: [0]=gcd [1]=lcm and [2]=polynomial with
+     *         BigInteger coefficients.
+     */
+    public static Object[] integerFromRationalCoefficientsFactor(GenPolynomialRing<BigInteger> fac,
+                    GenPolynomial<BigRational> A) {
+        Object[] result = new Object[3];
+        if (A == null || A.isZERO()) {
+            result[0] = java.math.BigInteger.ONE;
+            result[1] = java.math.BigInteger.ZERO;
+            result[2] = fac.getZERO();
+            return result;
+        }
+        java.math.BigInteger gcd = null;
+        java.math.BigInteger lcm = null;
+        int sLCM = 0;
+        int sGCD = 0;
+        // lcm of denominators
+        for (BigRational y : A.val.values()) {
+            java.math.BigInteger numerator = y.numerator();
+            java.math.BigInteger denominator = y.denominator();
+            // lcm = lcm(lcm,x)
+            if (lcm == null) {
+                lcm = denominator;
+                sLCM = denominator.signum();
+            } else {
+                java.math.BigInteger d = lcm.gcd(denominator);
+                lcm = lcm.multiply(denominator.divide(d));
+            }
+            // gcd = gcd(gcd,x)
+            if (gcd == null) {
+                gcd = numerator;
+                sGCD = numerator.signum();
+            } else {
+                gcd = gcd.gcd(numerator);
+            }
+        }
+        if (sLCM < 0) {
+            lcm = lcm.negate();
+        }
+        if (sGCD < 0) {
+            gcd = gcd.negate();
+        }
+        //System.out.println("gcd* = " + gcd + ", lcm = " + lcm);
+        result[0] = gcd;
+        result[1] = lcm;
+        result[2] = PolyUtil.<BigRational, BigInteger> map(fac, A, new RatToIntFactor(gcd, lcm));
+        return result;
+    }
+
+
+    /**
+     * BigInteger from BigRational coefficients. Represent as polynomial with
+     * BigInteger coefficients by multiplication with the gcd of the numerators
+     * and the lcm of the denominators of the BigRational coefficients. <br />
+     * @param fac result polynomial factory.
+     * @param gcd of rational coefficient numerators.
+     * @param lcm of rational coefficient denominators.
+     * @param A polynomial with BigRational coefficients to be converted.
+     * @return polynomial with BigInteger coefficients.
+     */
+    public static GenPolynomial<BigInteger> integerFromRationalCoefficients(GenPolynomialRing<BigInteger> fac,
+                    java.math.BigInteger gcd, java.math.BigInteger lcm, GenPolynomial<BigRational> A) {
+        //System.out.println("gcd = " + gcd + ", lcm = " + lcm);
+        GenPolynomial<BigInteger> Ai = PolyUtil.<BigRational, BigInteger> map(fac, A,
+                        new RatToIntFactor(gcd, lcm));
+        return Ai;
+    }
+
+
+    /**
+     * BigInteger from BigRational coefficients. Represent as list of
+     * polynomials with BigInteger coefficients by multiplication with the lcm
+     * of the numerators of the BigRational coefficients of each polynomial.
+     * @param fac result polynomial factory.
+     * @param L list of polynomials with BigRational coefficients to be
+     *            converted.
+     * @return polynomial list with BigInteger coefficients.
+     */
+    public static List<GenPolynomial<BigInteger>> integerFromRationalCoefficients(
+                    GenPolynomialRing<BigInteger> fac, List<GenPolynomial<BigRational>> L) {
+        return ListUtil.<GenPolynomial<BigRational>, GenPolynomial<BigInteger>> map(L, new RatToIntPoly(fac));
+    }
+
+
+    /**
+     * From BigInteger coefficients. Represent as polynomial with type C
+     * coefficients, e.g. ModInteger or BigRational.
+     * @param <C> coefficient type.
+     * @param fac result polynomial factory.
+     * @param A polynomial with BigInteger coefficients to be converted.
+     * @return polynomial with type C coefficients.
+     */
+    public static <C extends RingElem<C>> GenPolynomial<C> fromIntegerCoefficients(GenPolynomialRing<C> fac,
+                    GenPolynomial<BigInteger> A) {
+        return PolyUtil.<BigInteger, C> map(fac, A, new FromInteger<C>(fac.coFac));
+    }
+
+
+    /**
+     * From BigInteger coefficients. Represent as list of polynomials with type
+     * C coefficients, e.g. ModInteger or BigRational.
+     * @param <C> coefficient type.
+     * @param fac result polynomial factory.
+     * @param L list of polynomials with BigInteger coefficients to be
+     *            converted.
+     * @return list of polynomials with type C coefficients.
+     */
+    public static <C extends RingElem<C>> List<GenPolynomial<C>> fromIntegerCoefficients(
+                    GenPolynomialRing<C> fac, List<GenPolynomial<BigInteger>> L) {
+        return ListUtil.<GenPolynomial<BigInteger>, GenPolynomial<C>> map(L, new FromIntegerPoly<C>(fac));
+    }
+
+
+    /**
+     * Convert to decimal coefficients.
+     * @param fac result polynomial factory.
+     * @param A polynomial with Rational coefficients to be converted.
+     * @return polynomial with BigDecimal coefficients.
+     */
+    public static <C extends RingElem<C> & Rational> GenPolynomial<BigDecimal> decimalFromRational(
+                    GenPolynomialRing<BigDecimal> fac, GenPolynomial<C> A) {
+        return PolyUtil.<C, BigDecimal> map(fac, A, new RatToDec<C>());
+    }
+
+
+    /**
+     * Convert to complex decimal coefficients.
+     * @param fac result polynomial factory.
+     * @param A polynomial with complex Rational coefficients to be converted.
+     * @return polynomial with Complex BigDecimal coefficients.
+     */
+    public static <C extends RingElem<C> & Rational> GenPolynomial<Complex<BigDecimal>> complexDecimalFromRational(
+                    GenPolynomialRing<Complex<BigDecimal>> fac, GenPolynomial<Complex<C>> A) {
+        return PolyUtil.<Complex<C>, Complex<BigDecimal>> map(fac, A, new CompRatToDec<C>(fac.coFac));
+    }
+
+
+    /**
+     * Real part.
+     * @param fac result polynomial factory.
+     * @param A polynomial with BigComplex coefficients to be converted.
+     * @return polynomial with real part of the coefficients.
+     */
+    public static GenPolynomial<BigRational> realPart(GenPolynomialRing<BigRational> fac,
+                    GenPolynomial<BigComplex> A) {
+        return PolyUtil.<BigComplex, BigRational> map(fac, A, new RealPart());
+    }
+
+
+    /**
+     * Imaginary part.
+     * @param fac result polynomial factory.
+     * @param A polynomial with BigComplex coefficients to be converted.
+     * @return polynomial with imaginary part of coefficients.
+     */
+    public static GenPolynomial<BigRational> imaginaryPart(GenPolynomialRing<BigRational> fac,
+                    GenPolynomial<BigComplex> A) {
+        return PolyUtil.<BigComplex, BigRational> map(fac, A, new ImagPart());
+    }
+
+
+    /**
+     * Real part.
+     * @param fac result polynomial factory.
+     * @param A polynomial with BigComplex coefficients to be converted.
+     * @return polynomial with real part of the coefficients.
+     */
+    public static <C extends RingElem<C>> GenPolynomial<C> realPartFromComplex(GenPolynomialRing<C> fac,
+                    GenPolynomial<Complex<C>> A) {
+        return PolyUtil.<Complex<C>, C> map(fac, A, new RealPartComplex<C>());
+    }
+
+
+    /**
+     * Imaginary part.
+     * @param fac result polynomial factory.
+     * @param A polynomial with BigComplex coefficients to be converted.
+     * @return polynomial with imaginary part of coefficients.
+     */
+    public static <C extends RingElem<C>> GenPolynomial<C> imaginaryPartFromComplex(GenPolynomialRing<C> fac,
+                    GenPolynomial<Complex<C>> A) {
+        return PolyUtil.<Complex<C>, C> map(fac, A, new ImagPartComplex<C>());
+    }
+
+
+    /**
+     * Complex from real polynomial.
+     * @param fac result polynomial factory.
+     * @param A polynomial with C coefficients to be converted.
+     * @return polynomial with Complex<C> coefficients.
+     */
+    public static <C extends RingElem<C>> GenPolynomial<Complex<C>> toComplex(
+                    GenPolynomialRing<Complex<C>> fac, GenPolynomial<C> A) {
+        return PolyUtil.<C, Complex<C>> map(fac, A, new ToComplex<C>(fac.coFac));
+    }
+
+
+    /**
+     * Complex from rational coefficients.
+     * @param fac result polynomial factory.
+     * @param A polynomial with BigRational coefficients to be converted.
+     * @return polynomial with BigComplex coefficients.
+     */
+    public static GenPolynomial<BigComplex> complexFromRational(GenPolynomialRing<BigComplex> fac,
+                    GenPolynomial<BigRational> A) {
+        return PolyUtil.<BigRational, BigComplex> map(fac, A, new RatToCompl());
+    }
+
+
+    /**
+     * Complex from ring element coefficients.
+     * @param fac result polynomial factory.
+     * @param A polynomial with RingElem coefficients to be converted.
+     * @return polynomial with Complex coefficients.
+     */
+    public static <C extends GcdRingElem<C>> GenPolynomial<Complex<C>> complexFromAny(
+                    GenPolynomialRing<Complex<C>> fac, GenPolynomial<C> A) {
+        ComplexRing<C> cr = (ComplexRing<C>) fac.coFac;
+        return PolyUtil.<C, Complex<C>> map(fac, A, new AnyToComplex<C>(cr));
+    }
+
+
+    /**
+     * From AlgebraicNumber coefficients. Represent as polynomial with type
+     * GenPolynomial&lt;C&gt; coefficients, e.g. ModInteger or BigRational.
+     * @param rfac result polynomial factory.
+     * @param A polynomial with AlgebraicNumber coefficients to be converted.
+     * @return polynomial with type GenPolynomial&lt;C&gt; coefficients.
+     */
+    public static <C extends GcdRingElem<C>> GenPolynomial<GenPolynomial<C>> fromAlgebraicCoefficients(
+                    GenPolynomialRing<GenPolynomial<C>> rfac, GenPolynomial<AlgebraicNumber<C>> A) {
+        return PolyUtil.<AlgebraicNumber<C>, GenPolynomial<C>> map(rfac, A, new AlgToPoly<C>());
+    }
+
+
+    /**
+     * Convert to AlgebraicNumber coefficients. Represent as polynomial with
+     * AlgebraicNumber<C> coefficients, C is e.g. ModInteger or BigRational.
+     * @param pfac result polynomial factory.
+     * @param A polynomial with C coefficients to be converted.
+     * @return polynomial with AlgebraicNumber&lt;C&gt; coefficients.
+     */
+    public static <C extends GcdRingElem<C>> GenPolynomial<AlgebraicNumber<C>> convertToAlgebraicCoefficients(
+                    GenPolynomialRing<AlgebraicNumber<C>> pfac, GenPolynomial<C> A) {
+        AlgebraicNumberRing<C> afac = (AlgebraicNumberRing<C>) pfac.coFac;
+        return PolyUtil.<C, AlgebraicNumber<C>> map(pfac, A, new CoeffToAlg<C>(afac));
+    }
+
+
+    /**
+     * Convert to recursive AlgebraicNumber coefficients. Represent as
+     * polynomial with recursive AlgebraicNumber<C> coefficients, C is e.g.
+     * ModInteger or BigRational.
+     * @param depth recursion depth of AlgebraicNumber coefficients.
+     * @param pfac result polynomial factory.
+     * @param A polynomial with C coefficients to be converted.
+     * @return polynomial with AlgebraicNumber&lt;C&gt; coefficients.
+     */
+    public static <C extends GcdRingElem<C>> GenPolynomial<AlgebraicNumber<C>> convertToRecAlgebraicCoefficients(
+                    int depth, GenPolynomialRing<AlgebraicNumber<C>> pfac, GenPolynomial<C> A) {
+        AlgebraicNumberRing<C> afac = (AlgebraicNumberRing<C>) pfac.coFac;
+        return PolyUtil.<C, AlgebraicNumber<C>> map(pfac, A, new CoeffToRecAlg<C>(depth, afac));
+    }
+
+
+    /**
+     * Convert to AlgebraicNumber coefficients. Represent as polynomial with
+     * AlgebraicNumber<C> coefficients, C is e.g. ModInteger or BigRational.
+     * @param pfac result polynomial factory.
+     * @param A recursive polynomial with GenPolynomial&lt;BigInteger&gt;
+     *            coefficients to be converted.
+     * @return polynomial with AlgebraicNumber&lt;C&gt; coefficients.
+     */
+    public static <C extends GcdRingElem<C>> GenPolynomial<AlgebraicNumber<C>> convertRecursiveToAlgebraicCoefficients(
+                    GenPolynomialRing<AlgebraicNumber<C>> pfac, GenPolynomial<GenPolynomial<C>> A) {
+        AlgebraicNumberRing<C> afac = (AlgebraicNumberRing<C>) pfac.coFac;
+        return PolyUtil.<GenPolynomial<C>, AlgebraicNumber<C>> map(pfac, A, new PolyToAlg<C>(afac));
+    }
+
+
+    /**
+     * Complex from algebraic coefficients.
+     * @param fac result polynomial factory.
+     * @param A polynomial with AlgebraicNumber coefficients Q(i) to be
+     *            converted.
+     * @return polynomial with Complex coefficients.
+     */
+    public static <C extends GcdRingElem<C>> GenPolynomial<Complex<C>> complexFromAlgebraic(
+                    GenPolynomialRing<Complex<C>> fac, GenPolynomial<AlgebraicNumber<C>> A) {
+        ComplexRing<C> cfac = (ComplexRing<C>) fac.coFac;
+        return PolyUtil.<AlgebraicNumber<C>, Complex<C>> map(fac, A, new AlgebToCompl<C>(cfac));
+    }
+
+
+    /**
+     * AlgebraicNumber from complex coefficients.
+     * @param fac result polynomial factory over Q(i).
+     * @param A polynomial with Complex coefficients to be converted.
+     * @return polynomial with AlgebraicNumber coefficients.
+     */
+    public static <C extends GcdRingElem<C>> GenPolynomial<AlgebraicNumber<C>> algebraicFromComplex(
+                    GenPolynomialRing<AlgebraicNumber<C>> fac, GenPolynomial<Complex<C>> A) {
+        AlgebraicNumberRing<C> afac = (AlgebraicNumberRing<C>) fac.coFac;
+        return PolyUtil.<Complex<C>, AlgebraicNumber<C>> map(fac, A, new ComplToAlgeb<C>(afac));
+    }
+
+
+    /**
+     * ModInteger chinese remainder algorithm on coefficients.
+     * @param fac GenPolynomial&lt;ModInteger&gt; result factory with
+     *            A.coFac.modul*B.coFac.modul = C.coFac.modul.
+     * @param A GenPolynomial&lt;ModInteger&gt;.
+     * @param B other GenPolynomial&lt;ModInteger&gt;.
+     * @param mi inverse of A.coFac.modul in ring B.coFac.
+     * @return S = cra(A,B), with S mod A.coFac.modul == A and S mod
+     *         B.coFac.modul == B.
+     */
+    public static <C extends RingElem<C> & Modular> GenPolynomial<C> chineseRemainder(
+                    GenPolynomialRing<C> fac, GenPolynomial<C> A, C mi, GenPolynomial<C> B) {
+        ModularRingFactory<C> cfac = (ModularRingFactory<C>) fac.coFac; // get RingFactory
+        GenPolynomial<C> S = fac.getZERO().copy();
+        GenPolynomial<C> Ap = A.copy();
+        SortedMap<ExpVector, C> av = Ap.val; //getMap();
+        SortedMap<ExpVector, C> bv = B.getMap();
+        SortedMap<ExpVector, C> sv = S.val; //getMap();
+        C c = null;
+        for (Map.Entry<ExpVector, C> me : bv.entrySet()) {
+            ExpVector e = me.getKey();
+            C y = me.getValue(); //bv.get(e); // assert y != null
+            C x = av.get(e);
+            if (x != null) {
+                av.remove(e);
+                c = cfac.chineseRemainder(x, mi, y);
+                if (!c.isZERO()) { // 0 cannot happen
+                    sv.put(e, c);
+                }
+            } else {
+                //c = cfac.fromInteger( y.getVal() );
+                c = cfac.chineseRemainder(A.ring.coFac.getZERO(), mi, y);
+                if (!c.isZERO()) { // 0 cannot happen
+                    sv.put(e, c); // c != null
+                }
+            }
+        }
+        // assert bv is empty = done
+        for (Map.Entry<ExpVector, C> me : av.entrySet()) { // rest of av
+            ExpVector e = me.getKey();
+            C x = me.getValue(); // av.get(e); // assert x != null
+            //c = cfac.fromInteger( x.getVal() );
+            c = cfac.chineseRemainder(x, mi, B.ring.coFac.getZERO());
+            if (!c.isZERO()) { // 0 cannot happen
+                sv.put(e, c); // c != null
+            }
+        }
+        return S;
+    }
+
+
+    /**
+     * GenPolynomial monic, i.e. leadingBaseCoefficient == 1. If
+     * leadingBaseCoefficient is not invertible returns this unmodified.
+     * @param <C> coefficient type.
+     * @param p recursive GenPolynomial&lt;GenPolynomial<C>&gt;.
+     * @return monic(p).
+     */
+    public static <C extends RingElem<C>> GenPolynomial<GenPolynomial<C>> monic(
+                    GenPolynomial<GenPolynomial<C>> p) {
+        if (p == null || p.isZERO()) {
+            return p;
+        }
+        C lc = p.leadingBaseCoefficient().leadingBaseCoefficient();
+        if (!lc.isUnit()) {
+            return p;
+        }
+        C lm = lc.inverse();
+        GenPolynomial<C> L = p.ring.coFac.getONE();
+        L = L.multiply(lm);
+        return p.multiplyLeft(L);
+    }
+
+
+    /**
+     * GenSolvablePolynomial monic, i.e. leadingBaseCoefficient == 1. If
+     * leadingBaseCoefficient is not invertible returns this unmodified.
+     * @param <C> coefficient type.
+     * @param p recursive GenSolvablePolynomial&lt;GenPolynomial<C>&gt;.
+     * @return monic(p).
+     */
+    public static <C extends RingElem<C>> GenSolvablePolynomial<GenPolynomial<C>> monic(
+                    GenSolvablePolynomial<GenPolynomial<C>> p) {
+        if (p == null || p.isZERO()) {
+            return p;
+        }
+        C lc = p.leadingBaseCoefficient().leadingBaseCoefficient();
+        if (!lc.isUnit()) {
+            return p;
+        }
+        C lm = lc.inverse();
+        GenPolynomial<C> L = p.ring.coFac.getONE();
+        L = L.multiply(lm);
+        return p.multiplyLeft(L);
+    }
+
+
+    /**
+     * Polynomial list monic.
+     * @param <C> coefficient type.
+     * @param L list of polynomials with field coefficients.
+     * @return list of polynomials with leading coefficient 1.
+     */
+    public static <C extends RingElem<C>> List<GenPolynomial<C>> monic(List<GenPolynomial<C>> L) {
+        return ListUtil.<GenPolynomial<C>, GenPolynomial<C>> map(L,
+                        new UnaryFunctor<GenPolynomial<C>, GenPolynomial<C>>() {
+
+
+                            public GenPolynomial<C> eval(GenPolynomial<C> c) {
+                                if (c == null) {
+                                    return null;
+                                }
+                                return c.monic();
+                            }
+                        });
+    }
+
+
+    /**
+     * Word polynomial list monic.
+     * @param <C> coefficient type.
+     * @param L list of word polynomials with field coefficients.
+     * @return list of word polynomials with leading coefficient 1.
+     */
+    public static <C extends RingElem<C>> List<GenWordPolynomial<C>> wordMonic(List<GenWordPolynomial<C>> L) {
+        return ListUtil.<GenWordPolynomial<C>, GenWordPolynomial<C>> map(L,
+                        new UnaryFunctor<GenWordPolynomial<C>, GenWordPolynomial<C>>() {
+
+
+                            public GenWordPolynomial<C> eval(GenWordPolynomial<C> c) {
+                                if (c == null) {
+                                    return null;
+                                }
+                                return c.monic();
+                            }
+                        });
+    }
+
+
+    /**
+     * Recursive polynomial list monic.
+     * @param <C> coefficient type.
+     * @param L list of recursive polynomials with field coefficients.
+     * @return list of polynomials with leading base coefficient 1.
+     */
+    public static <C extends RingElem<C>> List<GenPolynomial<GenPolynomial<C>>> monicRec(
+                    List<GenPolynomial<GenPolynomial<C>>> L) {
+        return ListUtil.<GenPolynomial<GenPolynomial<C>>, GenPolynomial<GenPolynomial<C>>> map(L,
+                        new UnaryFunctor<GenPolynomial<GenPolynomial<C>>, GenPolynomial<GenPolynomial<C>>>() {
+
+
+                            public GenPolynomial<GenPolynomial<C>> eval(GenPolynomial<GenPolynomial<C>> c) {
+                                if (c == null) {
+                                    return null;
+                                }
+                                return PolyUtil.<C> monic(c);
+                            }
+                        });
+    }
+
+
+    /**
+     * Polynomial list leading exponent vectors.
+     * @param <C> coefficient type.
+     * @param L list of polynomials.
+     * @return list of leading exponent vectors.
+     */
+    public static <C extends RingElem<C>> List<ExpVector> leadingExpVector(List<GenPolynomial<C>> L) {
+        return ListUtil.<GenPolynomial<C>, ExpVector> map(L, new UnaryFunctor<GenPolynomial<C>, ExpVector>() {
+
+
+            public ExpVector eval(GenPolynomial<C> c) {
+                if (c == null) {
+                    return null;
+                }
+                return c.leadingExpVector();
+            }
+        });
+    }
+
+
+    /**
+     * Extend coefficient variables. Extend all coefficient ExpVectors by i
+     * elements and multiply by x_j^k.
+     * @param pfac extended polynomial ring factory (by i variables in the
+     *            coefficients).
+     * @param j index of variable to be used for multiplication.
+     * @param k exponent for x_j.
+     * @return extended polynomial.
+     */
+    public static <C extends RingElem<C>> GenPolynomial<GenPolynomial<C>> extendCoefficients(
+                    GenPolynomialRing<GenPolynomial<C>> pfac, GenPolynomial<GenPolynomial<C>> A, int j,
+                    long k) {
+        GenPolynomial<GenPolynomial<C>> Cp = pfac.getZERO().copy();
+        if (A.isZERO()) {
+            return Cp;
+        }
+        GenPolynomialRing<C> cfac = (GenPolynomialRing<C>) pfac.coFac;
+        //GenPolynomialRing<C> acfac = (GenPolynomialRing<C>) A.ring.coFac;
+        //int i = cfac.nvar - acfac.nvar;
+        Map<ExpVector, GenPolynomial<C>> CC = Cp.val; //getMap();
+        for (Map.Entry<ExpVector, GenPolynomial<C>> y : A.val.entrySet()) {
+            ExpVector e = y.getKey();
+            GenPolynomial<C> a = y.getValue();
+            GenPolynomial<C> f = a.extend(cfac, j, k);
+            CC.put(e, f);
+        }
+        return Cp;
+    }
+
+
+    /**
+     * Extend coefficient variables. Extend all coefficient ExpVectors by i
+     * elements and multiply by x_j^k.
+     * @param pfac extended polynomial ring factory (by i variables in the
+     *            coefficients).
+     * @param j index of variable to be used for multiplication.
+     * @param k exponent for x_j.
+     * @return extended polynomial.
+     */
+    public static <C extends RingElem<C>> GenSolvablePolynomial<GenPolynomial<C>> extendCoefficients(
+                    GenSolvablePolynomialRing<GenPolynomial<C>> pfac,
+                    GenSolvablePolynomial<GenPolynomial<C>> A, int j, long k) {
+        GenSolvablePolynomial<GenPolynomial<C>> Cp = pfac.getZERO().copy();
+        if (A.isZERO()) {
+            return Cp;
+        }
+        GenPolynomialRing<C> cfac = (GenPolynomialRing<C>) pfac.coFac;
+        //GenPolynomialRing<C> acfac = (GenPolynomialRing<C>) A.ring.coFac;
+        //int i = cfac.nvar - acfac.nvar;
+        Map<ExpVector, GenPolynomial<C>> CC = Cp.val; //getMap();
+        for (Map.Entry<ExpVector, GenPolynomial<C>> y : A.val.entrySet()) {
+            ExpVector e = y.getKey();
+            GenPolynomial<C> a = y.getValue();
+            GenPolynomial<C> f = a.extend(cfac, j, k);
+            CC.put(e, f);
+        }
+        return Cp;
+    }
+
+
+    /**
+     * To recursive representation. Represent as polynomial in i+r variables
+     * with coefficients in i variables. Works for arbitrary term orders.
+     * @param <C> coefficient type.
+     * @param rfac recursive polynomial ring factory.
+     * @param A polynomial to be converted.
+     * @return Recursive represenations of A in the ring rfac.
+     */
+    public static <C extends RingElem<C>> GenPolynomial<GenPolynomial<C>> toRecursive(
+                    GenPolynomialRing<GenPolynomial<C>> rfac, GenPolynomial<C> A) {
+
+        GenPolynomial<GenPolynomial<C>> B = rfac.getZERO().copy();
+        if (A.isZERO()) {
+            return B;
+        }
+        //int i = rfac.nvar;
+        //GenPolynomial<C> zero = rfac.getZEROCoefficient();
+        GenPolynomial<C> one = rfac.getONECoefficient();
+        Map<ExpVector, GenPolynomial<C>> Bv = B.val; //getMap();
+        for (Monomial<C> m : A) {
+            ExpVector e = m.e;
+            C a = m.c;
+            GenPolynomial<C> p = one.multiply(a);
+            Bv.put(e, p);
+        }
+        return B;
+    }
+
+
+    /**
+     * To recursive representation. Represent as solvable polynomial in i+r
+     * variables with coefficients in i variables. Works for arbitrary term
+     * orders.
+     * @param <C> coefficient type.
+     * @param rfac recursive solvable polynomial ring factory.
+     * @param A solvable polynomial to be converted.
+     * @return Recursive represenations of A in the ring rfac.
+     */
+    public static <C extends RingElem<C>> GenSolvablePolynomial<GenPolynomial<C>> toRecursive(
+                    GenSolvablePolynomialRing<GenPolynomial<C>> rfac, GenSolvablePolynomial<C> A) {
+
+        GenSolvablePolynomial<GenPolynomial<C>> B = rfac.getZERO().copy();
+        if (A.isZERO()) {
+            return B;
+        }
+        //int i = rfac.nvar;
+        //GenPolynomial<C> zero = rfac.getZEROCoefficient();
+        GenPolynomial<C> one = rfac.getONECoefficient();
+        Map<ExpVector, GenPolynomial<C>> Bv = B.val; //getMap();
+        for (Monomial<C> m : A) {
+            ExpVector e = m.e;
+            C a = m.c;
+            GenPolynomial<C> p = one.multiply(a);
+            Bv.put(e, p);
+        }
+        return B;
+    }
+
+
+    /**
+     * GenPolynomial coefficient wise remainder.
+     * @param <C> coefficient type.
+     * @param P GenPolynomial.
+     * @param s nonzero coefficient.
+     * @return coefficient wise remainder.
+     * @see edu.jas.poly.GenPolynomial#remainder(edu.jas.poly.GenPolynomial).
+     */
+    public static <C extends RingElem<C>> GenPolynomial<C> baseRemainderPoly(GenPolynomial<C> P, C s) {
+        if (s == null || s.isZERO()) {
+            throw new ArithmeticException(P + " division by zero " + s);
+        }
+        GenPolynomial<C> h = P.ring.getZERO().copy();
+        Map<ExpVector, C> hm = h.val; //getMap();
+        for (Map.Entry<ExpVector, C> m : P.getMap().entrySet()) {
+            ExpVector f = m.getKey();
+            C a = m.getValue();
+            C x = a.remainder(s);
+            hm.put(f, x);
+        }
+        return h;
+    }
+
+
+    /**
+     * GenPolynomial sparse pseudo remainder. For univariate polynomials.
+     * @param <C> coefficient type.
+     * @param P GenPolynomial.
+     * @param S nonzero GenPolynomial.
+     * @return remainder with ldcf(S)<sup>m'</sup> P = quotient * S + remainder.
+     *         m' &le; deg(P)-deg(S)
+     * @see edu.jas.poly.GenPolynomial#remainder(edu.jas.poly.GenPolynomial).
+     * @deprecated(forRemoval=true) Use
+     *                              {@link #baseSparsePseudoRemainder(edu.jas.poly.GenPolynomial,edu.jas.poly.GenPolynomial)}
+     *                              instead
+     */
+    @Deprecated
+    public static <C extends RingElem<C>> GenPolynomial<C> basePseudoRemainder(GenPolynomial<C> P,
+                    GenPolynomial<C> S) {
+        return baseSparsePseudoRemainder(P, S);
+    }
+
+
+    /**
+     * GenPolynomial sparse pseudo remainder. For univariate polynomials.
+     * @param <C> coefficient type.
+     * @param P GenPolynomial.
+     * @param S nonzero GenPolynomial.
+     * @return remainder with ldcf(S)<sup>m'</sup> P = quotient * S + remainder.
+     *         m' &le; deg(P)-deg(S)
+     * @see edu.jas.poly.GenPolynomial#remainder(edu.jas.poly.GenPolynomial).
+     */
+    public static <C extends RingElem<C>> GenPolynomial<C> baseSparsePseudoRemainder(GenPolynomial<C> P,
+                    GenPolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            throw new ArithmeticException(P.toString() + " division by zero " + S);
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        if (S.isConstant()) {
+            return P.ring.getZERO();
+        }
+        C c = S.leadingBaseCoefficient();
+        ExpVector e = S.leadingExpVector();
+        GenPolynomial<C> h;
+        GenPolynomial<C> r = P;
+        while (!r.isZERO()) {
+            ExpVector f = r.leadingExpVector();
+            if (f.multipleOf(e)) {
+                C a = r.leadingBaseCoefficient();
+                ExpVector fe = f.subtract(e);
+                C x = a.remainder(c);
+                if (x.isZERO()) {
+                    C y = a.divide(c);
+                    h = S.multiply(y, fe); // coeff a
+                } else {
+                    r = r.multiply(c); // coeff ac
+                    h = S.multiply(a, fe); // coeff ac
+                }
+                r = r.subtract(h);
+            } else {
+                break;
+            }
+        }
+        return r;
+    }
+
+
+    /**
+     * GenPolynomial dense pseudo remainder. For univariate polynomials.
+     * @param P GenPolynomial.
+     * @param S nonzero GenPolynomial.
+     * @return remainder with ldcf(S)<sup>m</sup> P = quotient * S + remainder.
+     *         m == deg(P)-deg(S)
+     * @see edu.jas.poly.GenPolynomial#remainder(edu.jas.poly.GenPolynomial).
+     */
+    public static <C extends RingElem<C>> GenPolynomial<C> baseDensePseudoRemainder(GenPolynomial<C> P,
+                    GenPolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            throw new ArithmeticException(P + " division by zero " + S);
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        if (S.isConstant()) {
+            return P.ring.getZERO();
+        }
+        long m = P.degree(0);
+        long n = S.degree(0);
+        C c = S.leadingBaseCoefficient();
+        ExpVector e = S.leadingExpVector();
+        GenPolynomial<C> h;
+        GenPolynomial<C> r = P;
+        for (long i = m; i >= n; i--) {
+            if (r.isZERO()) {
+                return r;
+            }
+            long k = r.degree(0);
+            if (i == k) {
+                ExpVector f = r.leadingExpVector();
+                C a = r.leadingBaseCoefficient();
+                f = f.subtract(e); // EVDIF( f, e );
+                //System.out.println("red div = " + f);
+                r = r.multiply(c); // coeff ac
+                h = S.multiply(a, f); // coeff ac
+                r = r.subtract(h);
+            } else {
+                r = r.multiply(c);
+            }
+        }
+        return r;
+    }
+
+
+    /**
+     * GenPolynomial dense pseudo quotient. For univariate polynomials.
+     * @param P GenPolynomial.
+     * @param S nonzero GenPolynomial.
+     * @return quotient with ldcf(S)<sup>m</sup> P = quotient * S + remainder. m
+     *         == deg(P)-deg(S)
+     * @see edu.jas.poly.GenPolynomial#remainder(edu.jas.poly.GenPolynomial).
+     */
+    public static <C extends RingElem<C>> GenPolynomial<C> baseDensePseudoQuotient(GenPolynomial<C> P,
+                    GenPolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            throw new ArithmeticException(P + " division by zero " + S);
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        //if (S.degree() <= 0) {
+        //    return l^n P; //P.ring.getZERO();
+        //}
+        long m = P.degree(0);
+        long n = S.degree(0);
+        C c = S.leadingBaseCoefficient();
+        ExpVector e = S.leadingExpVector();
+        GenPolynomial<C> q = P.ring.getZERO();
+        GenPolynomial<C> h;
+        GenPolynomial<C> r = P;
+        for (long i = m; i >= n; i--) {
+            if (r.isZERO()) {
+                return q;
+            }
+            long k = r.degree(0);
+            if (i == k) {
+                ExpVector f = r.leadingExpVector();
+                C a = r.leadingBaseCoefficient();
+                f = f.subtract(e); // EVDIF( f, e );
+                //System.out.println("red div = " + f);
+                r = r.multiply(c); // coeff ac
+                h = S.multiply(a, f); // coeff ac
+                r = r.subtract(h);
+                q = q.multiply(c);
+                q = q.sum(a, f);
+            } else {
+                q = q.multiply(c);
+                r = r.multiply(c);
+            }
+        }
+        return q;
+    }
+
+
+    /**
+     * GenPolynomial sparse pseudo divide. For univariate polynomials or exact
+     * division.
+     * @param <C> coefficient type.
+     * @param P GenPolynomial.
+     * @param S nonzero GenPolynomial.
+     * @return quotient with ldcf(S)<sup>m'</sup> P = quotient * S + remainder.
+     *         m' &le; deg(P)-deg(S)
+     * @see edu.jas.poly.GenPolynomial#divide(edu.jas.poly.GenPolynomial).
+     */
+    public static <C extends RingElem<C>> GenPolynomial<C> basePseudoDivide(GenPolynomial<C> P,
+                    GenPolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            throw new ArithmeticException(P.toString() + " division by zero " + S);
+        }
+        //if (S.ring.nvar != 1) {
+        // ok if exact division
+        // throw new RuntimeException(this.getClass().getName()
+        //                            + " univariate polynomials only");
+        //}
+        if (P.isZERO() || S.isONE()) {
+            return P;
+        }
+        C c = S.leadingBaseCoefficient();
+        ExpVector e = S.leadingExpVector();
+        GenPolynomial<C> h;
+        GenPolynomial<C> r = P;
+        GenPolynomial<C> q = S.ring.getZERO().copy();
+
+        while (!r.isZERO()) {
+            ExpVector f = r.leadingExpVector();
+            if (f.multipleOf(e)) {
+                C a = r.leadingBaseCoefficient();
+                f = f.subtract(e);
+                C x = a.remainder(c);
+                if (x.isZERO()) {
+                    C y = a.divide(c);
+                    q = q.sum(y, f);
+                    h = S.multiply(y, f); // coeff a
+                } else {
+                    q = q.multiply(c);
+                    q = q.sum(a, f);
+                    r = r.multiply(c); // coeff ac
+                    h = S.multiply(a, f); // coeff ac
+                }
+                r = r.subtract(h);
+            } else {
+                break;
+            }
+        }
+        return q;
+    }
+
+
+    /**
+     * GenPolynomial sparse pseudo quotient and remainder. For univariate
+     * polynomials or exact division.
+     * @param <C> coefficient type.
+     * @param P GenPolynomial.
+     * @param S nonzero GenPolynomial.
+     * @return [ quotient, remainder ] with ldcf(S)<sup>m'</sup> P = quotient *
+     *         S + remainder. m' &le; deg(P)-deg(S)
+     * @see edu.jas.poly.GenPolynomial#divide(edu.jas.poly.GenPolynomial).
+     */
+    @SuppressWarnings("unchecked")
+    public static <C extends RingElem<C>> GenPolynomial<C>[] basePseudoQuotientRemainder(GenPolynomial<C> P,
+                    GenPolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            throw new ArithmeticException(P.toString() + " division by zero " + S);
+        }
+        //if (S.ring.nvar != 1) {
+        // ok if exact division
+        // throw new RuntimeException(this.getClass().getName()
+        //                            + " univariate polynomials only");
+        //}
+        GenPolynomial<C>[] ret = new GenPolynomial[2];
+        ret[0] = null;
+        ret[1] = null;
+        if (P.isZERO() || S.isONE()) {
+            ret[0] = P;
+            ret[1] = S.ring.getZERO();
+            return ret;
+        }
+        C c = S.leadingBaseCoefficient();
+        ExpVector e = S.leadingExpVector();
+        GenPolynomial<C> h;
+        GenPolynomial<C> r = P;
+        GenPolynomial<C> q = S.ring.getZERO().copy();
+
+        while (!r.isZERO()) {
+            ExpVector f = r.leadingExpVector();
+            if (f.multipleOf(e)) {
+                C a = r.leadingBaseCoefficient();
+                f = f.subtract(e);
+                C x = a.remainder(c);
+                if (x.isZERO()) {
+                    C y = a.divide(c);
+                    q = q.sum(y, f);
+                    h = S.multiply(y, f); // coeff a
+                } else {
+                    q = q.multiply(c);
+                    q = q.sum(a, f);
+                    r = r.multiply(c); // coeff a c
+                    h = S.multiply(a, f); // coeff c a
+                }
+                r = r.subtract(h);
+            } else {
+                break;
+            }
+        }
+        //GenPolynomial<C> rhs = q.multiply(S).sum(r);
+        //GenPolynomial<C> lhs = P;
+        ret[0] = q;
+        ret[1] = r;
+        return ret;
+    }
+
+
+    /**
+     * Is GenPolynomial pseudo quotient and remainder. For univariate
+     * polynomials.
+     * @param <C> coefficient type.
+     * @param P base GenPolynomial.
+     * @param S nonzero base GenPolynomial.
+     * @return true, if P = q * S + r, else false.
+     * @see edu.jas.poly.GenPolynomial#remainder(edu.jas.poly.GenPolynomial).
+     *      <b>Note:</b> not always meaningful and working
+     */
+    public static <C extends RingElem<C>> boolean isBasePseudoQuotientRemainder(GenPolynomial<C> P,
+                    GenPolynomial<C> S, GenPolynomial<C> q, GenPolynomial<C> r) {
+        GenPolynomial<C> rhs = q.multiply(S).sum(r);
+        //System.out.println("rhs,1 = " + rhs);
+        GenPolynomial<C> lhs = P;
+        C ldcf = S.leadingBaseCoefficient();
+        long d = P.degree(0) - S.degree(0) + 1;
+        d = (d > 0 ? d : -d + 2);
+        for (long i = 0; i <= d; i++) {
+            //System.out.println("lhs-rhs = " + lhs.subtract(rhs));
+            if (lhs.equals(rhs) || lhs.negate().equals(rhs)) {
+                //System.out.println("lhs,1 = " + lhs);
+                return true;
+            }
+            lhs = lhs.multiply(ldcf);
+        }
+        GenPolynomial<C> Pp = P;
+        rhs = q.multiply(S);
+        //System.out.println("rhs,2 = " + rhs);
+        for (long i = 0; i <= d; i++) {
+            lhs = Pp.subtract(r);
+            //System.out.println("lhs-rhs = " + lhs.subtract(rhs));
+            if (lhs.equals(rhs) || lhs.negate().equals(rhs)) {
+                //System.out.println("lhs,2 = " + lhs);
+                return true;
+            }
+            Pp = Pp.multiply(ldcf);
+        }
+        C a = P.leadingBaseCoefficient();
+        rhs = q.multiply(S).sum(r);
+        C b = rhs.leadingBaseCoefficient();
+        C gcd = a.gcd(b);
+        C p = a.multiply(b);
+        C lcm = p.divide(gcd);
+        C ap = lcm.divide(a);
+        C bp = lcm.divide(b);
+        if (P.multiply(ap).equals(rhs.multiply(bp))) {
+            return true;
+        }
+        return false;
+    }
+
+
+    /**
+     * GenPolynomial divide. For recursive polynomials. Division by coefficient
+     * ring element.
+     * @param <C> coefficient type.
+     * @param P recursive GenPolynomial.
+     * @param s GenPolynomial.
+     * @return this/s.
+     */
+    public static <C extends RingElem<C>> GenPolynomial<GenPolynomial<C>> recursiveDivide(
+                    GenPolynomial<GenPolynomial<C>> P, GenPolynomial<C> s) {
+        if (s == null || s.isZERO()) {
+            throw new ArithmeticException("division by zero " + P + ", " + s);
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        if (s.isONE()) {
+            return P;
+        }
+        GenPolynomial<GenPolynomial<C>> p = P.ring.getZERO().copy();
+        SortedMap<ExpVector, GenPolynomial<C>> pv = p.val; //getMap();
+        for (Map.Entry<ExpVector, GenPolynomial<C>> m1 : P.getMap().entrySet()) {
+            GenPolynomial<C> c1 = m1.getValue();
+            ExpVector e1 = m1.getKey();
+            GenPolynomial<C> c = PolyUtil.<C> basePseudoDivide(c1, s);
+            if (!c.isZERO()) {
+                pv.put(e1, c); // or m1.setValue( c )
+            } else {
+                logger.warn("rDiv, P  = " + P);
+                logger.warn("rDiv, c1 = " + c1);
+                logger.warn("rDiv, s  = " + s);
+                logger.warn("rDiv, c  = " + c);
+                throw new RuntimeException("something is wrong");
+            }
+        }
+        return p;
+    }
+
+
+    /**
+     * GenPolynomial divide. For recursive polynomials. Division by coefficient
+     * ring element.
+     * @param <C> coefficient type.
+     * @param P recursive GenPolynomial.
+     * @param s GenPolynomial.
+     * @return this/s.
+     */
+    public static <C extends RingElem<C>> GenWordPolynomial<GenPolynomial<C>> recursiveDivide(
+                    GenWordPolynomial<GenPolynomial<C>> P, GenPolynomial<C> s) {
+        if (s == null || s.isZERO()) {
+            throw new ArithmeticException("division by zero " + P + ", " + s);
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        if (s.isONE()) {
+            return P;
+        }
+        GenWordPolynomial<GenPolynomial<C>> p = P.ring.getZERO().copy();
+        SortedMap<Word, GenPolynomial<C>> pv = p.val; //getMap();
+        for (Map.Entry<Word, GenPolynomial<C>> m1 : P.getMap().entrySet()) {
+            GenPolynomial<C> c1 = m1.getValue();
+            Word e1 = m1.getKey();
+            GenPolynomial<C> c = PolyUtil.<C> basePseudoDivide(c1, s);
+            if (!c.isZERO()) {
+                pv.put(e1, c); // or m1.setValue( c )
+            } else {
+                logger.warn("rDiv, P  = " + P);
+                logger.warn("rDiv, c1 = " + c1);
+                logger.warn("rDiv, s  = " + s);
+                logger.warn("rDiv, c  = " + c);
+                throw new RuntimeException("something is wrong");
+            }
+        }
+        return p;
+    }
+
+
+    /**
+     * GenPolynomial base divide. For recursive polynomials. Division by
+     * coefficient ring element.
+     * @param <C> coefficient type.
+     * @param P recursive GenPolynomial.
+     * @param s coefficient.
+     * @return this/s.
+     */
+    public static <C extends RingElem<C>> GenPolynomial<GenPolynomial<C>> baseRecursiveDivide(
+                    GenPolynomial<GenPolynomial<C>> P, C s) {
+        if (s == null || s.isZERO()) {
+            throw new ArithmeticException("division by zero " + P + ", " + s);
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        if (s.isONE()) {
+            return P;
+        }
+        GenPolynomial<GenPolynomial<C>> p = P.ring.getZERO().copy();
+        SortedMap<ExpVector, GenPolynomial<C>> pv = p.val; //getMap();
+        for (Map.Entry<ExpVector, GenPolynomial<C>> m1 : P.getMap().entrySet()) {
+            GenPolynomial<C> c1 = m1.getValue();
+            ExpVector e1 = m1.getKey();
+            GenPolynomial<C> c = PolyUtil.<C> coefficientBasePseudoDivide(c1, s);
+            if (!c.isZERO()) {
+                pv.put(e1, c); // or m1.setValue( c )
+            } else {
+                logger.warn("pu, c1 = " + c1);
+                logger.warn("pu, s  = " + s);
+                logger.warn("pu, c  = " + c);
+                throw new RuntimeException("something is wrong");
+            }
+        }
+        return p;
+    }
+
+
+    /**
+     * GenPolynomial sparse pseudo remainder. For recursive polynomials.
+     * @param <C> coefficient type.
+     * @param P recursive GenPolynomial.
+     * @param S nonzero recursive GenPolynomial.
+     * @return remainder with ldcf(S)<sup>m'</sup> P = quotient * S + remainder.
+     * @see edu.jas.poly.GenPolynomial#remainder(edu.jas.poly.GenPolynomial).
+     * @deprecated(forRemoval=true) Use
+     *                              {@link #recursiveSparsePseudoRemainder(edu.jas.poly.GenPolynomial,edu.jas.poly.GenPolynomial)}
+     *                              instead
+     */
+    @Deprecated
+    public static <C extends RingElem<C>> GenPolynomial<GenPolynomial<C>> recursivePseudoRemainder(
+                    GenPolynomial<GenPolynomial<C>> P, GenPolynomial<GenPolynomial<C>> S) {
+        return recursiveSparsePseudoRemainder(P, S);
+    }
+
+
+    /**
+     * GenPolynomial sparse pseudo remainder. For recursive polynomials.
+     * @param <C> coefficient type.
+     * @param P recursive GenPolynomial.
+     * @param S nonzero recursive GenPolynomial.
+     * @return remainder with ldcf(S)<sup>m'</sup> P = quotient * S + remainder.
+     * @see edu.jas.poly.GenPolynomial#remainder(edu.jas.poly.GenPolynomial).
+     */
+    public static <C extends RingElem<C>> GenPolynomial<GenPolynomial<C>> recursiveSparsePseudoRemainder(
+                    GenPolynomial<GenPolynomial<C>> P, GenPolynomial<GenPolynomial<C>> S) {
+        if (S == null || S.isZERO()) {
+            throw new ArithmeticException(P + " division by zero " + S);
+        }
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        if (S.isConstant()) {
+            return P.ring.getZERO();
+        }
+        GenPolynomial<C> c = S.leadingBaseCoefficient();
+        ExpVector e = S.leadingExpVector();
+        GenPolynomial<GenPolynomial<C>> h;
+        GenPolynomial<GenPolynomial<C>> r = P;
+        while (!r.isZERO()) {
+            ExpVector f = r.leadingExpVector();
+            if (f.multipleOf(e)) {
+                GenPolynomial<C> a = r.leadingBaseCoefficient();
+                f = f.subtract(e);
+                GenPolynomial<C> x = c; //test basePseudoRemainder(a,c);
+                if (x.isZERO()) {
+                    GenPolynomial<C> y = PolyUtil.<C> basePseudoDivide(a, c);
+                    h = S.multiply(y, f); // coeff a
+                } else {
+                    r = r.multiply(c); // coeff a c
+                    h = S.multiply(a, f); // coeff c a
+                }
+                r = r.subtract(h);
+            } else {
+                break;
+            }
+        }
+        return r;
+    }
+
+
+    /**
+     * GenPolynomial dense pseudo remainder. For recursive polynomials.
+     * @param P recursive GenPolynomial.
+     * @param S nonzero recursive GenPolynomial.
+     * @return remainder with ldcf(S)<sup>m'</sup> P = quotient * S + remainder.
+     * @see edu.jas.poly.GenPolynomial#remainder(edu.jas.poly.GenPolynomial).
+     */
+    public static <C extends RingElem<C>> GenPolynomial<GenPolynomial<C>> recursiveDensePseudoRemainder(
+                    GenPolynomial<GenPolynomial<C>> P, GenPolynomial<GenPolynomial<C>> S) {
+        if (S == null || S.isZERO()) {
+            throw new ArithmeticException(P + " division by zero " + S);
+        }
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        if (S.isConstant()) {
+            return P.ring.getZERO();
+        }
+        long m = P.degree(0);
+        long n = S.degree(0);
+        GenPolynomial<C> c = S.leadingBaseCoefficient();
+        ExpVector e = S.leadingExpVector();
+        GenPolynomial<GenPolynomial<C>> h;
+        GenPolynomial<GenPolynomial<C>> r = P;
+        for (long i = m; i >= n; i--) {
+            if (r.isZERO()) {
+                return r;
+            }
+            long k = r.degree(0);
+            if (i == k) {
+                ExpVector f = r.leadingExpVector();
+                GenPolynomial<C> a = r.leadingBaseCoefficient();
+                f = f.subtract(e); //EVDIF( f, e );
+                //System.out.println("red div = " + f);
+                r = r.multiply(c); // coeff ac
+                h = S.multiply(a, f); // coeff ac
+                r = r.subtract(h);
+            } else {
+                r = r.multiply(c);
+            }
+        }
+        return r;
+    }
+
+
+    /**
+     * GenPolynomial recursive pseudo divide. For recursive polynomials.
+     * @param <C> coefficient type.
+     * @param P recursive GenPolynomial.
+     * @param S nonzero recursive GenPolynomial.
+     * @return quotient with ldcf(S)<sup>m'</sup> P = quotient * S + remainder.
+     * @see edu.jas.poly.GenPolynomial#remainder(edu.jas.poly.GenPolynomial).
+     */
+    public static <C extends RingElem<C>> GenPolynomial<GenPolynomial<C>> recursivePseudoDivide(
+                    GenPolynomial<GenPolynomial<C>> P, GenPolynomial<GenPolynomial<C>> S) {
+        if (S == null || S.isZERO()) {
+            throw new ArithmeticException(P + " division by zero " + S);
+        }
+        //if (S.ring.nvar != 1) {
+        // ok if exact division
+        // throw new RuntimeException(this.getClass().getName()
+        //                            + " univariate polynomials only");
+        //}
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        if (S.isONE()) {
+            return P;
+        }
+        GenPolynomial<C> c = S.leadingBaseCoefficient();
+        ExpVector e = S.leadingExpVector();
+        GenPolynomial<GenPolynomial<C>> h;
+        GenPolynomial<GenPolynomial<C>> r = P;
+        GenPolynomial<GenPolynomial<C>> q = S.ring.getZERO().copy();
+        while (!r.isZERO()) {
+            ExpVector f = r.leadingExpVector();
+            if (f.multipleOf(e)) {
+                GenPolynomial<C> a = r.leadingBaseCoefficient();
+                f = f.subtract(e);
+                GenPolynomial<C> x = PolyUtil.<C> baseSparsePseudoRemainder(a, c);
+                if (x.isZERO() && !c.isConstant()) {
+                    GenPolynomial<C> y = PolyUtil.<C> basePseudoDivide(a, c);
+                    q = q.sum(y, f);
+                    h = S.multiply(y, f); // coeff a
+                } else {
+                    q = q.multiply(c);
+                    q = q.sum(a, f);
+                    r = r.multiply(c); // coeff ac
+                    h = S.multiply(a, f); // coeff ac
+                }
+                r = r.subtract(h);
+            } else {
+                break;
+            }
+        }
+        return q;
+    }
+
+
+    /**
+     * Is recursive GenPolynomial pseudo quotient and remainder. For recursive
+     * polynomials.
+     * @param <C> coefficient type.
+     * @param P recursive GenPolynomial.
+     * @param S nonzero recursive GenPolynomial.
+     * @return true, if P ~= q * S + r, else false.
+     * @see edu.jas.poly.GenPolynomial#remainder(edu.jas.poly.GenPolynomial).
+     *      <b>Note:</b> not always meaningful and working
+     */
+    public static <C extends RingElem<C>> boolean isRecursivePseudoQuotientRemainder(
+                    GenPolynomial<GenPolynomial<C>> P, GenPolynomial<GenPolynomial<C>> S,
+                    GenPolynomial<GenPolynomial<C>> q, GenPolynomial<GenPolynomial<C>> r) {
+        GenPolynomial<GenPolynomial<C>> rhs = q.multiply(S).sum(r);
+        GenPolynomial<GenPolynomial<C>> lhs = P;
+        GenPolynomial<C> ldcf = S.leadingBaseCoefficient();
+        long d = P.degree(0) - S.degree(0) + 1;
+        d = (d > 0 ? d : -d + 2);
+        for (long i = 0; i <= d; i++) {
+            //System.out.println("lhs = " + lhs);
+            //System.out.println("rhs = " + rhs);
+            //System.out.println("lhs-rhs = " + lhs.subtract(rhs));
+            if (lhs.equals(rhs)) {
+                return true;
+            }
+            lhs = lhs.multiply(ldcf);
+        }
+        GenPolynomial<GenPolynomial<C>> Pp = P;
+        rhs = q.multiply(S);
+        //System.out.println("rhs,2 = " + rhs);
+        for (long i = 0; i <= d; i++) {
+            lhs = Pp.subtract(r);
+            //System.out.println("lhs-rhs = " + lhs.subtract(rhs));
+            if (lhs.equals(rhs)) {
+                //System.out.println("lhs,2 = " + lhs);
+                return true;
+            }
+            Pp = Pp.multiply(ldcf);
+        }
+        GenPolynomial<C> a = P.leadingBaseCoefficient();
+        rhs = q.multiply(S).sum(r);
+        GenPolynomial<C> b = rhs.leadingBaseCoefficient();
+        if (P.multiply(b).equals(rhs.multiply(a))) {
+            return true;
+        }
+        return false;
+    }
+
+
+    /**
+     * GenPolynomial pseudo divide. For recursive polynomials.
+     * @param <C> coefficient type.
+     * @param P recursive GenPolynomial.
+     * @param s nonzero GenPolynomial.
+     * @return quotient with ldcf(s)<sup>m</sup> P = quotient * s + remainder.
+     * @see edu.jas.poly.GenPolynomial#remainder(edu.jas.poly.GenPolynomial).
+     */
+    public static <C extends RingElem<C>> GenPolynomial<GenPolynomial<C>> coefficientPseudoDivide(
+                    GenPolynomial<GenPolynomial<C>> P, GenPolynomial<C> s) {
+        if (s == null || s.isZERO()) {
+            throw new ArithmeticException(P + " division by zero " + s);
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        GenPolynomial<GenPolynomial<C>> p = P.ring.getZERO().copy();
+        SortedMap<ExpVector, GenPolynomial<C>> pv = p.val;
+        for (Map.Entry<ExpVector, GenPolynomial<C>> m : P.getMap().entrySet()) {
+            ExpVector e = m.getKey();
+            GenPolynomial<C> c1 = m.getValue();
+            GenPolynomial<C> c = basePseudoDivide(c1, s);
+            if (debug) {
+                GenPolynomial<C> x = c1.remainder(s);
+                if (!x.isZERO()) {
+                    logger.info("divide x = " + x);
+                    throw new ArithmeticException("no exact division: " + c1 + "/" + s);
+                }
+            }
+            if (c.isZERO()) {
+                //logger.warn("no exact division: " + c1 + "/" + s);
+                throw new ArithmeticException("no exact division: " + c1 + "/" + s);
+            }
+            pv.put(e, c); // or m1.setValue( c )
+        }
+        return p;
+    }
+
+
+    /**
+     * GenPolynomial pseudo divide. For polynomials.
+     * @param <C> coefficient type.
+     * @param P GenPolynomial.
+     * @param s nonzero coefficient.
+     * @return quotient with ldcf(s)<sup>m</sup> P = quotient * s + remainder.
+     * @see edu.jas.poly.GenPolynomial#remainder(edu.jas.poly.GenPolynomial).
+     */
+    public static <C extends RingElem<C>> GenPolynomial<C> coefficientBasePseudoDivide(GenPolynomial<C> P,
+                    C s) {
+        if (s == null || s.isZERO()) {
+            throw new ArithmeticException(P + " division by zero " + s);
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        GenPolynomial<C> p = P.ring.getZERO().copy();
+        SortedMap<ExpVector, C> pv = p.val;
+        for (Map.Entry<ExpVector, C> m : P.getMap().entrySet()) {
+            ExpVector e = m.getKey();
+            C c1 = m.getValue();
+            C c = c1.divide(s);
+            if (debug) {
+                C x = c1.remainder(s);
+                if (!x.isZERO()) {
+                    logger.info("divide x = " + x);
+                    throw new ArithmeticException("no exact division: " + c1 + "/" + s);
+                }
+            }
+            if (c.isZERO()) {
+                //logger.warn("no exact division: " + c1 + "/" + s);
+                throw new ArithmeticException("no exact division: " + c1 + "/" + s);
+            }
+            pv.put(e, c); // or m1.setValue( c )
+        }
+        return p;
+    }
+
+
+    /**
+     * GenPolynomial polynomial derivative main variable.
+     * @param <C> coefficient type.
+     * @param P GenPolynomial.
+     * @return deriviative(P).
+     */
+    public static <C extends RingElem<C>> GenPolynomial<C> baseDeriviative(GenPolynomial<C> P) {
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        GenPolynomialRing<C> pfac = P.ring;
+        if (pfac.nvar == 0) {
+            return pfac.getZERO();
+        }
+        if (pfac.nvar > 1) {
+            // baseContent not possible by return type
+            throw new IllegalArgumentException(P.getClass().getName() + " only for univariate polynomials");
+        }
+        RingFactory<C> rf = pfac.coFac;
+        GenPolynomial<C> d = pfac.getZERO().copy();
+        Map<ExpVector, C> dm = d.val; //getMap();
+        for (Map.Entry<ExpVector, C> m : P.getMap().entrySet()) {
+            ExpVector f = m.getKey();
+            long fl = f.getVal(0);
+            if (fl > 0) {
+                C cf = rf.fromInteger(fl);
+                C a = m.getValue();
+                C x = a.multiply(cf);
+                if (x != null && !x.isZERO()) {
+                    ExpVector e = ExpVector.create(1, 0, fl - 1L);
+                    dm.put(e, x);
+                }
+            }
+        }
+        return d;
+    }
+
+
+    /**
+     * GenPolynomial polynomial partial derivative variable r.
+     * @param <C> coefficient type.
+     * @param P GenPolynomial.
+     * @param r variable for partial deriviate.
+     * @return deriviative(P,r).
+     */
+    public static <C extends RingElem<C>> GenPolynomial<C> baseDeriviative(GenPolynomial<C> P, int r) {
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        GenPolynomialRing<C> pfac = P.ring;
+        if (r < 0 || pfac.nvar <= r) {
+            throw new IllegalArgumentException(
+                            P.getClass().getName() + " deriviative variable out of bound " + r);
+        }
+        int rp = pfac.nvar - 1 - r;
+        RingFactory<C> rf = pfac.coFac;
+        GenPolynomial<C> d = pfac.getZERO().copy();
+        Map<ExpVector, C> dm = d.val; //getMap();
+        for (Map.Entry<ExpVector, C> m : P.getMap().entrySet()) {
+            ExpVector f = m.getKey();
+            long fl = f.getVal(rp);
+            if (fl > 0) {
+                C cf = rf.fromInteger(fl);
+                C a = m.getValue();
+                C x = a.multiply(cf);
+                if (x != null && !x.isZERO()) {
+                    ExpVector e = f.subst(rp, fl - 1L);
+                    dm.put(e, x);
+                }
+            }
+        }
+        return d;
+    }
+
+
+    /**
+     * GenPolynomial polynomial integral main variable.
+     * @param <C> coefficient type.
+     * @param P GenPolynomial.
+     * @return integral(P).
+     */
+    public static <C extends RingElem<C>> GenPolynomial<C> baseIntegral(GenPolynomial<C> P) {
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        GenPolynomialRing<C> pfac = P.ring;
+        if (pfac.nvar == 0) {
+            return pfac.getONE();
+        }
+        if (pfac.nvar > 1) {
+            // baseContent not possible by return type
+            throw new IllegalArgumentException(P.getClass().getName() + " only for univariate polynomials");
+        }
+        RingFactory<C> rf = pfac.coFac;
+        GenPolynomial<C> d = pfac.getZERO().copy();
+        Map<ExpVector, C> dm = d.val; //getMap();
+        for (Map.Entry<ExpVector, C> m : P.getMap().entrySet()) {
+            ExpVector f = m.getKey();
+            long fl = f.getVal(0);
+            fl++;
+            C cf = rf.fromInteger(fl);
+            C a = m.getValue();
+            C x = a.divide(cf);
+            if (x != null && !x.isZERO()) {
+                ExpVector e = ExpVector.create(1, 0, fl);
+                dm.put(e, x);
+            }
+        }
+        return d;
+    }
+
+
+    /**
+     * GenPolynomial recursive polynomial derivative main variable.
+     * @param <C> coefficient type.
+     * @param P recursive GenPolynomial.
+     * @return deriviative(P).
+     */
+    public static <C extends RingElem<C>> GenPolynomial<GenPolynomial<C>> recursiveDeriviative(
+                    GenPolynomial<GenPolynomial<C>> P) {
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        GenPolynomialRing<GenPolynomial<C>> pfac = P.ring;
+        if (pfac.nvar == 0) {
+            return pfac.getZERO();
+        }
+        if (pfac.nvar > 1) {
+            // baseContent not possible by return type
+            throw new IllegalArgumentException(P.getClass().getName() + " only for univariate polynomials");
+        }
+        GenPolynomialRing<C> pr = (GenPolynomialRing<C>) pfac.coFac;
+        RingFactory<C> rf = pr.coFac;
+        GenPolynomial<GenPolynomial<C>> d = pfac.getZERO().copy();
+        Map<ExpVector, GenPolynomial<C>> dm = d.val; //getMap();
+        for (Map.Entry<ExpVector, GenPolynomial<C>> m : P.getMap().entrySet()) {
+            ExpVector f = m.getKey();
+            long fl = f.getVal(0);
+            if (fl > 0) {
+                C cf = rf.fromInteger(fl);
+                GenPolynomial<C> a = m.getValue();
+                GenPolynomial<C> x = a.multiply(cf);
+                if (x != null && !x.isZERO()) {
+                    ExpVector e = ExpVector.create(1, 0, fl - 1L);
+                    dm.put(e, x);
+                }
+            }
+        }
+        return d;
+    }
+
+
+    /**
+     * Factor coefficient bound. See SACIPOL.IPFCB: the product of all maxNorms
+     * of potential factors is less than or equal to 2**b times the maxNorm of
+     * A.
+     * @param e degree vector of a GenPolynomial A.
+     * @return 2**b.
+     */
+    public static BigInteger factorBound(ExpVector e) {
+        long n = 0;
+        java.math.BigInteger p = java.math.BigInteger.ONE;
+        java.math.BigInteger v;
+        if (e == null || e.isZERO()) {
+            return BigInteger.ONE;
+        }
+        for (int i = 0; i < e.length(); i++) {
+            if (e.getVal(i) > 0L) {
+                n += (2 * e.getVal(i) - 1);
+                v = new java.math.BigInteger("" + (e.getVal(i) - 1));
+                p = p.multiply(v);
+            }
+        }
+        n += (p.bitCount() + 1); // log2(p)
+        n /= 2;
+        v = new java.math.BigInteger("" + 2);
+        while (n >= 16) {
+            n -= 16;
+            v = v.shiftLeft(16);
+        }
+        if (n > 0) {
+            v = v.shiftLeft((int) n); // n < 16
+        }
+        BigInteger N = new BigInteger(v);
+        return N;
+    }
+
+
+    /**
+     * Absoulte norm. Square root of the sum of the squared coefficients.
+     * @param p GenPolynomial
+     * @return sqrt( sum<sub>i</sub> |c<sub>i</sub>|<sup>2</sup> ).
+     */
+    @SuppressWarnings("unchecked")
+    public static <C extends RingElem<C>> C absNorm(GenPolynomial<C> p) {
+        if (p == null) {
+            return null;
+        }
+        C a = p.ring.getZEROCoefficient();
+        if (a instanceof StarRingElem) {
+            //System.out.println("StarRingElem case");
+            for (C c : p.val.values()) {
+                @SuppressWarnings("unchecked")
+                C n = (C) ((StarRingElem) c).norm();
+                a = a.sum(n);
+            }
+        } else {
+            for (C c : p.val.values()) {
+                C n = c.multiply(c);
+                a = a.sum(n);
+            }
+        }
+        // compute square root if possible
+        // refactor for sqrt in RingElem ?
+        if (a instanceof BigRational) {
+            BigRational b = (BigRational) a;
+            a = (C) Roots.sqrt(b);
+        } else if (a instanceof BigComplex) {
+            BigComplex b = (BigComplex) a;
+            a = (C) Roots.sqrt(b);
+        } else if (a instanceof BigInteger) {
+            BigInteger b = (BigInteger) a;
+            a = (C) Roots.sqrt(b);
+        } else if (a instanceof BigDecimal) {
+            BigDecimal b = (BigDecimal) a;
+            a = (C) Roots.sqrt(b);
+        } else if (a instanceof BigDecimalComplex) {
+            BigDecimalComplex b = (BigDecimalComplex) a;
+            a = (C) Roots.sqrt(b);
+        } else {
+            logger.error("no square root implemented for " + a.toScriptFactory());
+        }
+        return a;
+    }
+
+
+    /**
+     * Evaluate at main variable.
+     * @param <C> coefficient type.
+     * @param cfac coefficent polynomial ring factory.
+     * @param A recursive polynomial to be evaluated.
+     * @param a value to evaluate at.
+     * @return A( x_1, ..., x_{n-1}, a ).
+     */
+    public static <C extends RingElem<C>> GenPolynomial<C> evaluateMainRecursive(GenPolynomialRing<C> cfac,
+                    GenPolynomial<GenPolynomial<C>> A, C a) {
+        if (A == null || A.isZERO()) {
+            return cfac.getZERO();
+        }
+        if (A.ring.nvar != 1) {
+            throw new IllegalArgumentException("evaluateMain no univariate polynomial");
+        }
+        if (a == null || a.isZERO()) {
+            return A.trailingBaseCoefficient();
+        }
+        // assert descending exponents, i.e. compatible term order
+        Map<ExpVector, GenPolynomial<C>> val = A.getMap();
+        GenPolynomial<C> B = null;
+        long el1 = -1; // undefined
+        long el2 = -1;
+        for (Map.Entry<ExpVector, GenPolynomial<C>> me : val.entrySet()) {
+            ExpVector e = me.getKey();
+            el2 = e.getVal(0);
+            if (B == null /*el1 < 0*/) { // first turn
+                B = me.getValue();
+            } else {
+                for (long i = el2; i < el1; i++) {
+                    B = B.multiply(a);
+                }
+                B = B.sum(me.getValue());
+            }
+            el1 = el2;
+        }
+        for (long i = 0; i < el2; i++) {
+            B = B.multiply(a);
+        }
+        return B;
+    }
+
+
+    /**
+     * Evaluate at main variable.
+     * @param <C> coefficient type.
+     * @param cfac coefficent polynomial ring factory.
+     * @param A distributed polynomial to be evaluated.
+     * @param a value to evaluate at.
+     * @return A( x_1, ..., x_{n-1}, a ).
+     */
+    public static <C extends RingElem<C>> GenPolynomial<C> evaluateMain(GenPolynomialRing<C> cfac,
+                    GenPolynomial<C> A, C a) {
+        if (A == null || A.isZERO()) {
+            return cfac.getZERO();
+        }
+        GenPolynomialRing<GenPolynomial<C>> rfac = A.ring.recursive(1);
+        if (rfac.nvar + cfac.nvar != A.ring.nvar) {
+            throw new IllegalArgumentException("evaluateMain number of variabes mismatch");
+        }
+        GenPolynomial<GenPolynomial<C>> Ap = recursive(rfac, A);
+        return PolyUtil.<C> evaluateMainRecursive(cfac, Ap, a);
+    }
+
+
+    /**
+     * Evaluate at main variable.
+     * @param <C> coefficient type.
+     * @param cfac coefficent ring factory.
+     * @param L list of univariate polynomials to be evaluated.
+     * @param a value to evaluate at.
+     * @return list( A( x_1, ..., x_{n-1}, a ) ) for A in L.
+     */
+    public static <C extends RingElem<C>> List<GenPolynomial<C>> evaluateMain(GenPolynomialRing<C> cfac,
+                    List<GenPolynomial<C>> L, C a) {
+        return ListUtil.<GenPolynomial<C>, GenPolynomial<C>> map(L, new EvalMainPol<C>(cfac, a));
+    }
+
+
+    /**
+     * Evaluate at main variable.
+     * @param <C> coefficient type.
+     * @param cfac coefficent ring factory.
+     * @param A univariate polynomial to be evaluated.
+     * @param a value to evaluate at.
+     * @return A( a ).
+     */
+    public static <C extends RingElem<C>> C evaluateMain(RingFactory<C> cfac, GenPolynomial<C> A, C a) {
+        if (A == null || A.isZERO()) {
+            return cfac.getZERO();
+        }
+        if (A.ring.nvar != 1) {
+            throw new IllegalArgumentException("evaluateMain no univariate polynomial");
+        }
+        if (a == null || a.isZERO()) {
+            return A.trailingBaseCoefficient();
+        }
+        // assert decreasing exponents, i.e. compatible term order
+        Map<ExpVector, C> val = A.getMap();
+        C B = null;
+        long el1 = -1; // undefined
+        long el2 = -1;
+        for (Map.Entry<ExpVector, C> me : val.entrySet()) {
+            ExpVector e = me.getKey();
+            el2 = e.getVal(0);
+            if (B == null /*el1 < 0*/) { // first turn
+                B = me.getValue();
+            } else {
+                for (long i = el2; i < el1; i++) {
+                    B = B.multiply(a);
+                }
+                B = B.sum(me.getValue());
+            }
+            el1 = el2;
+        }
+        for (long i = 0; i < el2; i++) {
+            B = B.multiply(a);
+        }
+        return B;
+    }
+
+
+    /**
+     * Evaluate at main variable.
+     * @param <C> coefficient type.
+     * @param cfac coefficent ring factory.
+     * @param L list of univariate polynomial to be evaluated.
+     * @param a value to evaluate at.
+     * @return list( A( a ) ) for A in L.
+     */
+    public static <C extends RingElem<C>> List<C> evaluateMain(RingFactory<C> cfac, List<GenPolynomial<C>> L,
+                    C a) {
+        return ListUtil.<GenPolynomial<C>, C> map(L, new EvalMain<C>(cfac, a));
+    }
+
+
+    /**
+     * Evaluate at k-th variable.
+     * @param <C> coefficient type.
+     * @param cfac coefficient polynomial ring in k variables C[x_1, ..., x_k]
+     *            factory.
+     * @param rfac coefficient polynomial ring C[x_1, ..., x_{k-1}] [x_k]
+     *            factory, a recursive polynomial ring in 1 variable with
+     *            coefficients in k-1 variables.
+     * @param nfac polynomial ring in n-1 varaibles C[x_1, ..., x_{k-1}]
+     *            [x_{k+1}, ..., x_n] factory, a recursive polynomial ring in
+     *            n-k+1 variables with coefficients in k-1 variables.
+     * @param dfac polynomial ring in n-1 variables. C[x_1, ..., x_{k-1},
+     *            x_{k+1}, ..., x_n] factory.
+     * @param A polynomial to be evaluated.
+     * @param a value to evaluate at.
+     * @return A( x_1, ..., x_{k-1}, a, x_{k+1}, ..., x_n).
+     */
+    public static <C extends RingElem<C>> GenPolynomial<C> evaluate(GenPolynomialRing<C> cfac,
+                    GenPolynomialRing<GenPolynomial<C>> rfac, GenPolynomialRing<GenPolynomial<C>> nfac,
+                    GenPolynomialRing<C> dfac, GenPolynomial<C> A, C a) {
+        if (rfac.nvar != 1) {
+            throw new IllegalArgumentException("evaluate coefficient ring not univariate");
+        }
+        if (A == null || A.isZERO()) {
+            return cfac.getZERO();
+        }
+        Map<ExpVector, GenPolynomial<C>> Ap = A.contract(cfac);
+        GenPolynomialRing<C> rcf = (GenPolynomialRing<C>) rfac.coFac;
+        GenPolynomial<GenPolynomial<C>> Ev = nfac.getZERO().copy();
+        Map<ExpVector, GenPolynomial<C>> Evm = Ev.val; //getMap();
+        for (Map.Entry<ExpVector, GenPolynomial<C>> m : Ap.entrySet()) {
+            ExpVector e = m.getKey();
+            GenPolynomial<C> b = m.getValue();
+            GenPolynomial<GenPolynomial<C>> c = recursive(rfac, b);
+            GenPolynomial<C> d = evaluateMainRecursive(rcf, c, a);
+            if (d != null && !d.isZERO()) {
+                Evm.put(e, d);
+            }
+        }
+        GenPolynomial<C> B = distribute(dfac, Ev);
+        return B;
+    }
+
+
+    /**
+     * Evaluate at first (lowest) variable.
+     * @param <C> coefficient type.
+     * @param cfac coefficient polynomial ring in first variable C[x_1] factory.
+     * @param dfac polynomial ring in n-1 variables. C[x_2, ..., x_n] factory.
+     * @param A polynomial to be evaluated.
+     * @param a value to evaluate at.
+     * @return A( a, x_2, ..., x_n).
+     */
+    public static <C extends RingElem<C>> GenPolynomial<C> evaluateFirst(GenPolynomialRing<C> cfac,
+                    GenPolynomialRing<C> dfac, GenPolynomial<C> A, C a) {
+        if (A == null || A.isZERO()) {
+            return dfac.getZERO();
+        }
+        Map<ExpVector, GenPolynomial<C>> Ap = A.contract(cfac);
+        //RingFactory<C> rcf = cfac.coFac; // == dfac.coFac
+
+        GenPolynomial<C> B = dfac.getZERO().copy();
+        Map<ExpVector, C> Bm = B.val; //getMap();
+
+        for (Map.Entry<ExpVector, GenPolynomial<C>> m : Ap.entrySet()) {
+            ExpVector e = m.getKey();
+            GenPolynomial<C> b = m.getValue();
+            C d = evaluateMain(cfac.coFac, b, a);
+            if (d != null && !d.isZERO()) {
+                Bm.put(e, d);
+            }
+        }
+        return B;
+    }
+
+
+    /**
+     * Evaluate at first (lowest) variable. Could also be called
+     * <code>evaluateFirst()</code>, but type erasure of parameter
+     * <code>A</code> does not allow the same name.
+     * @param <C> coefficient type.
+     * @param cfac coefficient polynomial ring in first variable C[x_1] factory.
+     * @param dfac polynomial ring in n-1 variables. C[x_2, ..., x_n] factory.
+     * @param A recursive polynomial to be evaluated.
+     * @param a value to evaluate at.
+     * @return A( a, x_2, ..., x_n).
+     */
+    public static <C extends RingElem<C>> GenPolynomial<C> evaluateFirstRec(GenPolynomialRing<C> cfac,
+                    GenPolynomialRing<C> dfac, GenPolynomial<GenPolynomial<C>> A, C a) {
+        if (A == null || A.isZERO()) {
+            return dfac.getZERO();
+        }
+        Map<ExpVector, GenPolynomial<C>> Ap = A.getMap();
+        GenPolynomial<C> B = dfac.getZERO().copy();
+        Map<ExpVector, C> Bm = B.val; //getMap();
+        for (Map.Entry<ExpVector, GenPolynomial<C>> m : Ap.entrySet()) {
+            ExpVector e = m.getKey();
+            GenPolynomial<C> b = m.getValue();
+            C d = evaluateMain(cfac.coFac, b, a);
+            if (d != null && !d.isZERO()) {
+                Bm.put(e, d);
+            }
+        }
+        return B;
+    }
+
+
+    /**
+     * Evaluate all variables.
+     * @param <C> coefficient type.
+     * @param cfac coefficient ring factory.
+     * @param A polynomial to be evaluated.
+     * @param a = (a_1, a_2, ..., a_n) a tuple of values to evaluate at.
+     * @return A(a_1, a_2, ..., a_n).
+     */
+    public static <C extends RingElem<C>> C evaluateAll(RingFactory<C> cfac, GenPolynomial<C> A, List<C> a) {
+        if (A == null || A.isZERO()) {
+            return cfac.getZERO();
+        }
+        GenPolynomialRing<C> dfac = A.ring;
+        if (a == null || a.size() != dfac.nvar) {
+            throw new IllegalArgumentException("evaluate tuple size not equal to number of variables");
+        }
+        if (dfac.nvar == 0) {
+            return A.trailingBaseCoefficient();
+        }
+        if (dfac.nvar == 1) {
+            return evaluateMain(cfac, A, a.get(0));
+        }
+        C b = cfac.getZERO();
+        GenPolynomial<C> Ap = A;
+        for (int k = 0; k < dfac.nvar - 1; k++) {
+            C ap = a.get(k);
+            GenPolynomialRing<C> c1fac = new GenPolynomialRing<C>(cfac, 1); // no vars
+            GenPolynomialRing<C> cnfac = new GenPolynomialRing<C>(cfac, dfac.nvar - 1 - k); // no vars
+            GenPolynomial<C> Bp = evaluateFirst(c1fac, cnfac, Ap, ap);
+            if (Bp.isZERO()) {
+                return b;
+            }
+            Ap = Bp;
+            //System.out.println("Ap = " + Ap);
+        }
+        C ap = a.get(dfac.nvar - 1);
+        b = evaluateMain(cfac, Ap, ap);
+        return b;
+    }
+
+
+    /**
+     * Substitute main variable.
+     * @param A univariate polynomial.
+     * @param s polynomial for substitution.
+     * @return polynomial A(x &lt;- s).
+     */
+    public static <C extends RingElem<C>> GenPolynomial<C> substituteMain(GenPolynomial<C> A,
+                    GenPolynomial<C> s) {
+        return substituteUnivariate(A, s);
+    }
+
+
+    /**
+     * Substitute univariate polynomial.
+     * @param f univariate polynomial.
+     * @param t polynomial for substitution.
+     * @return polynomial f(x &lt;- t).
+     */
+    public static <C extends RingElem<C>> GenPolynomial<C> substituteUnivariate(GenPolynomial<C> f,
+                    GenPolynomial<C> t) {
+        if (f == null || t == null) {
+            return null;
+        }
+        GenPolynomialRing<C> fac = f.ring;
+        if (fac.nvar > 1) {
+            throw new IllegalArgumentException("only for univariate polynomial f");
+        }
+        if (f.isZERO() || f.isConstant()) {
+            return f;
+        }
+        if (t.ring.nvar > 1) {
+            fac = t.ring;
+        }
+        // assert decending exponents, i.e. compatible term order
+        Map<ExpVector, C> val = f.getMap();
+        GenPolynomial<C> s = null;
+        long el1 = -1; // undefined
+        long el2 = -1;
+        for (Map.Entry<ExpVector, C> me : val.entrySet()) {
+            ExpVector e = me.getKey();
+            el2 = e.getVal(0);
+            if (s == null /*el1 < 0*/) { // first turn
+                s = fac.getZERO().sum(me.getValue());
+            } else {
+                for (long i = el2; i < el1; i++) {
+                    s = s.multiply(t);
+                }
+                s = s.sum(me.getValue());
+            }
+            el1 = el2;
+        }
+        for (long i = 0; i < el2; i++) {
+            s = s.multiply(t);
+        }
+        //System.out.println("s = " + s);
+        return s;
+    }
+
+
+    /**
+     * Substitute univariate polynomial with multivariate coefficients.
+     * @param f univariate polynomial with multivariate coefficients.
+     * @param t polynomial for substitution.
+     * @return polynomial f(x &lt;- t).
+     */
+    public static <C extends RingElem<C>> GenPolynomial<C> substituteUnivariateMult(GenPolynomial<C> f,
+                    GenPolynomial<C> t) {
+        if (f == null || t == null) {
+            return null;
+        }
+        GenPolynomialRing<C> fac = f.ring;
+        if (fac.nvar == 1) {
+            return substituteUnivariate(f, t);
+        }
+        GenPolynomialRing<GenPolynomial<C>> rfac = fac.recursive(1);
+        GenPolynomial<GenPolynomial<C>> fr = PolyUtil.<C> recursive(rfac, f);
+        GenPolynomial<GenPolynomial<C>> tr = PolyUtil.<C> recursive(rfac, t);
+        //System.out.println("fr = " + fr);
+        //System.out.println("tr = " + tr);
+        GenPolynomial<GenPolynomial<C>> sr = PolyUtil.<GenPolynomial<C>> substituteUnivariate(fr, tr);
+        //System.out.println("sr = " + sr);
+        GenPolynomial<C> s = PolyUtil.<C> distribute(fac, sr);
+        return s;
+    }
+
+
+    /**
+     * Taylor series for polynomial.
+     * @param f univariate polynomial.
+     * @param a expansion point.
+     * @return Taylor series (a polynomial) of f at a.
+     */
+    public static <C extends RingElem<C>> GenPolynomial<C> seriesOfTaylor(GenPolynomial<C> f, C a) {
+        if (f == null) {
+            return null;
+        }
+        GenPolynomialRing<C> fac = f.ring;
+        if (fac.nvar > 1) {
+            throw new IllegalArgumentException("only for univariate polynomials");
+        }
+        if (f.isZERO() || f.isConstant()) {
+            return f;
+        }
+        GenPolynomial<C> s = fac.getZERO();
+        C fa = PolyUtil.<C> evaluateMain(fac.coFac, f, a);
+        s = s.sum(fa);
+        long n = 1;
+        long i = 0;
+        GenPolynomial<C> g = PolyUtil.<C> baseDeriviative(f);
+        //GenPolynomial<C> p = fac.getONE();
+        while (!g.isZERO()) {
+            i++;
+            n *= i;
+            fa = PolyUtil.<C> evaluateMain(fac.coFac, g, a);
+            GenPolynomial<C> q = fac.univariate(0, i); //p;
+            q = q.multiply(fa);
+            q = q.divide(fac.fromInteger(n));
+            s = s.sum(q);
+            g = PolyUtil.<C> baseDeriviative(g);
+        }
+        //System.out.println("s = " + s);
+        return s;
+    }
+
+
+    /**
+     * ModInteger interpolate on first variable.
+     * @param <C> coefficient type.
+     * @param fac GenPolynomial<C> result factory.
+     * @param A GenPolynomial.
+     * @param M GenPolynomial interpolation modul of A.
+     * @param mi inverse of M(am) in ring fac.coFac.
+     * @param B evaluation of other GenPolynomial.
+     * @param am evaluation point (interpolation modul) of B, i.e. P(am) = B.
+     * @return S, with S mod M == A and S(am) == B.
+     */
+    public static <C extends RingElem<C>> GenPolynomial<GenPolynomial<C>> interpolate(
+                    GenPolynomialRing<GenPolynomial<C>> fac, GenPolynomial<GenPolynomial<C>> A,
+                    GenPolynomial<C> M, C mi, GenPolynomial<C> B, C am) {
+        GenPolynomial<GenPolynomial<C>> S = fac.getZERO().copy();
+        GenPolynomial<GenPolynomial<C>> Ap = A.copy();
+        SortedMap<ExpVector, GenPolynomial<C>> av = Ap.val; //getMap();
+        SortedMap<ExpVector, C> bv = B.getMap();
+        SortedMap<ExpVector, GenPolynomial<C>> sv = S.val; //getMap();
+        GenPolynomialRing<C> cfac = (GenPolynomialRing<C>) fac.coFac;
+        RingFactory<C> bfac = cfac.coFac;
+        GenPolynomial<C> c = null;
+        for (Map.Entry<ExpVector, C> me : bv.entrySet()) {
+            ExpVector e = me.getKey();
+            C y = me.getValue(); //bv.get(e); // assert y != null
+            GenPolynomial<C> x = av.get(e);
+            if (x != null) {
+                av.remove(e);
+                c = PolyUtil.<C> interpolate(cfac, x, M, mi, y, am);
+                if (!c.isZERO()) { // 0 cannot happen
+                    sv.put(e, c);
+                }
+            } else {
+                c = PolyUtil.<C> interpolate(cfac, cfac.getZERO(), M, mi, y, am);
+                if (!c.isZERO()) { // 0 cannot happen
+                    sv.put(e, c); // c != null
+                }
+            }
+        }
+        // assert bv is empty = done
+        for (Map.Entry<ExpVector, GenPolynomial<C>> me : av.entrySet()) { // rest of av
+            ExpVector e = me.getKey();
+            GenPolynomial<C> x = me.getValue(); //av.get(e); // assert x != null
+            c = PolyUtil.<C> interpolate(cfac, x, M, mi, bfac.getZERO(), am);
+            if (!c.isZERO()) { // 0 cannot happen
+                sv.put(e, c); // c != null
+            }
+        }
+        return S;
+    }
+
+
+    /**
+     * Univariate polynomial interpolation.
+     * @param <C> coefficient type.
+     * @param fac GenPolynomial<C> result factory.
+     * @param A GenPolynomial.
+     * @param M GenPolynomial interpolation modul of A.
+     * @param mi inverse of M(am) in ring fac.coFac.
+     * @param a evaluation of other GenPolynomial.
+     * @param am evaluation point (interpolation modul) of a, i.e. P(am) = a.
+     * @return S, with S mod M == A and S(am) == a.
+     */
+    public static <C extends RingElem<C>> GenPolynomial<C> interpolate(GenPolynomialRing<C> fac,
+                    GenPolynomial<C> A, GenPolynomial<C> M, C mi, C a, C am) {
+        GenPolynomial<C> s;
+        C b = PolyUtil.<C> evaluateMain(fac.coFac, A, am);
+        // A mod a.modul
+        C d = a.subtract(b); // a-A mod a.modul
+        if (d.isZERO()) {
+            return A;
+        }
+        b = d.multiply(mi); // b = (a-A)*mi mod a.modul
+        // (M*b)+A mod M = A mod M = 
+        // (M*mi*(a-A)+A) mod a.modul = a mod a.modul
+        s = M.multiply(b);
+        s = s.sum(A);
+        return s;
+    }
+
+
+    /**
+     * Recursive GenPolynomial switch varaible blocks.
+     * @param <C> coefficient type.
+     * @param P recursive GenPolynomial in R[X,Y].
+     * @return this in R[Y,X].
+     */
+    public static <C extends RingElem<C>> GenPolynomial<GenPolynomial<C>> switchVariables(
+                    GenPolynomial<GenPolynomial<C>> P) {
+        if (P == null) {
+            throw new IllegalArgumentException("P == null");
+        }
+        GenPolynomialRing<GenPolynomial<C>> rfac1 = P.ring;
+        GenPolynomialRing<C> cfac1 = (GenPolynomialRing<C>) rfac1.coFac;
+        GenPolynomialRing<C> cfac2 = new GenPolynomialRing<C>(cfac1.coFac, rfac1);
+        GenPolynomial<C> zero = cfac2.getZERO();
+        GenPolynomialRing<GenPolynomial<C>> rfac2 = new GenPolynomialRing<GenPolynomial<C>>(cfac2, cfac1);
+        GenPolynomial<GenPolynomial<C>> B = rfac2.getZERO().copy();
+        if (P.isZERO()) {
+            return B;
+        }
+        for (Monomial<GenPolynomial<C>> mr : P) {
+            GenPolynomial<C> cr = mr.c;
+            for (Monomial<C> mc : cr) {
+                GenPolynomial<C> c = zero.sum(mc.c, mr.e);
+                B = B.sum(c, mc.e);
+            }
+        }
+        return B;
+    }
+
+
+    /**
+     * Maximal degree of leading terms of a polynomial list.
+     * @return maximum degree of the leading terms of a polynomial list.
+     */
+    public static <C extends RingElem<C>> long totalDegreeLeadingTerm(List<GenPolynomial<C>> P) {
+        long degree = 0;
+        for (GenPolynomial<C> g : P) {
+            long total = g.leadingExpVector().totalDeg();
+            if (degree < total) {
+                degree = total;
+            }
+        }
+        return degree;
+    }
+
+
+    /**
+     * Total degree of polynomial list.
+     * @return total degree of the polynomial list.
+     */
+    public static <C extends RingElem<C>> long totalDegree(List<GenPolynomial<C>> P) {
+        long degree = 0;
+        for (GenPolynomial<C> g : P) {
+            long total = g.totalDegree();
+            if (degree < total) {
+                degree = total;
+            }
+        }
+        return degree;
+    }
+
+
+    /**
+     * Maximal degree of polynomial list.
+     * @return maximal degree of the polynomial list.
+     */
+    public static <C extends RingElem<C>> long maxDegree(List<GenPolynomial<C>> P) {
+        long degree = 0;
+        for (GenPolynomial<C> g : P) {
+            long total = g.degree();
+            if (degree < total) {
+                degree = total;
+            }
+        }
+        return degree;
+    }
+
+
+    /**
+     * Maximal degree in the coefficient polynomials.
+     * @param <C> coefficient type.
+     * @return maximal degree in the coefficients.
+     */
+    public static <C extends RingElem<C>> long coeffMaxDegree(GenPolynomial<GenPolynomial<C>> A) {
+        if (A.isZERO()) {
+            return 0; // 0 or -1 ?;
+        }
+        long deg = 0;
+        for (GenPolynomial<C> a : A.getMap().values()) {
+            long d = a.degree();
+            if (d > deg) {
+                deg = d;
+            }
+        }
+        return deg;
+    }
+
+
+    /**
+     * Map a unary function to the coefficients.
+     * @param ring result polynomial ring factory.
+     * @param p polynomial.
+     * @param f evaluation functor.
+     * @return new polynomial with coefficients f(p(e)).
+     */
+    public static <C extends RingElem<C>, D extends RingElem<D>> GenPolynomial<D> map(
+                    GenPolynomialRing<D> ring, GenPolynomial<C> p, UnaryFunctor<C, D> f) {
+        GenPolynomial<D> n = ring.getZERO().copy();
+        SortedMap<ExpVector, D> nv = n.val;
+        for (Monomial<C> m : p) {
+            D c = f.eval(m.c);
+            if (c != null && !c.isZERO()) {
+                nv.put(m.e, c);
+            }
+        }
+        return n;
+    }
+
+
+    /**
+     * Product representation.
+     * @param <C> coefficient type.
+     * @param pfac polynomial ring factory.
+     * @param L list of polynomials to be represented.
+     * @return Product represenation of L in the polynomial ring pfac.
+     */
+    public static <C extends GcdRingElem<C>> List<GenPolynomial<Product<C>>> toProductGen(
+                    GenPolynomialRing<Product<C>> pfac, List<GenPolynomial<C>> L) {
+
+        List<GenPolynomial<Product<C>>> list = new ArrayList<GenPolynomial<Product<C>>>();
+        if (L == null || L.size() == 0) {
+            return list;
+        }
+        for (GenPolynomial<C> a : L) {
+            GenPolynomial<Product<C>> b = toProductGen(pfac, a);
+            list.add(b);
+        }
+        return list;
+    }
+
+
+    /**
+     * Product representation.
+     * @param <C> coefficient type.
+     * @param pfac polynomial ring factory.
+     * @param A polynomial to be represented.
+     * @return Product represenation of A in the polynomial ring pfac.
+     */
+    public static <C extends GcdRingElem<C>> GenPolynomial<Product<C>> toProductGen(
+                    GenPolynomialRing<Product<C>> pfac, GenPolynomial<C> A) {
+
+        GenPolynomial<Product<C>> P = pfac.getZERO().copy();
+        if (A == null || A.isZERO()) {
+            return P;
+        }
+        RingFactory<Product<C>> rpfac = pfac.coFac;
+        ProductRing<C> rfac = (ProductRing<C>) rpfac;
+        for (Map.Entry<ExpVector, C> y : A.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            C a = y.getValue();
+            Product<C> p = toProductGen(rfac, a);
+            if (!p.isZERO()) {
+                P.doPutToMap(e, p);
+            }
+        }
+        return P;
+    }
+
+
+    /**
+     * Product representation.
+     * @param <C> coefficient type.
+     * @param pfac product ring factory.
+     * @param c coefficient to be represented.
+     * @return Product represenation of c in the ring pfac.
+     */
+    public static <C extends GcdRingElem<C>> Product<C> toProductGen(ProductRing<C> pfac, C c) {
+
+        SortedMap<Integer, C> elem = new TreeMap<Integer, C>();
+        for (int i = 0; i < pfac.length(); i++) {
+            RingFactory<C> rfac = pfac.getFactory(i);
+            C u = rfac.copy(c);
+            if (u != null && !u.isZERO()) {
+                elem.put(i, u);
+            }
+        }
+        return new Product<C>(pfac, elem);
+    }
+
+
+    /**
+     * Product representation.
+     * @param <C> coefficient type.
+     * @param pfac product polynomial ring factory.
+     * @param c coefficient to be used.
+     * @param e exponent vector.
+     * @return Product represenation of c X^e in the ring pfac.
+     */
+    public static <C extends RingElem<C>> Product<GenPolynomial<C>> toProduct(
+                    ProductRing<GenPolynomial<C>> pfac, C c, ExpVector e) {
+        SortedMap<Integer, GenPolynomial<C>> elem = new TreeMap<Integer, GenPolynomial<C>>();
+        for (int i = 0; i < e.length(); i++) {
+            RingFactory<GenPolynomial<C>> rfac = pfac.getFactory(i);
+            GenPolynomialRing<C> fac = (GenPolynomialRing<C>) rfac;
+            //GenPolynomialRing<C> cfac = fac.ring;
+            long a = e.getVal(i);
+            GenPolynomial<C> u;
+            if (a == 0) {
+                u = fac.getONE();
+            } else {
+                u = fac.univariate(0, a);
+            }
+            u = u.multiply(c);
+            elem.put(i, u);
+        }
+        return new Product<GenPolynomial<C>>(pfac, elem);
+    }
+
+
+    /**
+     * Product representation.
+     * @param <C> coefficient type.
+     * @param pfac product polynomial ring factory.
+     * @param A polynomial.
+     * @return Product represenation of the terms of A in the ring pfac.
+     */
+    public static <C extends RingElem<C>> Product<GenPolynomial<C>> toProduct(
+                    ProductRing<GenPolynomial<C>> pfac, GenPolynomial<C> A) {
+        Product<GenPolynomial<C>> P = pfac.getZERO();
+        if (A == null || A.isZERO()) {
+            return P;
+        }
+        for (Map.Entry<ExpVector, C> y : A.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            C a = y.getValue();
+            Product<GenPolynomial<C>> p = toProduct(pfac, a, e);
+            P = P.sum(p);
+        }
+        return P;
+    }
+
+
+    /**
+     * Product representation.
+     * @param pfac product ring factory.
+     * @param c coefficient to be represented.
+     * @return Product represenation of c in the ring pfac.
+     */
+    public static Product<ModInteger> toProduct(ProductRing<ModInteger> pfac, BigInteger c) {
+
+        SortedMap<Integer, ModInteger> elem = new TreeMap<Integer, ModInteger>();
+        for (int i = 0; i < pfac.length(); i++) {
+            RingFactory<ModInteger> rfac = pfac.getFactory(i);
+            ModIntegerRing fac = (ModIntegerRing) rfac;
+            ModInteger u = fac.fromInteger(c.getVal());
+            if (!u.isZERO()) {
+                elem.put(i, u);
+            }
+        }
+        return new Product<ModInteger>(pfac, elem);
+    }
+
+
+    /**
+     * Product representation.
+     * @param pfac polynomial ring factory.
+     * @param A polynomial to be represented.
+     * @return Product represenation of A in the polynomial ring pfac.
+     */
+    public static GenPolynomial<Product<ModInteger>> toProduct(GenPolynomialRing<Product<ModInteger>> pfac,
+                    GenPolynomial<BigInteger> A) {
+
+        GenPolynomial<Product<ModInteger>> P = pfac.getZERO().copy();
+        if (A == null || A.isZERO()) {
+            return P;
+        }
+        RingFactory<Product<ModInteger>> rpfac = pfac.coFac;
+        ProductRing<ModInteger> fac = (ProductRing<ModInteger>) rpfac;
+        for (Map.Entry<ExpVector, BigInteger> y : A.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            BigInteger a = y.getValue();
+            Product<ModInteger> p = toProduct(fac, a);
+            if (!p.isZERO()) {
+                P.doPutToMap(e, p);
+            }
+        }
+        return P;
+    }
+
+
+    /**
+     * Product representation.
+     * @param pfac polynomial ring factory.
+     * @param L list of polynomials to be represented.
+     * @return Product represenation of L in the polynomial ring pfac.
+     */
+    public static List<GenPolynomial<Product<ModInteger>>> toProduct(
+                    GenPolynomialRing<Product<ModInteger>> pfac, List<GenPolynomial<BigInteger>> L) {
+
+        List<GenPolynomial<Product<ModInteger>>> list = new ArrayList<GenPolynomial<Product<ModInteger>>>();
+        if (L == null || L.size() == 0) {
+            return list;
+        }
+        for (GenPolynomial<BigInteger> a : L) {
+            GenPolynomial<Product<ModInteger>> b = toProduct(pfac, a);
+            list.add(b);
+        }
+        return list;
+    }
+
+
+    /**
+     * Intersection. Intersection of a list of polynomials with a polynomial
+     * ring. The polynomial ring must be a contraction of the polynomial ring of
+     * the list of polynomials and the TermOrder must be an elimination order.
+     * @param R polynomial ring
+     * @param F list of polynomials
+     * @return R \cap F
+     */
+    public static <C extends RingElem<C>> List<GenPolynomial<C>> intersect(GenPolynomialRing<C> R,
+                    List<GenPolynomial<C>> F) {
+        if (F == null || F.isEmpty()) {
+            return F;
+        }
+        GenPolynomialRing<C> pfac = F.get(0).ring;
+        int d = pfac.nvar - R.nvar;
+        if (d <= 0) {
+            return F;
+        }
+        List<GenPolynomial<C>> H = new ArrayList<GenPolynomial<C>>(F.size());
+        for (GenPolynomial<C> p : F) {
+            Map<ExpVector, GenPolynomial<C>> m = null;
+            m = p.contract(R);
+            if (logger.isDebugEnabled()) {
+                logger.debug("intersect contract m = " + m);
+            }
+            if (m.size() == 1) { // contains one power of variables
+                for (Map.Entry<ExpVector, GenPolynomial<C>> me : m.entrySet()) {
+                    ExpVector e = me.getKey();
+                    if (e.isZERO()) {
+                        H.add(me.getValue());
+                    }
+                }
+            }
+        }
+        GenPolynomialRing<C> tfac = pfac.contract(d);
+        if (tfac.equals(R)) { // check 
+            return H;
+        }
+        logger.warn("tfac != R: tfac = " + tfac.toScript() + ", R = " + R.toScript() + ", pfac = "
+                        + pfac.toScript());
+        // throw new RuntimeException("contract(pfac) != R");
+        return H;
+    }
+
+
+    /**
+     * Intersection. Intersection of a list of solvable polynomials with a
+     * solvable polynomial ring. The solvable polynomial ring must be a
+     * contraction of the solvable polynomial ring of the list of polynomials
+     * and the TermOrder must be an elimination order.
+     * @param R solvable polynomial ring
+     * @param F list of solvable polynomials
+     * @return R \cap F
+     */
+    @SuppressWarnings("cast")
+    public static <C extends RingElem<C>> List<GenSolvablePolynomial<C>> intersect(
+                    GenSolvablePolynomialRing<C> R, List<GenSolvablePolynomial<C>> F) {
+        List<GenPolynomial<C>> Fp = PolynomialList.<C> castToList(F);
+        GenPolynomialRing<C> Rp = (GenPolynomialRing<C>) R;
+        List<GenPolynomial<C>> H = intersect(Rp, Fp);
+        return PolynomialList.<C> castToSolvableList(H);
+    }
+
+
+    /**
+     * Intersection. Intersection of a list of word polynomials with a word
+     * polynomial ring. The polynomial ring must be a contraction of the
+     * polynomial ring of the list of polynomials,
+     * @param R word polynomial ring
+     * @param F list of word polynomials
+     * @return R \cap F
+     */
+    public static <C extends RingElem<C>> List<GenWordPolynomial<C>> intersect(GenWordPolynomialRing<C> R,
+                    List<GenWordPolynomial<C>> F) {
+        if (F == null || F.isEmpty()) {
+            return F;
+        }
+        GenWordPolynomialRing<C> pfac = F.get(0).ring;
+        assert pfac.alphabet.isSubFactory(R.alphabet) : "pfac=" + pfac.alphabet + ", R=" + R.alphabet;
+        List<GenWordPolynomial<C>> H = new ArrayList<GenWordPolynomial<C>>(F.size());
+        for (GenWordPolynomial<C> p : F) {
+            if (p == null || p.isZERO()) {
+                continue;
+            }
+            GenWordPolynomial<C> m = p.contract(R);
+            if (logger.isDebugEnabled()) {
+                logger.debug("intersect contract m = " + m);
+            }
+            if (!m.isZERO()) {
+                H.add(m);
+            }
+        }
+        // throw new RuntimeException("contract(pfac) != R");
+        return H;
+    }
+
+
+    /**
+     * Remove all upper variables which do not occur in polynomial.
+     * @param p polynomial.
+     * @return polynomial with removed variables
+     */
+    public static <C extends RingElem<C>> GenPolynomial<C> removeUnusedUpperVariables(GenPolynomial<C> p) {
+        GenPolynomialRing<C> fac = p.ring;
+        if (fac.nvar <= 1) { // univariate
+            return p;
+        }
+        int[] dep = p.degreeVector().dependencyOnVariables();
+        if (fac.nvar == dep.length) { // all variables appear
+            return p;
+        }
+        if (dep.length == 0) { // no variables
+            GenPolynomialRing<C> fac0 = new GenPolynomialRing<C>(fac.coFac, 0);
+            GenPolynomial<C> p0 = new GenPolynomial<C>(fac0, p.leadingBaseCoefficient());
+            return p0;
+        }
+        int l = dep[0]; // higher variable
+        int r = dep[dep.length - 1]; // lower variable
+        if (l == 0 /*|| l == fac.nvar-1*/) { // upper variable appears
+            return p;
+        }
+        int n = l;
+        GenPolynomialRing<C> facr = fac.contract(n);
+        Map<ExpVector, GenPolynomial<C>> mpr = p.contract(facr);
+        if (mpr.size() != 1) {
+            logger.warn("upper ex, l = " + l + ", r = " + r + ", p = " + p + ", fac = " + fac.toScript());
+            throw new RuntimeException("this should not happen " + mpr);
+        }
+        GenPolynomial<C> pr = mpr.values().iterator().next();
+        n = fac.nvar - 1 - r;
+        if (n == 0) {
+            return pr;
+        } // else case not implemented
+        return pr;
+    }
+
+
+    /**
+     * Remove all lower variables which do not occur in polynomial.
+     * @param p polynomial.
+     * @return polynomial with removed variables
+     */
+    public static <C extends RingElem<C>> GenPolynomial<C> removeUnusedLowerVariables(GenPolynomial<C> p) {
+        GenPolynomialRing<C> fac = p.ring;
+        if (fac.nvar <= 1) { // univariate
+            return p;
+        }
+        int[] dep = p.degreeVector().dependencyOnVariables();
+        if (fac.nvar == dep.length) { // all variables appear
+            return p;
+        }
+        if (dep.length == 0) { // no variables
+            GenPolynomialRing<C> fac0 = new GenPolynomialRing<C>(fac.coFac, 0);
+            GenPolynomial<C> p0 = new GenPolynomial<C>(fac0, p.leadingBaseCoefficient());
+            return p0;
+        }
+        int l = dep[0]; // higher variable
+        int r = dep[dep.length - 1]; // lower variable
+        if (r == fac.nvar - 1) { // lower variable appears
+            return p;
+        }
+        int n = r + 1;
+        GenPolynomialRing<GenPolynomial<C>> rfac = fac.recursive(n);
+        GenPolynomial<GenPolynomial<C>> mpr = recursive(rfac, p);
+        if (mpr.length() != p.length()) {
+            logger.warn("lower ex, l = " + l + ", r = " + r + ", p = " + p + ", fac = " + fac.toScript());
+            throw new RuntimeException("this should not happen " + mpr);
+        }
+        RingFactory<C> cf = fac.coFac;
+        GenPolynomialRing<C> facl = new GenPolynomialRing<C>(cf, rfac);
+        GenPolynomial<C> pr = facl.getZERO().copy();
+        for (Monomial<GenPolynomial<C>> m : mpr) {
+            ExpVector e = m.e;
+            GenPolynomial<C> a = m.c;
+            if (!a.isConstant()) {
+                throw new RuntimeException("this can not happen " + a);
+            }
+            C c = a.leadingBaseCoefficient();
+            pr.doPutToMap(e, c);
+        }
+        return pr;
+    }
+
+
+    /**
+     * Remove upper block of middle variables which do not occur in polynomial.
+     * @param p polynomial.
+     * @return polynomial with removed variables
+     */
+    public static <C extends RingElem<C>> GenPolynomial<C> removeUnusedMiddleVariables(GenPolynomial<C> p) {
+        GenPolynomialRing<C> fac = p.ring;
+        if (fac.nvar <= 2) { // univariate or bi-variate
+            return p;
+        }
+        int[] dep = p.degreeVector().dependencyOnVariables();
+        if (fac.nvar == dep.length) { // all variables appear
+            return p;
+        }
+        if (dep.length == 0) { // no variables
+            GenPolynomialRing<C> fac0 = new GenPolynomialRing<C>(fac.coFac, 0);
+            GenPolynomial<C> p0 = new GenPolynomial<C>(fac0, p.leadingBaseCoefficient());
+            return p0;
+        }
+        ExpVector e1 = p.leadingExpVector();
+        if (dep.length == 1) { // one variable
+            TermOrder to = new TermOrder(fac.tord.getEvord());
+            int i = dep[0];
+            String v1 = e1.indexVarName(i, fac.getVars());
+            String[] vars = new String[] { v1 };
+            GenPolynomialRing<C> fac1 = new GenPolynomialRing<C>(fac.coFac, to, vars);
+            GenPolynomial<C> p1 = fac1.getZERO().copy();
+            for (Monomial<C> m : p) {
+                ExpVector e = m.e;
+                ExpVector f = ExpVector.create(1, 0, e.getVal(i));
+                p1.doPutToMap(f, m.c);
+            }
+            return p1;
+        }
+        GenPolynomialRing<GenPolynomial<C>> rfac = fac.recursive(1);
+        GenPolynomial<GenPolynomial<C>> mpr = recursive(rfac, p);
+
+        int l = dep[0]; // higher variable
+        int r = fac.nvar - dep[1]; // next variable
+        //System.out.println("l  = " + l);
+        //System.out.println("r  = " + r);
+
+        TermOrder to = new TermOrder(fac.tord.getEvord());
+        String[] vs = fac.getVars();
+        String[] vars = new String[r + 1];
+        for (int i = 0; i < r; i++) {
+            vars[i] = vs[i];
+        }
+        vars[r] = e1.indexVarName(l, vs);
+        //System.out.println("fac  = " + fac);
+        GenPolynomialRing<C> dfac = new GenPolynomialRing<C>(fac.coFac, to, vars);
+        //System.out.println("dfac = " + dfac);
+        GenPolynomialRing<GenPolynomial<C>> fac2 = dfac.recursive(1);
+        GenPolynomialRing<C> cfac = (GenPolynomialRing<C>) fac2.coFac;
+        GenPolynomial<GenPolynomial<C>> p2r = fac2.getZERO().copy();
+        for (Monomial<GenPolynomial<C>> m : mpr) {
+            ExpVector e = m.e;
+            GenPolynomial<C> a = m.c;
+            Map<ExpVector, GenPolynomial<C>> cc = a.contract(cfac);
+            for (Map.Entry<ExpVector, GenPolynomial<C>> me : cc.entrySet()) {
+                ExpVector f = me.getKey();
+                if (f.isZERO()) {
+                    GenPolynomial<C> c = me.getValue(); //cc.get(f);
+                    p2r.doPutToMap(e, c);
+                } else {
+                    throw new RuntimeException("this should not happen " + cc);
+                }
+            }
+        }
+        GenPolynomial<C> p2 = distribute(dfac, p2r);
+        return p2;
+    }
+
+
+    /**
+     * Select polynomial with univariate leading term in variable i.
+     * @param i variable index.
+     * @return polynomial with head term in variable i
+     */
+    public static <C extends RingElem<C>> GenPolynomial<C> selectWithVariable(List<GenPolynomial<C>> P,
+                    int i) {
+        for (GenPolynomial<C> p : P) {
+            int[] dep = p.leadingExpVector().dependencyOnVariables();
+            if (dep.length == 1 && dep[0] == i) {
+                return p;
+            }
+        }
+        return null; // not found       
+    }
+
+}
+
+
+/**
+ * Conversion of distributive to recursive representation.
+ */
+class DistToRec<C extends RingElem<C>>
+                implements UnaryFunctor<GenPolynomial<C>, GenPolynomial<GenPolynomial<C>>> {
+
+
+    GenPolynomialRing<GenPolynomial<C>> fac;
+
+
+    public DistToRec(GenPolynomialRing<GenPolynomial<C>> fac) {
+        this.fac = fac;
+    }
+
+
+    public GenPolynomial<GenPolynomial<C>> eval(GenPolynomial<C> c) {
+        if (c == null) {
+            return fac.getZERO();
+        }
+        return PolyUtil.<C> recursive(fac, c);
+    }
+}
+
+
+/**
+ * Conversion of recursive to distributive representation.
+ */
+class RecToDist<C extends RingElem<C>>
+                implements UnaryFunctor<GenPolynomial<GenPolynomial<C>>, GenPolynomial<C>> {
+
+
+    GenPolynomialRing<C> fac;
+
+
+    public RecToDist(GenPolynomialRing<C> fac) {
+        this.fac = fac;
+    }
+
+
+    public GenPolynomial<C> eval(GenPolynomial<GenPolynomial<C>> c) {
+        if (c == null) {
+            return fac.getZERO();
+        }
+        return PolyUtil.<C> distribute(fac, c);
+    }
+}
+
+
+/**
+ * BigRational numerator functor.
+ */
+class RatNumer implements UnaryFunctor<BigRational, BigInteger> {
+
+
+    public BigInteger eval(BigRational c) {
+        if (c == null) {
+            return new BigInteger();
+        }
+        return new BigInteger(c.numerator());
+    }
+}
+
+
+/**
+ * Conversion of symmetric ModInteger to BigInteger functor.
+ */
+class ModSymToInt<C extends RingElem<C> & Modular> implements UnaryFunctor<C, BigInteger> {
+
+
+    public BigInteger eval(C c) {
+        if (c == null) {
+            return new BigInteger();
+        }
+        return c.getSymmetricInteger();
+    }
+}
+
+
+/**
+ * Conversion of ModInteger to BigInteger functor.
+ */
+class ModToInt<C extends RingElem<C> & Modular> implements UnaryFunctor<C, BigInteger> {
+
+
+    public BigInteger eval(C c) {
+        if (c == null) {
+            return new BigInteger();
+        }
+        return c.getInteger();
+    }
+}
+
+
+/**
+ * Conversion of BigRational to BigInteger with division by lcm functor. result
+ * = num*(lcm/denom).
+ */
+class RatToInt implements UnaryFunctor<BigRational, BigInteger> {
+
+
+    java.math.BigInteger lcm;
+
+
+    public RatToInt(java.math.BigInteger lcm) {
+        this.lcm = lcm; //.getVal();
+    }
+
+
+    public BigInteger eval(BigRational c) {
+        if (c == null) {
+            return new BigInteger();
+        }
+        // p = num*(lcm/denom)
+        java.math.BigInteger b = lcm.divide(c.denominator());
+        return new BigInteger(c.numerator().multiply(b));
+    }
+}
+
+
+/**
+ * Conversion of BigRational to BigInteger. result = (num/gcd)*(lcm/denom).
+ */
+class RatToIntFactor implements UnaryFunctor<BigRational, BigInteger> {
+
+
+    final java.math.BigInteger lcm;
+
+
+    final java.math.BigInteger gcd;
+
+
+    public RatToIntFactor(java.math.BigInteger gcd, java.math.BigInteger lcm) {
+        this.gcd = gcd;
+        this.lcm = lcm; // .getVal();
+    }
+
+
+    public BigInteger eval(BigRational c) {
+        if (c == null) {
+            return new BigInteger();
+        }
+        if (gcd.equals(java.math.BigInteger.ONE)) {
+            // p = num*(lcm/denom)
+            java.math.BigInteger b = lcm.divide(c.denominator());
+            return new BigInteger(c.numerator().multiply(b));
+        }
+        // p = (num/gcd)*(lcm/denom)
+        java.math.BigInteger a = c.numerator().divide(gcd);
+        java.math.BigInteger b = lcm.divide(c.denominator());
+        return new BigInteger(a.multiply(b));
+    }
+}
+
+
+/**
+ * Conversion of Rational to BigDecimal. result = decimal(r).
+ */
+class RatToDec<C extends Element<C> & Rational> implements UnaryFunctor<C, BigDecimal> {
+
+
+    public BigDecimal eval(C c) {
+        if (c == null) {
+            return new BigDecimal();
+        }
+        return new BigDecimal(c.getRational());
+    }
+}
+
+
+/**
+ * Conversion of Complex Rational to Complex BigDecimal. result = decimal(r).
+ */
+class CompRatToDec<C extends RingElem<C> & Rational>
+                implements UnaryFunctor<Complex<C>, Complex<BigDecimal>> {
+
+
+    ComplexRing<BigDecimal> ring;
+
+
+    public CompRatToDec(RingFactory<Complex<BigDecimal>> ring) {
+        this.ring = (ComplexRing<BigDecimal>) ring;
+    }
+
+
+    public Complex<BigDecimal> eval(Complex<C> c) {
+        if (c == null) {
+            return ring.getZERO();
+        }
+        BigDecimal r = new BigDecimal(c.getRe().getRational());
+        BigDecimal i = new BigDecimal(c.getIm().getRational());
+        return new Complex<BigDecimal>(ring, r, i);
+    }
+}
+
+
+/**
+ * Conversion from BigInteger functor.
+ */
+class FromInteger<D extends RingElem<D>> implements UnaryFunctor<BigInteger, D> {
+
+
+    RingFactory<D> ring;
+
+
+    public FromInteger(RingFactory<D> ring) {
+        this.ring = ring;
+    }
+
+
+    public D eval(BigInteger c) {
+        if (c == null) {
+            return ring.getZERO();
+        }
+        return ring.fromInteger(c.getVal());
+    }
+}
+
+
+/**
+ * Conversion from GenPolynomial<BigInteger> functor.
+ */
+class FromIntegerPoly<D extends RingElem<D>>
+                implements UnaryFunctor<GenPolynomial<BigInteger>, GenPolynomial<D>> {
+
+
+    GenPolynomialRing<D> ring;
+
+
+    FromInteger<D> fi;
+
+
+    public FromIntegerPoly(GenPolynomialRing<D> ring) {
+        if (ring == null) {
+            throw new IllegalArgumentException("ring must not be null");
+        }
+        this.ring = ring;
+        fi = new FromInteger<D>(ring.coFac);
+    }
+
+
+    public GenPolynomial<D> eval(GenPolynomial<BigInteger> c) {
+        if (c == null) {
+            return ring.getZERO();
+        }
+        return PolyUtil.<BigInteger, D> map(ring, c, fi);
+    }
+}
+
+
+/**
+ * Conversion from GenPolynomial<BigRational> to GenPolynomial <BigInteger>
+ * functor.
+ */
+class RatToIntPoly implements UnaryFunctor<GenPolynomial<BigRational>, GenPolynomial<BigInteger>> {
+
+
+    GenPolynomialRing<BigInteger> ring;
+
+
+    public RatToIntPoly(GenPolynomialRing<BigInteger> ring) {
+        if (ring == null) {
+            throw new IllegalArgumentException("ring must not be null");
+        }
+        this.ring = ring;
+    }
+
+
+    public GenPolynomial<BigInteger> eval(GenPolynomial<BigRational> c) {
+        if (c == null) {
+            return ring.getZERO();
+        }
+        return PolyUtil.integerFromRationalCoefficients(ring, c);
+    }
+}
+
+
+/**
+ * Real part functor.
+ */
+class RealPart implements UnaryFunctor<BigComplex, BigRational> {
+
+
+    public BigRational eval(BigComplex c) {
+        if (c == null) {
+            return new BigRational();
+        }
+        return c.getRe();
+    }
+}
+
+
+/**
+ * Imaginary part functor.
+ */
+class ImagPart implements UnaryFunctor<BigComplex, BigRational> {
+
+
+    public BigRational eval(BigComplex c) {
+        if (c == null) {
+            return new BigRational();
+        }
+        return c.getIm();
+    }
+}
+
+
+/**
+ * Real part functor.
+ */
+class RealPartComplex<C extends RingElem<C>> implements UnaryFunctor<Complex<C>, C> {
+
+
+    public C eval(Complex<C> c) {
+        if (c == null) {
+            return null;
+        }
+        return c.getRe();
+    }
+}
+
+
+/**
+ * Imaginary part functor.
+ */
+class ImagPartComplex<C extends RingElem<C>> implements UnaryFunctor<Complex<C>, C> {
+
+
+    public C eval(Complex<C> c) {
+        if (c == null) {
+            return null;
+        }
+        return c.getIm();
+    }
+}
+
+
+/**
+ * Rational to complex functor.
+ */
+class ToComplex<C extends RingElem<C>> implements UnaryFunctor<C, Complex<C>> {
+
+
+    final protected ComplexRing<C> cfac;
+
+
+    @SuppressWarnings("unchecked")
+    public ToComplex(RingFactory<Complex<C>> fac) {
+        if (fac == null) {
+            throw new IllegalArgumentException("fac must not be null");
+        }
+        cfac = (ComplexRing<C>) fac;
+    }
+
+
+    public Complex<C> eval(C c) {
+        if (c == null) {
+            return cfac.getZERO();
+        }
+        return new Complex<C>(cfac, c);
+    }
+}
+
+
+/**
+ * Rational to complex functor.
+ */
+class RatToCompl implements UnaryFunctor<BigRational, BigComplex> {
+
+
+    public BigComplex eval(BigRational c) {
+        if (c == null) {
+            return new BigComplex();
+        }
+        return new BigComplex(c);
+    }
+}
+
+
+/**
+ * Any ring element to generic complex functor.
+ */
+class AnyToComplex<C extends GcdRingElem<C>> implements UnaryFunctor<C, Complex<C>> {
+
+
+    final protected ComplexRing<C> cfac;
+
+
+    public AnyToComplex(ComplexRing<C> fac) {
+        if (fac == null) {
+            throw new IllegalArgumentException("fac must not be null");
+        }
+        cfac = fac;
+    }
+
+
+    public AnyToComplex(RingFactory<C> fac) {
+        this(new ComplexRing<C>(fac));
+    }
+
+
+    public Complex<C> eval(C a) {
+        if (a == null || a.isZERO()) { // should not happen
+            return cfac.getZERO();
+        } else if (a.isONE()) {
+            return cfac.getONE();
+        } else {
+            return new Complex<C>(cfac, a);
+        }
+    }
+}
+
+
+/**
+ * Algebraic to generic complex functor.
+ */
+class AlgebToCompl<C extends GcdRingElem<C>> implements UnaryFunctor<AlgebraicNumber<C>, Complex<C>> {
+
+
+    final protected ComplexRing<C> cfac;
+
+
+    public AlgebToCompl(ComplexRing<C> fac) {
+        if (fac == null) {
+            throw new IllegalArgumentException("fac must not be null");
+        }
+        cfac = fac;
+    }
+
+
+    public Complex<C> eval(AlgebraicNumber<C> a) {
+        if (a == null || a.isZERO()) { // should not happen
+            return cfac.getZERO();
+        } else if (a.isONE()) {
+            return cfac.getONE();
+        } else {
+            GenPolynomial<C> p = a.getVal();
+            C real = cfac.ring.getZERO();
+            C imag = cfac.ring.getZERO();
+            for (Monomial<C> m : p) {
+                if (m.exponent().getVal(0) == 1L) {
+                    imag = m.coefficient();
+                } else if (m.exponent().getVal(0) == 0L) {
+                    real = m.coefficient();
+                } else {
+                    throw new IllegalArgumentException("unexpected monomial " + m);
+                }
+            }
+            //Complex<C> c = new Complex<C>(cfac,real,imag);
+            return new Complex<C>(cfac, real, imag);
+        }
+    }
+}
+
+
+/**
+ * Ceneric complex to algebraic number functor.
+ */
+class ComplToAlgeb<C extends GcdRingElem<C>> implements UnaryFunctor<Complex<C>, AlgebraicNumber<C>> {
+
+
+    final protected AlgebraicNumberRing<C> afac;
+
+
+    final protected AlgebraicNumber<C> I;
+
+
+    public ComplToAlgeb(AlgebraicNumberRing<C> fac) {
+        if (fac == null) {
+            throw new IllegalArgumentException("fac must not be null");
+        }
+        afac = fac;
+        I = afac.getGenerator();
+    }
+
+
+    public AlgebraicNumber<C> eval(Complex<C> c) {
+        if (c == null || c.isZERO()) { // should not happen
+            return afac.getZERO();
+        } else if (c.isONE()) {
+            return afac.getONE();
+        } else if (c.isIMAG()) {
+            return I;
+        } else {
+            return I.multiply(c.getIm()).sum(c.getRe());
+        }
+    }
+}
+
+
+/**
+ * Algebraic to polynomial functor.
+ */
+class AlgToPoly<C extends GcdRingElem<C>> implements UnaryFunctor<AlgebraicNumber<C>, GenPolynomial<C>> {
+
+
+    public GenPolynomial<C> eval(AlgebraicNumber<C> c) {
+        if (c == null) {
+            return null;
+        }
+        return c.val;
+    }
+}
+
+
+/**
+ * Polynomial to algebriac functor.
+ */
+class PolyToAlg<C extends GcdRingElem<C>> implements UnaryFunctor<GenPolynomial<C>, AlgebraicNumber<C>> {
+
+
+    final protected AlgebraicNumberRing<C> afac;
+
+
+    public PolyToAlg(AlgebraicNumberRing<C> fac) {
+        if (fac == null) {
+            throw new IllegalArgumentException("fac must not be null");
+        }
+        afac = fac;
+    }
+
+
+    public AlgebraicNumber<C> eval(GenPolynomial<C> c) {
+        if (c == null) {
+            return afac.getZERO();
+        }
+        return new AlgebraicNumber<C>(afac, c);
+    }
+}
+
+
+/**
+ * Coefficient to algebriac functor.
+ */
+class CoeffToAlg<C extends GcdRingElem<C>> implements UnaryFunctor<C, AlgebraicNumber<C>> {
+
+
+    final protected AlgebraicNumberRing<C> afac;
+
+
+    final protected GenPolynomial<C> zero;
+
+
+    public CoeffToAlg(AlgebraicNumberRing<C> fac) {
+        if (fac == null) {
+            throw new IllegalArgumentException("fac must not be null");
+        }
+        afac = fac;
+        GenPolynomialRing<C> pfac = afac.ring;
+        zero = pfac.getZERO();
+    }
+
+
+    public AlgebraicNumber<C> eval(C c) {
+        if (c == null) {
+            return afac.getZERO();
+        }
+        return new AlgebraicNumber<C>(afac, zero.sum(c));
+    }
+}
+
+
+/**
+ * Coefficient to recursive algebriac functor.
+ */
+class CoeffToRecAlg<C extends GcdRingElem<C>> implements UnaryFunctor<C, AlgebraicNumber<C>> {
+
+
+    final protected List<AlgebraicNumberRing<C>> lfac;
+
+
+    final int depth;
+
+
+    @SuppressWarnings({ "unchecked", "cast" })
+    public CoeffToRecAlg(int depth, AlgebraicNumberRing<C> fac) {
+        if (fac == null) {
+            throw new IllegalArgumentException("fac must not be null");
+        }
+        AlgebraicNumberRing<C> afac = fac;
+        this.depth = depth;
+        lfac = new ArrayList<AlgebraicNumberRing<C>>(this.depth);
+        lfac.add(fac);
+        for (int i = 1; i < this.depth; i++) {
+            RingFactory<C> rf = afac.ring.coFac;
+            if (!(rf instanceof AlgebraicNumberRing)) {
+                throw new IllegalArgumentException("fac depth to low");
+            }
+            afac = (AlgebraicNumberRing<C>) (Object) rf;
+            lfac.add(afac);
+        }
+    }
+
+
+    @SuppressWarnings({ "unchecked" })
+    public AlgebraicNumber<C> eval(C c) {
+        if (c == null) {
+            return lfac.get(0).getZERO();
+        }
+        C ac = c;
+        AlgebraicNumberRing<C> af = lfac.get(lfac.size() - 1);
+        GenPolynomial<C> zero = af.ring.getZERO();
+        AlgebraicNumber<C> an = new AlgebraicNumber<C>(af, zero.sum(ac));
+        for (int i = lfac.size() - 2; i >= 0; i--) {
+            af = lfac.get(i);
+            zero = af.ring.getZERO();
+            ac = (C) (Object) an;
+            an = new AlgebraicNumber<C>(af, zero.sum(ac));
+        }
+        return an;
+    }
+}
+
+
+/**
+ * Evaluate main variable functor.
+ */
+class EvalMain<C extends RingElem<C>> implements UnaryFunctor<GenPolynomial<C>, C> {
+
+
+    final RingFactory<C> cfac;
+
+
+    final C a;
+
+
+    public EvalMain(RingFactory<C> cfac, C a) {
+        this.cfac = cfac;
+        this.a = a;
+    }
+
+
+    public C eval(GenPolynomial<C> c) {
+        if (c == null) {
+            return cfac.getZERO();
+        }
+        return PolyUtil.<C> evaluateMain(cfac, c, a);
+    }
+}
+
+
+/**
+ * Evaluate main variable functor.
+ */
+class EvalMainPol<C extends RingElem<C>> implements UnaryFunctor<GenPolynomial<C>, GenPolynomial<C>> {
+
+
+    final GenPolynomialRing<C> cfac;
+
+
+    final C a;
+
+
+    public EvalMainPol(GenPolynomialRing<C> cfac, C a) {
+        this.cfac = cfac;
+        this.a = a;
+    }
+
+
+    public GenPolynomial<C> eval(GenPolynomial<C> c) {
+        if (c == null) {
+            return cfac.getZERO();
+        }
+        return PolyUtil.<C> evaluateMain(cfac, c, a);
+    }
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/Polynomial.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/Polynomial.java
@@ -1,0 +1,110 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.util.Map;
+import java.util.Iterator;
+
+
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Polynomial interface.
+ * Adds methods specific to polynomials.
+ * @param <C> ring element type
+ * @author Heinz Kredel
+ */
+
+public interface Polynomial<C extends RingElem<C>> 
+                 extends RingElem< Polynomial<C> > {
+
+    /**
+     * Leading monomial.
+     * @return first map entry.
+     */
+    public Map.Entry<ExpVector,C> leadingMonomial();
+
+
+    /**
+     * Leading exponent vector.
+     * @return first exponent.
+     */
+    public ExpVector leadingExpVector();
+
+
+    /**
+     * Leading base coefficient.
+     * @return first coefficient.
+     */
+    public C leadingBaseCoefficient();
+
+
+    /**
+     * Trailing base coefficient.
+     * @return coefficient of constant term.
+     */
+    public C trailingBaseCoefficient();
+
+
+    /**
+     * Reductum.
+     * @return this - leading monomial.
+     */
+    public Polynomial<C> reductum();
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding.
+     * Extend all ExpVectors by i elements and multiply by x_j^k.
+     * @param pfac extended polynomial ring factory (by i variables).
+     * @param j index of variable to be used for multiplication.
+     * @param k exponent for x_j.
+     * @return extended polynomial.
+     */
+    public Polynomial<C> extend(PolynomialRing<C> pfac, int j, long k);
+
+
+    /**
+     * Contract variables. Used e.g. in module embedding.
+     * remove i elements of each ExpVector.
+     * @param pfac contracted polynomial ring factory (by i variables).
+     * @return Map of exponents and contracted polynomials.
+     * <b>Note:</b> could return SortedMap
+     */
+    public Map<ExpVector,Polynomial<C>> contract(PolynomialRing<C> pfac);
+
+
+    /**
+     * Reverse variables. Used e.g. in opposite rings.
+     * @return polynomial with reversed variables.
+     */
+    public Polynomial<C> reverse(PolynomialRing<C> oring);
+
+
+    /**
+     * Iterator over coefficients. 
+     * @return val.values().iterator().
+     */
+    public Iterator<C> coefficientIterator();
+
+
+    /**
+     * Iterator over exponents. 
+     * @return val.keySet().iterator().
+     */
+    public Iterator<ExpVector> exponentIterator();
+
+
+    /**
+     * Iterator over monomials. 
+     * @return a PolyIterator.
+     */
+    public Iterator<Monomial<C>> monomialIterator();
+
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/PolynomialComparator.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/PolynomialComparator.java
@@ -1,0 +1,95 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.io.Serializable;
+import java.util.Comparator;
+
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Comparator for polynomials.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+public class PolynomialComparator<C extends RingElem<C>>
+                implements Serializable, Comparator<GenPolynomial<C>> {
+
+
+    public final TermOrder tord;
+
+
+    public final boolean reverse;
+
+
+    /**
+     * Constructor.
+     * @param t TermOrder.
+     * @param reverse flag if reverse ordering is requested.
+     */
+    public PolynomialComparator(TermOrder t, boolean reverse) {
+        tord = t;
+        this.reverse = reverse;
+    }
+
+
+    /**
+     * Compare polynomials.
+     * @param p1 first polynomial.
+     * @param p2 second polynomial.
+     * @return 0 if ( p1 == p2 ), -1 if ( p1 &lt; p2 ) and +1 if ( p1 &gt; p2 ).
+     */
+    public int compare(GenPolynomial<C> p1, GenPolynomial<C> p2) {
+        // check if p1.tord = p2.tord = tord ?
+        int s = p1.compareTo(p2);
+        //System.out.println("p1.compareTo(p2) = " + s);
+        if (reverse) {
+            return -s;
+        }
+        return s;
+    }
+
+
+    /**
+     * Equals test of comparator.
+     * @param o other object.
+     * @return true if this = o, else false.
+     */
+    @Override
+    public boolean equals(Object o) {
+        PolynomialComparator pc = null;
+        try {
+            pc = (PolynomialComparator) o;
+        } catch (ClassCastException ignored) {
+            return false;
+        }
+        if (pc == null) {
+            return false;
+        }
+        return tord.equals(pc.tord);
+    }
+
+
+    /**
+     * Hash code for this PolynomialComparator.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return tord.hashCode();
+    }
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString() {
+        return "PolynomialComparator(" + tord + ")";
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/PolynomialList.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/PolynomialList.java
@@ -1,0 +1,589 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.kern.Scripting;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * List of polynomials. Mainly for storage and printing / toString and
+ * conversions to other representations.
+ * @author Heinz Kredel
+ */
+
+public class PolynomialList<C extends RingElem<C>> implements Comparable<PolynomialList<C>>, Serializable {
+
+
+    /**
+     * The factory for the solvable polynomial ring.
+     */
+    public final GenPolynomialRing<C> ring;
+
+
+    /**
+     * The data structure is a List of polynomials.
+     */
+    public final List<GenPolynomial<C>> list;
+
+
+    private static final Logger logger = LogManager.getLogger(PolynomialList.class);
+
+
+    /**
+     * Constructor.
+     * @param r polynomial ring factory.
+     * @param l list of polynomials.
+     */
+    public PolynomialList(GenPolynomialRing<C> r, List<GenPolynomial<C>> l) {
+        ring = r;
+        list = l;
+    }
+
+
+    /**
+     * Constructor.
+     * @param r solvable polynomial ring factory.
+     * @param l list of solvable polynomials.
+     */
+    public PolynomialList(GenSolvablePolynomialRing<C> r, List<GenSolvablePolynomial<C>> l) {
+        this(r, PolynomialList.<C> castToList(l));
+    }
+
+
+    /**
+     * Copy this.
+     * @return a copy of this.
+     */
+    public PolynomialList<C> copy() {
+        return new PolynomialList<C>(ring, new ArrayList<GenPolynomial<C>>(list));
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object p) {
+        if (p == null) {
+            return false;
+        }
+        if (!(p instanceof PolynomialList)) {
+            System.out.println("no PolynomialList");
+            return false;
+        }
+        PolynomialList<C> pl = (PolynomialList<C>) p;
+        if (!ring.equals(pl.ring)) {
+            System.out.println("not same Ring " + ring.toScript() + ", " + pl.ring.toScript());
+            return false;
+        }
+        return (compareTo(pl) == 0);
+        // otherwise tables may be different
+    }
+
+
+    /**
+     * Polynomial list comparison.
+     * @param L other PolynomialList.
+     * @return lexicographical comparison, sign of first different polynomials.
+     */
+    public int compareTo(PolynomialList<C> L) {
+        int si = L.list.size();
+        if (list.size() < si) { // minimum
+            si = list.size();
+        }
+        int s = 0;
+        List<GenPolynomial<C>> l1 = OrderedPolynomialList.<C> sort(ring, list);
+        List<GenPolynomial<C>> l2 = OrderedPolynomialList.<C> sort(ring, L.list);
+        for (int i = 0; i < si; i++) {
+            GenPolynomial<C> a = l1.get(i);
+            GenPolynomial<C> b = l2.get(i);
+            s = a.compareTo(b);
+            if (s != 0) {
+                return s;
+            }
+        }
+        if (list.size() > si) {
+            return 1;
+        }
+        if (L.list.size() > si) {
+            return -1;
+        }
+        return s;
+    }
+
+
+    /**
+     * Hash code for this polynomial list.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = ring.hashCode();
+        h = 37 * h + (list == null ? 0 : list.hashCode());
+        return h;
+    }
+
+
+    /**
+     * Test if list is empty.
+     * @return true if this is empty, alse false.
+     */
+    public boolean isEmpty() {
+        if (list == null) {
+            return true;
+        }
+        return list.isEmpty();
+    }
+
+
+    /**
+     * String representation of the polynomial list.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer erg = new StringBuffer();
+        String[] vars = null;
+        if (ring != null) {
+            erg.append(ring.toString());
+            vars = ring.getVars();
+        }
+        boolean first = true;
+        erg.append("\n(\n");
+        String sa = null;
+        for (GenPolynomial<C> oa : list) {
+            if (vars != null) {
+                sa = oa.toString(vars);
+            } else {
+                sa = oa.toString();
+            }
+            if (first) {
+                first = false;
+            } else {
+                erg.append(", ");
+                if (sa.length() > 10) {
+                    erg.append("\n");
+                }
+            }
+            erg.append("( " + sa + " )");
+        }
+        erg.append("\n)");
+        return erg.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this polynomial list.
+     */
+    public String toScript() {
+        StringBuffer s = new StringBuffer();
+        if (ring instanceof GenSolvablePolynomialRing) {
+            switch (Scripting.getLang()) {
+            case Ruby:
+                s.append("SolvIdeal.new(");
+                break;
+            case Python:
+            default:
+                s.append("SolvableIdeal(");
+            }
+        } else {
+            switch (Scripting.getLang()) {
+            case Ruby:
+                s.append("SimIdeal.new(");
+                break;
+            case Python:
+            default:
+                s.append("Ideal(");
+            }
+        }
+        if (ring != null) {
+            s.append(ring.toScript());
+        }
+        if (list == null) {
+            s.append(")");
+            return s.toString();
+        }
+        switch (Scripting.getLang()) {
+        case Ruby:
+            s.append(",\"\",[");
+            break;
+        case Python:
+        default:
+            s.append(",list=[");
+        }
+        boolean first = true;
+        String sa = null;
+        for (GenPolynomial<C> oa : list) {
+            sa = oa.toScript();
+            if (first) {
+                first = false;
+            } else {
+                s.append(", ");
+            }
+            //s.append("( " + sa + " )");
+            s.append(sa);
+        }
+        s.append("])");
+        return s.toString();
+    }
+
+
+    /**
+     * Get ModuleList from PolynomialList. Extract module from polynomial ring.
+     * @see edu.jas.poly.ModuleList
+     * @param i number of variables to be contract form the polynomials.
+     * @return module list corresponding to this.
+     */
+    @SuppressWarnings("unchecked")
+    public ModuleList<C> getModuleList(int i) {
+        GenPolynomialRing<C> pfac = ring.contract(i);
+        logger.debug("contracted ring = " + pfac);
+        //System.out.println("contracted ring = " + pfac);
+
+        List<List<GenPolynomial<C>>> vecs = null;
+        if (list == null) {
+            return new ModuleList<C>(pfac, vecs);
+        }
+        int rows = list.size();
+        vecs = new ArrayList<List<GenPolynomial<C>>>(rows);
+        if (rows == 0) { // nothing to do
+            return new ModuleList<C>(pfac, vecs);
+        }
+
+        ArrayList<GenPolynomial<C>> zr = new ArrayList<GenPolynomial<C>>(i - 1);
+        GenPolynomial<C> zero = pfac.getZERO();
+        for (int j = 0; j < i; j++) {
+            zr.add(j, zero);
+        }
+
+        for (GenPolynomial<C> p : list) {
+            if (p != null) {
+                Map<ExpVector, GenPolynomial<C>> r = p.contract(pfac);
+                //System.out.println("r = " + r ); 
+                List<GenPolynomial<C>> row = new ArrayList<GenPolynomial<C>>(zr); //zr.clone();
+                for (Map.Entry<ExpVector, GenPolynomial<C>> me : r.entrySet()) {
+                    ExpVector e = me.getKey();
+                    int[] dov = e.dependencyOnVariables();
+                    int ix = 0;
+                    if (dov.length > 1) {
+                        throw new IllegalArgumentException("wrong dependencyOnVariables " + e);
+                    } else if (dov.length == 1) {
+                        ix = dov[0];
+                    }
+                    //ix = i-1 - ix; // revert
+                    //System.out.println("ix = " + ix ); 
+                    GenPolynomial<C> vi = me.getValue(); //r.get( e );
+                    row.set(ix, vi);
+                }
+                //System.out.println("row = " + row ); 
+                vecs.add(row);
+            }
+        }
+        return new ModuleList<C>(pfac, vecs);
+    }
+
+
+    /**
+     * Get list.
+     * @return list from this.
+     */
+    public List<GenPolynomial<C>> getList() {
+        return list;
+    }
+
+
+    /**
+     * Get list as List of GenSolvablePolynomials. Required because no List
+     * casts allowed. Equivalent to cast
+     * (List&lt;GenSolvablePolynomial&lt;C&gt;&gt;) list.
+     * @return solvable polynomial list from this.
+     */
+    public List<GenSolvablePolynomial<C>> castToSolvableList() {
+        return castToSolvableList(list);
+    }
+
+
+    /**
+     * Get list as List of GenSolvablePolynomials. Required because no List
+     * casts allowed. Equivalent to cast
+     * (List&lt;GenSolvablePolynomial&lt;C&gt;&gt;) list.
+     * @return solvable polynomial list from this.
+     */
+    public List<GenSolvablePolynomial<C>> getSolvableList() {
+        return castToSolvableList(list);
+    }
+
+
+    /**
+     * Get ring as GenSolvablePolynomialRing.
+     * @return solvable polynomial ring list from this.
+     */
+    public GenSolvablePolynomialRing<C> getSolvableRing() {
+        return (GenSolvablePolynomialRing<C>) ring;
+    }
+
+
+    /**
+     * Get list as List of GenSolvablePolynomials. Required because no List
+     * casts allowed. Equivalent to cast
+     * (List&lt;GenSolvablePolynomial&lt;C&gt;&gt;) list.
+     * @param list list of extensions of polynomials.
+     * @return solvable polynomial list from this.
+     */
+    public static <C extends RingElem<C>> List<GenSolvablePolynomial<C>> castToSolvableList(
+                    List<GenPolynomial<C>> list) {
+        List<GenSolvablePolynomial<C>> slist = null;
+        if (list == null) {
+            return slist;
+        }
+        slist = new ArrayList<GenSolvablePolynomial<C>>(list.size());
+        GenSolvablePolynomial<C> s;
+        for (GenPolynomial<C> p : list) {
+            if (!(p instanceof GenSolvablePolynomial)) {
+                throw new IllegalArgumentException("no solvable polynomial " + p);
+            }
+            s = (GenSolvablePolynomial<C>) p;
+            slist.add(s);
+        }
+        return slist;
+    }
+
+
+    /**
+     * Get list of list as List of List of GenSolvablePolynomials. Required
+     * because no List casts allowed. Equivalent to cast
+     * (List&lt;GenSolvablePolynomial&lt;C&gt;&gt;) list.
+     * @param list list of extensions of polynomials.
+     * @return solvable polynomial list from this.
+     */
+    public static <C extends RingElem<C>> List<List<GenSolvablePolynomial<C>>> castToSolvableMatrix(
+                    List<List<GenPolynomial<C>>> list) {
+        List<List<GenSolvablePolynomial<C>>> slist = null;
+        if (list == null) {
+            return slist;
+        }
+        slist = new ArrayList<List<GenSolvablePolynomial<C>>>(list.size());
+        List<GenSolvablePolynomial<C>> s;
+        for (List<GenPolynomial<C>> p : list) {
+            s = PolynomialList.<C> castToSolvableList(p);
+            slist.add(s);
+        }
+        return slist;
+    }
+
+
+    /**
+     * Get list of extensions of polynomials as List of GenPolynomials. Required
+     * because no List casts allowed. Equivalent to cast
+     * (List&lt;GenPolynomial&lt;C&gt;&gt;) list. Mainly used for lists of
+     * GenSolvablePolynomials.
+     * @param slist list of extensions of polynomials.
+     * @return polynomial list from slist.
+     */
+    public static <C extends RingElem<C>> List<GenPolynomial<C>> castToList(
+                    List<? extends GenPolynomial<C>> slist) {
+        logger.debug("warn: can lead to wrong method dispatch");
+        List<GenPolynomial<C>> list = null;
+        if (slist == null) {
+            return list;
+        }
+        list = new ArrayList<GenPolynomial<C>>(slist.size());
+        for (GenPolynomial<C> p : slist) {
+            list.add(p);
+        }
+        return list;
+    }
+
+
+    /**
+     * Get list of list of extensions of polynomials as List of List of
+     * GenPolynomials. Required because no List casts allowed. Equivalent to
+     * cast (List&lt;GenPolynomial&lt;C&gt;&gt;) list. Mainly used for lists of
+     * GenSolvablePolynomials.
+     * @param slist list of extensions of polynomials.
+     * @return polynomial list from slist.
+     */
+    public static <C extends RingElem<C>> List<List<GenPolynomial<C>>> castToMatrix(
+                    List<List<? extends GenPolynomial<C>>> slist) {
+        logger.debug("warn: can lead to wrong method dispatch");
+        List<List<GenPolynomial<C>>> list = null;
+        if (slist == null) {
+            return list;
+        }
+        list = new ArrayList<List<GenPolynomial<C>>>(slist.size());
+        for (List<? extends GenPolynomial<C>> p : slist) {
+            list.add(PolynomialList.<C> castToList(p));
+        }
+        return list;
+    }
+
+
+    /**
+     * Test if list contains only ZEROs.
+     * @return true, if this is the 0 list, else false
+     */
+    public boolean isZERO() {
+        if (list == null) {
+            return true;
+        }
+        for (GenPolynomial<C> p : list) {
+            if (p == null) {
+                continue;
+            }
+            if (!p.isZERO()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Test if list contains a ONE.
+     * @return true, if this contains 1, else false
+     */
+    public boolean isONE() {
+        if (list == null) {
+            return false;
+        }
+        for (GenPolynomial<C> p : list) {
+            if (p == null) {
+                continue;
+            }
+            if (p.isONE()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    /**
+     * Make homogeneous.
+     * @return polynomial list of homogeneous polynomials.
+     */
+    public PolynomialList<C> homogenize() {
+        GenPolynomialRing<C> pfac = ring.extend(1);
+        List<GenPolynomial<C>> hom = new ArrayList<GenPolynomial<C>>(list.size());
+        for (GenPolynomial<C> p : list) {
+            GenPolynomial<C> h = p.homogenize(pfac);
+            hom.add(h);
+        }
+        return new PolynomialList<C>(pfac, hom);
+    }
+
+
+    /**
+     * Dehomogenize.
+     * @return polynomial list of de-homogenized polynomials.
+     */
+    public PolynomialList<C> deHomogenize() {
+        GenPolynomialRing<C> pfac = ring.contract(1);
+        List<GenPolynomial<C>> dehom = new ArrayList<GenPolynomial<C>>(list.size());
+        for (GenPolynomial<C> p : list) {
+            GenPolynomial<C> h = p.deHomogenize(pfac);
+            dehom.add(h);
+        }
+        return new PolynomialList<C>(pfac, dehom);
+    }
+
+
+    /**
+     * Test if all polynomials are homogeneous.
+     * @return true, if all polynomials are homogeneous, else false
+     */
+    public boolean isHomogeneous() {
+        if (list == null) {
+            return true;
+        }
+        for (GenPolynomial<C> p : list) {
+            if (p == null) {
+                continue;
+            }
+            if (!p.isHomogeneous()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Union of the delta of exponent vectors of all polynomials.
+     * @return list of u-v, where u = lt() and v != u in p in list.
+     */
+    public SortedSet<ExpVector> deltaExpVectors() {
+        SortedSet<ExpVector> de = new TreeSet<ExpVector>(ring.tord.getAscendComparator());
+        if (list.isEmpty()) {
+            return de;
+        }
+        for (GenPolynomial<C> p : list) {
+            List<ExpVector> pe = p.deltaExpVectors();
+            de.addAll(pe);
+        }
+        return de;
+    }
+
+
+    /**
+     * Union of the delta of exponent vectors of all polynomials.
+     * @param mark list of marked exp vectors of polynomials.
+     * @return list of u-v, where u in mark and v != u in p.expVectors in list.
+     */
+    public SortedSet<ExpVector> deltaExpVectors(List<ExpVector> mark) {
+        SortedSet<ExpVector> de = new TreeSet<ExpVector>(ring.tord.getAscendComparator());
+        if (list.isEmpty()) {
+            return de;
+        }
+        if (mark.isEmpty()) {
+            return deltaExpVectors();
+        }
+        if (list.size() != mark.size()) {
+            throw new IllegalArgumentException("#list != #mark");
+        }
+        int i = 0;
+        for (GenPolynomial<C> p : list) {
+            ExpVector u = mark.get(i);
+            List<ExpVector> pe = p.deltaExpVectors(u);
+            de.addAll(pe);
+            i++;
+        }
+        return de;
+    }
+
+
+    /**
+     * Leading weight polynomials.
+     * @return list of polynomials with terms of maximal weight degree.
+     */
+    public List<GenPolynomial<C>> leadingWeightPolynomials() {
+        List<GenPolynomial<C>> lw = new ArrayList<GenPolynomial<C>>(list.size());
+        if (list.isEmpty()) {
+            return lw;
+        }
+        for (GenPolynomial<C> p : list) {
+            GenPolynomial<C> pw = p.leadingWeightPolynomial();
+            lw.add(pw);
+        }
+        return lw;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/PolynomialRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/PolynomialRing.java
@@ -1,0 +1,111 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.util.List;
+import java.util.Random;
+
+
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Polynomial factory interface.
+ * Defines polynomial specific factory methods.
+ * @author Heinz Kredel
+ */
+
+public interface PolynomialRing<C extends RingElem<C>> 
+                 extends RingFactory< Polynomial<C> > {
+
+
+    /**
+     * Number of variables.
+     * @return the number of variables.
+     */
+    public int numberOfVariables();
+
+
+    /** Get the variable names. 
+     * @return vars.
+     */
+    public String[] getVars();
+
+
+    /**
+     * Generate a random polynomial.
+     * @param k bitsize of random coefficients.
+     * @param l number of terms.
+     * @param d maximal degree in each variable.
+     * @param q density of nozero exponents.
+     * @return a random polynomial.
+     */
+    public Polynomial<C> random(int k, int l, int d, float q);
+
+
+    /**
+     * Generate a random polynomial.
+     * @param k bitsize of random coefficients.
+     * @param l number of terms.
+     * @param d maximal degree in each variable.
+     * @param q density of nozero exponents.
+     * @param rnd is a source for random bits.
+     * @return a random polynomial.
+     */
+    public Polynomial<C> random(int k, int l, int d, float q, Random rnd);
+
+
+    /**
+     * Generate univariate polynomial in a given variable.
+     * @param i the index of the variable.
+     * @return X_i as univariate polynomial.
+     */
+    public Polynomial<C> univariate(int i);
+
+
+    /**
+     * Generate univariate polynomial in a given variable with given exponent.
+     * @param i the index of the variable.
+     * @param e the exponent of the variable.
+     * @return X_i^e as univariate polynomial.
+     */
+    public Polynomial<C> univariate(int i, long e);
+
+
+    /**
+     * Generate list of univariate polynomials in all variables.
+     * @return List(X_1,...,X_n) a list of univariate polynomials.
+     */
+    public List<? extends Polynomial<C>> univariateList();
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding.
+     * Extend number of variables by i.
+     * @param i number of variables to extend.
+     * @return extended polynomial ring factory.
+     */
+    public PolynomialRing<C> extend(int i);
+
+
+    /**
+     * Contract variables. Used e.g. in module embedding.
+     * Contract number of variables by i.
+     * @param i number of variables to remove.
+     * @return contracted polynomial ring factory.
+     */
+    public PolynomialRing<C> contract(int i);
+
+
+    /**
+     * Reverse variables. Used e.g. in opposite rings.
+     * @return polynomial ring factory with reversed variables.
+     */
+    public PolynomialRing<C> reverse();
+
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/QLRSolvablePolynomial.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/QLRSolvablePolynomial.java
@@ -1,0 +1,616 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.QuotPair;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * QLRSolvablePolynomial generic recursive solvable polynomials implementing
+ * RingElem. n-variate ordered solvable polynomials over solvable quotient,
+ * local and local-residue coefficients. Objects of this class are intended to
+ * be immutable. The implementation is based on TreeMap respectively SortedMap
+ * from exponents to coefficients by extension of GenPolynomial.
+ * @param <C> polynomial coefficient type
+ * @param <D> quotient coefficient type
+ * @author Heinz Kredel
+ */
+
+public class QLRSolvablePolynomial<C extends GcdRingElem<C> & QuotPair<GenPolynomial<D>>, D extends GcdRingElem<D>>
+                extends GenSolvablePolynomial<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(QLRSolvablePolynomial.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * The factory for the recursive solvable polynomial ring. Hides super.ring.
+     */
+    public final QLRSolvablePolynomialRing<C, D> ring;
+
+
+    /**
+     * Constructor for zero QLRSolvablePolynomial.
+     * @param r solvable polynomial ring factory.
+     */
+    public QLRSolvablePolynomial(QLRSolvablePolynomialRing<C, D> r) {
+        super(r);
+        ring = r;
+    }
+
+
+    /**
+     * Constructor for QLRSolvablePolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param c coefficient polynomial.
+     * @param e exponent.
+     */
+    public QLRSolvablePolynomial(QLRSolvablePolynomialRing<C, D> r, C c, ExpVector e) {
+        this(r);
+        if (c != null && !c.isZERO()) {
+            val.put(e, c);
+        }
+    }
+
+
+    /**
+     * Constructor for QLRSolvablePolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param c coefficient polynomial.
+     */
+    public QLRSolvablePolynomial(QLRSolvablePolynomialRing<C, D> r, C c) {
+        this(r, c, r.evzero);
+    }
+
+
+    /**
+     * Constructor for QLRSolvablePolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param S solvable polynomial.
+     */
+    public QLRSolvablePolynomial(QLRSolvablePolynomialRing<C, D> r, GenSolvablePolynomial<C> S) {
+        this(r, S.getMap());
+    }
+
+
+    /**
+     * Constructor for QLRSolvablePolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param v the SortedMap of some other (solvable) polynomial.
+     */
+    protected QLRSolvablePolynomial(QLRSolvablePolynomialRing<C, D> r, SortedMap<ExpVector, C> v) {
+        this(r);
+        val.putAll(v); // assume no zero coefficients
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    @Override
+    public QLRSolvablePolynomialRing<C, D> factory() {
+        return ring;
+    }
+
+
+    /**
+     * Clone this QLRSolvablePolynomial.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public QLRSolvablePolynomial<C, D> copy() {
+        return new QLRSolvablePolynomial<C, D>(ring, this.val);
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object B) {
+        if (!(B instanceof QLRSolvablePolynomial)) {
+            return false;
+        }
+        return super.equals(B);
+    }
+
+
+    /**
+     * Hash code for this polynomial.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+
+    /**
+     * QLRSolvablePolynomial multiplication.
+     * @param Bp QLRSolvablePolynomial.
+     * @return this*Bp, where * denotes solvable multiplication.
+     */
+    // not @Override
+    @SuppressWarnings("unchecked")
+    public QLRSolvablePolynomial<C, D> multiply(QLRSolvablePolynomial<C, D> Bp) {
+        if (Bp == null || Bp.isZERO()) {
+            return ring.getZERO();
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        if (Bp.isONE()) {
+            return this;
+        }
+        if (this.isONE()) {
+            return Bp;
+        }
+        assert (ring.nvar == Bp.ring.nvar);
+        if (debug) {
+            logger.debug("ring = " + ring);
+        }
+        //System.out.println("this = " + this + ", Bp = " + Bp);
+        ExpVector Z = ring.evzero;
+        QLRSolvablePolynomial<C, D> Dp = ring.getZERO().copy();
+        QLRSolvablePolynomial<C, D> zero = ring.getZERO().copy();
+        C one = ring.getONECoefficient();
+
+        Map<ExpVector, C> A = val;
+        Map<ExpVector, C> B = Bp.val;
+        Set<Map.Entry<ExpVector, C>> Bk = B.entrySet();
+        for (Map.Entry<ExpVector, C> y : A.entrySet()) {
+            C a = y.getValue();
+            ExpVector e = y.getKey();
+            if (debug)
+                logger.info("e = " + e + ", a = " + a);
+            //int[] ep = e.dependencyOnVariables();
+            //int el1 = ring.nvar + 1;
+            //if (ep.length > 0) {
+            //    el1 = ep[0];
+            //}
+            //int el1s = ring.nvar + 1 - el1;
+            for (Map.Entry<ExpVector, C> x : Bk) {
+                C b = x.getValue();
+                ExpVector f = x.getKey();
+                if (debug)
+                    logger.info("f = " + f + ", b = " + b);
+                int[] fp = f.dependencyOnVariables();
+                int fl1 = 0;
+                if (fp.length > 0) {
+                    fl1 = fp[fp.length - 1];
+                }
+                int fl1s = ring.nvar + 1 - fl1;
+                // polynomial with coefficient multiplication 
+                QLRSolvablePolynomial<C, D> Cps = ring.getZERO().copy();
+                //QLRSolvablePolynomial<C, D> Cs;
+                QLRSolvablePolynomial<C, D> qp;
+                if (ring.polCoeff.isCommutative() || b.isConstant() || e.isZERO()) { // symmetric
+                    Cps = new QLRSolvablePolynomial<C, D>(ring, b, e);
+                    if (debug)
+                        logger.info("symmetric coeff: b = " + b + ", e = " + e);
+                } else { // unsymmetric
+                    if (debug)
+                        logger.info("unsymmetric coeff: b = " + b + ", e = " + e);
+                    // compute e * b as ( e * 1/b.den ) * b.num
+                    if (b.denominator().isONE()) { // recursion base
+                        // recursive polynomial coefficient multiplication : e * b.num
+                        RecSolvablePolynomial<D> rsp1 = new RecSolvablePolynomial<D>(ring.polCoeff, e);
+                        RecSolvablePolynomial<D> rsp2 = new RecSolvablePolynomial<D>(ring.polCoeff,
+                                        b.numerator());
+                        RecSolvablePolynomial<D> rsp3 = rsp1.multiply(rsp2);
+                        QLRSolvablePolynomial<C, D> rsp = ring.fromPolyCoefficients(rsp3);
+                        Cps = rsp;
+                    } else { // b.denominator() != 1
+                        if (debug)
+                            logger.info("coeff-num: Cps = " + Cps + ", num = " + b.numerator() + ", den = "
+                                            + b.denominator());
+                        RingFactory<C> bfq = (RingFactory<C>) b.factory();
+                        Cps = new QLRSolvablePolynomial<C, D>(ring, bfq.getONE(), e);
+
+                        // coefficient multiplication with 1/den: 
+                        QLRSolvablePolynomial<C, D> qv = Cps;
+                        //C qden = new C(b.denominator().factory(), b.denominator()); // den/1
+                        C qden = ring.qpfac.create(b.denominator()); // den/1
+                        //System.out.println("qv = " + qv + ", den = " + den);
+                        // recursion with den==1:
+                        QLRSolvablePolynomial<C, D> v = qv.multiply(qden);
+                        QLRSolvablePolynomial<C, D> vl = qv.multiplyLeft(qden);
+                        //System.out.println("v = " + v + ", vl = " + vl + ", qden = " + qden);
+                        QLRSolvablePolynomial<C, D> vr = (QLRSolvablePolynomial<C, D>) v.subtract(vl);
+                        //C qdeni = new C(b.factory(), b.factory().getONE().numerator(), b.denominator());
+                        C qdeni = ring.qpfac.create(ring.qpfac.pairFactory().getONE(), b.denominator()); // 1/den
+                        //System.out.println("vr = " + vr + ", qdeni = " + qdeni);
+                        // recursion with smaller head term:
+                        if (qv.leadingExpVector().equals(vr.leadingExpVector())) {
+                            throw new IllegalArgumentException("qr !> vr: qv = " + qv + ", vr = " + vr);
+                        }
+                        QLRSolvablePolynomial<C, D> rq = vr.multiply(qdeni);
+                        qp = (QLRSolvablePolynomial<C, D>) qv.subtract(rq);
+                        qp = qp.multiplyLeft(qdeni);
+                        //System.out.println("qp_i = " + qp);
+                        Cps = qp;
+
+                        if (!b.numerator().isONE()) {
+                            //C qnum = new C(b.denominator().factory(), b.numerator()); // num/1
+                            C qnum = ring.qpfac.create(b.numerator()); // num/1
+                            // recursion with den == 1:
+                            Cps = Cps.multiply(qnum);
+                        }
+                    }
+                } // end coeff
+                if (debug)
+                    logger.info("coeff-den: Cps = " + Cps);
+                // polynomial multiplication 
+                QLRSolvablePolynomial<C, D> Dps = ring.getZERO().copy();
+                QLRSolvablePolynomial<C, D> Ds = null;
+                QLRSolvablePolynomial<C, D> D1, D2;
+                if (ring.isCommutative() || Cps.isConstant() || f.isZERO()) { // symmetric
+                    if (debug)
+                        logger.info("symmetric poly: b = " + b + ", e = " + e);
+                    if (Cps.isConstant()) {
+                        ExpVector g = e.sum(f);
+                        Ds = new QLRSolvablePolynomial<C, D>(ring, Cps.leadingBaseCoefficient(), g); // symmetric!
+                    } else {
+                        Ds = Cps.shift(f); // symmetric
+                    }
+                } else { // eventually unsymmetric
+                    if (debug)
+                        logger.info("unsymmetric poly: Cps = " + Cps + ", f = " + f);
+                    for (Map.Entry<ExpVector, C> z : Cps.val.entrySet()) {
+                        // split g = g1 * g2, f = f1 * f2
+                        C c = z.getValue();
+                        ExpVector g = z.getKey();
+                        if (debug)
+                            logger.info("g = " + g + ", c = " + c);
+                        int[] gp = g.dependencyOnVariables();
+                        int gl1 = ring.nvar + 1;
+                        if (gp.length > 0) {
+                            gl1 = gp[0];
+                        }
+                        int gl1s = ring.nvar + 1 - gl1;
+                        if (gl1s <= fl1s) { // symmetric
+                            ExpVector h = g.sum(f);
+                            if (debug)
+                                logger.info("disjoint poly: g = " + g + ", f = " + f + ", h = " + h);
+                            Ds = (QLRSolvablePolynomial<C, D>) zero.sum(one, h); // symmetric!
+                        } else {
+                            ExpVector g1 = g.subst(gl1, 0);
+                            ExpVector g2 = Z.subst(gl1, g.getVal(gl1)); // bug el1, gl1
+                            ExpVector g4;
+                            ExpVector f1 = f.subst(fl1, 0);
+                            ExpVector f2 = Z.subst(fl1, f.getVal(fl1));
+                            if (debug) {
+                                logger.info("poly, g1 = " + g1 + ", f1 = " + f1 + ", Dps = " + Dps);
+                                logger.info("poly, g2 = " + g2 + ", f2 = " + f2);
+                            }
+                            TableRelation<C> rel = ring.table.lookup(g2, f2);
+                            if (debug)
+                                logger.info("poly, g  = " + g + ", f  = " + f + ", rel = " + rel);
+                            Ds = new QLRSolvablePolynomial<C, D>(ring, rel.p); //ring.copy(rel.p);
+                            if (rel.f != null) {
+                                D2 = new QLRSolvablePolynomial<C, D>(ring, one, rel.f);
+                                Ds = Ds.multiply(D2);
+                                if (rel.e == null) {
+                                    g4 = g2;
+                                } else {
+                                    g4 = g2.subtract(rel.e);
+                                }
+                                ring.table.update(g4, f2, Ds);
+                            }
+                            if (rel.e != null) {
+                                D1 = new QLRSolvablePolynomial<C, D>(ring, one, rel.e);
+                                Ds = D1.multiply(Ds);
+                                ring.table.update(g2, f2, Ds);
+                            }
+                            if (!f1.isZERO()) {
+                                D2 = new QLRSolvablePolynomial<C, D>(ring, one, f1);
+                                Ds = Ds.multiply(D2);
+                                //ring.table.update(?,f1,Ds)
+                            }
+                            if (!g1.isZERO()) {
+                                D1 = new QLRSolvablePolynomial<C, D>(ring, one, g1);
+                                Ds = D1.multiply(Ds);
+                                //ring.table.update(e1,?,Ds)
+                            }
+                        }
+                        Ds = Ds.multiplyLeft(c); // c * Ds
+                        //Dps = (QLRSolvablePolynomial<C, D>) Dps.sum(Ds);
+                        Dps.doAddTo(Ds);
+                    } // end Dps loop
+                    Ds = Dps;
+                }
+                Ds = Ds.multiplyLeft(a); // multiply(a,b); // non-symmetric 
+                if (debug)
+                    logger.debug("Ds = " + Ds);
+                //Dp = (QLRSolvablePolynomial<C, D>) Dp.sum(Ds);
+                Dp.doAddTo(Ds);
+            } // end B loop
+        } // end A loop
+          //System.out.println("this * Bp = " + Dp);
+        return Dp;
+    }
+
+
+    /**
+     * QLRSolvablePolynomial left and right multiplication. Product with two
+     * polynomials.
+     * @param S QLRSolvablePolynomial.
+     * @param T QLRSolvablePolynomial.
+     * @return S*this*T.
+     */
+    // not @Override
+    public QLRSolvablePolynomial<C, D> multiply(QLRSolvablePolynomial<C, D> S, QLRSolvablePolynomial<C, D> T) {
+        if (S.isZERO() || T.isZERO() || this.isZERO()) {
+            return ring.getZERO();
+        }
+        if (S.isONE()) {
+            return multiply(T);
+        }
+        if (T.isONE()) {
+            return S.multiply(this);
+        }
+        return S.multiply(this).multiply(T);
+    }
+
+
+    /**
+     * QLRSolvablePolynomial multiplication. Product with coefficient ring
+     * element.
+     * @param b solvable coefficient.
+     * @return this*b, where * is coefficient multiplication.
+     */
+    @Override
+    public QLRSolvablePolynomial<C, D> multiply(C b) {
+        QLRSolvablePolynomial<C, D> Cp = ring.getZERO().copy();
+        if (b == null || b.isZERO()) {
+            return Cp;
+        }
+        if (b.isONE()) {
+            return this;
+        }
+        Cp = new QLRSolvablePolynomial<C, D>(ring, b, ring.evzero);
+        return multiply(Cp);
+    }
+
+
+    /**
+     * QLRSolvablePolynomial left and right multiplication. Product with
+     * coefficient ring element.
+     * @param b coefficient polynomial.
+     * @param c coefficient polynomial.
+     * @return b*this*c, where * is coefficient multiplication.
+     */
+    @Override
+    public QLRSolvablePolynomial<C, D> multiply(C b, C c) {
+        QLRSolvablePolynomial<C, D> Cp = ring.getZERO().copy();
+        if (b == null || b.isZERO()) {
+            return Cp;
+        }
+        if (c == null || c.isZERO()) {
+            return Cp;
+        }
+        if (b.isONE() && c.isONE()) {
+            return this;
+        }
+        Cp = new QLRSolvablePolynomial<C, D>(ring, b, ring.evzero);
+        QLRSolvablePolynomial<C, D> Dp = new QLRSolvablePolynomial<C, D>(ring, c, ring.evzero);
+        return multiply(Cp, Dp);
+    }
+
+
+    /**
+     * QLRSolvablePolynomial multiplication. Product with exponent vector.
+     * @param e exponent.
+     * @return this * x<sup>e</sup>, where * denotes solvable multiplication.
+     */
+    @Override
+    public QLRSolvablePolynomial<C, D> multiply(ExpVector e) {
+        if (e == null || e.isZERO()) {
+            return this;
+        }
+        C b = ring.getONECoefficient();
+        return multiply(b, e);
+    }
+
+
+    /**
+     * QLRSolvablePolynomial left and right multiplication. Product with
+     * exponent vector.
+     * @param e exponent.
+     * @param f exponent.
+     * @return x<sup>e</sup> * this * x<sup>f</sup>, where * denotes solvable
+     *         multiplication.
+     */
+    @Override
+    public QLRSolvablePolynomial<C, D> multiply(ExpVector e, ExpVector f) {
+        if (e == null || e.isZERO()) {
+            return this;
+        }
+        if (f == null || f.isZERO()) {
+            return this;
+        }
+        C b = ring.getONECoefficient();
+        return multiply(b, e, b, f);
+    }
+
+
+    /**
+     * QLRSolvablePolynomial multiplication. Product with ring element and
+     * exponent vector.
+     * @param b coefficient polynomial.
+     * @param e exponent.
+     * @return this * b x<sup>e</sup>, where * denotes solvable multiplication.
+     */
+    @Override
+    public QLRSolvablePolynomial<C, D> multiply(C b, ExpVector e) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        if (b.isONE() && e.isZERO()) {
+            return this;
+        }
+        QLRSolvablePolynomial<C, D> Cp = new QLRSolvablePolynomial<C, D>(ring, b, e);
+        return multiply(Cp);
+    }
+
+
+    /**
+     * QLRSolvablePolynomial left and right multiplication. Product with ring
+     * element and exponent vector.
+     * @param b coefficient polynomial.
+     * @param e exponent.
+     * @param c coefficient polynomial.
+     * @param f exponent.
+     * @return b x<sup>e</sup> * this * c x<sup>f</sup>, where * denotes
+     *         solvable multiplication.
+     */
+    @Override
+    public QLRSolvablePolynomial<C, D> multiply(C b, ExpVector e, C c, ExpVector f) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        if (c == null || c.isZERO()) {
+            return ring.getZERO();
+        }
+        if (b.isONE() && e.isZERO() && c.isONE() && f.isZERO()) {
+            return this;
+        }
+        QLRSolvablePolynomial<C, D> Cp = new QLRSolvablePolynomial<C, D>(ring, b, e);
+        QLRSolvablePolynomial<C, D> Dp = new QLRSolvablePolynomial<C, D>(ring, c, f);
+        return multiply(Cp, Dp);
+    }
+
+
+    /**
+     * QLRSolvablePolynomial multiplication. Left product with ring element and
+     * exponent vector.
+     * @param b coefficient polynomial.
+     * @param e exponent.
+     * @return b x<sup>e</sup> * this, where * denotes solvable multiplication.
+     */
+    @Override
+    public QLRSolvablePolynomial<C, D> multiplyLeft(C b, ExpVector e) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        QLRSolvablePolynomial<C, D> Cp = new QLRSolvablePolynomial<C, D>(ring, b, e);
+        return Cp.multiply(this);
+    }
+
+
+    /**
+     * QLRSolvablePolynomial multiplication. Left product with exponent vector.
+     * @param e exponent.
+     * @return x<sup>e</sup> * this, where * denotes solvable multiplication.
+     */
+    @Override
+    public QLRSolvablePolynomial<C, D> multiplyLeft(ExpVector e) {
+        if (e == null || e.isZERO()) {
+            return this;
+        }
+        C b = ring.getONECoefficient();
+        QLRSolvablePolynomial<C, D> Cp = new QLRSolvablePolynomial<C, D>(ring, b, e);
+        return Cp.multiply(this);
+    }
+
+
+    /**
+     * QLRSolvablePolynomial multiplication. Left product with coefficient ring
+     * element.
+     * @param b coefficient polynomial.
+     * @return b*this, where * is coefficient multiplication.
+     */
+    @Override
+    public QLRSolvablePolynomial<C, D> multiplyLeft(C b) {
+        QLRSolvablePolynomial<C, D> Cp = ring.getZERO().copy();
+        if (b == null || b.isZERO()) {
+            return Cp;
+        }
+        Map<ExpVector, C> Cm = Cp.val; //getMap();
+        Map<ExpVector, C> Am = val;
+        C c;
+        for (Map.Entry<ExpVector, C> y : Am.entrySet()) {
+            ExpVector e = y.getKey();
+            C a = y.getValue();
+            c = b.multiply(a);
+            if (!c.isZERO()) {
+                Cm.put(e, c);
+            }
+        }
+        return Cp;
+    }
+
+
+    /**
+     * QLRSolvablePolynomial multiplication. Left product with 'monomial'.
+     * @param m 'monomial'.
+     * @return m * this, where * denotes solvable multiplication.
+     */
+    @Override
+    public QLRSolvablePolynomial<C, D> multiplyLeft(Map.Entry<ExpVector, C> m) {
+        if (m == null) {
+            return ring.getZERO();
+        }
+        return multiplyLeft(m.getValue(), m.getKey());
+    }
+
+
+    /**
+     * QLRSolvablePolynomial multiplication. Product with 'monomial'.
+     * @param m 'monomial'.
+     * @return this * m, where * denotes solvable multiplication.
+     */
+    @Override
+    public QLRSolvablePolynomial<C, D> multiply(Map.Entry<ExpVector, C> m) {
+        if (m == null) {
+            return ring.getZERO();
+        }
+        return multiply(m.getValue(), m.getKey());
+    }
+
+
+    /**
+     * QLRSolvablePolynomial multiplication with exponent vector. 
+     * @param f exponent vector.
+     * @return B*f, where * is commutative multiplication.
+     */
+    protected QLRSolvablePolynomial<C, D> shift(ExpVector f) {
+        QLRSolvablePolynomial<C, D> C = ring.getZERO().copy();
+        if (this.isZERO()) {
+            return C;
+        }
+        if (f == null || f.isZERO()) {
+            return this;
+        }
+        Map<ExpVector, C> Cm = C.val;
+        Map<ExpVector, C> Bm = this.val;
+        for (Map.Entry<ExpVector, C> y : Bm.entrySet()) {
+            ExpVector e = y.getKey();
+            C a = y.getValue();
+            ExpVector d = e.sum(f);
+            if (!a.isZERO()) {
+                Cm.put(d, a);
+            }
+        }
+        return C;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/QLRSolvablePolynomialRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/QLRSolvablePolynomialRing.java
@@ -1,0 +1,837 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.kern.PrettyPrint;
+import edu.jas.kern.Scripting;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.structure.QuotPair;
+import edu.jas.structure.QuotPairFactory;
+
+
+/**
+ * QLRSolvablePolynomialRing generic recursive solvable polynomial
+ * factory implementing RingFactory and extending
+ * GenSolvablePolynomialRing factory.  Factory for n-variate ordered
+ * solvable polynomials over solvable quotient, local and
+ * local-residue coefficients. The non-commutative multiplication
+ * relations are maintained in a relation table and the
+ * non-commutative multiplication relations between the coefficients
+ * and the main variables are maintained in a coefficient relation
+ * table. Almost immutable object, except variable names and relation
+ * table contents.
+ * @param <C> polynomial coefficient type
+ * @param <D> quotient coefficient type
+ * @author Heinz Kredel
+ */
+
+public class QLRSolvablePolynomialRing<C extends GcdRingElem<C> & QuotPair<GenPolynomial<D>>, 
+                                       D extends GcdRingElem<D> > 
+       extends GenSolvablePolynomialRing<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(QLRSolvablePolynomialRing.class);
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Recursive solvable polynomial ring with polynomial coefficients.
+     */
+    public final RecSolvablePolynomialRing<D> polCoeff;
+
+
+    /**
+     * The constant polynomial 0 for this ring. Hides super ZERO.
+     */
+    public final QLRSolvablePolynomial<C,D> ZERO;
+
+
+    /**
+     * The constant polynomial 1 for this ring. Hides super ONE.
+     */
+    public final QLRSolvablePolynomial<C,D> ONE;
+
+
+    /**
+     * Factory to create coefficients.
+     */
+    public final QuotPairFactory<GenPolynomial<D>,C> qpfac;
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * default term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     */
+    public QLRSolvablePolynomialRing(RingFactory<C> cf, int n) {
+        this(cf, n, new TermOrder(), null, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * default term order.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param rt solvable multiplication relations.
+     */
+    public QLRSolvablePolynomialRing(RingFactory<C> cf, int n,
+                    RelationTable<C> rt) {
+        this(cf, n, new TermOrder(), null, rt);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     */
+    public QLRSolvablePolynomialRing(RingFactory<C> cf, int n, TermOrder t) {
+        this(cf, n, t, null, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     * @param rt solvable multiplication relations.
+     */
+    public QLRSolvablePolynomialRing(RingFactory<C> cf, int n, TermOrder t,
+                    RelationTable<C> rt) {
+        this(cf, n, t, null, rt);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     * @param v names for the variables.
+     */
+    public QLRSolvablePolynomialRing(RingFactory<C> cf, int n, TermOrder t, String[] v) {
+        this(cf, n, t, v, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param t a term order.
+     * @param v names for the variables.
+     */
+    public QLRSolvablePolynomialRing(RingFactory<C> cf, TermOrder t, String[] v) {
+        this(cf, v.length, t, v, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * default term order.
+     * @param cf factory for coefficients of type C.
+     * @param v names for the variables.
+     */
+    public QLRSolvablePolynomialRing(RingFactory<C> cf, String[] v) {
+        this(cf, v.length, new TermOrder(), v, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the the
+     * same term order, number of variables and variable names as the given
+     * polynomial factory, only the coefficient factories differ and the
+     * solvable multiplication relations are <b>empty</b>.
+     * @param cf factory for coefficients of type C.
+     * @param o other solvable polynomial ring.
+     */
+    public QLRSolvablePolynomialRing(RingFactory<C> cf, GenSolvablePolynomialRing o) {
+        this(cf, o.nvar, o.tord, o.getVars(), null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the the
+     * same term order, number of variables and variable names as the given
+     * polynomial factory, only the coefficient factories differ and the
+     * solvable multiplication relations are <b>empty</b>.
+     * @param cf factory for coefficients of type C.
+     * @param o other solvable polynomial ring.
+     */
+    public QLRSolvablePolynomialRing(RingFactory<C> cf, QLRSolvablePolynomialRing o) {
+        this(cf, (GenSolvablePolynomialRing) o);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     * @param v names for the variables.
+     * @param rt solvable multiplication relations.
+     */
+    @SuppressWarnings("unchecked")
+    public QLRSolvablePolynomialRing(RingFactory<C> cf, int n, TermOrder t, String[] v,
+                    RelationTable<C> rt) {
+        super(cf, n, t, v, rt);
+        //if (rt == null) { // handled in super }
+        qpfac = (QuotPairFactory<GenPolynomial<D>,C>) cf; // crucial part of type
+        RingFactory<GenPolynomial<D>> cfring = qpfac.pairFactory(); // == coFac.ring
+        polCoeff = new RecSolvablePolynomialRing<D>(cfring, n, t, v);
+        if (table.size() > 0) { // TODO
+            ExpVector e = null;
+            ExpVector f = null;
+            GenSolvablePolynomial<GenPolynomial<D>> p = null;
+            polCoeff.table.update(e, f, p); // from rt
+            throw new RuntimeException("TODO");
+        }
+        ZERO = new QLRSolvablePolynomial<C,D>(this);
+        C coeff = coFac.getONE();
+        ONE = new QLRSolvablePolynomial<C,D>(this, coeff, evzero);
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        String res = super.toString();
+        if (PrettyPrint.isTrue()) {
+            res += "\n" + polCoeff.coeffTable.toString(vars);
+            res += "\n" + polCoeff.table.toString(vars);
+        } else {
+            res += ", #rel = " + table.size() + " + " + polCoeff.coeffTable.size() + " + " + polCoeff.table.size();
+        }
+        return res;
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        StringBuffer s = new StringBuffer();
+        switch (Scripting.getLang()) {
+        case Ruby:
+            s.append("SolvPolyRing.new(");
+            break;
+        case Python:
+        default:
+            s.append("SolvPolyRing(");
+        }
+        if (coFac instanceof RingElem) {
+            s.append(((RingElem<C>) coFac).toScriptFactory());
+        } else {
+            s.append(coFac.toScript().trim());
+        }
+        s.append(",\"" + varsToString() + "\",");
+        String to = tord.toScript();
+        s.append(to);
+        String rel = "";
+        if (table.size() > 0) {
+            rel = table.toScript();
+            s.append(",rel=");
+            s.append(rel);
+        }
+        if (polCoeff.coeffTable.size() > 0) {
+            String crel = polCoeff.coeffTable.toScript();
+            s.append(",coeffrel=");
+            s.append(crel);
+        }
+        if (polCoeff.table.size() > 0) { // should not be printed
+            String polrel = polCoeff.table.toScript();
+            if (!rel.equals(polrel)) {
+                s.append(",polrel=");
+                s.append(polrel);
+            }
+        }
+        s.append(")");
+        return s.toString();
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object other) {
+        if (!(other instanceof QLRSolvablePolynomialRing)) {
+            return false;
+        }
+        QLRSolvablePolynomialRing<C,D> oring = null;
+        try {
+            oring = (QLRSolvablePolynomialRing<C,D>) other;
+        } catch (ClassCastException ignored) {
+        }
+        if (oring == null) {
+            return false;
+        }
+        // do a super.equals( )
+        if (!super.equals(other)) {
+            return false;
+        }
+        // check same base relations
+        //if ( ! table.equals(oring.table) ) { // done in super
+        //    return false;
+        //}
+        if (!polCoeff.coeffTable.equals(oring.polCoeff.coeffTable)) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Hash code for this polynomial ring.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = super.hashCode();
+        h = 37 * h + table.hashCode(); // may be different after some computations
+        h = 37 * h + polCoeff.coeffTable.hashCode(); // may be different
+        return h;
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as QLRSolvablePolynomial.
+     */
+    @Override
+    public QLRSolvablePolynomial<C,D> getZERO() {
+        return ZERO;
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as QLRSolvablePolynomial.
+     */
+    @Override
+    public QLRSolvablePolynomial<C,D> getONE() {
+        return ONE;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true if this ring is commutative, else false.
+     */
+    @Override
+    public boolean isCommutative() {
+        if (polCoeff.isCommutative()) {
+            return super.isCommutative();
+        }
+        return false;
+    }
+
+
+    /**
+     * Query if this ring is associative. Test if the relations between the mian
+     * variables and the coefficient generators define an associative solvable
+     * ring.
+     * @return true, if this ring is associative, else false.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean isAssociative() {
+        if (!coFac.isAssociative()) {
+            return false;
+        }
+        //System.out.println("polCoeff = " + polCoeff.toScript());
+        if (!polCoeff.isAssociative()) { // not done via generators??
+            return false;
+        }
+        QLRSolvablePolynomial<C,D> Xi, Xj, Xk, p, q;
+        List<GenPolynomial<C>> gens = generators();
+        //System.out.println("QLR gens = " + gens);
+        int ngen = gens.size();
+        for (int i = 0; i < ngen; i++) {
+            Xi = (QLRSolvablePolynomial<C,D>) gens.get(i);
+            if(Xi.degree() == 0) {
+                C lbc = Xi.leadingBaseCoefficient();
+                if (lbc.numerator().degree() == 0 && lbc.denominator().degree() == 0) {
+                    //System.out.println("qlr assoc skip: Xi = " + lbc);
+                    continue; // skip
+                }
+            }
+            for (int j = i + 1; j < ngen; j++) {
+                Xj = (QLRSolvablePolynomial<C,D>) gens.get(j);
+                if(Xj.degree() == 0) {
+                   C lbc = Xi.leadingBaseCoefficient();
+                   if (lbc.numerator().degree() == 0 && lbc.denominator().degree() == 0) {
+                       //System.out.println("qlr assoc skip: Xj = " + lbc);
+                       continue; // skip
+                   }
+                }
+                for (int k = j + 1; k < ngen; k++) {
+                    Xk = (QLRSolvablePolynomial<C,D>) gens.get(k);
+                    if (Xi.degree() == 0 && Xj.degree() == 0 && Xk.degree() == 0) {
+                        //System.out.println("qlr assoc degree == 0");
+                        continue; // skip
+                    }
+                    try {
+                        p = Xk.multiply(Xj).multiply(Xi);
+                        q = Xk.multiply(Xj.multiply(Xi));
+                        //System.out.println("qlr assoc: p = " + p);
+                        //System.out.println("qlr assoc: q = " + q);
+                    } catch (IllegalArgumentException e) {
+                        System.out.println("qlr assoc: Xi = " + Xi);
+                        System.out.println("qlr assoc: Xj = " + Xj);
+                        System.out.println("qlr assoc: Xk = " + Xk);
+                        e.printStackTrace();
+                        continue;
+                    }
+                    if (!p.equals(q)) {
+                        if (logger.isInfoEnabled()) {
+                            //System.out.println("qlr assoc: Xk = " + Xk + ", Xj = " + Xj + ", Xi = " + Xi);
+                            logger.info("Xk = " + Xk + ", Xj = " + Xj + ", Xi = " + Xi);
+                            logger.info("p = ( Xk * Xj ) * Xi = " + p);
+                            logger.info("q = Xk * ( Xj * Xi ) = " + q);
+                            logger.info("q-p = " + p.subtract(q));
+                        }
+                        return false;
+                    }
+                }
+            }
+        }
+        return true; 
+    }
+
+
+    /**
+     * Get a (constant) QLRSolvablePolynomial&lt;C&gt; element from a long
+     * value.
+     * @param a long.
+     * @return a QLRSolvablePolynomial&lt;C&gt;.
+     */
+    @Override
+    public QLRSolvablePolynomial<C,D> fromInteger(long a) {
+        return new QLRSolvablePolynomial<C,D>(this, coFac.fromInteger(a), evzero);
+    }
+
+
+    /**
+     * Get a (constant) QLRSolvablePolynomial&lt;C&gt; element from a
+     * BigInteger value.
+     * @param a BigInteger.
+     * @return a QLRSolvablePolynomial&lt;C&gt;.
+     */
+    @Override
+    public QLRSolvablePolynomial<C,D> fromInteger(BigInteger a) {
+        return new QLRSolvablePolynomial<C,D>(this, coFac.fromInteger(a), evzero);
+    }
+
+
+    /**
+     * Random solvable polynomial. Generates a random solvable polynomial with k
+     * = 5, l = n, d = (nvar == 1) ? n : 3, q = (nvar == 1) ? 0.7 : 0.3.
+     * @param n number of terms.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    public QLRSolvablePolynomial<C,D> random(int n) {
+        return random(n, random);
+    }
+
+
+    /**
+     * Random solvable polynomial. Generates a random solvable polynomial with k
+     * = 5, l = n, d = (nvar == 1) ? n : 3, q = (nvar == 1) ? 0.7 : 0.3.
+     * @param n number of terms.
+     * @param rnd is a source for random bits.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    public QLRSolvablePolynomial<C,D> random(int n, Random rnd) {
+        if (nvar == 1) {
+            return random(5, n, n, 0.7f, rnd);
+        }
+        return random(5, n, 3, 0.3f, rnd);
+    }
+
+
+    /**
+     * Generate a random solvable polynomial.
+     * @param k bitsize of random coefficients.
+     * @param l number of terms.
+     * @param d maximal degree in each variable.
+     * @param q density of nozero exponents.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    public QLRSolvablePolynomial<C,D> random(int k, int l, int d, float q) {
+        return random(k, l, d, q, random);
+    }
+
+
+    /**
+     * Random solvable polynomial.
+     * @param k size of random coefficients.
+     * @param l number of terms.
+     * @param d maximal degree in each variable.
+     * @param q density of nozero exponents.
+     * @param rnd is a source for random bits.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public QLRSolvablePolynomial<C,D> random(int k, int l, int d, float q, Random rnd) {
+        QLRSolvablePolynomial<C,D> r = getZERO(); // copy( ZERO ); 
+        ExpVector e;
+        C a;
+        // add random coeffs and exponents
+        for (int i = 0; i < l; i++) {
+            e = ExpVector.random(nvar, d, q, rnd);
+            a = coFac.random(k, rnd);
+            r = (QLRSolvablePolynomial<C,D>) r.sum(a, e);
+            // somewhat inefficient but clean
+        }
+        return r;
+    }
+
+
+    /**
+     * Copy polynomial c.
+     * @param c
+     * @return a copy of c.
+     */
+    public QLRSolvablePolynomial<C,D> copy(QLRSolvablePolynomial<C,D> c) {
+        return new QLRSolvablePolynomial<C,D>(this, c.getMap());
+    }
+
+
+    /**
+     * Parse a solvable polynomial with the use of GenPolynomialTokenizer
+     * @param s String.
+     * @return QLRSolvablePolynomial from s.
+     */
+    @Override
+    public QLRSolvablePolynomial<C,D> parse(String s) {
+        return parse(new StringReader(s));
+    }
+
+
+    /**
+     * Parse a solvable polynomial with the use of GenPolynomialTokenizer
+     * @param r Reader.
+     * @return next QLRSolvablePolynomial from r.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public QLRSolvablePolynomial<C,D> parse(Reader r) {
+        GenPolynomialTokenizer pt = new GenPolynomialTokenizer(this, r);
+        QLRSolvablePolynomial<C,D> p = null;
+        try {
+            GenSolvablePolynomial<C> s = pt.nextSolvablePolynomial();
+            p = new QLRSolvablePolynomial<C,D>(this, s);
+        } catch (IOException e) {
+            logger.error(e.toString() + " parse " + this);
+            p = ZERO;
+        }
+        return p;
+    }
+
+
+    /**
+     * Generate univariate solvable polynomial in a given variable.
+     * @param i the index of the variable.
+     * @return X_i as solvable univariate polynomial.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public QLRSolvablePolynomial<C,D> univariate(int i) {
+        return (QLRSolvablePolynomial<C,D>) super.univariate(i);
+    }
+
+
+    /**
+     * Generate univariate solvable polynomial in a given variable with given
+     * exponent.
+     * @param i the index of the variable.
+     * @param e the exponent of the variable.
+     * @return X_i^e as solvable univariate polynomial.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public QLRSolvablePolynomial<C,D> univariate(int i, long e) {
+        return (QLRSolvablePolynomial<C,D>) super.univariate(i, e);
+    }
+
+
+    /**
+     * Generate univariate solvable polynomial in a given variable with given
+     * exponent.
+     * @param modv number of module variables.
+     * @param i the index of the variable.
+     * @param e the exponent of the variable.
+     * @return X_i^e as solvable univariate polynomial.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public QLRSolvablePolynomial<C,D> univariate(int modv, int i, long e) {
+        return (QLRSolvablePolynomial<C,D>) super.univariate(modv, i, e);
+    }
+
+
+    /**
+     * Generate list of univariate polynomials in all variables.
+     * @return List(X_1,...,X_n) a list of univariate polynomials.
+     */
+    @Override
+    public List<QLRSolvablePolynomial<C,D>> univariateList() {
+        return univariateList(0, 1L);
+    }
+
+
+    /**
+     * Generate list of univariate polynomials in all variables.
+     * @param modv number of module variables.
+     * @return List(X_1,...,X_n) a list of univariate polynomials.
+     */
+    @Override
+    public List<QLRSolvablePolynomial<C,D>> univariateList(int modv) {
+        return univariateList(modv, 1L);
+    }
+
+
+    /**
+     * Generate list of univariate polynomials in all variables with given
+     * exponent.
+     * @param modv number of module variables.
+     * @param e the exponent of the variables.
+     * @return List(X_1^e,...,X_n^e) a list of univariate polynomials.
+     */
+    @Override
+    public List<QLRSolvablePolynomial<C,D>> univariateList(int modv, long e) {
+        List<QLRSolvablePolynomial<C,D>> pols = new ArrayList<QLRSolvablePolynomial<C,D>>(nvar);
+        int nm = nvar - modv;
+        for (int i = 0; i < nm; i++) {
+            QLRSolvablePolynomial<C,D> p = univariate(modv, nm - 1 - i, e);
+            pols.add(p);
+        }
+        return pols;
+    }
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by i.
+     * @param i number of variables to extend.
+     * @return extended solvable polynomial ring factory.
+     */
+    @Override
+    public QLRSolvablePolynomialRing<C,D> extend(int i) {
+        return extend(i,false);
+    }
+
+    
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by i.
+     * @param i number of variables to extend.
+     * @param top true for TOP term order, false for POT term order.
+     * @return extended solvable polynomial ring factory.
+     */
+    @Override
+    public QLRSolvablePolynomialRing<C,D> extend(int i, boolean top) {
+        GenPolynomialRing<C> pfac = super.extend(i, top);
+        QLRSolvablePolynomialRing<C,D> spfac = new QLRSolvablePolynomialRing<C,D>(pfac.coFac, pfac.nvar,
+                        pfac.tord, pfac.getVars());
+        spfac.table.extend(this.table);
+        spfac.polCoeff.coeffTable.extend(this.polCoeff.coeffTable);
+        return spfac;
+    }
+
+    
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by length(vn). New variables commute with the exiting
+     * variables.
+     * @param vn names for extended variables.
+     * @return extended polynomial ring factory.
+     */
+    @Override
+    public QLRSolvablePolynomialRing<C,D> extend(String[] vn) {
+        return extend(vn, false);
+    }
+
+    
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by length(vn). New variables commute with the exiting
+     * variables.
+     * @param vn names for extended variables.
+     * @param top true for TOP term order, false for POT term order.
+     * @return extended polynomial ring factory.
+     */
+    @Override
+    public QLRSolvablePolynomialRing<C,D> extend(String[] vn, boolean top) {
+        GenPolynomialRing<C> pfac = super.extend(vn, top);
+        QLRSolvablePolynomialRing<C,D> spfac = new QLRSolvablePolynomialRing<C,D>(pfac.coFac, pfac.nvar,
+                        pfac.tord, pfac.vars);
+        spfac.table.extend(this.table);
+        spfac.polCoeff.coeffTable.extend(this.polCoeff.coeffTable);
+        return spfac;
+    }
+    
+    
+    /**
+     * Contract variables. Used e.g. in module embedding. Contract number of
+     * variables by i.
+     * @param i number of variables to remove.
+     * @return contracted solvable polynomial ring factory.
+     */
+    @Override
+    public QLRSolvablePolynomialRing<C,D> contract(int i) {
+        GenPolynomialRing<C> pfac = super.contract(i);
+        QLRSolvablePolynomialRing<C,D> spfac = new QLRSolvablePolynomialRing<C,D>(pfac.coFac, pfac.nvar,
+                        pfac.tord, pfac.getVars());
+        spfac.table.contract(this.table);
+        spfac.polCoeff.coeffTable.contract(this.polCoeff.coeffTable);
+        return spfac;
+    }
+
+
+    /**
+     * Reverse variables. Used e.g. in opposite rings.
+     * @return solvable polynomial ring factory with reversed variables.
+     */
+    @Override
+    public QLRSolvablePolynomialRing<C,D> reverse() {
+        return reverse(false);
+    }
+
+
+    /**
+     * Reverse variables. Used e.g. in opposite rings.
+     * @param partial true for partialy reversed term orders.
+     * @return solvable polynomial ring factory with reversed variables.
+     */
+    @Override
+    public QLRSolvablePolynomialRing<C,D> reverse(boolean partial) {
+        GenPolynomialRing<C> pfac = super.reverse(partial);
+        QLRSolvablePolynomialRing<C,D> spfac = new QLRSolvablePolynomialRing<C,D>(pfac.coFac, pfac.nvar,
+                        pfac.tord, pfac.getVars());
+        spfac.partial = partial;
+        spfac.table.reverse(this.table);
+        spfac.polCoeff.coeffTable.reverse(this.polCoeff.coeffTable);
+        return spfac;
+    }
+
+
+    /**
+     * Rational function from integral polynomial coefficients. Represent as
+     * polynomial with type C coefficients.
+     * @param A polynomial with integral polynomial coefficients to be
+     *            converted.
+     * @return polynomial with type C coefficients.
+     */
+    public QLRSolvablePolynomial<C,D> fromPolyCoefficients(GenSolvablePolynomial<GenPolynomial<D>> A) {
+        QLRSolvablePolynomial<C,D> B = getZERO().copy();
+        if (A == null || A.isZERO()) {
+            return B;
+        }
+        for (Map.Entry<ExpVector, GenPolynomial<D>> y : A.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            GenSolvablePolynomial<D> a = (GenSolvablePolynomial<D>) y.getValue();
+            //C p = new C(qfac, a); 
+            C p = qpfac.create(a); 
+            if (!p.isZERO()) {
+                B.doPutToMap(e, p);
+            }
+        }
+        return B;
+    }
+
+
+    /**
+     * Integral function from rational polynomial coefficients. Represent as
+     * polynomial with type GenSolvablePolynomial<C> coefficients.
+     * @param A polynomial with rational polynomial coefficients to be
+     *            converted.
+     * @return polynomial with type GenSolvablePolynomial<C> coefficients.
+     */
+    public RecSolvablePolynomial<D> toPolyCoefficients(QLRSolvablePolynomial<C,D> A) {
+        RecSolvablePolynomial<D> B = polCoeff.getZERO().copy();
+        if (A == null || A.isZERO()) {
+            return B;
+        }
+        for (Map.Entry<ExpVector, C> y : A.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            C a = y.getValue();
+            if (!a.denominator().isONE()) {
+                throw new IllegalArgumentException("den != 1 not supported: " + a);
+            }
+            GenPolynomial<D> p = a.numerator(); // can not be zero
+            if (!p.isZERO()) {
+                B.doPutToMap(e, p);
+            }
+        }
+        return B;
+    }
+
+
+    /**
+     * Integral function from rational polynomial coefficients. Represent as
+     * polynomial with type GenSolvablePolynomial coefficients.
+     * @param A polynomial with rational polynomial coefficients to be
+     *            converted.
+     * @return polynomial with type GenSolvablePolynomial coefficients.
+     */
+    public RecSolvablePolynomial<D> toPolyCoefficients(GenPolynomial<C> A) {
+        RecSolvablePolynomial<D> B = polCoeff.getZERO().copy();
+        if (A == null || A.isZERO()) {
+            return B;
+        }
+        for (Map.Entry<ExpVector, C> y : A.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            C a = y.getValue();
+            if (!a.denominator().isONE()) {
+                throw new IllegalArgumentException("den != 1 not supported: " + a);
+            }
+            GenPolynomial<D> p = a.numerator(); // can not be zero
+            if (!p.isZERO()) {
+                B.doPutToMap(e, p);
+            }
+        }
+        return B;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/Quotient.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/Quotient.java
@@ -1,0 +1,483 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.QuotPair;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Quotient element based on RingElem pairs. Objects of this class are
+ * immutable.
+ * @author Heinz Kredel
+ */
+public class Quotient<C extends RingElem<C>> implements RingElem<Quotient<C>>, QuotPair<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(Quotient.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Quotient class factory data structure.
+     */
+    public final QuotientRing<C> ring;
+
+
+    /**
+     * Numerator part of the element data structure.
+     */
+    public final C num;
+
+
+    /**
+     * Denominator part of the element data structure.
+     */
+    public final C den;
+
+
+    /**
+     * The constructor creates a Quotient object from a ring factory.
+     * @param r ring factory.
+     */
+    public Quotient(QuotientRing<C> r) {
+        this(r, r.ring.getZERO());
+    }
+
+
+    /**
+     * The constructor creates a Quotient object from a ring factory and a
+     * numerator element. The denominator is assumed to be 1.
+     * @param r ring factory.
+     * @param n numerator.
+     */
+    public Quotient(QuotientRing<C> r, C n) {
+        this(r, n, r.ring.getONE(), true);
+    }
+
+
+    /**
+     * The constructor creates a Quotient object from a ring factory and a
+     * numerator and denominator element.
+     * @param r ring factory.
+     * @param n numerator.
+     * @param d denominator.
+     */
+    public Quotient(QuotientRing<C> r, C n, C d) {
+        this(r, n, d, false);
+    }
+
+
+    /**
+     * The constructor creates a Quotient object from a ring factory and a
+     * numerator and denominator element.
+     * @param r ring factory.
+     * @param n numerator.
+     * @param d denominator.
+     * @param isred true if gcd(n,d) == 1, else false.
+     */
+    @SuppressWarnings("unchecked")
+    protected Quotient(QuotientRing<C> r, C n, C d, boolean isred) {
+        if (d == null || d.isZERO()) {
+            throw new IllegalArgumentException("denominator may not be zero");
+        }
+        ring = r;
+        if (d.signum() < 0) {
+            n = n.negate();
+            d = d.negate();
+        }
+        if (isred) {
+            num = n;
+            den = d;
+            return;
+        }
+        // must reduce to lowest terms
+        if (n instanceof GcdRingElem && d instanceof GcdRingElem) {
+            GcdRingElem ng = (GcdRingElem) n;
+            GcdRingElem dg = (GcdRingElem) d;
+            C gcd = (C) ng.gcd(dg);
+            if (debug) {
+                logger.info("gcd = " + gcd);
+            }
+            //RingElem<C> gcd = ring.ring.getONE();
+            if (gcd.isONE()) {
+                num = n;
+                den = d;
+            } else {
+                num = n.divide(gcd);
+                den = d.divide(gcd);
+            }
+            // } else { // univariate polynomial?
+        } else {
+            logger.warn("gcd = ????: " + n.getClass() + ", " + d.getClass());
+            num = n;
+            den = d;
+        }
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public QuotientRing<C> factory() {
+        return ring;
+    }
+
+
+    /**
+     * Numerator.
+     * @see edu.jas.structure.QuotPair#numerator()
+     */
+    public C numerator() {
+        return num;
+    }
+
+
+    /**
+     * Denominator.
+     * @see edu.jas.structure.QuotPair#denominator()
+     */
+    public C denominator() {
+        return den;
+    }
+
+
+    /**
+     * Is Quotient a constant. Not implemented.
+     * @throws UnsupportedOperationException.
+     */
+    public boolean isConstant() {
+        throw new UnsupportedOperationException("isConstant not implemented");
+    }
+
+
+    /**
+     * Clone this.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public Quotient<C> copy() {
+        return new Quotient<C>(ring, num, den, true);
+    }
+
+
+    /**
+     * Is Quotient zero.
+     * @return If this is 0 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isZERO()
+     */
+    public boolean isZERO() {
+        return num.isZERO();
+    }
+
+
+    /**
+     * Is Quotient one.
+     * @return If this is 1 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isONE()
+     */
+    public boolean isONE() {
+        return num.equals(den);
+    }
+
+
+    /**
+     * Is Quotient unit.
+     * @return If this is a unit then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isUnit()
+     */
+    public boolean isUnit() {
+        if (num.isZERO()) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Get the String representation as RingElem.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "Quotient[ " + num.toString() + " / " + den.toString() + " ]";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        return "Quotient( " + num.toScript() + " , " + den.toScript() + " )";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python case
+        return factory().toScript();
+    }
+
+
+    /**
+     * Quotient comparison.
+     * @param b Quotient.
+     * @return sign(this-b).
+     */
+    @Override
+    public int compareTo(Quotient<C> b) {
+        if (b == null || b.isZERO()) {
+            return this.signum();
+        }
+        C r = num.multiply(b.den);
+        C s = den.multiply(b.num);
+        C x = r.subtract(s);
+        return x.signum();
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (b == null) {
+            return false;
+        }
+        if (!(b instanceof Quotient)) {
+            return false;
+        }
+        Quotient<C> a = (Quotient<C>) b;
+        return (0 == compareTo(a));
+    }
+
+
+    /**
+     * Hash code for this local.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = ring.hashCode();
+        h = 37 * h + num.hashCode();
+        h = 37 * h + den.hashCode();
+        return h;
+    }
+
+
+    /**
+     * Quotient absolute value.
+     * @return the absolute value of this.
+     * @see edu.jas.structure.RingElem#abs()
+     */
+    public Quotient<C> abs() {
+        return new Quotient<C>(ring, num.abs(), den, true);
+    }
+
+
+    /**
+     * Quotient summation.
+     * @param S Quotient.
+     * @return this+S.
+     */
+    public Quotient<C> sum(Quotient<C> S) {
+        if (S == null || S.isZERO()) {
+            return this;
+        }
+        C n = num.multiply(S.den);
+        n = n.sum(den.multiply(S.num));
+        C d = den.multiply(S.den);
+        return new Quotient<C>(ring, n, d, false);
+    }
+
+
+    /**
+     * Quotient negate.
+     * @return -this.
+     * @see edu.jas.structure.RingElem#negate()
+     */
+    public Quotient<C> negate() {
+        return new Quotient<C>(ring, num.negate(), den, true);
+    }
+
+
+    /**
+     * Quotient signum.
+     * @see edu.jas.structure.RingElem#signum()
+     * @return signum(this).
+     */
+    public int signum() {
+        return num.signum();
+    }
+
+
+    /**
+     * Quotient subtraction.
+     * @param S Quotient.
+     * @return this-S.
+     */
+    public Quotient<C> subtract(Quotient<C> S) {
+        if (S == null || S.isZERO()) {
+            return this;
+        }
+        C n = num.multiply(S.den);
+        n = n.subtract(den.multiply(S.num));
+        C d = den.multiply(S.den);
+        return new Quotient<C>(ring, n, d, false);
+    }
+
+
+    /**
+     * Quotient division.
+     * @param S Quotient.
+     * @return this/S.
+     */
+    public Quotient<C> divide(Quotient<C> S) {
+        return multiply(S.inverse());
+    }
+
+
+    /**
+     * Quotient inverse.
+     * @see edu.jas.structure.RingElem#inverse()
+     * @return S with S = 1/this.
+     */
+    public Quotient<C> inverse() {
+        return new Quotient<C>(ring, den, num, true);
+    }
+
+
+    /**
+     * Quotient remainder.
+     * @param S Quotient.
+     * @return this - (this/S)*S.
+     */
+    public Quotient<C> remainder(Quotient<C> S) {
+        if (num.isZERO()) {
+            throw new ArithmeticException("element not invertible " + this);
+        }
+        return ring.getZERO();
+    }
+
+
+    /**
+     * Quotient and remainder by division of this by S.
+     * @param S a Quotient
+     * @return [this/S, this - (this/S)*S].
+     */
+    @SuppressWarnings("unchecked")
+    public Quotient<C>[] quotientRemainder(Quotient<C> S) {
+        return new Quotient[] { divide(S), remainder(S) };
+    }
+
+
+    /**
+     * Quotient multiplication.
+     * @param S Quotient.
+     * @return this*S.
+     */
+    public Quotient<C> multiply(Quotient<C> S) {
+        if (S == null || S.isZERO()) {
+            return S;
+        }
+        if (num.isZERO()) {
+            return this;
+        }
+        if (S.isONE()) {
+            return this;
+        }
+        if (this.isONE()) {
+            return S;
+        }
+        C n = num.multiply(S.num);
+        C d = den.multiply(S.den);
+        return new Quotient<C>(ring, n, d, false);
+    }
+
+
+    /**
+     * Quotient monic.
+     * @return this with monic value part.
+     */
+    public Quotient<C> monic() {
+        logger.info("monic not implemented");
+        return this;
+    }
+
+
+    /**
+     * Greatest common divisor. <b>Note:</b> If not defined, throws
+     * UnsupportedOperationException.
+     * @param b other element.
+     * @return gcd(this,b).
+     */
+    public Quotient<C> gcd(Quotient<C> b) {
+        if (b == null || b.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return b;
+        }
+        if (num instanceof GcdRingElem && den instanceof GcdRingElem && b.num instanceof GcdRingElem
+                        && b.den instanceof GcdRingElem) {
+            return ring.getONE();
+        }
+        throw new UnsupportedOperationException("gcd not implemented " + num.getClass().getName());
+    }
+
+
+    /**
+     * Extended greatest common divisor. <b>Note:</b> If not defined, throws
+     * UnsupportedOperationException.
+     * @param b other element.
+     * @return [ gcd(this,b), c1, c2 ] with c1*this + c2*b = gcd(this,b).
+     */
+    public Quotient<C>[] egcd(Quotient<C> b) {
+        @SuppressWarnings("unchecked")
+        Quotient<C>[] ret = (Quotient<C>[]) new Quotient[3];
+        ret[0] = null;
+        ret[1] = null;
+        ret[2] = null;
+        if (b == null || b.isZERO()) {
+            ret[0] = this;
+            return ret;
+        }
+        if (this.isZERO()) {
+            ret[0] = b;
+            return ret;
+        }
+        if (num instanceof GcdRingElem && den instanceof GcdRingElem && b.num instanceof GcdRingElem
+                        && b.den instanceof GcdRingElem) {
+            Quotient<C> two = ring.fromInteger(2);
+            ret[0] = ring.getONE();
+            ret[1] = (this.multiply(two)).inverse();
+            ret[2] = (b.multiply(two)).inverse();
+            return ret;
+        }
+        throw new UnsupportedOperationException("egcd not implemented " + num.getClass().getName());
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/QuotientRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/QuotientRing.java
@@ -1,0 +1,292 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+// import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.QuotPairFactory;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Quotient ring factory using RingElem and RingFactory. Objects of this class
+ * are immutable.
+ * @author Heinz Kredel
+ */
+public class QuotientRing<C extends RingElem<C>> implements RingFactory<Quotient<C>>,
+                QuotPairFactory<C, Quotient<C>> {
+
+
+    private static final Logger logger = LogManager.getLogger(QuotientRing.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Ring factory of this factory.
+     */
+    public final RingFactory<C> ring;
+
+
+    /**
+     * The constructor creates a QuotientRing object from a RingFactory.
+     * @param r ring factory.
+     */
+    public QuotientRing(RingFactory<C> r) {
+        ring = r;
+    }
+
+
+    /**
+     * Factory for base elements.
+     */
+    public RingFactory<C> pairFactory() {
+        return ring;
+    }
+
+
+    /**
+     * Create from numerator.
+     */
+    public Quotient<C> create(C n) {
+        return new Quotient<C>(this, n);
+    }
+
+
+    /**
+     * Create from numerator, denominator pair.
+     */
+    public Quotient<C> create(C n, C d) {
+        return new Quotient<C>(this, n, d);
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite()
+     */
+    public boolean isFinite() {
+        return ring.isFinite();
+    }
+
+
+    /**
+     * Copy Quotient element c.
+     * @param c
+     * @return a copy of c.
+     */
+    public Quotient<C> copy(Quotient<C> c) {
+        return new Quotient<C>(c.ring, c.num, c.den, true);
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as Quotient.
+     */
+    public Quotient<C> getZERO() {
+        return new Quotient<C>(this, ring.getZERO());
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as Quotient.
+     */
+    public Quotient<C> getONE() {
+        return new Quotient<C>(this, ring.getONE());
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     * @see edu.jas.structure.ElemFactory#generators()
+     */
+    public List<Quotient<C>> generators() {
+        List<? extends C> rgens = ring.generators();
+        List<Quotient<C>> gens = new ArrayList<Quotient<C>>(rgens.size());
+        for (C c : rgens) {
+            gens.add(new Quotient<C>(this, c));
+        }
+        return gens;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true if this ring is commutative, else false.
+     */
+    public boolean isCommutative() {
+        return ring.isCommutative();
+    }
+
+
+    /**
+     * Query if this ring is associative.
+     * @return true if this ring is associative, else false.
+     */
+    public boolean isAssociative() {
+        return ring.isAssociative();
+    }
+
+
+    /**
+     * Query if this ring is a field.
+     * @return true.
+     */
+    public boolean isField() {
+        return true;
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic() {
+        return ring.characteristic();
+    }
+
+
+    /**
+     * Get a Quotient element from a BigInteger value.
+     * @param a BigInteger.
+     * @return a Quotient.
+     */
+    public Quotient<C> fromInteger(java.math.BigInteger a) {
+        return new Quotient<C>(this, ring.fromInteger(a));
+    }
+
+
+    /**
+     * Get a Quotient element from a long value.
+     * @param a long.
+     * @return a Quotient.
+     */
+    public Quotient<C> fromInteger(long a) {
+        return new Quotient<C>(this, ring.fromInteger(a));
+    }
+
+
+    /**
+     * Get the String representation as RingFactory.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "Quotient[ " + ring.toString() + " ]";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.ElemFactory#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        return "QuotientRing(" + ring.toScript() + ")";
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (b == null) {
+            return false;
+        }
+        if (!(b instanceof QuotientRing)) {
+            return false;
+        }
+        QuotientRing<C> a = (QuotientRing<C>) b;
+        return ring.equals(a.ring);
+    }
+
+
+    /**
+     * Hash code for this quotient ring.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = ring.hashCode();
+        return h;
+    }
+
+
+    /**
+     * Quotient random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @return a random residue element.
+     */
+    public Quotient<C> random(int n) {
+        C r = ring.random(n);
+        C s = ring.random(n);
+        while (s.isZERO()) {
+            s = ring.random(n);
+        }
+        return new Quotient<C>(this, r, s, false);
+    }
+
+
+    /**
+     * Quotient random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @param rnd is a source for random bits.
+     * @return a random residue element.
+     */
+    public Quotient<C> random(int n, Random rnd) {
+        C r = ring.random(n, rnd);
+        C s = ring.random(n, rnd);
+        while (s.isZERO()) {
+            s = ring.random(n, rnd);
+        }
+        return new Quotient<C>(this, r, s, false);
+    }
+
+
+    /**
+     * Parse Quotient from String.
+     * @param s String.
+     * @return Quotient from s.
+     */
+    public Quotient<C> parse(String s) {
+        C x = ring.parse(s);
+        return new Quotient<C>(this, x);
+    }
+
+
+    /**
+     * Parse Quotient from Reader.
+     * @param r Reader.
+     * @return next Quotient from r.
+     */
+    public Quotient<C> parse(Reader r) {
+        C x = ring.parse(r);
+        if (debug) {
+            logger.debug("x = " + x);
+        }
+        return new Quotient<C>(this, x);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/RecSolvablePolynomial.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/RecSolvablePolynomial.java
@@ -1,0 +1,834 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.structure.RingElem;
+
+
+/**
+ * RecSolvablePolynomial generic recursive solvable polynomials implementing
+ * RingElem. n-variate ordered solvable polynomials over solvable polynomial
+ * coefficients. Objects of this class are intended to be immutable. The
+ * implementation is based on TreeMap respectively SortedMap from exponents to
+ * coefficients by extension of GenPolynomial.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class RecSolvablePolynomial<C extends RingElem<C>> extends GenSolvablePolynomial<GenPolynomial<C>> {
+
+
+    /**
+     * The factory for the recursive solvable polynomial ring. Hides super.ring.
+     */
+    public final RecSolvablePolynomialRing<C> ring;
+
+
+    private static final Logger logger = LogManager.getLogger(RecSolvablePolynomial.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor for zero RecSolvablePolynomial.
+     * @param r solvable polynomial ring factory.
+     */
+    public RecSolvablePolynomial(RecSolvablePolynomialRing<C> r) {
+        super(r);
+        ring = r;
+    }
+
+
+    /**
+     * Constructor for RecSolvablePolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param e exponent.
+     */
+    public RecSolvablePolynomial(RecSolvablePolynomialRing<C> r, ExpVector e) {
+        this(r);
+        val.put(e, ring.getONECoefficient());
+    }
+
+
+    /**
+     * Constructor for RecSolvablePolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param c coefficient polynomial.
+     * @param e exponent.
+     */
+    public RecSolvablePolynomial(RecSolvablePolynomialRing<C> r, GenPolynomial<C> c, ExpVector e) {
+        this(r);
+        if (c != null && !c.isZERO()) {
+            val.put(e, c);
+        }
+    }
+
+
+    /**
+     * Constructor for RecSolvablePolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param c coefficient polynomial.
+     */
+    public RecSolvablePolynomial(RecSolvablePolynomialRing<C> r, GenPolynomial<C> c) {
+        this(r, c, r.evzero);
+    }
+
+
+    /**
+     * Constructor for RecSolvablePolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param S solvable polynomial.
+     */
+    public RecSolvablePolynomial(RecSolvablePolynomialRing<C> r, GenSolvablePolynomial<GenPolynomial<C>> S) {
+        this(r, S.val);
+    }
+
+
+    /**
+     * Constructor for RecSolvablePolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param v the SortedMap of some other (solvable) polynomial.
+     */
+    protected RecSolvablePolynomial(RecSolvablePolynomialRing<C> r, SortedMap<ExpVector, GenPolynomial<C>> v) {
+        this(r);
+        val.putAll(v); // assume no zero coefficients
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    @Override
+    public RecSolvablePolynomialRing<C> factory() {
+        return ring;
+    }
+
+
+    /**
+     * Clone this RecSolvablePolynomial.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public RecSolvablePolynomial<C> copy() {
+        return new RecSolvablePolynomial<C>(ring, this.val);
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object B) {
+        if (!(B instanceof RecSolvablePolynomial)) {
+            return false;
+        }
+        // compare also coeffTable?
+        return super.equals(B);
+    }
+
+
+    /**
+     * Hash code for this polynomial.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+
+    /**
+     * RecSolvablePolynomial multiplication.
+     * @param Bp RecSolvablePolynomial.
+     * @return this*Bp, where * denotes solvable multiplication.
+     */
+    // cannot @Override, @NoOverride
+    public RecSolvablePolynomial<C> multiply(RecSolvablePolynomial<C> Bp) {
+        if (Bp == null || Bp.isZERO()) {
+            return ring.getZERO();
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        assert (ring.nvar == Bp.ring.nvar);
+        if (debug) {
+            logger.info("ring = " + ring.toScript());
+        }
+        final boolean commute = ring.table.isEmpty();
+        final boolean commuteCoeff = ring.coeffTable.isEmpty();
+        GenPolynomialRing<C> cfac = (GenPolynomialRing<C>) ring.coFac;
+        RecSolvablePolynomial<C> Dp = ring.getZERO().copy();
+        ExpVector Z = ring.evzero;
+        ExpVector Zc = cfac.evzero;
+        GenPolynomial<C> one = ring.getONECoefficient();
+
+        RecSolvablePolynomial<C> C1 = null;
+        RecSolvablePolynomial<C> C2 = null;
+        Map<ExpVector, GenPolynomial<C>> A = val;
+        Map<ExpVector, GenPolynomial<C>> B = Bp.val;
+        Set<Map.Entry<ExpVector, GenPolynomial<C>>> Bk = B.entrySet();
+        if (debug)
+            logger.info("input A = " + this);
+        for (Map.Entry<ExpVector, GenPolynomial<C>> y : A.entrySet()) {
+            GenPolynomial<C> a = y.getValue();
+            ExpVector e = y.getKey();
+            if (debug)
+                logger.info("e = " + e + ", a = " + a);
+            int[] ep = e.dependencyOnVariables();
+            int el1 = ring.nvar + 1;
+            if (ep.length > 0) {
+                el1 = ep[0];
+            }
+            //int el1s = ring.nvar + 1 - el1;
+            if (debug)
+                logger.info("input B = " + Bp);
+            for (Map.Entry<ExpVector, GenPolynomial<C>> x : Bk) {
+                GenPolynomial<C> b = x.getValue();
+                ExpVector f = x.getKey();
+                if (debug)
+                    logger.info("f = " + f + ", b = " + b);
+                int[] fp = f.dependencyOnVariables();
+                int fl1 = 0;
+                if (fp.length > 0) {
+                    fl1 = fp[fp.length - 1];
+                }
+                int fl1s = ring.nvar + 1 - fl1;
+                // polynomial coefficient multiplication e*b = P_eb, for a*((e*b)*f)
+                RecSolvablePolynomial<C> Cps = ring.getZERO().copy();
+                RecSolvablePolynomial<C> Cs = null;
+                if (commuteCoeff || b.isConstant() || e.isZERO()) { // symmetric
+                    Cps.doAddTo(b, e);
+                    if (debug)
+                        logger.info("symmetric coeff, e*b: b = " + b + ", e = " + e);
+                } else { // unsymmetric
+                    if (debug)
+                        logger.info("unsymmetric coeff, e*b: b = " + b + ", e = " + e);
+                    for (Map.Entry<ExpVector, C> z : b.val.entrySet()) {
+                        C c = z.getValue();
+                        GenPolynomial<C> cc = b.ring.valueOf(c); 
+                        ExpVector g = z.getKey();
+                        if (debug)
+                            logger.info("g = " + g + ", c = " + c);
+                        int[] gp = g.dependencyOnVariables();
+                        int gl1 = 0;
+                        if (gp.length > 0) {
+                            gl1 = gp[gp.length - 1];
+                        }
+                        int gl1s = b.ring.nvar + 1 - gl1;
+                        if (debug) {
+                            logger.info("gl1s = " + gl1s);
+                        }
+                        // split e = e1 * e2, g = g2 * g1 (= g1 * g2)
+                        ExpVector e1 = e;
+                        ExpVector e2 = Z;
+                        if (!e.isZERO()) {
+                            e1 = e.subst(el1, 0);
+                            e2 = Z.subst(el1, e.getVal(el1));
+                        }
+                        ExpVector e4;
+                        ExpVector g1 = g;
+                        ExpVector g2 = Zc;
+                        if (!g.isZERO()) {
+                            g1 = g.subst(gl1, 0);
+                            g2 = Zc.subst(gl1, g.getVal(gl1));
+                        }
+                        if (debug) {
+                            logger.info("coeff, e1 = " + e1 + ", e2 = " + e2 + ", Cps = " + Cps);
+                            logger.info("coeff, g1 = " + g1 + ", g2 = " + g2);
+                        }
+                        TableRelation<GenPolynomial<C>> crel = ring.coeffTable.lookup(e2, g2);
+                        if (debug)
+                            logger.info("coeff, crel = " + crel.p);
+                        //logger.info("coeff, e  = " + e + " g, = " + g + ", crel = " + crel);
+                        Cs = new RecSolvablePolynomial<C>(ring, crel.p);
+                        // rest of multiplication and update relations
+                        if (crel.f != null) { // process remaining right power
+                            GenPolynomial<C> c2 = b.ring.valueOf(crel.f); 
+                            C2 = new RecSolvablePolynomial<C>(ring, c2, Z);
+                            Cs = Cs.multiply(C2);
+                            if (crel.e == null) {
+                                e4 = e2;
+                            } else {
+                                e4 = e2.subtract(crel.e);
+                            }
+                            ring.coeffTable.update(e4, g2, Cs);
+                        }
+                        if (crel.e != null) { // process remaining left power
+                            C1 = new RecSolvablePolynomial<C>(ring, one, crel.e);
+                            Cs = C1.multiply(Cs);
+                            ring.coeffTable.update(e2, g2, Cs);
+                        }
+                        if (!g1.isZERO()) { // process remaining right part
+                            GenPolynomial<C> c2 = b.ring.valueOf(g1); 
+                            C2 = new RecSolvablePolynomial<C>(ring, c2, Z);
+                            Cs = Cs.multiply(C2);
+                        }
+                        if (!e1.isZERO()) { // process remaining left part
+                            C1 = new RecSolvablePolynomial<C>(ring, one, e1);
+                            Cs = C1.multiply(Cs);
+                        }
+                        //System.out.println("e1*Cs*g1 = " + Cs);
+                        Cs = Cs.multiplyLeft(cc); // assume c, coeff(cc) commutes with Cs
+                        //Cps = (RecSolvablePolynomial<C>) Cps.sum(Cs);
+                        Cps.doAddTo(Cs);
+                    } // end b loop 
+                    if (debug)
+                        logger.info("coeff, Cs = " + Cs + ", Cps = " + Cps);
+                }
+                if (debug)
+                    logger.info("coeff-poly: Cps = " + Cps);
+                // polynomial multiplication P_eb*f, for a*(P_eb*f)
+                RecSolvablePolynomial<C> Dps = ring.getZERO().copy();
+                RecSolvablePolynomial<C> Ds = null;
+                RecSolvablePolynomial<C> D1, D2;
+                if (commute || Cps.isConstant() || f.isZERO()) { // symmetric
+                    if (debug)
+                        logger.info("symmetric poly, P_eb*f: Cps = " + Cps + ", f = " + f);
+                    ExpVector g = e.sum(f);
+                    if (Cps.isConstant()) {
+                        Ds = new RecSolvablePolynomial<C>(ring, Cps.leadingBaseCoefficient(), g); // symmetric!
+                    } else {
+                        Ds = Cps.shift(f); // symmetric
+                    }
+                } else { // eventually unsymmetric
+                    if (debug)
+                        logger.info("unsymmetric poly, P_eb*f: Cps = " + Cps + ", f = " + f);
+                    for (Map.Entry<ExpVector, GenPolynomial<C>> z : Cps.val.entrySet()) {
+                        // split g = g1 * g2, f = f1 * f2
+                        GenPolynomial<C> c = z.getValue();
+                        ExpVector g = z.getKey();
+                        if (debug)
+                            logger.info("g = " + g + ", c = " + c);
+                        int[] gp = g.dependencyOnVariables();
+                        int gl1 = ring.nvar + 1;
+                        if (gp.length > 0) {
+                            gl1 = gp[0];
+                        }
+                        int gl1s = ring.nvar + 1 - gl1;
+                        if (gl1s <= fl1s) { // symmetric
+                            ExpVector h = g.sum(f);
+                            if (debug)
+                                logger.info("disjoint poly: g = " + g + ", f = " + f + ", h = " + h);
+                            Ds = ring.valueOf(h); // symmetric! 
+                        } else {
+                            ExpVector g1 = g.subst(gl1, 0);
+                            ExpVector g2 = Z.subst(gl1, g.getVal(gl1)); // bug el1, gl1
+                            ExpVector g4;
+                            ExpVector f1 = f.subst(fl1, 0);
+                            ExpVector f2 = Z.subst(fl1, f.getVal(fl1));
+                            if (debug) {
+                                logger.info("poly, g1 = " + g1 + ", f1 = " + f1 + ", Dps = " + Dps);
+                                logger.info("poly, g2 = " + g2 + ", f2 = " + f2);
+                            }
+                            TableRelation<GenPolynomial<C>> rel = ring.table.lookup(g2, f2);
+                            if (debug)
+                                logger.info("poly, g  = " + g + ", f  = " + f + ", rel = " + rel);
+                            Ds = new RecSolvablePolynomial<C>(ring, rel.p); //ring.copy(rel.p);
+                            if (rel.f != null) {
+                                D2 = ring.valueOf(rel.f); 
+                                Ds = Ds.multiply(D2);
+                                if (rel.e == null) {
+                                    g4 = g2;
+                                } else {
+                                    g4 = g2.subtract(rel.e);
+                                }
+                                ring.table.update(g4, f2, Ds);
+                            }
+                            if (rel.e != null) {
+                                D1 = ring.valueOf(rel.e); 
+                                Ds = D1.multiply(Ds);
+                                ring.table.update(g2, f2, Ds);
+                            }
+                            if (!f1.isZERO()) {
+                                D2 = ring.valueOf(f1); 
+                                Ds = Ds.multiply(D2);
+                                //ring.table.update(?,f1,Ds)
+                            }
+                            if (!g1.isZERO()) {
+                                D1 = ring.valueOf(g1); 
+                                Ds = D1.multiply(Ds);
+                                //ring.table.update(e1,?,Ds)
+                            }
+                        }
+                        Ds = Ds.multiplyLeft(c); // assume c commutes with Cs
+                        Dps.doAddTo(Ds);
+                    } // end Dps loop
+                    Ds = Dps;
+                }
+                if (debug) {
+                    logger.info("recursion+: Ds = " + Ds + ", a = " + a);
+                }
+                // polynomial coefficient multiplication a*(P_eb*f) = a*Ds
+                Ds = Ds.multiplyLeft(a); // multiply(a,b); // non-symmetric 
+                if (debug)
+                    logger.info("recursion-: Ds = " + Ds);
+                Dp.doAddTo(Ds);
+                if (debug)
+                    logger.info("end B loop: Dp = " + Dp);
+            } // end B loop
+            if (debug)
+                logger.info("end A loop: Dp = " + Dp);
+        } // end A loop
+        return Dp;
+    }
+
+
+    /**
+     * RecSolvablePolynomial left and right multiplication. Product with two
+     * polynomials.
+     * @param S RecSolvablePolynomial.
+     * @param T RecSolvablePolynomial.
+     * @return S*this*T.
+     */
+    // cannot @Override, @NoOverride
+    public RecSolvablePolynomial<C> multiply(RecSolvablePolynomial<C> S, RecSolvablePolynomial<C> T) {
+        if (S.isZERO() || T.isZERO() || this.isZERO()) {
+            return ring.getZERO();
+        }
+        if (S.isONE()) {
+            return multiply(T);
+        }
+        if (T.isONE()) {
+            return S.multiply(this);
+        }
+        return S.multiply(this).multiply(T);
+    }
+
+
+    /**
+     * RecSolvablePolynomial multiplication. Product with coefficient ring
+     * element.
+     * @param b coefficient polynomial.
+     * @return this*b, where * is coefficient multiplication.
+     */
+    // cannot @Override
+    //public RecSolvablePolynomial<C> multiply(GenPolynomial<C> b) {
+    //public GenSolvablePolynomial<GenPolynomial<C>> multiply(GenPolynomial<C> b) {
+    public RecSolvablePolynomial<C> recMultiply(GenPolynomial<C> b) {
+        RecSolvablePolynomial<C> Cp = ring.getZERO().copy();
+        if (b == null || b.isZERO()) {
+            return Cp;
+        }
+        Cp = new RecSolvablePolynomial<C>(ring, b, ring.evzero);
+        return multiply(Cp);
+        // wrong:
+        // Map<ExpVector, GenPolynomial<C>> Cm = Cp.val; //getMap();
+        // Map<ExpVector, GenPolynomial<C>> Am = val;
+        // for (Map.Entry<ExpVector, GenPolynomial<C>> y : Am.entrySet()) {
+        //     ExpVector e = y.getKey();
+        //     GenPolynomial<C> a = y.getValue();
+        //     GenPolynomial<C> c = a.multiply(b);
+        //     if (!c.isZERO()) {
+        //         Cm.put(e, c);
+        //     }
+        // }
+        // return Cp;
+    }
+
+
+    /**
+     * RecSolvablePolynomial left and right multiplication. Product with
+     * coefficient ring element.
+     * @param b coefficient polynomial.
+     * @param c coefficient polynomial.
+     * @return b*this*c, where * is coefficient multiplication.
+     */
+    @Override
+    public RecSolvablePolynomial<C> multiply(GenPolynomial<C> b, GenPolynomial<C> c) {
+        RecSolvablePolynomial<C> Cp = ring.getZERO().copy();
+        if (b == null || b.isZERO()) {
+            return Cp;
+        }
+        if (c == null || c.isZERO()) {
+            return Cp;
+        }
+        RecSolvablePolynomial<C> Cb = ring.valueOf(b); 
+        RecSolvablePolynomial<C> Cc = ring.valueOf(c); 
+        return Cb.multiply(this).multiply(Cc);
+        // wrong:
+        // Map<ExpVector, GenPolynomial<C>> Cm = Cp.val; //getMap();
+        // Map<ExpVector, GenPolynomial<C>> Am = val;
+        // for (Map.Entry<ExpVector, GenPolynomial<C>> y : Am.entrySet()) {
+        //     ExpVector e = y.getKey();
+        //     GenPolynomial<C> a = y.getValue();
+        //     GenPolynomial<C> d = b.multiply(a).multiply(c);
+        //     if (!d.isZERO()) {
+        //         Cm.put(e, d);
+        //     }
+        // }
+        // return Cp;
+    }
+
+
+    /*
+     * RecSolvablePolynomial multiplication. Product with coefficient ring
+     * element.
+     * @param b coefficient of coefficient.
+     * @return this*b, where * is coefficient multiplication.
+     */
+    //@Override not possible, @NoOverride
+    //public RecSolvablePolynomial<C> multiply(C b) { ... }
+
+
+    /**
+     * RecSolvablePolynomial multiplication. Product with exponent vector.
+     * @param e exponent.
+     * @return this * x<sup>e</sup>, where * denotes solvable multiplication.
+     */
+    @Override
+    public RecSolvablePolynomial<C> multiply(ExpVector e) {
+        if (e == null || e.isZERO()) {
+            return this;
+        }
+        GenPolynomial<C> b = ring.getONECoefficient();
+        return multiply(b, e);
+    }
+
+
+    /**
+     * RecSolvablePolynomial left and right multiplication. Product with
+     * exponent vector.
+     * @param e exponent.
+     * @param f exponent.
+     * @return x<sup>e</sup> * this * x<sup>f</sup>, where * denotes solvable
+     *         multiplication.
+     */
+    @Override
+    public RecSolvablePolynomial<C> multiply(ExpVector e, ExpVector f) {
+        if (e == null || e.isZERO()) {
+            return this;
+        }
+        if (f == null || f.isZERO()) {
+            return this;
+        }
+        GenPolynomial<C> b = ring.getONECoefficient();
+        return multiply(b, e, b, f);
+    }
+
+
+    /**
+     * RecSolvablePolynomial multiplication. Product with ring element and
+     * exponent vector.
+     * @param b coefficient polynomial.
+     * @param e exponent.
+     * @return this * b x<sup>e</sup>, where * denotes solvable multiplication.
+     */
+    @Override
+    public RecSolvablePolynomial<C> multiply(GenPolynomial<C> b, ExpVector e) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        RecSolvablePolynomial<C> Cp = ring.valueOf(b, e); 
+        return multiply(Cp);
+    }
+
+
+    /**
+     * RecSolvablePolynomial left and right multiplication. Product with ring
+     * element and exponent vector.
+     * @param b coefficient polynomial.
+     * @param e exponent.
+     * @param c coefficient polynomial.
+     * @param f exponent.
+     * @return b x<sup>e</sup> * this * c x<sup>f</sup>, where * denotes
+     *         solvable multiplication.
+     */
+    @Override
+    public RecSolvablePolynomial<C> multiply(GenPolynomial<C> b, ExpVector e, GenPolynomial<C> c, ExpVector f) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        if (c == null || c.isZERO()) {
+            return ring.getZERO();
+        }
+        RecSolvablePolynomial<C> Cp = ring.valueOf(b, e); 
+        RecSolvablePolynomial<C> Dp = ring.valueOf(c, f); 
+        return multiply(Cp, Dp);
+    }
+
+
+    /**
+     * RecSolvablePolynomial multiplication. Left product with ring element and
+     * exponent vector.
+     * @param b coefficient polynomial.
+     * @param e exponent.
+     * @return b x<sup>e</sup> * this, where * denotes solvable multiplication.
+     */
+    @Override
+    public RecSolvablePolynomial<C> multiplyLeft(GenPolynomial<C> b, ExpVector e) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        RecSolvablePolynomial<C> Cp = ring.valueOf(b, e); 
+        return Cp.multiply(this);
+    }
+
+
+    /**
+     * RecSolvablePolynomial multiplication. Left product with exponent vector.
+     * @param e exponent.
+     * @return x<sup>e</sup> * this, where * denotes solvable multiplication.
+     */
+    @Override
+    public RecSolvablePolynomial<C> multiplyLeft(ExpVector e) {
+        if (e == null || e.isZERO()) {
+            return this;
+        }
+        RecSolvablePolynomial<C> Cp = ring.valueOf(e); 
+        return Cp.multiply(this);
+    }
+
+
+    /**
+     * RecSolvablePolynomial multiplication. Left product with coefficient ring
+     * element.
+     * @param b coefficient polynomial.
+     * @return b*this, where * is coefficient multiplication.
+     */
+    @Override
+    public RecSolvablePolynomial<C> multiplyLeft(GenPolynomial<C> b) {
+        RecSolvablePolynomial<C> Cp = ring.getZERO().copy();
+        if (b == null || b.isZERO()) {
+            return Cp;
+        }
+        GenSolvablePolynomial<C> bb = null;
+        if (b instanceof GenSolvablePolynomial) {
+            //throw new RuntimeException("wrong method dispatch in JRE ");
+            logger.debug("warn: wrong method dispatch in JRE multiply(b) - trying to fix");
+            bb = (GenSolvablePolynomial<C>) b;
+        }
+        Map<ExpVector, GenPolynomial<C>> Cm = Cp.val; //getMap();
+        Map<ExpVector, GenPolynomial<C>> Am = val;
+        GenPolynomial<C> c;
+        for (Map.Entry<ExpVector, GenPolynomial<C>> y : Am.entrySet()) {
+            ExpVector e = y.getKey();
+            GenPolynomial<C> a = y.getValue();
+            if (bb != null) {
+                GenSolvablePolynomial<C> aa = (GenSolvablePolynomial<C>) a;
+                c = bb.multiply(aa);
+            } else {
+                c = b.multiply(a);
+            }
+            if (!c.isZERO()) {
+                Cm.put(e, c);
+            }
+        }
+        return Cp;
+    }
+
+
+    /**
+     * RecSolvablePolynomial multiplication. Left product with 'monomial'.
+     * @param m 'monomial'.
+     * @return m * this, where * denotes solvable multiplication.
+     */
+    @Override
+    public RecSolvablePolynomial<C> multiplyLeft(Map.Entry<ExpVector, GenPolynomial<C>> m) {
+        if (m == null) {
+            return ring.getZERO();
+        }
+        return multiplyLeft(m.getValue(), m.getKey());
+    }
+
+
+    /**
+     * RecSolvablePolynomial multiplication. Product with 'monomial'.
+     * @param m 'monomial'.
+     * @return this * m, where * denotes solvable multiplication.
+     */
+    @Override
+    public RecSolvablePolynomial<C> multiply(Map.Entry<ExpVector, GenPolynomial<C>> m) {
+        if (m == null) {
+            return ring.getZERO();
+        }
+        return multiply(m.getValue(), m.getKey());
+    }
+
+
+    /**
+     * RecSolvablePolynomial multiplication. Commutative product with exponent
+     * vector.
+     * @param f exponent vector.
+     * @return B*f, where * is commutative multiplication.
+     */
+    public RecSolvablePolynomial<C> shift(ExpVector f) {
+        RecSolvablePolynomial<C> C = ring.getZERO().copy();
+        if (this.isZERO()) {
+            return C;
+        }
+        if (f == null || f.isZERO()) {
+            return this;
+        }
+        Map<ExpVector, GenPolynomial<C>> Cm = C.val;
+        Map<ExpVector, GenPolynomial<C>> Bm = this.val;
+        for (Map.Entry<ExpVector, GenPolynomial<C>> y : Bm.entrySet()) {
+            ExpVector e = y.getKey();
+            GenPolynomial<C> a = y.getValue();
+            ExpVector d = e.sum(f);
+            if (!a.isZERO()) {
+                Cm.put(d, a);
+            }
+        }
+        return C;
+    }
+
+
+    /**
+     * RecSolvablePolynomial multiplication. Commutative product with 
+     * coefficient.
+     * @param b coefficient.
+     * @return B*b, where * is commutative multiplication with respect to main variables.
+     */
+     public RecSolvablePolynomial<C> multiplyRightComm(GenPolynomial<C> b) {
+        RecSolvablePolynomial<C> C = ring.getZERO().copy();
+        if (this.isZERO()) {
+            return C;
+        }
+        if (b == null || b.isZERO()) {
+            return this;
+        }
+        Map<ExpVector, GenPolynomial<C>> Cm = C.val;
+        Map<ExpVector, GenPolynomial<C>> Bm = this.val;
+        for (Map.Entry<ExpVector, GenPolynomial<C>> y : Bm.entrySet()) {
+            ExpVector e = y.getKey();
+            GenPolynomial<C> a = y.getValue();
+            a = a.multiply(b);
+            if (!a.isZERO()) {
+                Cm.put(e, a);
+            }
+        }
+        return C;
+    }
+
+
+    /**
+     * RecSolvablePolynomial right coefficients from left coefficients.
+     * <b>Note:</b> R is represented as a polynomial with left coefficients, the
+     * implementation can at the moment not distinguish between left and right
+     * coefficients.
+     * @return R = sum( X<sup>i</sup> b<sub>i</sub> ), with this =
+     *         sum(a<sub>i</sub> X<sup>i</sup> ) and eval(sum(X<sup>i</sup>
+     *         b<sub>i</sub>)) == sum(a<sub>i</sub> X<sup>i</sup>)
+     */
+    @SuppressWarnings("cast")
+    @Override
+    public GenSolvablePolynomial<GenPolynomial<C>> rightRecursivePolynomial() {
+        if (this.isZERO()) {
+            return this;
+        }
+        if (!(this instanceof RecSolvablePolynomial)) {
+            return this;
+        }
+        RecSolvablePolynomialRing<C> rfac = (RecSolvablePolynomialRing<C>) ring;
+        if (rfac.coeffTable.isEmpty()) {
+            return this;
+        }
+        RecSolvablePolynomial<C> R = rfac.getZERO().copy();
+        RecSolvablePolynomial<C> p = this;
+        RecSolvablePolynomial<C> r;
+        while (!p.isZERO()) {
+            ExpVector f = p.leadingExpVector();
+            GenPolynomial<C> a = p.leadingBaseCoefficient();
+            //r = h.multiply(a); // wrong method dispatch // right: f*a
+            //okay: r = onep.multiply(one, f, a, zero); // right: (1 f) * 1 * (a zero)
+            r = rfac.valueOf(f).multiply(rfac.valueOf(a)); // right: (1 f) * 1 * (a zero)
+            //System.out.println("a,f = " + a + ", " + f); // + ", h.ring = " + h.ring.toScript());
+            //System.out.println("f*a = " + r); // + ", r.ring = " + r.ring.toScript());
+            p = (RecSolvablePolynomial<C>) p.subtract(r);
+            R = (RecSolvablePolynomial<C>) R.sum(a, f);
+            //R.doPutToMap(f, a);
+        }
+        return R;
+    }
+
+
+    /**
+     * Evaluate RecSolvablePolynomial as right coefficients polynomial.
+     * <b>Note:</b> R is represented as a polynomial with left coefficients, the
+     * implementation can at the moment not distinguish between left and right
+     * coefficients.
+     * @return this as evaluated polynomial R. R = sum( X<sup>i</sup>
+     *         b<sub>i</sub> ), this = sum(a<sub>i</sub> X<sup>i</sup> ) =
+     *         eval(sum(X<sup>i</sup> b<sub>i</sub>))
+     */
+    @SuppressWarnings("cast")
+    @Override
+    public GenSolvablePolynomial<GenPolynomial<C>> evalAsRightRecursivePolynomial() {
+        if (this.isONE() || this.isZERO()) {
+            return this;
+        }
+        if (!(this instanceof RecSolvablePolynomial)) {
+            return this;
+        }
+        RecSolvablePolynomialRing<C> rfac = (RecSolvablePolynomialRing<C>) ring;
+        if (rfac.coeffTable.isEmpty()) {
+            return this;
+        }
+        RecSolvablePolynomial<C> q = rfac.getZERO();
+        RecSolvablePolynomial<C> s;
+        RecSolvablePolynomial<C> r = (RecSolvablePolynomial<C>) this;
+        for (Map.Entry<ExpVector, GenPolynomial<C>> y : r.getMap().entrySet()) {
+            ExpVector f = y.getKey();
+            GenPolynomial<C> a = y.getValue();
+            // f.multiply(a); // wrong method dispatch // right: f*a
+            // onep.multiply(f).multiply(a) // should do now
+            //okay: s = onep.multiply(one, f, a, zero); // right: (1 f) * 1 * (a zero)
+            s = rfac.valueOf(f).multiply(rfac.valueOf(a)); // right: (1 f) * 1 * (a zero)
+            q = (RecSolvablePolynomial<C>) q.sum(s);
+        }
+        return q;
+    }
+
+
+    /**
+     * Test RecSolvablePolynomial right coefficients polynomial. <b>Note:</b> R
+     * is represented as a polynomial with left coefficients, the implementation
+     * can at the moment not distinguish between left and right coefficients.
+     * @param R GenSolvablePolynomial with right coefficients.
+     * @return true, if R is polynomial with right coefficients of this. R =
+     *         sum( X<sup>i</sup> b<sub>i</sub> ), with this = sum(a<sub>i</sub>
+     *         X<sup>i</sup> ) and eval(sum(X<sup>i</sup> b<sub>i</sub>)) ==
+     *         sum(a<sub>i</sub> X<sup>i</sup>)
+     */
+    @SuppressWarnings("cast")
+    @Override
+    public boolean isRightRecursivePolynomial(GenSolvablePolynomial<GenPolynomial<C>> R) {
+        if (this.isZERO()) {
+            return R.isZERO();
+        }
+        if (this.isONE()) {
+            return R.isONE();
+        }
+        if (!(this instanceof RecSolvablePolynomial)) {
+            return !(R instanceof RecSolvablePolynomial);
+        }
+        if (!(R instanceof RecSolvablePolynomial)) {
+            return false;
+        }
+        RecSolvablePolynomialRing<C> rfac = (RecSolvablePolynomialRing<C>) ring;
+        if (rfac.coeffTable.isEmpty()) {
+            RecSolvablePolynomialRing<C> rf = (RecSolvablePolynomialRing<C>) R.ring;
+            return rf.coeffTable.isEmpty();
+        }
+        RecSolvablePolynomial<C> p = (RecSolvablePolynomial<C>) this;
+        RecSolvablePolynomial<C> q = (RecSolvablePolynomial<C>) R.evalAsRightRecursivePolynomial();
+        p = (RecSolvablePolynomial<C>) PolyUtil.<C> monic(p);
+        q = (RecSolvablePolynomial<C>) PolyUtil.<C> monic(q);
+        return p.equals(q);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/RecSolvablePolynomialRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/RecSolvablePolynomialRing.java
@@ -1,0 +1,744 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.kern.PrettyPrint;
+import edu.jas.kern.Scripting;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * RecSolvablePolynomialRing generic recursive solvable polynomial factory
+ * implementing RingFactory and extending GenSolvablePolynomialRing factory.
+ * Factory for n-variate ordered solvable polynomials over solvable polynomial
+ * coefficients. The non-commutative multiplication relations are maintained in
+ * a relation table and the non-commutative multiplication relations between the
+ * coefficients and the main variables are maintained in a coefficient relation
+ * table. Almost immutable object, except variable names and relation table
+ * contents.
+ * @param <C> coefficient type.
+ * @author Heinz Kredel
+ */
+
+public class RecSolvablePolynomialRing<C extends RingElem<C>> extends
+                GenSolvablePolynomialRing<GenPolynomial<C>> {
+
+
+    /**
+     * The solvable multiplication relations between variables and coefficients.
+     */
+    public final RelationTable<GenPolynomial<C>> coeffTable;
+
+
+    /**
+     * The constant polynomial 0 for this ring. Hides super ZERO.
+     */
+    public final RecSolvablePolynomial<C> ZERO;
+
+
+    /**
+     * The constant polynomial 1 for this ring. Hides super ONE.
+     */
+    public final RecSolvablePolynomial<C> ONE;
+
+
+    private static final Logger logger = LogManager.getLogger(RecSolvablePolynomialRing.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * default term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     */
+    public RecSolvablePolynomialRing(RingFactory<GenPolynomial<C>> cf, int n) {
+        this(cf, n, new TermOrder(), null, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * default term order.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param rt solvable multiplication relations.
+     */
+    public RecSolvablePolynomialRing(RingFactory<GenPolynomial<C>> cf, int n,
+                    RelationTable<GenPolynomial<C>> rt) {
+        this(cf, n, new TermOrder(), null, rt);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     */
+    public RecSolvablePolynomialRing(RingFactory<GenPolynomial<C>> cf, int n, TermOrder t) {
+        this(cf, n, t, null, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     * @param rt solvable multiplication relations.
+     */
+    public RecSolvablePolynomialRing(RingFactory<GenPolynomial<C>> cf, int n, TermOrder t,
+                    RelationTable<GenPolynomial<C>> rt) {
+        this(cf, n, t, null, rt);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     * @param v names for the variables.
+     */
+    public RecSolvablePolynomialRing(RingFactory<GenPolynomial<C>> cf, int n, TermOrder t, String[] v) {
+        this(cf, n, t, v, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param t a term order.
+     * @param v names for the variables.
+     */
+    public RecSolvablePolynomialRing(RingFactory<GenPolynomial<C>> cf, TermOrder t, String[] v) {
+        this(cf, v.length, t, v, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * default term order.
+     * @param cf factory for coefficients of type C.
+     * @param v names for the variables.
+     */
+    public RecSolvablePolynomialRing(RingFactory<GenPolynomial<C>> cf, String[] v) {
+        this(cf, v.length, new TermOrder(), v, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     * @param v names for the variables.
+     * @param rt solvable multiplication relations.
+     */
+    public RecSolvablePolynomialRing(RingFactory<GenPolynomial<C>> cf, int n, TermOrder t, String[] v,
+                    RelationTable<GenPolynomial<C>> rt) {
+        super(cf, n, t, v, rt);
+        //if (rt == null) { // handled in super }
+        coeffTable = new RelationTable<GenPolynomial<C>>(this, true);
+        ZERO = new RecSolvablePolynomial<C>(this);
+        GenPolynomial<C> coeff = coFac.getONE();
+        //evzero = ExpVector.create(nvar); // from super
+        ONE = new RecSolvablePolynomial<C>(this, coeff, evzero);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the the
+     * same term order, number of variables and variable names as the given
+     * polynomial factory, only the coefficient factories differ and the
+     * solvable multiplication relations are <b>empty</b>.
+     * @param cf factory for coefficients of type C.
+     * @param o other solvable polynomial ring.
+     */
+    public RecSolvablePolynomialRing(RingFactory<GenPolynomial<C>> cf, RecSolvablePolynomialRing o) {
+        this(cf, o.nvar, o.tord, o.getVars(), null);
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        String res = super.toString();
+        if (PrettyPrint.isTrue()) {
+            //res += "\n" + table.toString(vars);
+            res += "\n" + coeffTable.toString(vars);
+        } else {
+            res += ", #rel = " + table.size() + " + " + coeffTable.size();
+        }
+        return res;
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        StringBuffer s = new StringBuffer();
+        switch (Scripting.getLang()) {
+        case Ruby:
+            s.append("SolvPolyRing.new(");
+            break;
+        case Python:
+        default:
+            s.append("SolvPolyRing(");
+        }
+        if (coFac instanceof RingElem) {
+            s.append(((RingElem<GenPolynomial<C>>) coFac).toScriptFactory());
+        } else {
+            s.append(coFac.toScript().trim());
+        }
+        s.append(",\"" + varsToString() + "\",");
+        String to = tord.toScript();
+        s.append(to);
+        if (table.size() > 0) {
+            String rel = table.toScript();
+            s.append(",rel=");
+            s.append(rel);
+        }
+        if (coeffTable.size() > 0) {
+            String rel = coeffTable.toScript();
+            s.append(",coeffrel=");
+            s.append(rel);
+        }
+        s.append(")");
+        return s.toString();
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        }
+        if (!(other instanceof RecSolvablePolynomialRing)) {
+            return false;
+        }
+        // do a super.equals( )
+        if (!super.equals(other)) {
+            return false;
+        }
+        RecSolvablePolynomialRing<C> oring = (RecSolvablePolynomialRing<C>) other;
+        // check same base relations
+        //if ( ! table.equals(oring.table) ) { // done in super
+        //    return false;
+        //}
+        if (!coeffTable.equals(oring.coeffTable)) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Hash code for this polynomial ring.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = super.hashCode();
+        h = 37 * h + table.hashCode(); // may be different after some computations
+        h = 37 * h + coeffTable.hashCode(); // may be different
+        return h;
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as RecSolvablePolynomial<C>.
+     */
+    @Override
+    public RecSolvablePolynomial<C> getZERO() {
+        return ZERO;
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as RecSolvablePolynomial<C>.
+     */
+    @Override
+    public RecSolvablePolynomial<C> getONE() {
+        return ONE;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true if this ring is commutative, else false.
+     */
+    @Override
+    public boolean isCommutative() {
+        if (coeffTable.isEmpty()) {
+            return super.isCommutative();
+        }
+        return false;
+    }
+
+
+    /**
+     * Query if this ring is associative. Test if the relations between the mian
+     * variables and the coefficient generators define an associative solvable
+     * ring.
+     * @return true, if this ring is associative, else false.
+     */
+    @SuppressWarnings("unused")
+    @Override
+    public boolean isAssociative() {
+        if (!coFac.isAssociative()) {
+            return false;
+        }
+        RecSolvablePolynomial<C> Xi, Xj, Xk, p, q;
+        List<GenPolynomial<GenPolynomial<C>>> gens = generators();
+        //System.out.println("Rec gens = " + gens);
+        int ngen = gens.size();
+        for (int i = 0; i < ngen; i++) {
+            Xi = (RecSolvablePolynomial<C>) gens.get(i);
+            for (int j = i + 1; j < ngen; j++) {
+                Xj = (RecSolvablePolynomial<C>) gens.get(j);
+                for (int k = j + 1; k < ngen; k++) {
+                    Xk = (RecSolvablePolynomial<C>) gens.get(k);
+                    p = Xk.multiply(Xj).multiply(Xi);
+                    q = Xk.multiply(Xj.multiply(Xi));
+                    if (!p.equals(q)) {
+                        if (logger.isInfoEnabled()) {
+                            logger.info("Xk = " + Xk + ", Xj = " + Xj + ", Xi = " + Xi);
+                            logger.info("p = ( Xk * Xj ) * Xi = " + p);
+                            logger.info("q = Xk * ( Xj * Xi ) = " + q);
+                        }
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Get a (constant) RecSolvablePolynomial&lt;C&gt; element from a coefficient value.
+     * @param a coefficient.
+     * @return a RecSolvablePolynomial&lt;C&gt;.
+     */
+    @Override
+    public RecSolvablePolynomial<C> valueOf(GenPolynomial<C> a) {
+        return new RecSolvablePolynomial<C>(this, a);
+    }
+
+
+    /**
+     * Get a RecSolvablePolynomial&lt;C&gt; element from an exponent vector.
+     * @param e exponent vector.
+     * @return a RecSolvablePolynomial&lt;C&gt;.
+     */
+    @Override
+    public RecSolvablePolynomial<C> valueOf(ExpVector e) {
+        return new RecSolvablePolynomial<C>(this, coFac.getONE(), e);
+    }
+
+
+    /**
+     * Get a RecSolvablePolynomial&lt;C&gt; element from a coeffcient and an exponent
+     * vector.
+     * @param a coefficient.
+     * @param e exponent vector.
+     * @return a RecSolvablePolynomial&lt;C&gt;.
+     */
+    @Override
+    public RecSolvablePolynomial<C> valueOf(GenPolynomial<C> a, ExpVector e) {
+        return new RecSolvablePolynomial<C>(this, a, e);
+    }
+
+
+    /**
+     * Get a (constant) RecSolvablePolynomial&lt;C&gt; element from a long
+     * value
+     * @param a long.
+     * @return a RecSolvablePolynomial&lt;C&gt;.
+     */
+    @Override
+    public RecSolvablePolynomial<C> fromInteger(long a) {
+        return new RecSolvablePolynomial<C>(this, coFac.fromInteger(a), evzero);
+    }
+
+
+    /**
+     * Get a (constant) RecSolvablePolynomial&lt;C&gt; element from a BigInteger
+     * value.
+     * @param a BigInteger.
+     * @return a RecSolvablePolynomial&lt;C&gt;.
+     */
+    @Override
+    public RecSolvablePolynomial<C> fromInteger(BigInteger a) {
+        return new RecSolvablePolynomial<C>(this, coFac.fromInteger(a), evzero);
+    }
+
+
+    /**
+     * Random solvable polynomial. Generates a random solvable polynomial with k
+     * = 5, l = n, d = (nvar == 1) ? n : 3, q = (nvar == 1) ? 0.7 : 0.3.
+     * @param n number of terms.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    public RecSolvablePolynomial<C> random(int n) {
+        return random(n, random);
+    }
+
+
+    /**
+     * Random solvable polynomial. Generates a random solvable polynomial with k
+     * = 5, l = n, d = (nvar == 1) ? n : 3, q = (nvar == 1) ? 0.7 : 0.3.
+     * @param n number of terms.
+     * @param rnd is a source for random bits.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    public RecSolvablePolynomial<C> random(int n, Random rnd) {
+        if (nvar == 1) {
+            return random(5, n, n, 0.7f, rnd);
+        }
+        return random(5, n, 3, 0.3f, rnd);
+    }
+
+
+    /**
+     * Generate a random solvable polynomial.
+     * @param k bitsize of random coefficients.
+     * @param l number of terms.
+     * @param d maximal degree in each variable.
+     * @param q density of nozero exponents.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    public RecSolvablePolynomial<C> random(int k, int l, int d, float q) {
+        return random(k, l, d, q, random);
+    }
+
+
+    /**
+     * Random solvable polynomial.
+     * @param k size of random coefficients.
+     * @param l number of terms.
+     * @param d maximal degree in each variable.
+     * @param q density of nozero exponents.
+     * @param rnd is a source for random bits.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    public RecSolvablePolynomial<C> random(int k, int l, int d, float q, Random rnd) {
+        RecSolvablePolynomial<C> r = getZERO(); // copy( ZERO ); 
+        ExpVector e;
+        GenPolynomial<C> a;
+        // add random coeffs and exponents
+        for (int i = 0; i < l; i++) {
+            e = ExpVector.random(nvar, d, q, rnd);
+            a = coFac.random(k, rnd);
+            r = (RecSolvablePolynomial<C>) r.sum(a, e);
+            // somewhat inefficient but clean
+        }
+        return r;
+    }
+
+
+    /**
+     * Copy polynomial c.
+     * @param c
+     * @return a copy of c.
+     */
+    public RecSolvablePolynomial<C> copy(RecSolvablePolynomial<C> c) {
+        return new RecSolvablePolynomial<C>(this, c.val);
+    }
+
+
+    /**
+     * Parse a solvable polynomial with the use of GenPolynomialTokenizer
+     * @param s String.
+     * @return RecSolvablePolynomial from s.
+     */
+    @Override
+    public RecSolvablePolynomial<C> parse(String s) {
+        return parse(new StringReader(s));
+    }
+
+
+    /**
+     * Parse a solvable polynomial with the use of GenPolynomialTokenizer
+     * @param r Reader.
+     * @return next RecSolvablePolynomial from r.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public RecSolvablePolynomial<C> parse(Reader r) {
+        GenPolynomialTokenizer pt = new GenPolynomialTokenizer(this, r);
+        RecSolvablePolynomial<C> p = null;
+        try {
+            GenSolvablePolynomial<GenPolynomial<C>> s = pt.nextSolvablePolynomial();
+            p = new RecSolvablePolynomial<C>(this, s);
+        } catch (IOException e) {
+            logger.error(e.toString() + " parse " + this);
+            p = ZERO;
+        }
+        return p;
+    }
+
+
+    /**
+     * Generate univariate solvable polynomial in a given variable.
+     * @param i the index of the variable.
+     * @return X_i as solvable univariate polynomial.
+     */
+    @Override
+    public RecSolvablePolynomial<C> univariate(int i) {
+        return (RecSolvablePolynomial<C>) super.univariate(i);
+    }
+
+
+    /**
+     * Generate univariate solvable polynomial in a given variable with given
+     * exponent.
+     * @param i the index of the variable.
+     * @param e the exponent of the variable.
+     * @return X_i^e as solvable univariate polynomial.
+     */
+    @Override
+    public RecSolvablePolynomial<C> univariate(int i, long e) {
+        return (RecSolvablePolynomial<C>) super.univariate(i, e);
+    }
+
+
+    /**
+     * Generate univariate solvable polynomial in a given variable with given
+     * exponent.
+     * @param modv number of module variables.
+     * @param i the index of the variable.
+     * @param e the exponent of the variable.
+     * @return X_i^e as solvable univariate polynomial.
+     */
+    @Override
+    public RecSolvablePolynomial<C> univariate(int modv, int i, long e) {
+        return (RecSolvablePolynomial<C>) super.univariate(modv, i, e);
+    }
+
+
+    /**
+     * Generate list of univariate polynomials in all variables.
+     * @return List(X_1,...,X_n) a list of univariate polynomials.
+     */
+    @Override
+    public List<RecSolvablePolynomial<C>> univariateList() {
+        //return castToSolvableList( super.univariateList() );
+        return univariateList(0, 1L);
+    }
+
+
+    /**
+     * Generate list of univariate polynomials in all variables.
+     * @param modv number of module variables.
+     * @return List(X_1,...,X_n) a list of univariate polynomials.
+     */
+    @Override
+    public List<RecSolvablePolynomial<C>> univariateList(int modv) {
+        return univariateList(modv, 1L);
+    }
+
+
+    /**
+     * Generate list of univariate polynomials in all variables with given
+     * exponent.
+     * @param modv number of module variables.
+     * @param e the exponent of the variables.
+     * @return List(X_1^e,...,X_n^e) a list of univariate polynomials.
+     */
+    @Override
+    public List<RecSolvablePolynomial<C>> univariateList(int modv, long e) {
+        List<RecSolvablePolynomial<C>> pols = new ArrayList<RecSolvablePolynomial<C>>(nvar);
+        int nm = nvar - modv;
+        for (int i = 0; i < nm; i++) {
+            RecSolvablePolynomial<C> p = univariate(modv, nm - 1 - i, e);
+            pols.add(p);
+        }
+        return pols;
+    }
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by i.
+     * @param i number of variables to extend.
+     * @return extended solvable polynomial ring factory.
+     */
+    @Override
+    public RecSolvablePolynomialRing<C> extend(int i) {
+        return extend(i,false);
+    }
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by i.
+     * @param i number of variables to extend.
+     * @param top true for TOP term order, false for POT term order.
+     * @return extended solvable polynomial ring factory.
+     */
+    @Override
+    public RecSolvablePolynomialRing<C> extend(int i, boolean top) {
+        GenSolvablePolynomialRing<GenPolynomial<C>> pfac = super.extend(i, top);
+        RecSolvablePolynomialRing<C> spfac = new RecSolvablePolynomialRing<C>(pfac.coFac, pfac.nvar,
+                        pfac.tord, pfac.vars, pfac.table);
+        //spfac.table.extend(this.table); // pfac.table
+        spfac.coeffTable.extend(this.coeffTable);
+        return spfac;
+    }
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by length(vn). New variables commute with the exiting
+     * variables.
+     * @param vs names for extended variables.
+     * @return extended polynomial ring factory.
+     */
+    @Override
+    public RecSolvablePolynomialRing<C> extend(String[] vs) {
+        return extend(vs, false);
+    }
+
+    
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by length(vn). New variables commute with the exiting
+     * variables.
+     * @param vs names for extended variables.
+     * @param top true for TOP term order, false for POT term order.
+     * @return extended polynomial ring factory.
+     */
+    @Override
+    public RecSolvablePolynomialRing<C> extend(String[] vs, boolean top) {
+        GenSolvablePolynomialRing<GenPolynomial<C>> pfac = super.extend(vs, top);
+        RecSolvablePolynomialRing<C> spfac = new RecSolvablePolynomialRing<C>(pfac.coFac, pfac.nvar,
+                        pfac.tord, pfac.vars, pfac.table);
+        //spfac.table.extend(this.table); // is in pfac.table
+        spfac.coeffTable.extend(this.coeffTable);
+        return spfac;
+    }
+
+
+    /**
+     * Contract variables. Used e.g. in module embedding. Contract number of
+     * variables by i.
+     * @param i number of variables to remove.
+     * @return contracted solvable polynomial ring factory.
+     */
+    @Override
+    public RecSolvablePolynomialRing<C> contract(int i) {
+        GenPolynomialRing<GenPolynomial<C>> pfac = super.contract(i);
+        RecSolvablePolynomialRing<C> spfac = new RecSolvablePolynomialRing<C>(pfac.coFac, pfac.nvar,
+                        pfac.tord, pfac.vars);
+        spfac.table.contract(this.table);
+        spfac.coeffTable.contract(this.coeffTable);
+        return spfac;
+    }
+
+
+    /**
+     * Reverse variables. Used e.g. in opposite rings.
+     * @return solvable polynomial ring factory with reversed variables.
+     */
+    @Override
+    public RecSolvablePolynomialRing<C> reverse() {
+        return reverse(false);
+    }
+
+
+    /**
+     * Reverse variables. Used e.g. in opposite rings.
+     * @param partial true for partialy reversed term orders.
+     * @return solvable polynomial ring factory with reversed variables.
+     */
+    @Override
+    public RecSolvablePolynomialRing<C> reverse(boolean partial) {
+        GenPolynomialRing<GenPolynomial<C>> pfac = super.reverse(partial);
+        RecSolvablePolynomialRing<C> spfac = new RecSolvablePolynomialRing<C>(pfac.coFac, pfac.nvar,
+                        pfac.tord, pfac.vars);
+        spfac.partial = partial;
+        spfac.table.reverse(this.table);
+        spfac.coeffTable.reverse(this.coeffTable);
+        return spfac;
+    }
+
+
+    /**
+     * Distributive representation as polynomial with all main variables.
+     * @return distributive polynomial ring factory.
+     */
+    @SuppressWarnings({"cast","unchecked"})
+    public static <C extends RingElem<C>> // must be static because of types
+    GenSolvablePolynomialRing<C> distribute(RecSolvablePolynomialRing<C> rf) {
+        // setup solvable polynomial ring
+        GenSolvablePolynomialRing<C> fring = (GenSolvablePolynomialRing<C>) (GenSolvablePolynomialRing) rf;
+        GenSolvablePolynomialRing<C> pfd = fring.distribute();
+        // add coefficient relations:
+        List<GenPolynomial<GenPolynomial<C>>> rl = (List<GenPolynomial<GenPolynomial<C>>>) (List) PolynomialList
+                        .castToList(rf.coeffTable.relationList());
+        List<GenPolynomial<C>> rld = PolyUtil.<C> distribute(pfd, rl);
+        pfd.table.addRelations(rld);
+        //System.out.println("pfd = " + pfd.toScript());
+        return pfd;
+    }
+
+
+    /**
+     * Permutation of polynomial ring variables.
+     * @param P permutation.
+     * @return P(this).
+     */
+    @Override
+    public GenSolvablePolynomialRing<GenPolynomial<C>> permutation(List<Integer> P) {
+        if (!coeffTable.isEmpty()) {
+            throw new UnsupportedOperationException("permutation with coeff relations: " + this);
+        }
+        GenSolvablePolynomialRing<GenPolynomial<C>> pfac = (GenSolvablePolynomialRing<GenPolynomial<C>>) super.permutation(P);
+        return pfac;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/RecSolvableWordPolynomial.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/RecSolvableWordPolynomial.java
@@ -1,0 +1,658 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.structure.RingElem;
+
+
+/**
+ * RecSolvableWordPolynomial generic recursive solvable polynomials implementing
+ * RingElem. n-variate ordered solvable polynomials over non-commutative word
+ * polynomial coefficients. Objects of this class are intended to be immutable.
+ * The implementation is based on TreeMap respectively SortedMap from exponents
+ * to coefficients by extension of GenPolynomial.
+ * @param <C> base coefficient type
+ * @author Heinz Kredel
+ */
+
+public class RecSolvableWordPolynomial<C extends RingElem<C>> extends
+                GenSolvablePolynomial<GenWordPolynomial<C>> {
+
+
+    /**
+     * The factory for the recursive solvable polynomial ring. Hides super.ring.
+     */
+    public final RecSolvableWordPolynomialRing<C> ring;
+
+
+    private static final Logger logger = LogManager.getLogger(RecSolvableWordPolynomial.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor for zero RecSolvableWordPolynomial.
+     * @param r solvable polynomial ring factory.
+     */
+    public RecSolvableWordPolynomial(RecSolvableWordPolynomialRing<C> r) {
+        super(r);
+        ring = r;
+    }
+
+
+    /**
+     * Constructor for RecSolvableWordPolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param e exponent.
+     */
+    public RecSolvableWordPolynomial(RecSolvableWordPolynomialRing<C> r, ExpVector e) {
+        this(r);
+        val.put(e, ring.getONECoefficient());
+    }
+
+
+    /**
+     * Constructor for RecSolvableWordPolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param c coefficient polynomial.
+     * @param e exponent.
+     */
+    public RecSolvableWordPolynomial(RecSolvableWordPolynomialRing<C> r, GenWordPolynomial<C> c, ExpVector e) {
+        this(r);
+        if (c != null && !c.isZERO()) {
+            val.put(e, c);
+        }
+    }
+
+
+    /**
+     * Constructor for RecSolvableWordPolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param c coefficient polynomial.
+     */
+    public RecSolvableWordPolynomial(RecSolvableWordPolynomialRing<C> r, GenWordPolynomial<C> c) {
+        this(r, c, r.evzero);
+    }
+
+
+    /**
+     * Constructor for RecSolvableWordPolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param S solvable polynomial.
+     */
+    public RecSolvableWordPolynomial(RecSolvableWordPolynomialRing<C> r,
+                    GenSolvablePolynomial<GenWordPolynomial<C>> S) {
+        this(r, S.val);
+    }
+
+
+    /**
+     * Constructor for RecSolvableWordPolynomial.
+     * @param r solvable polynomial ring factory.
+     * @param v the SortedMap of some other (solvable) polynomial.
+     */
+    protected RecSolvableWordPolynomial(RecSolvableWordPolynomialRing<C> r,
+                    SortedMap<ExpVector, GenWordPolynomial<C>> v) {
+        this(r);
+        val.putAll(v); // assume no zero coefficients
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    @Override
+    public RecSolvableWordPolynomialRing<C> factory() {
+        return ring;
+    }
+
+
+    /**
+     * Clone this RecSolvableWordPolynomial.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public RecSolvableWordPolynomial<C> copy() {
+        return new RecSolvableWordPolynomial<C>(ring, this.val);
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object B) {
+        if (!(B instanceof RecSolvableWordPolynomial)) {
+            return false;
+        }
+        return super.equals(B);
+    }
+
+
+    /**
+     * Hash code for this polynomial.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+
+    /**
+     * RecSolvableWordPolynomial multiplication.
+     * @param Bp RecSolvableWordPolynomial.
+     * @return this*Bp, where * denotes solvable multiplication.
+     */
+    // cannot @Override, @NoOverride
+    public RecSolvableWordPolynomial<C> multiply(RecSolvableWordPolynomial<C> Bp) {
+        if (Bp == null || Bp.isZERO()) {
+            return ring.getZERO();
+        }
+        if (this.isZERO()) {
+            return this;
+        }
+        assert (ring.nvar == Bp.ring.nvar);
+        if (debug) {
+            logger.info("ring = " + ring.toScript());
+        }
+        final boolean commute = ring.table.isEmpty();
+        final boolean commuteCoeff = ring.coeffTable.isEmpty();
+        //GenWordPolynomialRing<C> cfac = (GenWordPolynomialRing<C>) ring.coFac;
+        RecSolvableWordPolynomial<C> Dp = ring.getZERO().copy();
+        RecSolvableWordPolynomial<C> zero = ring.getZERO(); //.copy(); not needed
+        ExpVector Z = ring.evzero;
+        //Word Zc = cfac.wone;
+        GenWordPolynomial<C> one = ring.getONECoefficient();
+
+        RecSolvableWordPolynomial<C> C1 = null;
+        RecSolvableWordPolynomial<C> C2 = null;
+        Map<ExpVector, GenWordPolynomial<C>> A = val;
+        Map<ExpVector, GenWordPolynomial<C>> B = Bp.val;
+        Set<Map.Entry<ExpVector, GenWordPolynomial<C>>> Bk = B.entrySet();
+        if (debug)
+            logger.info("input A = " + this);
+        for (Map.Entry<ExpVector, GenWordPolynomial<C>> y : A.entrySet()) {
+            GenWordPolynomial<C> a = y.getValue();
+            ExpVector e = y.getKey();
+            if (debug)
+                logger.info("e = " + e + ", a = " + a);
+            int[] ep = e.dependencyOnVariables();
+            int el1 = ring.nvar + 1;
+            if (ep.length > 0) {
+                el1 = ep[0];
+            }
+            //int el1s = ring.nvar + 1 - el1;
+            if (debug)
+                logger.info("input B = " + Bp);
+            for (Map.Entry<ExpVector, GenWordPolynomial<C>> x : Bk) {
+                GenWordPolynomial<C> b = x.getValue();
+                ExpVector f = x.getKey();
+                if (debug)
+                    logger.info("f = " + f + ", b = " + b);
+                int[] fp = f.dependencyOnVariables();
+                int fl1 = 0;
+                if (fp.length > 0) {
+                    fl1 = fp[fp.length - 1];
+                }
+                int fl1s = ring.nvar + 1 - fl1;
+                // polynomial coefficient multiplication e*b = P_eb, for a*((e*b)*f)
+                RecSolvableWordPolynomial<C> Cps = ring.getZERO().copy();
+                RecSolvableWordPolynomial<C> Cs = null;
+                if (commuteCoeff || b.isConstant() || e.isZERO()) { // symmetric
+                    //Cps = (RecSolvableWordPolynomial<C>) zero.sum(b, e);
+                    Cps.doAddTo(b, e);
+                    if (debug)
+                        logger.info("symmetric coeff, e*b: b = " + b + ", e = " + e);
+                } else { // unsymmetric
+                    if (debug)
+                        logger.info("unsymmetric coeff, e*b: b = " + b + ", e = " + e);
+                    for (Map.Entry<Word, C> z : b.val.entrySet()) {
+                        C c = z.getValue();
+                        GenWordPolynomial<C> cc = b.ring.getONE().multiply(c);
+                        Word g = z.getKey();
+                        if (debug)
+                            logger.info("g = " + g + ", c = " + c);
+                        // split e = e1 * e2, g = g2 * g1
+                        ExpVector g2 = g.leadingExpVector();
+                        Word g1 = g.reductum();
+                        //ExpVector g1;
+                        //System.out.println("c = " + c + ", g = " + g + ", g1 = " + g1 + ", g1 == 1: " + g1.isONE());
+                        ExpVector e1 = e;
+                        ExpVector e2 = Z;
+                        if (!e.isZERO()) {
+                            e1 = e.subst(el1, 0);
+                            e2 = Z.subst(el1, e.getVal(el1));
+                        }
+                        if (debug) {
+                            logger.info("coeff, e1 = " + e1 + ", e2 = " + e2 + ", Cps = " + Cps);
+                            logger.info("coeff, g2 = " + g2 + ", g1 = " + g1);
+                        }
+                        TableRelation<GenWordPolynomial<C>> crel = ring.coeffTable.lookup(e2, g2);
+                        if (debug)
+                            logger.info("coeff, crel = " + crel.p);
+                        //System.out.println("coeff, e  = " + e + ", g = " + g + ", crel = " + crel);
+                        Cs = new RecSolvableWordPolynomial<C>(ring, crel.p);
+                        // rest of multiplication and update relations
+                        if (crel.f != null) { // process remaining right power
+                            //GenWordPolynomial<C> c2 = b.ring.getONE().multiply(crel.f);
+                            GenWordPolynomial<C> c2 = b.ring.valueOf(crel.f);
+                            C2 = ring.valueOf(c2); //new RecSolvableWordPolynomial<C>(ring, c2, Z);
+                            Cs = Cs.multiply(C2);
+                            ExpVector e4;
+                            if (crel.e == null) {
+                                e4 = e2;
+                            } else {
+                                e4 = e2.subtract(crel.e);
+                            }
+                            ring.coeffTable.update(e4, g2, Cs);
+                        }
+                        if (crel.e != null) { // process remaining left power
+                            C1 = ring.valueOf(crel.e); //new RecSolvableWordPolynomial<C>(ring, one, crel.e);
+                            Cs = C1.multiply(Cs);
+                            ring.coeffTable.update(e2, g2, Cs);
+                        }
+                        if (!g1.isONE()) { // process remaining right part
+                            //GenWordPolynomial<C> c2 = b.ring.getONE().multiply(g1);
+                            GenWordPolynomial<C> c2 = b.ring.valueOf(g1);
+                            C2 = ring.valueOf(c2); //new RecSolvableWordPolynomial<C>(ring, c2, Z);
+                            Cs = Cs.multiply(C2);
+                        }
+                        if (!e1.isZERO()) { // process remaining left part
+                            C1 = ring.valueOf(e1); //new RecSolvableWordPolynomial<C>(ring, one, e1);
+                            Cs = C1.multiply(Cs);
+                        }
+                        //System.out.println("e1*Cs*g1 = " + Cs);
+                        Cs = Cs.multiplyLeft(cc); // assume c, coeff(cc) commutes with Cs
+                        //Cps = (RecSolvableWordPolynomial<C>) Cps.sum(Cs);
+                        Cps.doAddTo(Cs);
+                    } // end b loop 
+                    if (debug)
+                        logger.info("coeff, Cs = " + Cs + ", Cps = " + Cps);
+                    //System.out.println("coeff loop end, Cs = " + Cs + ", Cps = " + Cps);
+                }
+                if (debug)
+                    logger.info("coeff-poly: Cps = " + Cps);
+                // polynomial multiplication P_eb*f, for a*(P_eb*f)
+                RecSolvableWordPolynomial<C> Dps = ring.getZERO().copy();
+                RecSolvableWordPolynomial<C> Ds = null;
+                RecSolvableWordPolynomial<C> D1, D2;
+                if (commute || Cps.isConstant() || f.isZERO()) { // symmetric
+                    if (debug)
+                        logger.info("symmetric poly, P_eb*f: Cps = " + Cps + ", f = " + f);
+                    ExpVector g = e.sum(f);
+                    if (Cps.isConstant()) {
+                        Ds = ring.valueOf(Cps.leadingBaseCoefficient(), g); //new RecSolvableWordPolynomial<C>(ring, Cps.leadingBaseCoefficient(), g); // symmetric!
+                    } else {
+                        Ds = Cps.shift(f); // symmetric
+                    }
+                } else { // eventually unsymmetric
+                    if (debug)
+                        logger.info("unsymmetric poly, P_eb*f: Cps = " + Cps + ", f = " + f);
+                    for (Map.Entry<ExpVector, GenWordPolynomial<C>> z : Cps.val.entrySet()) {
+                        // split g = g1 * g2, f = f1 * f2
+                        GenWordPolynomial<C> c = z.getValue();
+                        ExpVector g = z.getKey();
+                        if (debug)
+                            logger.info("g = " + g + ", c = " + c);
+                        int[] gp = g.dependencyOnVariables();
+                        int gl1 = ring.nvar + 1;
+                        if (gp.length > 0) {
+                            gl1 = gp[0];
+                        }
+                        int gl1s = ring.nvar + 1 - gl1;
+                        if (gl1s <= fl1s) { // symmetric
+                            ExpVector h = g.sum(f);
+                            if (debug)
+                                logger.info("disjoint poly: g = " + g + ", f = " + f + ", h = " + h);
+                            Ds = (RecSolvableWordPolynomial<C>) zero.sum(one, h); // symmetric!
+                        } else {
+                            ExpVector g1 = g.subst(gl1, 0);
+                            ExpVector g2 = Z.subst(gl1, g.getVal(gl1)); // bug el1, gl1
+                            ExpVector g4;
+                            ExpVector f1 = f.subst(fl1, 0);
+                            ExpVector f2 = Z.subst(fl1, f.getVal(fl1));
+                            if (debug) {
+                                logger.info("poly, g1 = " + g1 + ", f1 = " + f1 + ", Dps = " + Dps);
+                                logger.info("poly, g2 = " + g2 + ", f2 = " + f2);
+                            }
+                            TableRelation<GenWordPolynomial<C>> rel = ring.table.lookup(g2, f2);
+                            if (debug)
+                                logger.info("poly, g  = " + g + ", f  = " + f + ", rel = " + rel);
+                            Ds = new RecSolvableWordPolynomial<C>(ring, rel.p); //ring.copy(rel.p);
+                            if (rel.f != null) {
+                                D2 = ring.valueOf(rel.f); //new RecSolvableWordPolynomial<C>(ring, one, rel.f);
+                                Ds = Ds.multiply(D2);
+                                if (rel.e == null) {
+                                    g4 = g2;
+                                } else {
+                                    g4 = g2.subtract(rel.e);
+                                }
+                                ring.table.update(g4, f2, Ds);
+                            }
+                            if (rel.e != null) {
+                                D1 = ring.valueOf(rel.e); //new RecSolvableWordPolynomial<C>(ring, one, rel.e);
+                                Ds = D1.multiply(Ds);
+                                ring.table.update(g2, f2, Ds);
+                            }
+                            if (!f1.isZERO()) {
+                                D2 = ring.valueOf(f1); //new RecSolvableWordPolynomial<C>(ring, one, f1);
+                                Ds = Ds.multiply(D2);
+                                //ring.table.update(?,f1,Ds)
+                            }
+                            if (!g1.isZERO()) {
+                                D1 = ring.valueOf(g1); //new RecSolvableWordPolynomial<C>(ring, one, g1);
+                                Ds = D1.multiply(Ds);
+                                //ring.table.update(e1,?,Ds)
+                            }
+                        }
+                        //System.out.println("main loop, Cs = " + Cs + ", c = " + c);
+                        Ds = Ds.multiplyLeft(c); // assume c commutes with Cs
+                        //Dps = (RecSolvableWordPolynomial<C>) Dps.sum(Ds);
+                        Dps.doAddTo(Ds);
+                    } // end Dps loop
+                    Ds = Dps;
+                }
+                if (debug) {
+                    logger.info("recursion+: Ds = " + Ds + ", a = " + a);
+                }
+                // polynomial coefficient multiplication a*(P_eb*f) = a*Ds
+                //System.out.println("main loop, Ds = " + Ds + ", a = " + a);
+                Ds = Ds.multiplyLeft(a); // multiply(a,b); // non-symmetric 
+                if (debug)
+                    logger.info("recursion-: Ds = " + Ds);
+                //Dp = (RecSolvableWordPolynomial<C>) Dp.sum(Ds);
+                Dp.doAddTo(Ds);
+                if (debug)
+                    logger.info("end B loop: Dp = " + Dp);
+            } // end B loop
+            if (debug)
+                logger.info("end A loop: Dp = " + Dp);
+        } // end A loop
+        return Dp;
+    }
+
+
+    /**
+     * RecSolvableWordPolynomial left and right multiplication. Product with two
+     * polynomials.
+     * @param S RecSolvableWordPolynomial.
+     * @param T RecSolvableWordPolynomial.
+     * @return S*this*T.
+     */
+    // cannot @Override, @NoOverride
+    public RecSolvableWordPolynomial<C> multiply(RecSolvableWordPolynomial<C> S,
+                    RecSolvableWordPolynomial<C> T) {
+        if (S.isZERO() || T.isZERO() || this.isZERO()) {
+            return ring.getZERO();
+        }
+        if (S.isONE()) {
+            return multiply(T);
+        }
+        if (T.isONE()) {
+            return S.multiply(this);
+        }
+        return S.multiply(this).multiply(T);
+    }
+
+
+    /**
+     * RecSolvableWordPolynomial multiplication. Product with coefficient ring
+     * element.
+     * @param b coefficient polynomial.
+     * @return this*b, where * is coefficient multiplication.
+     */
+    // cannot @Override
+    //public RecSolvableWordPolynomial<C> multiply(GenWordPolynomial<C> b) {
+    //public GenSolvablePolynomial<GenWordPolynomial<C>> multiply(GenWordPolynomial<C> b) {
+    public RecSolvableWordPolynomial<C> recMultiply(GenWordPolynomial<C> b) {
+        RecSolvableWordPolynomial<C> Cp = ring.getZERO().copy();
+        if (b == null || b.isZERO()) {
+            return Cp;
+        }
+        Cp = new RecSolvableWordPolynomial<C>(ring, b, ring.evzero);
+        return multiply(Cp);
+    }
+
+
+    /**
+     * RecSolvableWordPolynomial left and right multiplication. Product with
+     * coefficient ring element.
+     * @param b coefficient polynomial.
+     * @param c coefficient polynomial.
+     * @return b*this*c, where * is coefficient multiplication.
+     */
+    @Override
+    public RecSolvableWordPolynomial<C> multiply(GenWordPolynomial<C> b, GenWordPolynomial<C> c) {
+        RecSolvableWordPolynomial<C> Cp = ring.getZERO().copy();
+        if (b == null || b.isZERO()) {
+            return Cp;
+        }
+        if (c == null || c.isZERO()) {
+            return Cp;
+        }
+        RecSolvableWordPolynomial<C> Cb = ring.valueOf(b); //new RecSolvableWordPolynomial<C>(ring, b, ring.evzero);
+        RecSolvableWordPolynomial<C> Cc = ring.valueOf(c); //new RecSolvableWordPolynomial<C>(ring, c, ring.evzero);
+        return Cb.multiply(this).multiply(Cc);
+    }
+
+
+    /*
+     * RecSolvableWordPolynomial multiplication. Product with coefficient ring
+     * element.
+     * @param b coefficient of coefficient.
+     * @return this*b, where * is coefficient multiplication.
+     */
+    //@Override not possible, @NoOverride
+    //public RecSolvableWordPolynomial<C> multiply(C b) { ... }
+
+
+    /**
+     * RecSolvableWordPolynomial multiplication. Product with exponent vector.
+     * @param e exponent.
+     * @return this * x<sup>e</sup>, where * denotes solvable multiplication.
+     */
+    @Override
+    public RecSolvableWordPolynomial<C> multiply(ExpVector e) {
+        if (e == null || e.isZERO()) {
+            return this;
+        }
+        GenWordPolynomial<C> b = ring.getONECoefficient();
+        return multiply(b, e);
+    }
+
+
+    /**
+     * RecSolvableWordPolynomial left and right multiplication. Product with
+     * exponent vector.
+     * @param e exponent.
+     * @param f exponent.
+     * @return x<sup>e</sup> * this * x<sup>f</sup>, where * denotes solvable
+     *         multiplication.
+     */
+    @Override
+    public RecSolvableWordPolynomial<C> multiply(ExpVector e, ExpVector f) {
+        if (e == null || e.isZERO()) {
+            return this;
+        }
+        if (f == null || f.isZERO()) {
+            return this;
+        }
+        GenWordPolynomial<C> b = ring.getONECoefficient();
+        return multiply(b, e, b, f);
+    }
+
+
+    /**
+     * RecSolvableWordPolynomial multiplication. Product with ring element and
+     * exponent vector.
+     * @param b coefficient polynomial.
+     * @param e exponent.
+     * @return this * b x<sup>e</sup>, where * denotes solvable multiplication.
+     */
+    @Override
+    public RecSolvableWordPolynomial<C> multiply(GenWordPolynomial<C> b, ExpVector e) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        RecSolvableWordPolynomial<C> Cp = ring.valueOf(b, e); //new RecSolvableWordPolynomial<C>(ring, b, e);
+        return multiply(Cp);
+    }
+
+
+    /**
+     * RecSolvableWordPolynomial left and right multiplication. Product with
+     * ring element and exponent vector.
+     * @param b coefficient polynomial.
+     * @param e exponent.
+     * @param c coefficient polynomial.
+     * @param f exponent.
+     * @return b x<sup>e</sup> * this * c x<sup>f</sup>, where * denotes
+     *         solvable multiplication.
+     */
+    @Override
+    public RecSolvableWordPolynomial<C> multiply(GenWordPolynomial<C> b, ExpVector e, GenWordPolynomial<C> c,
+                    ExpVector f) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        if (c == null || c.isZERO()) {
+            return ring.getZERO();
+        }
+        RecSolvableWordPolynomial<C> Cp = ring.valueOf(b, e); //new RecSolvableWordPolynomial<C>(ring, b, e);
+        RecSolvableWordPolynomial<C> Dp = ring.valueOf(c, f); //new RecSolvableWordPolynomial<C>(ring, c, f);
+        return multiply(Cp, Dp);
+    }
+
+
+    /**
+     * RecSolvableWordPolynomial multiplication. Left product with ring element
+     * and exponent vector.
+     * @param b coefficient polynomial.
+     * @param e exponent.
+     * @return b x<sup>e</sup> * this, where * denotes solvable multiplication.
+     */
+    @Override
+    public RecSolvableWordPolynomial<C> multiplyLeft(GenWordPolynomial<C> b, ExpVector e) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        RecSolvableWordPolynomial<C> Cp = ring.valueOf(b, e); //new RecSolvableWordPolynomial<C>(ring, b, e);
+        return Cp.multiply(this);
+    }
+
+
+    /**
+     * RecSolvableWordPolynomial multiplication. Left product with exponent
+     * vector.
+     * @param e exponent.
+     * @return x<sup>e</sup> * this, where * denotes solvable multiplication.
+     */
+    @Override
+    public RecSolvableWordPolynomial<C> multiplyLeft(ExpVector e) {
+        if (e == null || e.isZERO()) {
+            return this;
+        }
+        //GenWordPolynomial<C> b = ring.getONECoefficient();
+        RecSolvableWordPolynomial<C> Cp = ring.valueOf(e); //new RecSolvableWordPolynomial<C>(ring, b, e);
+        return Cp.multiply(this);
+    }
+
+
+    /**
+     * RecSolvableWordPolynomial multiplication. Left product with coefficient
+     * ring element.
+     * @param b coefficient polynomial.
+     * @return b*this, where * is coefficient multiplication.
+     */
+    @Override
+    public RecSolvableWordPolynomial<C> multiplyLeft(GenWordPolynomial<C> b) {
+        RecSolvableWordPolynomial<C> Cp = ring.getZERO().copy();
+        if (b == null || b.isZERO()) {
+            return Cp;
+        }
+        Map<ExpVector, GenWordPolynomial<C>> Cm = Cp.val; //getMap();
+        Map<ExpVector, GenWordPolynomial<C>> Am = val;
+        GenWordPolynomial<C> c;
+        for (Map.Entry<ExpVector, GenWordPolynomial<C>> y : Am.entrySet()) {
+            ExpVector e = y.getKey();
+            GenWordPolynomial<C> a = y.getValue();
+            c = b.multiply(a);
+            if (!c.isZERO()) {
+                Cm.put(e, c);
+            }
+        }
+        return Cp;
+    }
+
+
+    /**
+     * RecSolvableWordPolynomial multiplication. Left product with 'monomial'.
+     * @param m 'monomial'.
+     * @return m * this, where * denotes solvable multiplication.
+     */
+    @Override
+    public RecSolvableWordPolynomial<C> multiplyLeft(Map.Entry<ExpVector, GenWordPolynomial<C>> m) {
+        if (m == null) {
+            return ring.getZERO();
+        }
+        return multiplyLeft(m.getValue(), m.getKey());
+    }
+
+
+    /**
+     * RecSolvableWordPolynomial multiplication. Product with 'monomial'.
+     * @param m 'monomial'.
+     * @return this * m, where * denotes solvable multiplication.
+     */
+    @Override
+    public RecSolvableWordPolynomial<C> multiply(Map.Entry<ExpVector, GenWordPolynomial<C>> m) {
+        if (m == null) {
+            return ring.getZERO();
+        }
+        return multiply(m.getValue(), m.getKey());
+    }
+
+
+    /**
+     * RecSolvableWordPolynomial multiplication. Commutative product with
+     * exponent vector.
+     * @param f exponent vector.
+     * @return B*f, where * is commutative multiplication.
+     */
+    protected RecSolvableWordPolynomial<C> shift(ExpVector f) {
+        RecSolvableWordPolynomial<C> C = ring.getZERO().copy();
+        if (this.isZERO()) {
+            return C;
+        }
+        if (f == null || f.isZERO()) {
+            return this;
+        }
+        Map<ExpVector, GenWordPolynomial<C>> Cm = C.val;
+        Map<ExpVector, GenWordPolynomial<C>> Bm = this.val;
+        for (Map.Entry<ExpVector, GenWordPolynomial<C>> y : Bm.entrySet()) {
+            ExpVector e = y.getKey();
+            GenWordPolynomial<C> a = y.getValue();
+            ExpVector d = e.sum(f);
+            if (!a.isZERO()) {
+                Cm.put(d, a);
+            }
+        }
+        return C;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/RecSolvableWordPolynomialRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/RecSolvableWordPolynomialRing.java
@@ -1,0 +1,717 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.kern.PrettyPrint;
+import edu.jas.kern.Scripting;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * RecSolvableWordPolynomialRing generic recursive solvable polynomial factory
+ * implementing RingFactory and extending GenSolvablePolynomialRing factory.
+ * Factory for n-variate ordered solvable polynomials over non-commutative word
+ * polynomial coefficients. The non-commutative multiplication relations are
+ * maintained in a relation table and the non-commutative multiplication
+ * relations between the coefficients and the main variables are maintained in a
+ * coefficient relation table. Almost immutable object, except variable names
+ * and relation table contents.
+ * @param <C> base coefficient type.
+ * @author Heinz Kredel
+ */
+
+public class RecSolvableWordPolynomialRing<C extends RingElem<C>> extends
+                GenSolvablePolynomialRing<GenWordPolynomial<C>> {
+
+
+    /**
+     * The solvable multiplication relations between variables and coefficients.
+     */
+    public final RelationTable<GenWordPolynomial<C>> coeffTable;
+
+
+    /**
+     * The constant polynomial 0 for this ring. Hides super ZERO.
+     */
+    public final RecSolvableWordPolynomial<C> ZERO;
+
+
+    /**
+     * The constant polynomial 1 for this ring. Hides super ONE.
+     */
+    public final RecSolvableWordPolynomial<C> ONE;
+
+
+    private static final Logger logger = LogManager.getLogger(RecSolvableWordPolynomialRing.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * default term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     */
+    public RecSolvableWordPolynomialRing(RingFactory<GenWordPolynomial<C>> cf, int n) {
+        this(cf, n, new TermOrder(), null, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * default term order.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param rt solvable multiplication relations.
+     */
+    public RecSolvableWordPolynomialRing(RingFactory<GenWordPolynomial<C>> cf, int n,
+                    RelationTable<GenWordPolynomial<C>> rt) {
+        this(cf, n, new TermOrder(), null, rt);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     */
+    public RecSolvableWordPolynomialRing(RingFactory<GenWordPolynomial<C>> cf, int n, TermOrder t) {
+        this(cf, n, t, null, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     * @param rt solvable multiplication relations.
+     */
+    public RecSolvableWordPolynomialRing(RingFactory<GenWordPolynomial<C>> cf, int n, TermOrder t,
+                    RelationTable<GenWordPolynomial<C>> rt) {
+        this(cf, n, t, null, rt);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     * @param v names for the variables.
+     */
+    public RecSolvableWordPolynomialRing(RingFactory<GenWordPolynomial<C>> cf, int n, TermOrder t, String[] v) {
+        this(cf, n, t, v, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order and commutative relations.
+     * @param cf factory for coefficients of type C.
+     * @param t a term order.
+     * @param v names for the variables.
+     */
+    public RecSolvableWordPolynomialRing(RingFactory<GenWordPolynomial<C>> cf, TermOrder t, String[] v) {
+        this(cf, v.length, t, v, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * default term order.
+     * @param cf factory for coefficients of type C.
+     * @param v names for the variables.
+     */
+    public RecSolvableWordPolynomialRing(RingFactory<GenWordPolynomial<C>> cf, String[] v) {
+        this(cf, v.length, new TermOrder(), v, null);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the
+     * given term order.
+     * @param cf factory for coefficients of type C.
+     * @param n number of variables.
+     * @param t a term order.
+     * @param v names for the variables.
+     * @param rt solvable multiplication relations.
+     */
+    public RecSolvableWordPolynomialRing(RingFactory<GenWordPolynomial<C>> cf, int n, TermOrder t,
+                    String[] v, RelationTable<GenWordPolynomial<C>> rt) {
+        super(cf, n, t, v, rt);
+        //if (rt == null) { // handled in super }
+        coeffTable = new RelationTable<GenWordPolynomial<C>>(this, true);
+        ZERO = new RecSolvableWordPolynomial<C>(this);
+        GenWordPolynomial<C> coeff = coFac.getONE();
+        //evzero = ExpVector.create(nvar); // from super
+        ONE = new RecSolvableWordPolynomial<C>(this, coeff, evzero);
+    }
+
+
+    /**
+     * The constructor creates a solvable polynomial factory object with the the
+     * same term order, number of variables and variable names as the given
+     * polynomial factory, only the coefficient factories differ and the
+     * solvable multiplication relations are <b>empty</b>.
+     * @param cf factory for coefficients of type C.
+     * @param o other solvable polynomial ring.
+     */
+    public RecSolvableWordPolynomialRing(RingFactory<GenWordPolynomial<C>> cf, RecSolvableWordPolynomialRing o) {
+        this(cf, o.nvar, o.tord, o.getVars(), null);
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        String res = super.toString();
+        if (PrettyPrint.isTrue()) {
+            //res += "\n" + table.toString(vars);
+            res += "\n" + coeffTable.toString(vars);
+        } else {
+            res += ", #rel = " + table.size() + " + " + coeffTable.size();
+        }
+        return res;
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        StringBuffer s = new StringBuffer();
+        switch (Scripting.getLang()) {
+        case Ruby:
+            s.append("SolvPolyRing.new(");
+            break;
+        case Python:
+        default:
+            s.append("SolvPolyRing(");
+        }
+        if (coFac instanceof RingElem) {
+            s.append(((RingElem<GenWordPolynomial<C>>) coFac).toScriptFactory());
+        } else {
+            s.append(coFac.toScript().trim());
+        }
+        s.append(",\"" + varsToString() + "\",");
+        String to = tord.toScript();
+        s.append(to);
+        if (table.size() > 0) {
+            String rel = table.toScript();
+            s.append(",rel=");
+            s.append(rel);
+        }
+        if (coeffTable.size() > 0) {
+            String rel = coeffTable.toScript();
+            s.append(",coeffrel=");
+            s.append(rel);
+        }
+        s.append(")");
+        return s.toString();
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object other) {
+        if (other == null) {
+            return false;
+        }
+        if (!(other instanceof RecSolvableWordPolynomialRing)) {
+            return false;
+        }
+        // do a super.equals( )
+        if (!super.equals(other)) {
+            return false;
+        }
+        RecSolvableWordPolynomialRing<C> oring = (RecSolvableWordPolynomialRing<C>) other;
+        // check same base relations
+        //if ( ! table.equals(oring.table) ) { // done in super
+        //    return false;
+        //}
+        if (!coeffTable.equals(oring.coeffTable)) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Hash code for this polynomial ring.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = super.hashCode();
+        h = 37 * h + table.hashCode(); // may be different after some computations
+        h = 37 * h + coeffTable.hashCode(); // may be different
+        return h;
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as RecSolvableWordPolynomial<C>.
+     */
+    @Override
+    public RecSolvableWordPolynomial<C> getZERO() {
+        return ZERO;
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as RecSolvableWordPolynomial<C>.
+     */
+    @Override
+    public RecSolvableWordPolynomial<C> getONE() {
+        return ONE;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true if this ring is commutative, else false.
+     */
+    @Override
+    public boolean isCommutative() {
+        if (coeffTable.isEmpty()) {
+            return super.isCommutative();
+        }
+        return false;
+    }
+
+
+    /**
+     * Query if this ring is associative. Test if the relations between the mian
+     * variables and the coefficient generators define an associative solvable
+     * ring.
+     * @return true, if this ring is associative, else false.
+     */
+    @SuppressWarnings("unused")
+    @Override
+    public boolean isAssociative() {
+        if (!coFac.isAssociative()) {
+            return false;
+        }
+        RecSolvableWordPolynomial<C> Xi, Xj, Xk, p, q;
+        List<GenPolynomial<GenWordPolynomial<C>>> gens = generators();
+        //System.out.println("Rec word gens = " + gens);
+        int ngen = gens.size();
+        for (int i = 0; i < ngen; i++) {
+            Xi = (RecSolvableWordPolynomial<C>) gens.get(i);
+            if (Xi.isONE()) {
+                continue;
+            }
+            for (int j = i + 1; j < ngen; j++) {
+                Xj = (RecSolvableWordPolynomial<C>) gens.get(j);
+                for (int k = j + 1; k < ngen; k++) {
+                    Xk = (RecSolvableWordPolynomial<C>) gens.get(k);
+                    try {
+                        p = Xk.multiply(Xj).multiply(Xi);
+                        q = Xk.multiply(Xj.multiply(Xi));
+                        if (!p.equals(q)) {
+                            if (logger.isInfoEnabled()) {
+                                logger.info("Xk = " + Xk + ", Xj = " + Xj + ", Xi = " + Xi);
+                                logger.info("p = ( Xk * Xj ) * Xi = " + p);
+                                logger.info("q = Xk * ( Xj * Xi ) = " + q);
+                            }
+                            return false;
+                        }
+                    } catch (RuntimeException e) {
+                        e.printStackTrace();
+                        System.out.println("Xk = " + Xk + ", Xj = " + Xj + ", Xi = " + Xi);
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Get a (constant) RecSolvableWordPolynomial&lt;C&gt; element from a
+     * coefficient value.
+     * @param a coefficient.
+     * @return a RecSolvableWordPolynomial&lt;C&gt;.
+     */
+    @Override
+    public RecSolvableWordPolynomial<C> valueOf(GenWordPolynomial<C> a) {
+        return new RecSolvableWordPolynomial<C>(this, a);
+    }
+
+
+    /**
+     * Get a RecSolvableWordPolynomial&lt;C&gt; element from an ExpVector.
+     * @param e exponent vector.
+     * @return a RecSolvableWordPolynomial&lt;C&gt;.
+     */
+    @Override
+    public RecSolvableWordPolynomial<C> valueOf(ExpVector e) {
+        return valueOf(coFac.getONE(), e);
+    }
+
+
+    /**
+     * Get a RecSolvableWordPolynomial&lt;C&gt; element from a coeffcient and an
+     * ExpVector.
+     * @param a coefficient.
+     * @param e exponent vector.
+     * @return a RecSolvableWordPolynomial&lt;C&gt;.
+     */
+    @Override
+    public RecSolvableWordPolynomial<C> valueOf(GenWordPolynomial<C> a, ExpVector e) {
+        return new RecSolvableWordPolynomial<C>(this, a, e);
+    }
+
+
+    /**
+     * Get a (constant) RecSolvableWordPolynomial&lt;C&gt; element from a long
+     * value.
+     * @param a long.
+     * @return a RecSolvableWordPolynomial&lt;C&gt;.
+     */
+    @Override
+    public RecSolvableWordPolynomial<C> fromInteger(long a) {
+        return new RecSolvableWordPolynomial<C>(this, coFac.fromInteger(a), evzero);
+    }
+
+
+    /**
+     * Get a (constant) RecSolvableWordPolynomial&lt;C&gt; element from a
+     * BigInteger value.
+     * @param a BigInteger.
+     * @return a RecSolvableWordPolynomial&lt;C&gt;.
+     */
+    @Override
+    public RecSolvableWordPolynomial<C> fromInteger(BigInteger a) {
+        return new RecSolvableWordPolynomial<C>(this, coFac.fromInteger(a), evzero);
+    }
+
+
+    /**
+     * Random solvable polynomial. Generates a random solvable polynomial with k
+     * = 5, l = n, d = (nvar == 1) ? n : 3, q = (nvar == 1) ? 0.7 : 0.3.
+     * @param n number of terms.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    public RecSolvableWordPolynomial<C> random(int n) {
+        return random(n, random);
+    }
+
+
+    /**
+     * Random solvable polynomial. Generates a random solvable polynomial with k
+     * = 5, l = n, d = (nvar == 1) ? n : 3, q = (nvar == 1) ? 0.7 : 0.3.
+     * @param n number of terms.
+     * @param rnd is a source for random bits.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    public RecSolvableWordPolynomial<C> random(int n, Random rnd) {
+        if (nvar == 1) {
+            return random(5, n, n, 0.7f, rnd);
+        }
+        return random(5, n, 3, 0.3f, rnd);
+    }
+
+
+    /**
+     * Generate a random solvable polynomial.
+     * @param k bitsize of random coefficients.
+     * @param l number of terms.
+     * @param d maximal degree in each variable.
+     * @param q density of nozero exponents.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    public RecSolvableWordPolynomial<C> random(int k, int l, int d, float q) {
+        return random(k, l, d, q, random);
+    }
+
+
+    /**
+     * Random solvable polynomial.
+     * @param k size of random coefficients.
+     * @param l number of terms.
+     * @param d maximal degree in each variable.
+     * @param q density of nozero exponents.
+     * @param rnd is a source for random bits.
+     * @return a random solvable polynomial.
+     */
+    @Override
+    public RecSolvableWordPolynomial<C> random(int k, int l, int d, float q, Random rnd) {
+        RecSolvableWordPolynomial<C> r = getZERO(); // copy( ZERO ); 
+        ExpVector e;
+        GenWordPolynomial<C> a;
+        // add random coeffs and exponents
+        for (int i = 0; i < l; i++) {
+            e = ExpVector.random(nvar, d, q, rnd);
+            a = coFac.random(k, rnd);
+            r = (RecSolvableWordPolynomial<C>) r.sum(a, e);
+            // somewhat inefficient but clean
+        }
+        return r;
+    }
+
+
+    /**
+     * Copy polynomial c.
+     * @param c
+     * @return a copy of c.
+     */
+    public RecSolvableWordPolynomial<C> copy(RecSolvableWordPolynomial<C> c) {
+        return new RecSolvableWordPolynomial<C>(this, c.val);
+    }
+
+
+    /**
+     * Parse a solvable polynomial with the use of GenPolynomialTokenizer
+     * @param s String.
+     * @return RecSolvableWordPolynomial from s.
+     */
+    @Override
+    public RecSolvableWordPolynomial<C> parse(String s) {
+        return parse(new StringReader(s));
+    }
+
+
+    /**
+     * Parse a solvable polynomial with the use of GenPolynomialTokenizer
+     * @param r Reader.
+     * @return next RecSolvableWordPolynomial from r.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public RecSolvableWordPolynomial<C> parse(Reader r) {
+        GenPolynomialTokenizer pt = new GenPolynomialTokenizer(this, r);
+        RecSolvableWordPolynomial<C> p = null;
+        try {
+            GenSolvablePolynomial<GenWordPolynomial<C>> s = pt.nextSolvablePolynomial();
+            p = new RecSolvableWordPolynomial<C>(this, s);
+        } catch (IOException e) {
+            logger.error(e.toString() + " parse " + this);
+            p = ZERO;
+        }
+        return p;
+    }
+
+
+    /**
+     * Generate univariate solvable polynomial in a given variable.
+     * @param i the index of the variable.
+     * @return X_i as solvable univariate polynomial.
+     */
+    @Override
+    public RecSolvableWordPolynomial<C> univariate(int i) {
+        return (RecSolvableWordPolynomial<C>) super.univariate(i);
+    }
+
+
+    /**
+     * Generate univariate solvable polynomial in a given variable with given
+     * exponent.
+     * @param i the index of the variable.
+     * @param e the exponent of the variable.
+     * @return X_i^e as solvable univariate polynomial.
+     */
+    @Override
+    public RecSolvableWordPolynomial<C> univariate(int i, long e) {
+        return (RecSolvableWordPolynomial<C>) super.univariate(i, e);
+    }
+
+
+    /**
+     * Generate univariate solvable polynomial in a given variable with given
+     * exponent.
+     * @param modv number of module variables.
+     * @param i the index of the variable.
+     * @param e the exponent of the variable.
+     * @return X_i^e as solvable univariate polynomial.
+     */
+    @Override
+    public RecSolvableWordPolynomial<C> univariate(int modv, int i, long e) {
+        return (RecSolvableWordPolynomial<C>) super.univariate(modv, i, e);
+    }
+
+
+    /**
+     * Generate list of univariate polynomials in all variables.
+     * @return List(X_1,...,X_n) a list of univariate polynomials.
+     */
+    @Override
+    public List<RecSolvableWordPolynomial<C>> univariateList() {
+        //return castToSolvableList( super.univariateList() );
+        return univariateList(0, 1L);
+    }
+
+
+    /**
+     * Generate list of univariate polynomials in all variables.
+     * @param modv number of module variables.
+     * @return List(X_1,...,X_n) a list of univariate polynomials.
+     */
+    @Override
+    public List<RecSolvableWordPolynomial<C>> univariateList(int modv) {
+        return univariateList(modv, 1L);
+    }
+
+
+    /**
+     * Generate list of univariate polynomials in all variables with given
+     * exponent.
+     * @param modv number of module variables.
+     * @param e the exponent of the variables.
+     * @return List(X_1^e,...,X_n^e) a list of univariate polynomials.
+     */
+    @Override
+    public List<RecSolvableWordPolynomial<C>> univariateList(int modv, long e) {
+        List<RecSolvableWordPolynomial<C>> pols = new ArrayList<RecSolvableWordPolynomial<C>>(nvar);
+        int nm = nvar - modv;
+        for (int i = 0; i < nm; i++) {
+            RecSolvableWordPolynomial<C> p = univariate(modv, nm - 1 - i, e);
+            pols.add(p);
+        }
+        return pols;
+    }
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by i.
+     * @param i number of variables to extend.
+     * @return extended solvable polynomial ring factory.
+     */
+    @Override
+    public RecSolvableWordPolynomialRing<C> extend(int i) {
+        GenSolvablePolynomialRing<GenWordPolynomial<C>> pfac = super.extend(i);
+        RecSolvableWordPolynomialRing<C> spfac = new RecSolvableWordPolynomialRing<C>(pfac.coFac, pfac.nvar,
+                        pfac.tord, pfac.vars, pfac.table);
+        //spfac.table.extend(this.table); // pfac.table
+        spfac.coeffTable.extend(this.coeffTable);
+        return spfac;
+    }
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend number of
+     * variables by length(vn). New variables commute with the exiting
+     * variables.
+     * @param vs names for extended variables.
+     * @return extended polynomial ring factory.
+     */
+    @Override
+    public RecSolvableWordPolynomialRing<C> extend(String[] vs) {
+        GenSolvablePolynomialRing<GenWordPolynomial<C>> pfac = super.extend(vs);
+        RecSolvableWordPolynomialRing<C> spfac = new RecSolvableWordPolynomialRing<C>(pfac.coFac, pfac.nvar,
+                        pfac.tord, pfac.vars, pfac.table);
+        //spfac.table.extend(this.table); // pfac.table??
+        spfac.coeffTable.extend(this.coeffTable);
+        return spfac;
+    }
+
+
+    /**
+     * Contract variables. Used e.g. in module embedding. Contract number of
+     * variables by i.
+     * @param i number of variables to remove.
+     * @return contracted solvable polynomial ring factory.
+     */
+    @Override
+    public RecSolvableWordPolynomialRing<C> contract(int i) {
+        GenPolynomialRing<GenWordPolynomial<C>> pfac = super.contract(i);
+        RecSolvableWordPolynomialRing<C> spfac = new RecSolvableWordPolynomialRing<C>(pfac.coFac, pfac.nvar,
+                        pfac.tord, pfac.vars);
+        spfac.table.contract(this.table);
+        spfac.coeffTable.contract(this.coeffTable);
+        return spfac;
+    }
+
+
+    /**
+     * Reverse variables. Used e.g. in opposite rings.
+     * @return solvable polynomial ring factory with reversed variables.
+     */
+    @Override
+    public RecSolvableWordPolynomialRing<C> reverse() {
+        return reverse(false);
+    }
+
+
+    /**
+     * Reverse variables. Used e.g. in opposite rings.
+     * @param partial true for partialy reversed term orders.
+     * @return solvable polynomial ring factory with reversed variables.
+     */
+    @Override
+    public RecSolvableWordPolynomialRing<C> reverse(boolean partial) {
+        GenPolynomialRing<GenWordPolynomial<C>> pfac = super.reverse(partial);
+        RecSolvableWordPolynomialRing<C> spfac = new RecSolvableWordPolynomialRing<C>(pfac.coFac, pfac.nvar,
+                        pfac.tord, pfac.vars);
+        spfac.partial = partial;
+        spfac.table.reverse(this.table);
+        spfac.coeffTable.reverse(this.coeffTable);
+        return spfac;
+    }
+
+
+    /* not possible:
+     * Distributive representation as polynomial with all main variables.
+     * @return distributive polynomial ring factory.
+    @SuppressWarnings({"cast","unchecked"})
+    public static <C extends RingElem<C>> // must be static because of types
+       GenSolvablePolynomialRing<C> distribute(RecSolvableWordPolynomialRing<C> rf) {
+    }
+     */
+
+
+    /**
+     * Permutation of polynomial ring variables.
+     * @param P permutation.
+     * @return P(this).
+     */
+    @Override
+    public GenSolvablePolynomialRing<GenWordPolynomial<C>> permutation(List<Integer> P) {
+        if (!coeffTable.isEmpty()) {
+            throw new UnsupportedOperationException("permutation with coeff relations: " + this);
+        }
+        GenSolvablePolynomialRing<GenWordPolynomial<C>> pfac = (GenSolvablePolynomialRing<GenWordPolynomial<C>>) super
+                        .permutation(P);
+        return pfac;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/RelationGenerator.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/RelationGenerator.java
@@ -1,0 +1,27 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Generate Relation Tables for solvable polynomial rings. Adds the respective
+ * relations to the relation table of the given solvable ring factory. Relations
+ * are of the form x<sub>j</sub> * x<sub>i</sub> = x<sub>i</sub> x<sub>j</sub> +
+ * p<sub>ij</sub> for 1 &le; i &lt; j &le; n = number of variables.
+ * @author Heinz Kredel
+ */
+public interface RelationGenerator<C extends RingElem<C>> {
+
+
+    /**
+     * Generates the relation table of a solvable polynomial ring.
+     * @param ring solvable polynomial ring factory.
+     */
+    public abstract void generate(GenSolvablePolynomialRing<C> ring);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/RelationTable.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/RelationTable.java
@@ -1,0 +1,1031 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.kern.PrettyPrint;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * RelationTable for solvable polynomials. This class maintains the
+ * non-commutative multiplication relations of solvable polynomial rings. The
+ * table entries are initialized with relations of the form x<sub>j</sub> *
+ * x<sub>i</sub> = p<sub>ij</sub>. During multiplication the relations are
+ * updated by relations of the form x<sub>j</sub><sup>k</sup> *
+ * x<sub>i</sub><sup>l</sup> = p<sub>ijkl</sub>. If no relation for
+ * x<sub>j</sub> * x<sub>i</sub> is found in the table, this multiplication is
+ * assumed to be commutative x<sub>i</sub> x<sub>j</sub>. Can also be used for
+ * relations between coefficients and main variables.
+ * @author Heinz Kredel
+ */
+public class RelationTable<C extends RingElem<C>> implements Serializable {
+
+
+    /**
+     * The data structure for the relations.
+     */
+    public final Map<List<Integer>, List> table;
+
+
+    /**
+     * The factory for the solvable polynomial ring.
+     */
+    public final GenSolvablePolynomialRing<C> ring;
+
+
+    /**
+     * Usage indicator: table or coeffTable.
+     */
+    public final boolean coeffTable;
+
+
+    private static final Logger logger = LogManager.getLogger(RelationTable.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor for RelationTable requires ring factory. Note: This
+     * constructor is called within the constructor of the ring factory, so
+     * methods of this class can only be used after the other constructor has
+     * terminated.
+     * @param r solvable polynomial ring factory.
+     */
+    public RelationTable(GenSolvablePolynomialRing<C> r) {
+        this(r, false);
+    }
+
+
+    /**
+     * Constructor for RelationTable requires ring factory. Note: This
+     * constructor is called within the constructor of the ring factory, so
+     * methods of this class can only be used after the other constructor has
+     * terminated.
+     * @param r solvable polynomial ring factory.
+     * @param coeffTable indicator for coeffTable.
+     */
+    public RelationTable(GenSolvablePolynomialRing<C> r, boolean coeffTable) {
+        table = new HashMap<List<Integer>, List>();
+        ring = r;
+        if (ring == null) {
+            throw new IllegalArgumentException("RelationTable no ring");
+        }
+        this.coeffTable = coeffTable;
+    }
+
+
+    /**
+     * RelationTable equals. Tests same keySets and base relations.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object p) {
+        if (p == null) {
+            return false;
+        }
+        if (!(p instanceof RelationTable)) {
+            logger.info("no RelationTable");
+            return false;
+        }
+        RelationTable<C> tab = (RelationTable<C>) p;
+        // not possible because of infinite recursion:
+        //if (!ring.equals(tab.ring)) {
+        //    logger.info("not same Ring " + ring.toScript() + ", " + tab.ring.toScript());
+        //    return false;
+        //}
+        if (!table.keySet().equals(tab.table.keySet())) {
+            logger.info("keySet != :  a = " + table.keySet() + ", b = " + tab.table.keySet());
+            return false;
+        }
+        for (Map.Entry<List<Integer>, List> me : table.entrySet()) {
+            List<Integer> k = me.getKey();
+            List a = me.getValue();
+            List b = tab.table.get(k);
+            // check contents, but only base relations
+            Map<ExpVectorPair, GenPolynomial<C>> t1ex = fromListDeg2(a);
+            Map<ExpVectorPair, GenPolynomial<C>> t2ex = fromListDeg2(b);
+            if (!equalMaps(t1ex, t2ex)) {
+                //System.out.println("a != b, a = " + t1ex + ", b = " + t2ex);
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Convert mixed list to map for base relations.
+     * @param a mixed list
+     * @returns a map constructed from the list with deg(key) == 2.
+     */
+    @SuppressWarnings("unchecked")
+    Map<ExpVectorPair, GenPolynomial<C>> fromListDeg2(List a) {
+        Map<ExpVectorPair, GenPolynomial<C>> tex = new HashMap<ExpVectorPair, GenPolynomial<C>>();
+        Iterator ait = a.iterator();
+        while (ait.hasNext()) {
+            ExpVectorPair ae = (ExpVectorPair) ait.next();
+            if (!ait.hasNext()) {
+                break;
+            }
+            GenPolynomial<C> p = (GenPolynomial<C>) ait.next();
+            if (ae.totalDeg() == 2) { // only base relations
+                //System.out.println("ae => p: " + ae + " => " + p);
+                tex.put(ae, p);
+            }
+        }
+        return tex;
+    }
+
+
+    /**
+     * Hash code for base relations.
+     * @param a mixed list
+     * @returns hashCode(a)
+     */
+    @SuppressWarnings("unchecked")
+    int fromListDeg2HashCode(List a) {
+        int h = 0;
+        Iterator ait = a.iterator();
+        while (ait.hasNext()) {
+            ExpVectorPair ae = (ExpVectorPair) ait.next();
+            h = 31 * h + ae.hashCode();
+            if (!ait.hasNext()) {
+                break;
+            }
+            GenPolynomial<C> p = (GenPolynomial<C>) ait.next();
+            if (ae.totalDeg() == 2) { // only base relations
+                //System.out.println("ae => p: " + ae + " => " + p);
+                h = 31 * h + p.val.hashCode(); // avoid hash of ring
+            }
+        }
+        return h;
+    }
+
+
+    /**
+     * Equals for special maps.
+     * @param m1 first map
+     * @param m2 second map
+     * @returns true if both maps are equal
+     */
+    @SuppressWarnings("unchecked")
+    boolean equalMaps(Map<ExpVectorPair, GenPolynomial<C>> m1, Map<ExpVectorPair, GenPolynomial<C>> m2) {
+        if (!m1.keySet().equals(m2.keySet())) {
+            return false;
+        }
+        for (Map.Entry<ExpVectorPair, GenPolynomial<C>> me : m1.entrySet()) {
+            GenPolynomial<C> p1 = me.getValue();
+            ExpVectorPair ep = me.getKey();
+            GenPolynomial<C> p2 = m2.get(ep);
+            if (p1.compareTo(p2) != 0) { // not working: !p1.equals(p2)
+                logger.info("ep = " + ep + ", p1 = " + p1 + ", p2 = " + p2);
+                //logger.info("p1.compareTo(p2) = " + p1.compareTo(p2));
+                //logger.info("p1.equals(p2) = " + p1.equals(p2));
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Hash code for this relation table.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        //int h = ring.hashCode(); // infinite recursion
+        int h = 0; //table.hashCode();
+        h = table.keySet().hashCode();
+        for (Map.Entry<List<Integer>, List> me : table.entrySet()) {
+            //List<Integer> k = me.getKey();
+            List a = me.getValue();
+            int t1 = fromListDeg2HashCode(a);
+            h = 31 * h + t1;
+        }
+        return h;
+    }
+
+
+    /**
+     * Test if the table is empty.
+     * @return true if the table is empty, else false.
+     */
+    public boolean isEmpty() {
+        return table.isEmpty();
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        List v;
+        StringBuffer s = new StringBuffer("RelationTable[");
+        boolean first = true;
+        for (Map.Entry<List<Integer>, List> me : table.entrySet()) {
+            List<Integer> k = me.getKey();
+            if (first) {
+                first = false;
+            } else {
+                s.append(", ");
+            }
+            s.append(k.toString());
+            v = me.getValue();
+            s.append("=");
+            s.append(v.toString());
+        }
+        s.append("]");
+        return s.toString();
+    }
+
+
+    /**
+     * Get the String representation.
+     * @param vars names for the variables.
+     * @see java.lang.Object#toString()
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    public String toString(String[] vars) {
+        if (vars == null) {
+            return toString();
+        }
+        StringBuffer s = new StringBuffer("");
+        String[] cvars = null;
+        if (coeffTable) {
+            if (ring.coFac instanceof GenPolynomialRing) {
+                cvars = ((GenPolynomialRing<C>) (Object) ring.coFac).getVars();
+            } else if (ring.coFac instanceof GenWordPolynomialRing) {
+                cvars = ((GenWordPolynomialRing<C>) (Object) ring.coFac).getVars();
+            }
+            s.append("Coefficient ");
+        }
+        s.append("RelationTable\n(");
+        List v;
+        if (PrettyPrint.isTrue()) {
+            boolean first = true;
+            for (Map.Entry<List<Integer>, List> me : table.entrySet()) {
+                //List<Integer> k = me.getKey();
+                if (first) {
+                    first = false;
+                    s.append("\n");
+                } else {
+                    s.append(",\n");
+                }
+                v = me.getValue();
+                for (Iterator jt = v.iterator(); jt.hasNext();) {
+                    ExpVectorPair ep = (ExpVectorPair) jt.next();
+                    GenSolvablePolynomial<C> p = (GenSolvablePolynomial<C>) jt.next();
+                    if (ep.totalDeg() != 2) { // only base relations
+                        continue;
+                    }
+                    s.append("( " + ep.getFirst().toString(vars) + " ), ");
+                    if (cvars == null) {
+                        s.append("( " + ep.getSecond().toString(vars) + " ), ");
+                    } else {
+                        s.append("( " + ep.getSecond().toString(cvars) + " ), ");
+                    }
+                    s.append("( " + p.toString(vars) + " )");
+                    if (jt.hasNext()) {
+                        s.append(",\n");
+                    }
+                }
+            }
+        } else {
+            boolean first = true;
+            for (Map.Entry<List<Integer>, List> me : table.entrySet()) {
+                //List<Integer> k = me.getKey();
+                if (first) {
+                    first = false;
+                } else {
+                    s.append(",\n");
+                }
+                v = me.getValue();
+                for (Iterator jt = v.iterator(); jt.hasNext();) {
+                    ExpVectorPair ep = (ExpVectorPair) jt.next();
+                    s.append("( " + ep.getFirst().toString(vars) + " ), ");
+                    if (cvars == null) {
+                        s.append("( " + ep.getSecond().toString(vars) + " ), ");
+                    } else {
+                        s.append("( " + ep.getSecond().toString(cvars) + " ), ");
+                    }
+                    GenSolvablePolynomial<C> p = (GenSolvablePolynomial<C>) jt.next();
+                    //s.append("( " + p.toString(vars) + " )");
+                    s.append(" " + p.toString(vars));
+                    if (jt.hasNext()) {
+                        s.append(",\n");
+                    }
+                }
+            }
+        }
+        s.append("\n)\n");
+        return s.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this relation table.
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    public String toScript() {
+        // Python case
+        String[] vars = ring.vars;
+        String[] cvars = null;
+        if (coeffTable) {
+            if (ring.coFac instanceof GenPolynomialRing) {
+                cvars = ((GenPolynomialRing<C>) (Object) ring.coFac).getVars();
+            } else if (ring.coFac instanceof GenWordPolynomialRing) {
+                cvars = ((GenWordPolynomialRing<C>) (Object) ring.coFac).getVars();
+            }
+        }
+        List v;
+        StringBuffer s = new StringBuffer("[");
+        boolean first = true;
+        for (Map.Entry<List<Integer>, List> me : table.entrySet()) {
+            //List<Integer> k = me.getKey();
+            if (first) {
+                first = false;
+                s.append("");
+            } else {
+                s.append(", ");
+            }
+            v = me.getValue();
+            for (Iterator jt = v.iterator(); jt.hasNext();) {
+                ExpVectorPair ep = (ExpVectorPair) jt.next();
+                GenPolynomial<C> p = (GenPolynomial<C>) jt.next();
+                if (ep.totalDeg() > 2) { // only base relations
+                    continue;
+                }
+                s.append("" + ep.getFirst().toScript(vars) + ", ");
+                if (coeffTable) {
+                    String eps = ep.getSecond().toScript(cvars);
+                    if (eps.isEmpty()) { // if from a deeper down ring
+                        eps = p.leadingBaseCoefficient().abs().toScript();
+                    }
+                    s.append("" + eps + ", ");
+                } else {
+                    s.append("" + ep.getSecond().toScript(vars) + ", ");
+                }
+                //s.append("( " + p.toScript() + " )");
+                s.append(" " + p.toScript());
+                if (jt.hasNext()) {
+                    s.append(", ");
+                }
+            }
+        }
+        s.append("]");
+        return s.toString();
+    }
+
+
+    /**
+     * Update or initialize RelationTable with new relation. relation is e * f =
+     * p.
+     * @param e first term.
+     * @param f second term.
+     * @param p solvable product polynomial.
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    public synchronized void update(ExpVector e, ExpVector f, GenSolvablePolynomial<C> p) {
+        if (p == null || e == null || f == null) {
+            throw new IllegalArgumentException("RelationTable update e|f|p == null");
+        }
+        GenSolvablePolynomialRing<C> sring = p.ring;
+        if (debug) {
+            logger.info("new relation = " + sring.toScript(e) + " .*. " + sring.toScript(f) + " = "
+                            + p.toScript());
+        }
+        // test equal HTs for left and right side
+        if (!coeffTable) { // old case
+            int[] de = e.dependencyOnVariables();
+            int[] df = f.dependencyOnVariables();
+            if (debug) {
+                logger.info("update e ? f " + Arrays.toString(de) + "   " + Arrays.toString(df) + " : "
+                                + sring.toScript(e) + " ? " + sring.toScript(f));
+            }
+            if (de.length != 1 || df.length != 1) { // can this be relaxed?
+                throw new IllegalArgumentException("RelationTable no univariate relations");
+            }
+            if (de[de.length - 1] == df[0]) { // error
+                throw new IllegalArgumentException("RelationTable update e == f");
+            }
+            if (de[de.length - 1] > df[0]) { // invalid update
+                throw new IllegalArgumentException("RelationTable update e < f");
+                // ExpVector tmp = e;
+                // e = f;
+                // f = tmp;
+                // Map.Entry<ExpVector, C> m = p.leadingMonomial();
+                // ExpVector ef = e.sum(f);
+                // if (!ef.equals(m.getKey())) {
+                //     throw new IllegalArgumentException("update e*f != lt(p): " + sring.toScript(ef)
+                //                     + ", lt = " + sring.toScript(m.getKey()));
+                // }
+                // GenPolynomial<C> r = p.reductum(); //subtract(m.getValue(), m.getKey());
+                // r = r.negate();
+                // //p = (GenSolvablePolynomial<C>) r.sum(m.getValue(), m.getKey());
+                // p = (GenSolvablePolynomial<C>) r;
+                // p.doPutToMap(m.getKey(), m.getValue());
+            }
+            ExpVector ef = e.sum(f);
+            ExpVector lp = p.leadingExpVector();
+            if (!ef.equals(lp)) { // check for suitable term order
+                logger.error("relation term order = " + ring.tord);
+                throw new IllegalArgumentException(
+                                "update e*f != lt(p): " + sring.toScript(ef) + " != " + sring.toScript(lp));
+            }
+        } else { // is coeffTable
+            ExpVector lp = p.leadingExpVector();
+            if (!e.equals(lp)) { // check for suitable term order
+                logger.error("relation term order = " + ring.tord);
+                throw new IllegalArgumentException("Coefficient RelationTable update e != lt(p): "
+                                + sring.toScript(e) + " != " + sring.toScript(lp));
+            }
+            if (p.leadingBaseCoefficient() instanceof GenPolynomial) {
+                lp = ((GenPolynomial<C>) (Object) p.leadingBaseCoefficient()).leadingExpVector();
+                if (!f.equals(lp)) { // check for suitable term order
+                    logger.error("relation term order = " + ring.tord);
+                    logger.error("Coefficient RelationTable update f != lt(lfcd(p)): " + sring.toScript(e)
+                                    + ", f = " + f + ", p = " + p.toScript());
+                    throw new IllegalArgumentException("Coefficient RelationTable update f != lt(lfcd(p)): "
+                                    + e + ", f = " + f + ", p = " + p);
+                }
+            } else if (p.leadingBaseCoefficient() instanceof GenWordPolynomial) {
+                lp = ((GenWordPolynomial<C>) (Object) p.leadingBaseCoefficient()).leadingWord()
+                                .leadingExpVector();
+                if (!f.equals(lp)) { // check for suitable term order and word structure
+                    logger.error("relation term order = " + ring.tord);
+                    logger.error("Coefficient RelationTable update f != lt(lfcd(p)): " + sring.toScript(e)
+                                    + ", f = " + f + ", p = " + p.toScript());
+                    throw new IllegalArgumentException("Coefficient RelationTable update f != lt(lfcd(p)): "
+                                    + e + ", f = " + f + ", p = " + p);
+                }
+            }
+        }
+        // now insert key-value
+        List<Integer> key = makeKey(e, f);
+        ExpVectorPair evp = new ExpVectorPair(e, f); // beware of leadingWord != leadingExpVector
+        if (key.size() != 2) {
+            logger.warn("key = " + key + ", evp = " + evp);
+        }
+        List part = table.get(key);
+        if (part == null) { // initialization
+            part = new LinkedList();
+            part.add(evp);
+            part.add(p);
+            table.put(key, part);
+            return;
+        }
+        @SuppressWarnings("unused")
+        Object skip;
+        int index = -1;
+        synchronized (part) { // with lookup()
+            for (ListIterator it = part.listIterator(); it.hasNext();) {
+                ExpVectorPair look = (ExpVectorPair) it.next();
+                skip = it.next(); // skip poly
+                if (look.isMultiple(evp)) {
+                    index = it.nextIndex();
+                    // last index of or first index of: break
+                }
+            }
+            if (index < 0) {
+                index = 0;
+            }
+            part.add(index, evp);
+            part.add(index + 1, p);
+        }
+        // table.put( key, part ); // required??
+    }
+
+
+    /**
+     * Update or initialize RelationTable with new relation. relation is e * f =
+     * p.
+     * @param E first term polynomial.
+     * @param F second term polynomial.
+     * @param p solvable product polynomial.
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    public void update(GenPolynomial<C> E, GenPolynomial<C> F, GenSolvablePolynomial<C> p) {
+        if (E.isZERO() || F.isZERO()) {
+            throw new IllegalArgumentException("polynomials may not be zero: " + E + ", " + F);
+        }
+        C ce = E.leadingBaseCoefficient();
+        C cf = F.leadingBaseCoefficient();
+        if (!ce.isONE()) {
+            throw new IllegalArgumentException(
+                            "lbcf of polynomials must be one: " + ce + ", " + cf + ", p = " + p);
+        }
+        ExpVector e = E.leadingExpVector();
+        ExpVector f = F.leadingExpVector();
+        if (coeffTable && f.isZERO()) {
+            if (cf instanceof GenPolynomial) {
+                f = ((GenPolynomial<C>) (Object) cf).leadingExpVector();
+            } else if (cf instanceof GenWordPolynomial) {
+                f = ((GenWordPolynomial<C>) (Object) cf).leadingWord().leadingExpVector();
+            }
+        }
+        //logger.info("update: " + e + " .*. " + f + " = " + p);
+        update(e, f, p);
+    }
+
+
+    /**
+     * Update or initialize RelationTable with new relation. relation is e * f =
+     * p.
+     * @param E first term polynomial.
+     * @param F second term polynomial.
+     * @param p product polynomial.
+     */
+    public void update(GenPolynomial<C> E, GenPolynomial<C> F, GenPolynomial<C> p) {
+        if (p.isZERO()) {
+            throw new IllegalArgumentException("polynomial may not be zero: " + p);
+        }
+        if (p.isONE()) {
+            throw new IllegalArgumentException("product of polynomials may not be one: " + p);
+        }
+        GenSolvablePolynomial<C> sp = new GenSolvablePolynomial<C>(ring, p.val);
+        update(E, F, sp);
+    }
+
+
+    /**
+     * Update or initialize RelationTable with new relation. relation is e * f =
+     * p.
+     * @param e first term.
+     * @param f second term.
+     * @param p solvable product polynomial.
+     */
+    public void update(ExpVector e, ExpVector f, GenPolynomial<C> p) {
+        if (p.isZERO()) {
+            throw new IllegalArgumentException("polynomial may not be zero: " + p);
+        }
+        if (p.isONE()) {
+            throw new IllegalArgumentException("product of polynomials may not be one: " + p);
+        }
+        GenSolvablePolynomial<C> sp = new GenSolvablePolynomial<C>(ring, p.val);
+        update(e, f, sp);
+    }
+
+
+    /**
+     * Lookup RelationTable for existing relation. Find p with e * f = p. If no
+     * relation for e * f is contained in the table then return the symmetric
+     * product p = 1 e f.
+     * @param e first term.
+     * @param f second term.
+     * @return t table relation container, contains e' and f' with e f = e'
+     *         lt(p) f'.
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    public TableRelation<C> lookup(ExpVector e, ExpVector f) {
+        List<Integer> key = makeKey(e, f);
+        List part = table.get(key);
+        if (part == null) { // symmetric product
+            GenSolvablePolynomial<C> p = null;
+            C c = null;
+            if (!coeffTable) {
+                ExpVector ef = e.sum(f);
+                //p = new GenSolvablePolynomial<C>(ring, ring.getONECoefficient(), ef);
+                p = ring.valueOf(ef);
+            } else {
+                if (ring.coFac instanceof GenPolynomialRing) {
+                    GenPolynomialRing<C> cofac = (GenPolynomialRing<C>) (Object) ring.coFac;
+                    //System.out.println("f = " + f + ", e = " + e);
+                    GenPolynomial<C> pc = cofac.valueOf(f);
+                    c = (C) (Object) pc;
+                } else if (ring.coFac instanceof GenWordPolynomialRing) {
+                    GenWordPolynomialRing<C> cofac = (GenWordPolynomialRing<C>) (Object) ring.coFac;
+                    //System.out.println("f = " + f + ", e = " + e);
+                    GenWordPolynomial<C> pc = cofac.valueOf(f);
+                    c = (C) (Object) pc;
+                }
+                p = new GenSolvablePolynomial<C>(ring, c, e);
+                //System.out.println("pc = " + pc + ", p = " + p);
+            }
+            return new TableRelation<C>(null, null, p);
+        }
+        // no distinction between coefficient f or polynomial f
+        ExpVectorPair evp = new ExpVectorPair(e, f);
+        ExpVector ep = null;
+        ExpVector fp = null;
+        ExpVectorPair look = null;
+        GenSolvablePolynomial<C> p = null;
+        synchronized (part) { // with update()
+            for (Iterator it = part.iterator(); it.hasNext();) {
+                look = (ExpVectorPair) it.next();
+                p = (GenSolvablePolynomial<C>) it.next();
+                if (evp.isMultiple(look)) {
+                    ep = e.subtract(look.getFirst());
+                    fp = f.subtract(look.getSecond());
+                    if (ep.isZERO()) {
+                        ep = null;
+                    }
+                    if (fp.isZERO()) {
+                        fp = null;
+                    }
+                    if (debug) {
+                        if (p != null && p.ring.vars != null) {
+                            logger.info("found relation = " + e.toString(p.ring.vars) + " .*. "
+                                            + f.toString(p.ring.vars) + " = " + p);
+                        } else {
+                            logger.info("found relation = " + e + " .*. " + f + " = " + p);
+                        }
+                    }
+                    return new TableRelation<C>(ep, fp, p);
+                }
+            }
+        }
+        // unreacheable code!
+        throw new RuntimeException("no entry found in relation table for " + evp);
+    }
+
+
+    /**
+     * Construct a key for (e,f).
+     * @param e first term.
+     * @param f second term.
+     * @return k key for (e,f).
+     */
+    protected List<Integer> makeKey(ExpVector e, ExpVector f) {
+        int[] de = e.dependencyOnVariables();
+        int[] df = f.dependencyOnVariables();
+        List<Integer> key = new ArrayList<Integer>(de.length + df.length);
+        for (int i = 0; i < de.length; i++) {
+            key.add(Integer.valueOf(de[i]));
+        }
+        for (int i = 0; i < df.length; i++) {
+            key.add(Integer.valueOf(df[i]));
+        }
+        return key;
+    }
+
+
+    /**
+     * Size of the table.
+     * @return n number of non-commutative relations.
+     */
+    public int size() {
+        int s = 0;
+        if (table == null || table.isEmpty()) {
+            return s;
+        }
+        for (Iterator<List> it = table.values().iterator(); it.hasNext();) {
+            List list = it.next();
+            s += list.size() / 2;
+        }
+        return s;
+    }
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend all ExpVectors
+     * and polynomials of the given relation table by i elements and put the
+     * relations into this table, i.e. this should be empty.
+     * @param tab a relation table to be extended and inserted into this.
+     */
+    @SuppressWarnings("unchecked")
+    public void extend(RelationTable<C> tab) {
+        if (tab.table.isEmpty()) {
+            return;
+        }
+        // assert this.size() == 0
+        int i = ring.nvar - tab.ring.nvar;
+        int j = 0;
+        long k = 0l;
+        List val;
+        for (List<Integer> key : tab.table.keySet()) {
+            val = tab.table.get(key);
+            for (Iterator jt = val.iterator(); jt.hasNext();) {
+                ExpVectorPair ep = (ExpVectorPair) jt.next();
+                ExpVector e = ep.getFirst();
+                ExpVector f = ep.getSecond();
+                GenSolvablePolynomial<C> p = (GenSolvablePolynomial<C>) jt.next();
+                ExpVector ex = e.extend(i, j, k);
+                ExpVector fx;
+                if (coeffTable) {
+                    fx = f;
+                } else {
+                    fx = f.extend(i, j, k);
+                }
+                GenSolvablePolynomial<C> px = (GenSolvablePolynomial<C>) p.extend(ring, j, k);
+                this.update(ex, fx, px);
+            }
+        }
+        return;
+    }
+
+
+    /**
+     * Contract variables. Used e.g. in module embedding. Contract all
+     * ExpVectors and polynomials of the given relation table by i elements and
+     * put the relations into this table, i.e. this should be empty.
+     * @param tab a relation table to be contracted and inserted into this.
+     */
+    @SuppressWarnings("unchecked")
+    public void contract(RelationTable<C> tab) {
+        if (tab.table.isEmpty()) {
+            return;
+        }
+        // assert this.size() == 0
+        int i = tab.ring.nvar - ring.nvar;
+        List val;
+        for (List<Integer> key : tab.table.keySet()) {
+            val = tab.table.get(key);
+            //System.out.println("key = " + key + ", val = " + val);
+            for (Iterator jt = val.iterator(); jt.hasNext();) {
+                ExpVectorPair ep = (ExpVectorPair) jt.next();
+                ExpVector e = ep.getFirst();
+                ExpVector f = ep.getSecond();
+                GenSolvablePolynomial<C> p = (GenSolvablePolynomial<C>) jt.next();
+                ExpVector ec = e.contract(i, e.length() - i);
+                ExpVector fc;
+                if (coeffTable) {
+                    fc = f;
+                } else {
+                    fc = f.contract(i, f.length() - i);
+                }
+                //System.out.println("ec = " + ec + ", fc = " + fc);
+                if (ec.isZERO()) {
+                    continue;
+                }
+                Map<ExpVector, GenPolynomial<C>> mc = p.contract(ring);
+                if (mc.size() != 1) {
+                    continue;
+                }
+                GenPolynomial<C> pc = mc.values().iterator().next();
+                this.update(ec, fc, pc);
+            }
+        }
+        return;
+    }
+
+
+    /**
+     * Recursive representation. Split all ExpVectors and polynomials of the
+     * given relation table to lower elements and upper elements and put the
+     * relations into this table or this as coefficient table, i.e. this should
+     * be empty.
+     * @param tab a relation table to be contracted and inserted into this.
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    public void recursive(RelationTable tab) { //<C>
+        if (tab.table.isEmpty()) {
+            return;
+        }
+        //System.out.println("rel ring = " + ring.toScript());
+        // assert this.size() == 0
+        GenPolynomialRing<C> cring = (GenPolynomialRing<C>) (Object) ring.coFac;
+        //System.out.println("cring    = " + cring.toScript());
+        GenSolvablePolynomial<C> pc;
+        int i = ring.nvar; // tab.ring.nvar -
+        for (Object okey : tab.table.keySet()) {
+            List<Integer> key = (List<Integer>) okey;
+            List val = (List) tab.table.get(key);
+            //System.out.println("key = " + key + ", val = " + val);
+            for (Iterator jt = val.iterator(); jt.hasNext();) {
+                ExpVectorPair ep = (ExpVectorPair) jt.next(); // ?? concurrent mod exception 
+                ExpVector e = ep.getFirst();
+                ExpVector f = ep.getSecond();
+                GenSolvablePolynomial<C> p = (GenSolvablePolynomial<C>) jt.next();
+                ExpVector ec = e.contract(0, i);
+                ExpVector fc;
+                if (coeffTable) {
+                    fc = f;
+                } else {
+                    fc = f.contract(0, i);
+                }
+                //System.out.println("ec = " + ec + ", fc = " + fc);
+                if (ec.isZERO()) {
+                    continue;
+                }
+                Map<ExpVector, GenPolynomial<C>> mc = p.contract(cring);
+                //System.out.println("mc = " + mc + ", p = " + p);
+                //System.out.println("mc.ring = " + mc.values().iterator().next().ring.toScript());
+                if (mc.size() == 1) { // < 1 only for p == 0
+                    pc = (GenSolvablePolynomial<C>) mc.values().iterator().next();
+                    this.update(ec, fc, pc);
+                } else { // construct recursive polynomial
+                    GenSolvablePolynomial<C> qr = ring.getZERO();
+                    for (Map.Entry<ExpVector, GenPolynomial<C>> mce : mc.entrySet()) {
+                        ExpVector g = mce.getKey();
+                        GenPolynomial<C> q = mce.getValue();
+                        C cq = (C) (Object) q;
+                        GenSolvablePolynomial<C> qp = new GenSolvablePolynomial<C>(ring, cq, g);
+                        qr = (GenSolvablePolynomial<C>) qr.sum(qp);
+                    }
+                    if (coeffTable) {
+                        fc = ((GenPolynomial<C>) (Object) qr.leadingBaseCoefficient()).leadingExpVector();
+                    }
+                    if (fc.isZERO()) {
+                        continue;
+                    }
+                    //System.out.println("ec = " + ec + ", fc = " + fc + ", qr = " + qr);
+                    if (coeffTable) {
+                        String qrs = ring.toScript(ec) + " * " + qr.leadingBaseCoefficient() + " = "
+                                        + qr.toScript();
+                        logger.info("coeffTable: adding " + qrs);
+                    } else {
+                        String qrs = ring.toScript(ec) + " * " + ring.toScript(fc) + " = " + qr.toScript();
+                        logger.info("no coeffTable: adding " + qrs);
+                    }
+                    this.update(ec, fc, qr);
+                }
+            }
+        }
+        return;
+    }
+
+
+    /**
+     * Reverse variables and relations. Used e.g. in opposite rings. Reverse all
+     * ExpVectors and polynomials of the given relation table and put the
+     * modified relations into this table, i.e. this should be empty.
+     * @param tab a relation table to be reverted and inserted into this.
+     */
+    @SuppressWarnings("unchecked")
+    public void reverse(RelationTable<C> tab) {
+        if (tab.table.isEmpty()) {
+            return;
+        }
+        if (!table.isEmpty()) {
+            logger.error("reverse table not empty");
+        }
+        int k = -1;
+        if (ring.tord.getEvord2() != 0 && ring.partial) {
+            k = ring.tord.getSplit();
+        }
+        logger.debug("k split = " + k);
+        //System.out.println("k split = " + k );
+        //System.out.println("reversed ring = " + ring.toScript() );
+        for (List<Integer> key : tab.table.keySet()) {
+            List val = tab.table.get(key);
+            for (Iterator jt = val.iterator(); jt.hasNext();) {
+                ExpVectorPair ep = (ExpVectorPair) jt.next();
+                ExpVector e = ep.getFirst();
+                ExpVector f = ep.getSecond();
+                GenSolvablePolynomial<C> p = (GenSolvablePolynomial<C>) jt.next();
+                //logger.info("e pre reverse = " + e );
+                //logger.info("f pre reverse = " + f );
+                //logger.info("p pre reverse = " + p );
+                //if (e.degree() > 1 || f.degree() > 1) { // not required
+                //    continue; // revert only base relations
+                //}
+                ExpVector ex;
+                ExpVector fx;
+                GenSolvablePolynomial<C> px;
+                boolean change = true; // if relevant vars reversed
+                if (k >= 0) {
+                    ex = e.reverse(k);
+                    if (coeffTable) {
+                        fx = f;
+                    } else {
+                        fx = f.reverse(k);
+                    }
+                    // todo check relevant vars
+                    //int[] ed = ex.dependencyOnVariables(); // = e
+                    //if (ed.length == 0 || ed[0] >= k) { // k >= 0
+                    //    change = false; 
+                    //}
+                    //int[] fd = fx.dependencyOnVariables(); // = f
+                    //if (fd.length == 0 || fd[0] >= k) { // k >= 0
+                    //    change = false; 
+                    //}
+                } else {
+                    ex = e.reverse();
+                    if (coeffTable) {
+                        fx = f;
+                    } else {
+                        fx = f.reverse();
+                    }
+                }
+                px = (GenSolvablePolynomial<C>) p.reverse(ring);
+                //System.out.println("update, p, px: " + p.toScript() + " reverse:" + px.toScript() );
+                if (!change) {
+                    this.update(e, f, px); // same order
+                } else {
+                    if (coeffTable) {
+                        this.update(ex, fx, px); // same order
+                    } else {
+                        this.update(fx, ex, px); // opposite order
+                    }
+                }
+            }
+        }
+        return;
+    }
+
+
+    /**
+     * Convert relation table to list of polynomial triples.
+     * @return rel = (e1,f1,p1, ...) where ei * fi = pi are solvable relations.
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    public List<GenSolvablePolynomial<C>> relationList() {
+        List<GenSolvablePolynomial<C>> rels = new ArrayList<GenSolvablePolynomial<C>>();
+        for (Map.Entry<List<Integer>, List> me : table.entrySet()) {
+            List v = me.getValue();
+            for (Iterator jt = v.iterator(); jt.hasNext();) {
+                ExpVectorPair ep = (ExpVectorPair) jt.next();
+                ExpVector e = ep.getFirst();
+                GenSolvablePolynomial<C> pe = ring.valueOf(e);
+                ExpVector f = ep.getSecond();
+                GenSolvablePolynomial<C> pf = null;
+                if (coeffTable) {
+                    C cf = null;
+                    if (ring.coFac instanceof GenPolynomialRing) {
+                        GenPolynomial<C> cpf;
+                        cpf = ((GenPolynomialRing<C>) (Object) ring.coFac).valueOf(f);
+                        cf = (C) (Object) cpf; // down cast
+                    } else if (ring.coFac instanceof GenWordPolynomialRing) {
+                        GenWordPolynomial<C> cpf;
+                        cpf = ((GenWordPolynomialRing<C>) (Object) ring.coFac).valueOf(f);
+                        cf = (C) (Object) cpf; // down cast
+                    }
+                    pf = ring.valueOf(cf);
+                } else {
+                    pf = ring.valueOf(f);
+                }
+                GenSolvablePolynomial<C> p = (GenSolvablePolynomial<C>) jt.next();
+                rels.add(pe);
+                rels.add(pf);
+                rels.add(p);
+            }
+        }
+        return rels;
+    }
+
+
+    /**
+     * Add list of polynomial triples as relations.
+     * @param rel = (e1,f1,p1, ...) where ei * fi = pi are solvable relations.
+     *            <b>Note:</b> Only because of type erasure, aequivalent to
+     *            addRelations().
+     */
+    public void addSolvRelations(List<GenSolvablePolynomial<C>> rel) {
+        PolynomialList<C> Prel = new PolynomialList<C>(ring, rel);
+        addRelations(Prel.getList());
+    }
+
+
+    /**
+     * Add list of polynomial triples as relations.
+     * @param rel = (e1,f1,p1, ...) where ei * fi = pi are solvable relations.
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    public void addRelations(List<GenPolynomial<C>> rel) {
+        if (rel == null || rel.isEmpty()) {
+            return;
+        }
+        Iterator<GenPolynomial<C>> relit = rel.iterator();
+        while (relit.hasNext()) {
+            GenPolynomial<C> E = relit.next();
+            ExpVector e = E.leadingExpVector();
+            ExpVector f = null;
+            if (!relit.hasNext()) {
+                throw new IllegalArgumentException("F and poly part missing");
+            }
+            GenPolynomial<C> F = relit.next();
+            if (!relit.hasNext()) {
+                throw new IllegalArgumentException("poly part missing");
+            }
+            GenPolynomial<C> P = relit.next();
+            if (coeffTable) {
+                if (!F.isConstant()) {
+                    throw new IllegalArgumentException("F  not constant for coeffTable: " + F);
+                }
+                if (ring.coFac instanceof GenPolynomialRing) {
+                    f = ((GenPolynomial<C>) (Object) F.leadingBaseCoefficient()).leadingExpVector();
+                } else if (ring.coFac instanceof GenWordPolynomialRing) {
+                    f = ((GenWordPolynomial<C>) (Object) F.leadingBaseCoefficient()).leadingWord()
+                                    .leadingExpVector();
+                }
+            } else {
+                f = F.leadingExpVector();
+            }
+            update(e, f, P);
+        }
+        return;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/Residue.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/Residue.java
@@ -1,0 +1,405 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.NotInvertibleException;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Residue element based on RingElem residue. Objects of this class are (nearly)
+ * immutable.
+ * @author Heinz Kredel
+ */
+public class Residue<C extends RingElem<C>> implements RingElem<Residue<C>> {
+
+
+    private static final Logger logger = LogManager.getLogger(Residue.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Residue class factory data structure.
+     */
+    protected final ResidueRing<C> ring;
+
+
+    /**
+     * Value part of the element data structure.
+     */
+    protected final C val;
+
+
+    /**
+     * Flag to remember if this residue element is a unit. -1 is unknown, 1 is
+     * unit, 0 not a unit.
+     */
+    protected int isunit = -1; // initially unknown
+
+
+    /**
+     * The constructor creates a Residue object from a ring factory.
+     * @param r ring factory.
+     */
+    public Residue(ResidueRing<C> r) {
+        this(r, r.ring.getZERO(), 0);
+    }
+
+
+    /**
+     * The constructor creates a Residue object from a ring factory and a ring
+     * element.
+     * @param r ring factory.
+     * @param a ring element.
+     */
+    public Residue(ResidueRing<C> r, C a) {
+        this(r, a, -1);
+    }
+
+
+    /**
+     * The constructor creates a Residue object from a ring factory, a ring
+     * element and an indicator if a is a unit.
+     * @param r ring factory.
+     * @param a ring element.
+     * @param u isunit indicator, -1, 0, 1.
+     */
+    public Residue(ResidueRing<C> r, C a, int u) {
+        ring = r;
+        C v = a.remainder(ring.modul);
+        if (v.signum() < 0) {
+            v = v.sum(ring.modul);
+        }
+        val = v;
+        if (u == 0 || u == 1) {
+            isunit = u;
+            return;
+        }
+        if (val.isZERO()) {
+            isunit = 0;
+            return;
+        }
+        if (val.isUnit()) {
+            isunit = 1;
+            //} else { // not possible
+            //isunit = 0;
+        }
+        isunit = -1;
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public ResidueRing<C> factory() {
+        return ring;
+    }
+
+
+    /**
+     * Copy this.
+     * @see edu.jas.structure.Element#copy()
+     */
+    @Override
+    public Residue<C> copy() {
+        return new Residue<C>(ring, val);
+    }
+
+
+    /**
+     * Is Residue zero.
+     * @return If this is 0 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isZERO()
+     */
+    public boolean isZERO() {
+        return val.equals(ring.ring.getZERO());
+    }
+
+
+    /**
+     * Is Residue one.
+     * @return If this is 1 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isONE()
+     */
+    public boolean isONE() {
+        return val.equals(ring.ring.getONE());
+    }
+
+
+    /**
+     * Is Residue unit.
+     * @return If this is a unit then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isUnit()
+     */
+    @SuppressWarnings("unchecked")
+    public boolean isUnit() {
+        if (isunit == 1) {
+            return true;
+        }
+        if (isunit == 0) {
+            return false;
+        }
+        // val.isUnit() already tested
+        // not jet known
+        if (val instanceof GcdRingElem && ring.modul instanceof GcdRingElem) {
+            GcdRingElem v = (GcdRingElem) val;
+            GcdRingElem m = (GcdRingElem) ring.modul;
+            C gcd = (C) v.gcd(m);
+            if (debug) {
+                logger.info("gcd = " + gcd);
+            }
+            boolean u = gcd.isONE();
+            if (u) {
+                isunit = 1;
+            } else {
+                isunit = 0;
+            }
+            return u;
+        }
+        // still unknown
+        return false;
+    }
+
+
+    /**
+     * Get the String representation as RingElem.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "Residue[ " + val.toString() + " mod " + ring.toString() + " ]";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        return "Residue( " + val.toScript() + " , " + ring.toScript() + " )";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python case
+        return factory().toScript();
+    }
+
+
+    /**
+     * Residue comparison.
+     * @param b Residue.
+     * @return sign(this-b), 0 means that this and b are equivalent in this
+     *         residue class ring.
+     */
+    @Override
+    public int compareTo(Residue<C> b) {
+        C v = b.val;
+        if (!ring.equals(b.ring)) {
+            v = v.remainder(ring.modul);
+        }
+        return val.compareTo(v);
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     * @return true means that this and b are equivalent in this residue class
+     *         ring.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (b == null) {
+            return false;
+        }
+        if (!(b instanceof Residue)) {
+            return false;
+        }
+        Residue<C> a = (Residue<C>) b;
+        return (0 == compareTo(a));
+    }
+
+
+    /**
+     * Hash code for this local.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = ring.hashCode();
+        h = 37 * h + val.hashCode();
+        return h;
+    }
+
+
+    /**
+     * Residue absolute value.
+     * @return the absolute value of this.
+     * @see edu.jas.structure.RingElem#abs()
+     */
+    public Residue<C> abs() {
+        return new Residue<C>(ring, val.abs());
+    }
+
+
+    /**
+     * Residue summation.
+     * @param S Residue.
+     * @return this+S.
+     */
+    public Residue<C> sum(Residue<C> S) {
+        return new Residue<C>(ring, val.sum(S.val));
+    }
+
+
+    /**
+     * Residue negate.
+     * @return -this.
+     * @see edu.jas.structure.RingElem#negate()
+     */
+    public Residue<C> negate() {
+        return new Residue<C>(ring, val.negate());
+    }
+
+
+    /**
+     * Residue signum.
+     * @see edu.jas.structure.RingElem#signum()
+     * @return signum(this).
+     */
+    public int signum() {
+        return val.signum();
+    }
+
+
+    /**
+     * Residue subtraction.
+     * @param S Residue.
+     * @return this-S.
+     */
+    public Residue<C> subtract(Residue<C> S) {
+        return new Residue<C>(ring, val.subtract(S.val));
+    }
+
+
+    /**
+     * Residue division.
+     * @param S Residue.
+     * @return this/S.
+     */
+    public Residue<C> divide(Residue<C> S) {
+        return multiply(S.inverse());
+    }
+
+
+    /**
+     * Residue inverse.
+     * @see edu.jas.structure.RingElem#inverse()
+     * @return S with S = 1/this if defined.
+     */
+    @SuppressWarnings("unchecked")
+    public Residue<C> inverse() {
+        if (isunit == 0) {
+            throw new NotInvertibleException("element not invertible (0) " + this);
+        }
+        if (val instanceof GcdRingElem && ring.modul instanceof GcdRingElem) {
+            GcdRingElem v = (GcdRingElem) val;
+            GcdRingElem m = (GcdRingElem) ring.modul;
+            C[] egcd = (C[]) v.egcd(m);
+            if (debug) {
+                logger.info("egcd = " + egcd[0] + ", f = " + egcd[1]);
+            }
+            if (!egcd[0].isONE()) {
+                isunit = 0;
+                throw new NotInvertibleException("element not invertible (gcd)" + this);
+            }
+            isunit = 1;
+            C x = egcd[1];
+            return new Residue<C>(ring, x);
+        }
+        if (val.isUnit()) {
+            C x = val.inverse();
+            return new Residue<C>(ring, x);
+        }
+        System.out.println("isunit = " + isunit + ", isUnit() = " + this.isUnit());
+        throw new NotInvertibleException("element not invertible (!gcd)" + this);
+    }
+
+
+    /**
+     * Residue remainder.
+     * @param S Residue.
+     * @return this - (this/S)*S.
+     */
+    public Residue<C> remainder(Residue<C> S) {
+        C x = val.remainder(S.val);
+        return new Residue<C>(ring, x);
+    }
+
+
+    /**
+     * Quotient and remainder by division of this by S.
+     * @param S a Residue
+     * @return [this/S, this - (this/S)*S].
+     */
+    @SuppressWarnings("unchecked")
+    public Residue<C>[] quotientRemainder(Residue<C> S) {
+        return new Residue[] { divide(S), remainder(S) };
+    }
+
+
+    /**
+     * Residue multiplication.
+     * @param S Residue.
+     * @return this*S.
+     */
+    public Residue<C> multiply(Residue<C> S) {
+        return new Residue<C>(ring, val.multiply(S.val));
+    }
+
+
+    /**
+     * Greatest common divisor. <b>Note: </b>Not implemented, throws
+     * UnsupportedOperationException.
+     * @param b other element.
+     * @return gcd(this,b).
+     */
+    public Residue<C> gcd(Residue<C> b) {
+        throw new UnsupportedOperationException("gcd not implemented " + this.getClass().getName());
+    }
+
+
+    /**
+     * Extended greatest common divisor. <b>Note: </b>Not implemented, throws
+     * UnsupportedOperationException.
+     * @param b other element.
+     * @return [ gcd(this,b), c1, c2 ] with c1*this + c2*b = gcd(this,b).
+     */
+    public Residue<C>[] egcd(Residue<C> b) {
+        throw new UnsupportedOperationException("egcd not implemented " + this.getClass().getName());
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/ResidueRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/ResidueRing.java
@@ -1,0 +1,296 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Residue ring factory based on RingElem and RingFactory module. Objects of
+ * this class are immutable.
+ * @author Heinz Kredel
+ */
+public class ResidueRing<C extends RingElem<C>> implements RingFactory<Residue<C>> {
+
+
+    private static final Logger logger = LogManager.getLogger(ResidueRing.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Ring element for reduction.
+     */
+    protected final C modul;
+
+
+    /**
+     * Ring factory.
+     */
+    protected final RingFactory<C> ring;
+
+
+    /**
+     * Indicator if this ring is a field.
+     */
+    protected int isField = -1; // initially unknown
+
+
+    /**
+     * The constructor creates a ResidueRing object from an ring factory and a
+     * modul.
+     * @param r ring factory.
+     * @param m modul.
+     */
+    public ResidueRing(RingFactory<C> r, C m) {
+        ring = r;
+        if (m.isZERO()) {
+            throw new IllegalArgumentException("modul may not be null");
+        }
+        if (m.isONE()) {
+            logger.warn("modul is one");
+        }
+        if (m.signum() < 0) {
+            m = m.negate();
+        }
+        modul = m;
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite()
+     */
+    public boolean isFinite() {
+        throw new UnsupportedOperationException("not implemented");
+        //return ring.isFinite();
+    }
+
+
+    /**
+     * Copy Residue element c.
+     * @param c
+     * @return a copy of c.
+     */
+    public Residue<C> copy(Residue<C> c) {
+        return new Residue<C>(c.ring, c.val);
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as Residue.
+     */
+    public Residue<C> getZERO() {
+        return new Residue<C>(this, ring.getZERO());
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as Residue.
+     */
+    public Residue<C> getONE() {
+        Residue<C> one = new Residue<C>(this, ring.getONE());
+        if (one.isZERO()) {
+            logger.warn("one is zero, so all residues are 0");
+        }
+        return one;
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     * @see edu.jas.structure.ElemFactory#generators()
+     */
+    public List<Residue<C>> generators() {
+        List<? extends C> rgens = ring.generators();
+        List<Residue<C>> gens = new ArrayList<Residue<C>>(rgens.size());
+        for (C c : rgens) {
+            gens.add(new Residue<C>(this, c));
+        }
+        return gens;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true if this ring is commutative, else false.
+     */
+    public boolean isCommutative() {
+        return ring.isCommutative();
+    }
+
+
+    /**
+     * Query if this ring is associative.
+     * @return true if this ring is associative, else false.
+     */
+    public boolean isAssociative() {
+        return ring.isAssociative();
+    }
+
+
+    /**
+     * Query if this ring is a field.
+     * @return false.
+     */
+    public boolean isField() {
+        if (isField > 0) {
+            return true;
+        }
+        if (isField == 0) {
+            return false;
+        }
+        // ideal is prime ?
+        return false;
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic() {
+        return ring.characteristic();
+    }
+
+
+    /**
+     * Get a Residue element from a BigInteger value.
+     * @param a BigInteger.
+     * @return a Residue.
+     */
+    public Residue<C> fromInteger(java.math.BigInteger a) {
+        return new Residue<C>(this, ring.fromInteger(a));
+    }
+
+
+    /**
+     * Get a Residue element from a long value.
+     * @param a long.
+     * @return a Residue.
+     */
+    public Residue<C> fromInteger(long a) {
+        return new Residue<C>(this, ring.fromInteger(a));
+    }
+
+
+    /**
+     * Get the String representation as RingFactory.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "Residue[ " + modul.toString() + " ]";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.ElemFactory#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        return "ResidueRing(" + modul.toScript() + ")";
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (b == null) {
+            return false;
+        }
+        if (!(b instanceof ResidueRing)) {
+            return false;
+        }
+        ResidueRing<C> a = (ResidueRing<C>) b;
+        if (!ring.equals(a.ring)) {
+            return false;
+        }
+        return modul.equals(a.modul);
+    }
+
+
+    /**
+     * Hash code for this residue ring.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = ring.hashCode();
+        h = 37 * h + modul.hashCode();
+        return h;
+    }
+
+
+    /**
+     * Residue random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @return a random residue element.
+     */
+    public Residue<C> random(int n) {
+        C x = ring.random(n);
+        // x = x.sum( ring.getONE() );
+        return new Residue<C>(this, x);
+    }
+
+
+    /**
+     * Residue random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @param rnd is a source for random bits.
+     * @return a random residue element.
+     */
+    public Residue<C> random(int n, Random rnd) {
+        C x = ring.random(n, rnd);
+        // x = x.sum( ring.getONE() );
+        return new Residue<C>(this, x);
+    }
+
+
+    /**
+     * Parse Residue from String.
+     * @param s String.
+     * @return Residue from s.
+     */
+    public Residue<C> parse(String s) {
+        C x = ring.parse(s);
+        return new Residue<C>(this, x);
+    }
+
+
+    /**
+     * Parse Residue from Reader.
+     * @param r Reader.
+     * @return next Residue from r.
+     */
+    public Residue<C> parse(Reader r) {
+        C x = ring.parse(r);
+        return new Residue<C>(this, x);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/TableRelation.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/TableRelation.java
@@ -1,0 +1,67 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.io.Serializable;
+
+import edu.jas.structure.RingElem;
+
+
+/**
+ * TableRelation container for storage and printing in RelationTable.
+ * @author Heinz Kredel
+ */
+public class TableRelation<C extends RingElem<C>> implements Serializable {
+
+
+    /**
+     * First ExpVector of the data structure.
+     */
+    public final ExpVector e;
+
+
+    /**
+     * Second ExpVector of the data structure.
+     */
+    public final ExpVector f;
+
+
+    /**
+     * GenSolvablePolynomial of the data structure.
+     */
+    public final GenSolvablePolynomial<C> p;
+
+
+    /**
+     * Constructor to setup the data structure.
+     * @param e first term.
+     * @param f second term.
+     * @param p product polynomial.
+     */
+    public TableRelation(ExpVector e, ExpVector f, GenSolvablePolynomial<C> p) {
+        this.e = e;
+        this.f = f;
+        this.p = p;
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer s = new StringBuffer("TableRelation[");
+        s.append("" + e);
+        s.append(" .*. ");
+        s.append("" + f);
+        s.append(" = ");
+        s.append("" + p);
+        s.append("]");
+        return s.toString();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/TermOrder.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/TermOrder.java
@@ -1,0 +1,2162 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.kern.Scripting;
+
+
+/**
+ * Term order class for ordered polynomials. Implements the most used term
+ * orders: graded, lexicographical, weight aray and block orders. For the
+ * definitions see for example the articles
+ * <a href="http://doi.acm.org/10.1145/43882.43887">Kredel "Admissible term
+ * orderings used in computer algebra systems"</a> and
+ * <a href="http://doi.acm.org/10.1145/70936.70941">Sit, "Some comments on
+ * term-ordering in Gr&ouml;bner basis computations"</a>. <b>Note: </b> the
+ * naming is not quite easy to understand: in case of doubt use the term orders
+ * with "I" in the name, like IGRLEX (the default) or INVLEX. Not all algorithms
+ * may work with all term orders since not all are well-founded, so watch your
+ * step. This class does not implement orders by linear forms over Q[t]. Objects
+ * of this class are immutable.
+ * 
+ * @author Heinz Kredel
+ */
+
+public final class TermOrder implements Serializable {
+
+
+    private static final Logger logger = LogManager.getLogger(TermOrder.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    // TermOrder index values
+
+    public static final int LEX = 1;
+
+
+    public final static int MIN_EVORD = LEX;
+
+
+    public static final int INVLEX = 2;
+
+
+    public static final int GRLEX = 3;
+
+
+    public static final int IGRLEX = 4;
+
+
+    public static final int REVLEX = 5;
+
+
+    public static final int REVILEX = 6;
+
+
+    public static final int REVTDEG = 7;
+
+
+    public static final int REVITDG = 8;
+
+
+    public static final int ITDEGLEX = 9;
+
+
+    public static final int REVITDEG = 10;
+
+
+    public final static int MAX_EVORD = REVITDEG;
+
+
+    public final static int DEFAULT_EVORD = IGRLEX;
+
+
+    //public final static int DEFAULT_EVORD = INVLEX;
+
+
+    // instance variables
+
+    private final int evord;
+
+
+    // for split termorders
+    private final int evord2;
+
+
+    private final int evbeg1;
+
+
+    private final int evend1;
+
+
+    private final int evbeg2;
+
+
+    private final int evend2;
+
+
+    /**
+     * Defined array of weight vectors.
+     */
+    private final long[][] weight;
+
+
+    /**
+     * Defined descending order comparator. Sorts the highest terms first.
+     */
+    private final EVComparator horder;
+
+
+    /**
+     * Defined ascending order comparator. Sorts the lowest terms first.
+     */
+    private final EVComparator lorder;
+
+
+    /**
+     * Defined sugar order comparator. Sorts the graded lowest terms first.
+     */
+    private final EVComparator sugar;
+
+
+    /**
+     * Termorders for modules: TOP or POT. POT: position over term (default)
+     * TOP: term over position (new)
+     */
+    public final boolean TOP;
+
+
+    /**
+     * Comparator for ExpVectors.
+     */
+    public static abstract class EVComparator implements Comparator<ExpVector>, Serializable {
+
+
+        public abstract int compare(ExpVector e1, ExpVector e2);
+    }
+
+
+    /**
+     * Constructor for default term order.
+     */
+    public TermOrder() {
+        this(DEFAULT_EVORD);
+    }
+
+
+    /**
+     * Constructor for given term order.
+     * @param evord requested term order indicator / enumerator.
+     */
+    public TermOrder(int evord) {
+        if (evord < MIN_EVORD || MAX_EVORD < evord) {
+            throw new IllegalArgumentException("invalid term order: " + evord);
+        }
+        this.evord = evord;
+        this.evord2 = 0;
+        weight = null;
+        evbeg1 = 0;
+        evend1 = Integer.MAX_VALUE;
+        evbeg2 = evend1;
+        evend2 = evend1;
+        TOP = false;
+        switch (evord) { // horder = new EVhorder();
+        case TermOrder.LEX: {
+            horder = new EVComparator() {
+
+
+                @Override
+                public int compare(ExpVector e1, ExpVector e2) {
+                    return e1.invLexCompareTo(e2);
+                }
+            };
+            break;
+        }
+        case TermOrder.INVLEX: {
+            horder = new EVComparator() {
+
+
+                @Override
+                public int compare(ExpVector e1, ExpVector e2) {
+                    return -e1.invLexCompareTo(e2);
+                }
+            };
+            break;
+        }
+        case TermOrder.GRLEX: {
+            horder = new EVComparator() {
+
+
+                @Override
+                public int compare(ExpVector e1, ExpVector e2) {
+                    return e1.invGradCompareTo(e2);
+                }
+            };
+            break;
+        }
+        case TermOrder.IGRLEX: {
+            horder = new EVComparator() {
+
+
+                @Override
+                public int compare(ExpVector e1, ExpVector e2) {
+                    return -e1.invGradCompareTo(e2);
+                }
+            };
+            break;
+        }
+        case TermOrder.REVLEX: {
+            horder = new EVComparator() {
+
+
+                @Override
+                public int compare(ExpVector e1, ExpVector e2) {
+                    return e1.revInvLexCompareTo(e2);
+                }
+            };
+            break;
+        }
+        case TermOrder.REVILEX: {
+            horder = new EVComparator() {
+
+
+                @Override
+                public int compare(ExpVector e1, ExpVector e2) {
+                    return -e1.revInvLexCompareTo(e2);
+                }
+            };
+            break;
+        }
+        case TermOrder.REVTDEG: {
+            horder = new EVComparator() {
+
+
+                @Override
+                public int compare(ExpVector e1, ExpVector e2) {
+                    return e1.revInvGradCompareTo(e2);
+                }
+            };
+            break;
+        }
+        case TermOrder.REVITDG: {
+            horder = new EVComparator() {
+
+
+                @Override
+                public int compare(ExpVector e1, ExpVector e2) {
+                    return -e1.revInvGradCompareTo(e2);
+                }
+            };
+            break;
+        }
+        case TermOrder.ITDEGLEX: {
+            horder = new EVComparator() {
+
+
+                @Override
+                public int compare(ExpVector e1, ExpVector e2) {
+                    return -e1.invTdegCompareTo(e2); // okay +/-
+                }
+            };
+            break;
+        }
+        case TermOrder.REVITDEG: {
+            horder = new EVComparator() {
+
+
+                @Override
+                public int compare(ExpVector e1, ExpVector e2) {
+                    return e1.revLexInvTdegCompareTo(e2); // okay +/-
+                }
+            };
+            break;
+        }
+        default: {
+            horder = null;
+        }
+        }
+        if (horder == null) {
+            throw new IllegalArgumentException("invalid term order: " + evord);
+        }
+
+        // lorder = new EVlorder();
+        lorder = new EVComparator() {
+
+
+            @Override
+            public int compare(ExpVector e1, ExpVector e2) {
+                return -horder.compare(e1, e2);
+            }
+        };
+
+        // sugar = new EVsugar();
+        sugar = new EVComparator() {
+
+
+            @Override
+            public int compare(ExpVector e1, ExpVector e2) {
+                return e1.invGradCompareTo(e2);
+            }
+        };
+    }
+
+
+    /**
+     * Constructor for given exponent weights.
+     * @param w weight vector of longs.
+     */
+    public TermOrder(long[] w) {
+        this(new long[][] { w });
+    }
+
+
+    /**
+     * Constructor for given exponent weights.
+     * @param w weight array of longs.
+     */
+    public TermOrder(long[][] w) {
+        if (w == null || w.length == 0) {
+            throw new IllegalArgumentException("invalid term order weight");
+        }
+        weight = Arrays.copyOf(w, w.length); // > Java-5
+        this.evord = 0;
+        this.evord2 = 0;
+        evbeg1 = 0;
+        evend1 = weight[0].length;
+        evbeg2 = evend1;
+        evend2 = evend1;
+        TOP = false;
+
+        horder = new EVComparator() {
+
+
+            @Override
+            public int compare(ExpVector e1, ExpVector e2) {
+                return -e1.invWeightCompareTo(weight, e2);
+            }
+        };
+
+        // lorder = new EVlorder();
+        lorder = new EVComparator() {
+
+
+            @Override
+            public int compare(ExpVector e1, ExpVector e2) {
+                return +e1.invWeightCompareTo(weight, e2);
+                // return - horder.compare( e1, e2 );
+            }
+        };
+
+        // sugar = new EVsugar();
+        sugar = horder;
+    }
+
+
+    /**
+     * Test if this term order is a split order.
+     * @return true if this is a split term order, else false.
+     */
+    public boolean isSplit() {
+        //System.out.println("isSplit: " + evend2 + " == " + evbeg2);
+        if (evend2 == evbeg2 || evend1 == Integer.MAX_VALUE) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Constructor for given split order.
+     * @param ev1 requested term order indicator for first block.
+     * @param ev2 requested term order indicator for second block.
+     * @param r max number of exponents to compare.
+     * @param split index.
+     */
+    public TermOrder(int ev1, int ev2, int r, int split) {
+        this(ev1, ev2, r, split, false);
+    }
+
+
+    /**
+     * Constructor for given split order.
+     * @param ev1 requested term order indicator for first block.
+     * @param ev2 requested term order indicator for second block.
+     * @param r max number of exponents to compare.
+     * @param split index.
+     * @param top module termorder, if true, default false.
+     */
+    public TermOrder(int ev1, int ev2, int r, int split, boolean top) {
+        if (ev1 < MIN_EVORD || MAX_EVORD - 2 < ev1) {
+            throw new IllegalArgumentException("invalid split term order 1: " + ev1);
+        }
+        if (ev2 < MIN_EVORD || MAX_EVORD - 2 < ev2) {
+            throw new IllegalArgumentException("invalid split term order 2: " + ev2);
+        }
+        this.evord = ev1;
+        this.evord2 = ev2;
+        weight = null;
+        evbeg1 = 0;
+        evend1 = split; // excluded
+        evbeg2 = split;
+        evend2 = r;
+        if (evbeg2 < 0 || evbeg2 > evend2) {
+            throw new IllegalArgumentException("invalid term order split, r = " + r + ", split = " + split);
+        }
+        //System.out.println("evbeg2 " + evbeg2 + ", evend2 " + evend2);
+        TOP = top;
+        if (debug) {
+            logger.info("module TermOrder is " + (TOP ? "TOP" : "POT") + ", split = " + split + ", evord = "
+                            + toScriptOrder(evord) + ", evord2 = " + toScriptOrder(evord2));
+        }
+        switch (evord) { // horder = new EVhorder();
+        case TermOrder.LEX: {
+            switch (evord2) {
+            case TermOrder.LEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = e1.invLexCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return e1.invLexCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.INVLEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = e1.invLexCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return -e1.invLexCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.GRLEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = e1.invLexCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return e1.invGradCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.IGRLEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = e1.invLexCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return -e1.invGradCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            default: {
+                horder = null;
+            }
+            }
+            break;
+        }
+        case TermOrder.INVLEX: {
+            switch (evord2) {
+            case TermOrder.LEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.invLexCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return e1.invLexCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.INVLEX: {
+                if (!TOP) {
+                    horder = new EVComparator() { // POT
+
+
+                        @Override
+                        public int compare(ExpVector e1, ExpVector e2) {
+                            int t = -e1.invLexCompareTo(e2, evbeg1, evend1);
+                            if (t != 0) {
+                                return t;
+                            }
+                            return -e1.invLexCompareTo(e2, evbeg2, evend2);
+                        }
+                    };
+                    break;
+                }
+                horder = new EVComparator() { // TOP
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.invLexCompareTo(e2, evbeg2, evend2);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return -e1.invLexCompareTo(e2, evbeg1, evend1);
+                    }
+                };
+                break;
+            }
+            case TermOrder.GRLEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.invLexCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return e1.invGradCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.IGRLEX: {
+                if (!TOP) {
+                    horder = new EVComparator() { // POT
+
+
+                        @Override
+                        public int compare(ExpVector e1, ExpVector e2) {
+                            int t = -e1.invLexCompareTo(e2, evbeg1, evend1);
+                            if (t != 0) {
+                                return t;
+                            }
+                            return -e1.invGradCompareTo(e2, evbeg2, evend2);
+                        }
+                    };
+                    break;
+                }
+                horder = new EVComparator() { // TOP
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.invGradCompareTo(e2, evbeg2, evend2);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return -e1.invLexCompareTo(e2, evbeg1, evend1);
+                    }
+                };
+                break;
+            }
+            case TermOrder.REVLEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.invLexCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return e1.revInvLexCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.REVILEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.invLexCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return -e1.revInvLexCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.REVTDEG: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.invLexCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return e1.revInvGradCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.REVITDG: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.invLexCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return -e1.revInvGradCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            default: {
+                horder = null;
+            }
+            }
+            break;
+        }
+        case TermOrder.GRLEX: {
+            switch (evord2) {
+            case TermOrder.LEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = e1.invGradCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return e1.invLexCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.INVLEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = e1.invGradCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return -e1.invLexCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.GRLEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = e1.invGradCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return e1.invGradCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.IGRLEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = e1.invGradCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return -e1.invGradCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            default: {
+                horder = null;
+            }
+            }
+            break;
+        }
+        case TermOrder.IGRLEX: {
+            switch (evord2) {
+            case TermOrder.LEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.invGradCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return e1.invLexCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.INVLEX: {
+                if (!TOP) {
+                    horder = new EVComparator() { // POT
+
+
+                        @Override
+                        public int compare(ExpVector e1, ExpVector e2) {
+                            int t = -e1.invGradCompareTo(e2, evbeg1, evend1);
+                            if (t != 0) {
+                                return t;
+                            }
+                            return -e1.invLexCompareTo(e2, evbeg2, evend2);
+                        }
+                    };
+                    break;
+                }
+                horder = new EVComparator() { // TOP
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.invLexCompareTo(e2, evbeg2, evend2);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return -e1.invGradCompareTo(e2, evbeg1, evend1);
+                    }
+                };
+                break;
+            }
+            case TermOrder.GRLEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.invGradCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return e1.invGradCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.IGRLEX: {
+                if (!TOP) {
+                    horder = new EVComparator() { // POT
+
+
+                        @Override
+                        public int compare(ExpVector e1, ExpVector e2) {
+                            int t = -e1.invGradCompareTo(e2, evbeg1, evend1);
+                            if (t != 0) {
+                                return t;
+                            }
+                            return -e1.invGradCompareTo(e2, evbeg2, evend2);
+                        }
+                    };
+                    break;
+                }
+                horder = new EVComparator() { // TOP
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.invGradCompareTo(e2, evbeg2, evend2);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return -e1.invGradCompareTo(e2, evbeg1, evend1);
+                    }
+                };
+                break;
+            }
+            case TermOrder.REVLEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.invGradCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return e1.revInvLexCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.REVILEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.invGradCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return -e1.revInvLexCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.REVTDEG: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.invGradCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return e1.revInvGradCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.REVITDG: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.invGradCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return -e1.revInvGradCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            default: {
+                horder = null;
+            }
+            }
+            break;
+        }
+        //----- begin reversed -----------
+        case TermOrder.REVLEX: {
+            switch (evord2) {
+            case TermOrder.LEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = e1.revInvLexCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return e1.invLexCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.INVLEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = e1.revInvLexCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return -e1.invLexCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.GRLEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = e1.revInvLexCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return e1.invGradCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.IGRLEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = e1.revInvLexCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return -e1.invGradCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.REVLEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = e1.revInvLexCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return e1.revInvLexCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.REVILEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = e1.revInvLexCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return -e1.revInvLexCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.REVTDEG: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = e1.revInvLexCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return e1.revInvGradCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.REVITDG: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = e1.revInvLexCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return -e1.revInvGradCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            default: {
+                horder = null;
+            }
+            }
+            break;
+        }
+        case TermOrder.REVILEX: {
+            switch (evord2) {
+            case TermOrder.LEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.revInvLexCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return e1.invLexCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.INVLEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.revInvLexCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return -e1.invLexCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.GRLEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.revInvLexCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return e1.revInvGradCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.IGRLEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.revInvLexCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return -e1.invGradCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.REVLEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.revInvLexCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return e1.revInvLexCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.REVILEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.revInvLexCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return -e1.revInvLexCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.REVTDEG: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.revInvLexCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return e1.revInvGradCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.REVITDG: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.revInvLexCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return -e1.revInvGradCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            default: {
+                horder = null;
+            }
+            }
+            break;
+        }
+        case TermOrder.REVTDEG: {
+            switch (evord2) {
+            case TermOrder.LEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = e1.revInvGradCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return e1.invLexCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.INVLEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = e1.revInvGradCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return -e1.invLexCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.GRLEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = e1.revInvGradCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return e1.invGradCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.IGRLEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = e1.revInvGradCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return -e1.invGradCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.REVLEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = e1.revInvGradCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return e1.revInvLexCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.REVILEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = e1.revInvGradCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return -e1.revInvLexCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.REVTDEG: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = e1.revInvGradCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return e1.revInvGradCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.REVITDG: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = e1.revInvGradCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return -e1.revInvGradCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            default: {
+                horder = null;
+            }
+            }
+            break;
+        }
+        case TermOrder.REVITDG: {
+            switch (evord2) {
+            case TermOrder.LEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.revInvGradCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return e1.invLexCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.INVLEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.revInvGradCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return -e1.invLexCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.GRLEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.revInvGradCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return e1.invGradCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.IGRLEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.revInvGradCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return -e1.invGradCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.REVLEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.revInvGradCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return e1.revInvLexCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.REVILEX: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.revInvGradCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return -e1.revInvLexCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.REVTDEG: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.revInvGradCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return e1.revInvGradCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            case TermOrder.REVITDG: {
+                horder = new EVComparator() {
+
+
+                    @Override
+                    public int compare(ExpVector e1, ExpVector e2) {
+                        int t = -e1.revInvGradCompareTo(e2, evbeg1, evend1);
+                        if (t != 0) {
+                            return t;
+                        }
+                        return -e1.revInvGradCompareTo(e2, evbeg2, evend2);
+                    }
+                };
+                break;
+            }
+            default: {
+                horder = null;
+            }
+            }
+            break;
+        }
+        //----- end reversed-----------
+        default: {
+            horder = null;
+        }
+        }
+        if (horder == null) {
+            throw new IllegalArgumentException("invalid term order: " + evord + " 2 " + evord2);
+        }
+
+        lorder = new EVComparator() {
+
+
+            @Override
+            public int compare(ExpVector e1, ExpVector e2) {
+                return -horder.compare(e1, e2);
+            }
+        };
+
+        // sugar = new EVsugar();
+        sugar = new EVComparator() {
+
+
+            @Override
+            public int compare(ExpVector e1, ExpVector e2) {
+                return e1.invGradCompareTo(e2);
+            }
+        };
+    }
+
+
+    /*
+     * Constructor for default split order.
+     * @param r max number of exponents to compare.
+     * @param split index.
+    public TermOrder(int r, int split) {
+        this(DEFAULT_EVORD, DEFAULT_EVORD, r, split);
+    }
+     */
+
+
+    /**
+     * Create block term order at split index.
+     * @param s split index.
+     * @return block TermOrder with split index.
+     */
+    public TermOrder blockOrder(int s) {
+        return blockOrder(s, Integer.MAX_VALUE);
+    }
+
+
+    /**
+     * Create block term order at split index.
+     * @param s split index.
+     * @param len length of ExpVectors to compare
+     * @return block TermOrder with split index.
+     */
+    public TermOrder blockOrder(int s, int len) {
+        return new TermOrder(evord, evord, len, s);
+    }
+
+
+    /**
+     * Create block term order at split index.
+     * @param s split index.
+     * @param t second term order.
+     * @return block TermOrder with split index.
+     */
+    public TermOrder blockOrder(int s, TermOrder t) {
+        return blockOrder(s, t, Integer.MAX_VALUE);
+    }
+
+
+    /**
+     * Create block term order at split index.
+     * @param s split index.
+     * @param t second term order.
+     * @param len length of ExpVectors to compare
+     * @return block TermOrder with split index.
+     */
+    public TermOrder blockOrder(int s, TermOrder t, int len) {
+        return new TermOrder(evord, t.evord, len, s);
+    }
+
+
+    /**
+     * Get the first defined order indicator.
+     * @return evord.
+     */
+    public int getEvord() {
+        return evord;
+    }
+
+
+    /**
+     * Get the second defined order indicator.
+     * @return evord2.
+     */
+    public int getEvord2() {
+        return evord2;
+    }
+
+
+    /**
+     * Get the split index.
+     * @return split.
+     */
+    public int getSplit() {
+        return evend1; // = evbeg2
+    }
+
+
+    /**
+     * Get the exponent vector size. <b>Note:</b> can be INTEGER.MAX_VALUE.
+     * @return size.
+     */
+    public int getSize() {
+        return evend2; // can be INTEGER.MAX_VALUE
+    }
+
+
+    /**
+     * Get the weight array.
+     * @return weight.
+     */
+    public long[][] getWeight() {
+        if (weight == null) {
+            return null;
+        }
+        return Arrays.copyOf(weight, weight.length); // > Java-5
+    }
+
+
+    /**
+     * Get the descending order comparator. Sorts the highest terms first.
+     * @return horder.
+     */
+    public EVComparator getDescendComparator() {
+        return horder;
+    }
+
+
+    /**
+     * Get the ascending order comparator. Sorts the lowest terms first.
+     * @return lorder.
+     */
+    public EVComparator getAscendComparator() {
+        return lorder;
+    }
+
+
+    /**
+     * Get the sugar order comparator. Sorts the graded lowest terms first.
+     * @return sugar.
+     */
+    public EVComparator getSugarComparator() {
+        return sugar;
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object B) {
+        if (!(B instanceof TermOrder)) {
+            return false;
+        }
+        TermOrder b = (TermOrder) B;
+        boolean t = evord == b.getEvord() && evord2 == b.evord2 && evbeg1 == b.evbeg1 && evend1 == b.evend1
+                        && evbeg2 == b.evbeg2 && evend2 == b.evend2;
+        if (!t) {
+            return t;
+        }
+        if (!Arrays.deepEquals(weight, b.weight)) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Hash code.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h = evord;
+        h = (h << 3) + evord2;
+        h = (h << 4) + evbeg1;
+        h = (h << 4) + evend1;
+        h = (h << 4) + evbeg2;
+        h = (h << 4) + evend2;
+        if (weight == null) {
+            return h;
+        }
+        h = h * 7 + Arrays.deepHashCode(weight);
+        return h;
+    }
+
+
+    /**
+     * String representation of weight matrix.
+     * @return string representation of weight matrix.
+     */
+    public String weightToString() {
+        StringBuffer erg = new StringBuffer();
+        if (weight != null) {
+            erg.append("(");
+            for (int j = 0; j < weight.length; j++) {
+                if (j > 0) {
+                    erg.append(",");
+                }
+                long[] wj = weight[j];
+                erg.append("(");
+                for (int i = 0; i < wj.length; i++) {
+                    if (i > 0) {
+                        erg.append(",");
+                    }
+                    erg.append(String.valueOf(wj[wj.length - 1 - i]));
+                }
+                erg.append(")");
+            }
+            erg.append(")");
+        }
+        return erg.toString();
+    }
+
+
+    /**
+     * Script representation of weight matrix.
+     * @return script representation of weight matrix.
+     */
+    public String weightToScript() {
+        // cases Python and Ruby
+        StringBuffer erg = new StringBuffer();
+        if (weight != null) {
+            erg.append("[");
+            for (int j = 0; j < weight.length; j++) {
+                if (j > 0) {
+                    erg.append(",");
+                }
+                long[] wj = weight[j];
+                erg.append("[");
+                for (int i = 0; i < wj.length; i++) {
+                    if (i > 0) {
+                        erg.append(",");
+                    }
+                    erg.append(String.valueOf(wj[wj.length - 1 - i]));
+                }
+                erg.append("]");
+            }
+            erg.append("]");
+        }
+        return erg.toString();
+    }
+
+
+    /**
+     * String representation of TermOrder.
+     * @return script representation of TermOrder.
+     */
+    public String toScript() {
+        // cases Python and Ruby
+        if (weight != null) {
+            StringBuffer erg = new StringBuffer();
+            //erg.append("TermOrder( ");
+            erg.append(weightToScript());
+            if (evend1 == evend2) {
+                //erg.append(" )");
+                return erg.toString();
+            }
+            erg.append("[" + evbeg1 + "," + evend1 + "]");
+            erg.append("[" + evbeg2 + "," + evend2 + "]");
+            //erg.append(" )");
+            return erg.toString();
+        }
+        return toScriptPlain();
+    }
+
+
+    /**
+     * String representation of TermOrder.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        if (weight != null) {
+            StringBuffer erg = new StringBuffer();
+            erg.append("W( ");
+            erg.append(weightToString());
+            if (evend1 == evend2) {
+                erg.append(" )");
+                return erg.toString();
+            }
+            erg.append("[" + evbeg1 + "," + evend1 + "]");
+            erg.append("[" + evbeg2 + "," + evend2 + "]");
+            erg.append(" )");
+            return erg.toString();
+        }
+        return toStringPlain();
+    }
+
+
+    /**
+     * String representation of TermOrder without prefix and weight matrix.
+     */
+    public String toStringPlain() {
+        StringBuffer erg = new StringBuffer();
+        if (weight != null) {
+            return erg.toString();
+        }
+        erg.append(toScriptOrder(evord)); // JAS only
+        if (evord2 <= 0) {
+            return erg.toString();
+        }
+        erg.append("[" + evbeg1 + "," + evend1 + "]");
+        erg.append(toScriptOrder(evord2)); // JAS only
+        erg.append("[" + evbeg2 + "," + evend2 + "]");
+        return erg.toString();
+    }
+
+
+    /**
+     * Script representation of TermOrder without prefix and weight matrix.
+     */
+    public String toScriptPlain() {
+        StringBuffer erg = new StringBuffer();
+        if (weight != null) {
+            return toScript();
+        }
+        erg.append("Order");
+        switch (Scripting.getLang()) {
+        case Ruby:
+            erg.append("::");
+            break;
+        case Python:
+        default:
+            erg.append(".");
+        }
+        erg.append(toScriptOrder(evord));
+        if (evord2 <= 0) {
+            return erg.toString();
+        }
+        if (evord == evord2) {
+            erg.append(".blockOrder(" + evend1 + ")");
+            return erg.toString();
+        }
+        erg.append(".blockOrder(");
+        erg.append(evend1 + ",");
+        erg.append("Order");
+        switch (Scripting.getLang()) {
+        case Ruby:
+            erg.append("::");
+            break;
+        case Python:
+        default:
+            erg.append(".");
+        }
+        erg.append(toScriptOrder(evord2));
+        erg.append(")");
+        return erg.toString();
+    }
+
+
+    /**
+     * Script and String representation of TermOrder name.
+     */
+    public String toScriptOrder(int ev) {
+        switch (Scripting.getCAS()) {
+        case Math:
+            switch (ev) {
+            case LEX:
+                return "NegativeReverseLexicographic";
+            case INVLEX:
+                return "ReverseLexicographic";
+            case GRLEX:
+                return "NegativeDegreeReverseLexicographic";
+            case ITDEGLEX: //IGRLEX:
+                return "DegreeReverseLexicographic";
+            case REVLEX:
+                return "NegativeLexicographic";
+            case REVILEX:
+                return "Lexicographic";
+            case REVITDEG: //REVTDEG:
+                return "NegativeDegreeLexicographic";
+            case REVITDG:
+                return "DegreeLexicographic";
+            default:
+                return "invalid(" + ev + ")";
+            }
+        case Sage:
+            switch (ev) {
+            case LEX:
+                return "negrevlex";
+            case INVLEX:
+                return "invlex";
+            case GRLEX:
+                return "negdegrevlex";
+            case ITDEGLEX: //IGRLEX:
+                return "degrevlex";
+            case REVLEX:
+                return "neglex";
+            case REVILEX:
+                return "lex";
+            case REVITDEG: //REVTDEG:
+                return "negdeglex";
+            case REVITDG:
+                return "deglex";
+            default:
+                return "invalid(" + ev + ")";
+            }
+        case Singular:
+            switch (ev) {
+            //case LEX: // missing
+            //return "negrevlex";
+            case INVLEX:
+                return "rp";
+            case GRLEX:
+                return "ds";
+            case ITDEGLEX: //IGRLEX:
+                return "dp";
+            case REVLEX:
+                return "ls";
+            case REVILEX:
+                return "lp";
+            case REVITDEG: //REVTDEG:
+                return "Ds";
+            case REVITDG:
+                return "Dp";
+            default:
+                return "invalid(" + ev + ")";
+            }
+        case JAS:
+        default:
+            switch (ev) {
+            case LEX:
+                return "LEX";
+            case INVLEX:
+                return "INVLEX";
+            case GRLEX:
+                return "GRLEX";
+            case IGRLEX:
+                return "IGRLEX";
+            case REVLEX:
+                return "REVLEX";
+            case REVILEX:
+                return "REVILEX";
+            case REVTDEG:
+                return "REVTDEG";
+            case REVITDG:
+                return "REVITDG";
+            case ITDEGLEX:
+                return "ITDEGLEX";
+            case REVITDEG:
+                return "REVITDEG";
+            default:
+                return "invalid(" + ev + ")";
+            }
+        }
+        //return "invalid(" + ev + ")";
+    }
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend TermOrder by k
+     * elements. <b>Note:</b> Use POT module term order.
+     * @param r current number of variables.
+     * @param k number of variables to extend.
+     * @return extended TermOrder.
+     */
+    public TermOrder extend(int r, int k) {
+        return extend(r, k, false);
+    }
+
+
+    /**
+     * Extend variables. Used e.g. in module embedding. Extend TermOrder by k
+     * elements. <b>Note:</b> Now TOP and POT orders are distinguished.
+     * @param r current number of variables.
+     * @param k number of variables to extend.
+     * @param top true for TOP term order, false for POT term order.
+     * @return extended TermOrder.
+     */
+    public TermOrder extend(int r, int k, boolean top) {
+        if (weight != null) {
+            long[][] w = new long[weight.length][];
+            for (int i = 0; i < weight.length; i++) {
+                long[] wi = weight[i];
+                long max = 0;
+                // long min = Long.MAX_VALUE;
+                for (int j = 0; j < wi.length; j++) {
+                    if (wi[j] > max)
+                        max = wi[j];
+                    //if ( wi[j] < min ) min = wi[j];
+                }
+                max++;
+                long[] wj = new long[wi.length + k];
+                for (int j = 0; j < k; j++) { //i#k
+                    wj[j] = max;
+                }
+                System.arraycopy(wi, 0, wj, k, wi.length);
+                w[i] = wj;
+            }
+            return new TermOrder(w);
+        }
+        if (evord2 != 0) {
+            logger.debug("warn: TermOrder is already extended");
+            if (debug) {
+                throw new IllegalArgumentException("TermOrder is already extended: " + this);
+            }
+            return new TermOrder(evord, evord2, r + k, evend1 + k, top);
+        }
+        //System.out.println("evord         = " + evord);
+        //System.out.println("DEFAULT_EVORD = " + DEFAULT_EVORD);
+        //System.out.println("tord          = " + this);
+        return new TermOrder(DEFAULT_EVORD/*evord*/, evord, r + k, k, top);
+        // don't change to evord, cause REVITDG || set evord1 per parameter?
+    }
+
+
+    /**
+     * Extend lower variables. Extend TermOrder by k elements. <b>Note:</b> Use
+     * POT module term order.
+     * @param r current number of variables.
+     * @param k number of variables to extend.
+     * @return extended TermOrder.
+     */
+    public TermOrder extendLower(int r, int k) {
+        return extendLower(r, k, false);
+    }
+
+
+    /**
+     * Extend lower variables. Extend TermOrder by k elements. <b>Note:</b> Now
+     * TOP and POT orders are distinguished.
+     * @param r current number of variables.
+     * @param k number of variables to extend.
+     * @param top true for TOP term order, false for POT term order.
+     * @return extended TermOrder.
+     */
+    public TermOrder extendLower(int r, int k, boolean top) {
+        if (weight != null) {
+            long[][] w = new long[weight.length][];
+            for (int i = 0; i < weight.length; i++) {
+                long[] wi = weight[i];
+                //long max = 0;
+                long min = Long.MAX_VALUE;
+                for (int j = 0; j < wi.length; j++) {
+                    //if ( wi[j] > max ) max = wi[j];
+                    if (wi[j] < min)
+                        min = wi[j];
+                }
+                //max++;
+                long[] wj = new long[wi.length + k];
+                for (int j = 0; j < k; j++) { //i#k
+                    wj[wi.length + j] = min;
+                }
+                System.arraycopy(wi, 0, wj, 0, wi.length);
+                w[i] = wj;
+            }
+            return new TermOrder(w);
+        }
+        if (evord2 != 0) {
+            if (debug) {
+                logger.warn("TermOrder is already extended");
+            }
+            return new TermOrder(evord, evord2, r + k, evend1 + k, top);
+        }
+        //System.out.println("evord         = " + evord);
+        //System.out.println("DEFAULT_EVORD = " + DEFAULT_EVORD);
+        //System.out.println("tord          = " + this);
+        return new TermOrder(evord, DEFAULT_EVORD, r + k, r, top);
+        // set evord2 per parameter?
+    }
+
+
+    /**
+     * Contract variables. Used e.g. in module embedding. Contract TermOrder to
+     * non split status.
+     * @param k position of first element to be copied.
+     * @param len new length.
+     * @return contracted TermOrder.
+     */
+    public TermOrder contract(int k, int len) {
+        if (weight != null) {
+            long[][] w = new long[weight.length][];
+            for (int i = 0; i < weight.length; i++) {
+                long[] wi = weight[i];
+                long[] wj = new long[len];
+                System.arraycopy(wi, k, wj, 0, len);
+                w[i] = wj;
+            }
+            return new TermOrder(w);
+        }
+        if (evord2 == 0) {
+            if (debug) {
+                logger.warn("TermOrder is already contracted");
+            }
+            return new TermOrder(evord);
+        }
+        if (evend1 > k) { // < IntMax since evord2 != 0
+            int el = evend1 - k;
+            while (el > len) {
+                el -= len;
+            }
+            if (el == 0L) {
+                return new TermOrder(evord);
+            }
+            if (el == len) {
+                return new TermOrder(evord);
+            }
+            return new TermOrder(evord, evord2, len, el);
+        }
+        return new TermOrder(evord2);
+    }
+
+
+    /**
+     * Reverse variables. Used e.g. in opposite rings.
+     * @return TermOrder for reversed variables.
+     */
+    public TermOrder reverse() {
+        return reverse(false);
+    }
+
+
+    /**
+     * Reverse variables. Used e.g. in opposite rings.
+     * @param partial true for partially reversed term orders.
+     * @return TermOrder for reversed variables.
+     */
+    public TermOrder reverse(boolean partial) {
+        TermOrder t;
+        if (weight != null) {
+            if (partial) {
+                logger.error("partial reversed weight order not implemented");
+            }
+            long[][] w = new long[weight.length][];
+            for (int i = 0; i < weight.length; i++) {
+                long[] wi = weight[i];
+                long[] wj = new long[wi.length];
+                for (int j = 0; j < wj.length; j++) {
+                    wj[j] = wi[wj.length - 1 - j];
+                }
+                w[i] = wj;
+            }
+            t = new TermOrder(w);
+            logger.info("reverse = " + t + ", from = " + this);
+            return t;
+        }
+        if (evord2 == 0) {
+            t = new TermOrder(revert(evord));
+            return t;
+        }
+        if (partial) {
+            t = new TermOrder(revert(evord), revert(evord2), evend2, evend1);
+        } else {
+            t = new TermOrder(revert(evord2), revert(evord), evend2, evend2 - evbeg2);
+        }
+        logger.info("reverse = " + t + ", from = " + this);
+        return t;
+    }
+
+
+    /**
+     * Revert exponent order. Used e.g. in opposite rings.
+     * @param evord exponent order to be reverted.
+     * @return reverted exponent order.
+     */
+    public static int revert(int evord) {
+        int i = evord;
+        switch (evord) {
+        case LEX:
+            i = REVLEX;
+            break;
+        case INVLEX:
+            i = REVILEX;
+            break;
+        case GRLEX:
+            i = REVTDEG;
+            break;
+        case IGRLEX:
+            i = REVITDG;
+            break;
+        case REVLEX:
+            i = LEX;
+            break;
+        case REVILEX:
+            i = INVLEX;
+            break;
+        case REVTDEG:
+            i = GRLEX;
+            break;
+        case REVITDG:
+            i = IGRLEX;
+            break;
+        default: // REVITDEG, ITDEGLEX
+            logger.error("can not revert " + evord);
+            break;
+        }
+        return i;
+    }
+
+
+    /**
+     * Permutation of a long array.
+     * @param a array of long.
+     * @param P permutation.
+     * @return P(a).
+     */
+    public static long[] longArrayPermutation(List<Integer> P, long[] a) {
+        if (a == null || a.length <= 1) {
+            return a;
+        }
+        long[] b = new long[a.length];
+        int j = 0;
+        for (Integer i : P) {
+            b[j] = a[i];
+            j++;
+        }
+        return b;
+    }
+
+
+    /**
+     * Permutation of the termorder.
+     * @param P permutation.
+     * @return P(a).
+     */
+    public TermOrder permutation(List<Integer> P) {
+        TermOrder tord = this;
+        if (getEvord2() != 0) {
+            //throw new IllegalArgumentException("split term orders not permutable");
+            tord = new TermOrder(getEvord2());
+            logger.warn("split term order '" + this + "' not permutable, resetting to most base term order "
+                            + tord);
+        }
+        long[][] weight = getWeight();
+        if (weight != null) {
+            long[][] w = new long[weight.length][];
+            for (int i = 0; i < weight.length; i++) {
+                w[i] = longArrayPermutation(P, weight[i]);
+            }
+            tord = new TermOrder(w);
+        }
+        return tord;
+    }
+
+
+    /**
+     * Weight TermOrder with reversed weight vectors.
+     * @param w weight matrix
+     * @return TermOrder with reversed weight vectors
+     */
+    public static TermOrder reverseWeight(long[][] w) {
+        if (w == null) {
+            logger.warn("null weight matrix ignored");
+            return new TermOrder();
+        }
+        long[][] wr = new long[w.length][];
+        for (int j = 0; j < w.length; j++) {
+            long[] wj = w[j];
+            //System.out.println("reverseWeight: " + wj);
+            long[] wrj = new long[wj.length];
+            for (int i = 0; i < wj.length; i++) {
+                wrj[i] = wj[wj.length - 1 - i];
+            }
+            wr[j] = wrj;
+        }
+        return new TermOrder(wr);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/TermOrderByName.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/TermOrderByName.java
@@ -1,0 +1,555 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * Term order names for ordered polynomials. Defines names for the most used
+ * term orders: graded and lexicographical orders. For the definitions see for
+ * example the articles <a href="http://doi.acm.org/10.1145/43882.43887">Kredel,
+ * Admissible term orderings used in computer algebra systems</a> and
+ *  <a href="http://doi.acm.org/10.1145/70936.70941">Sit, Some comments on
+ * term-ordering in Gr&ouml;bner basis computations</a>. Not all algorithms may
+ * work with all term orders since not all are well-founded, so watch your step.
+ * 
+ * <b>Note:</b> Variables in printed JAS polynomial <b>(low, ..., medium, ...,
+ * high)</b> Variables in other CAS polynomial <b>(high, ..., medium, ...,
+ * low)</b> with <b>low</b> &lt; <b>medium</b> &lt; <b>high</b>. Example: for
+ * variables x<sub>1</sub>, ..., x<sub>r</sub> it is assumed in JAS that
+ * x<sub>1</sub> &lt; ... &lt; x<sub>r</sub> in other CAS it means x<sub>1</sub>
+ * &gt; ... &gt; x<sub>r</sub>.
+ * 
+ * @author Heinz Kredel
+ */
+
+public class TermOrderByName {
+
+
+    private static final Logger logger = LogManager.getLogger(TermOrderByName.class);
+
+
+    /**
+     * TermOrder named LEX.
+     */
+    public static final TermOrder LEX = new TermOrder(TermOrder.LEX);
+
+
+    /**
+     * TermOrder named INVLEX.
+     */
+    public static final TermOrder INVLEX = new TermOrder(TermOrder.INVLEX);
+
+
+    /**
+     * TermOrder named GRLEX.
+     */
+    public static final TermOrder GRLEX = new TermOrder(TermOrder.GRLEX);
+
+
+    /**
+     * TermOrder named IGRLEX.
+     */
+    public static final TermOrder IGRLEX = new TermOrder(TermOrder.IGRLEX);
+
+
+    /**
+     * TermOrder named REVLEX.
+     */
+    public static final TermOrder REVLEX = new TermOrder(TermOrder.REVLEX);
+
+
+    /**
+     * TermOrder named REVILEX.
+     */
+    public static final TermOrder REVILEX = new TermOrder(TermOrder.REVILEX);
+
+
+    /**
+     * TermOrder named REVTDEG.
+     */
+    public static final TermOrder REVTDEG = new TermOrder(TermOrder.REVTDEG);
+
+
+    /**
+     * TermOrder named REVITDG.
+     */
+    public static final TermOrder REVITDG = new TermOrder(TermOrder.REVITDG);
+
+
+    /**
+     * TermOrder named ITDEGLEX.
+     */
+    public static final TermOrder ITDEGLEX = new TermOrder(TermOrder.ITDEGLEX);
+
+
+    /**
+     * TermOrder named REVITDEG.
+     */
+    public static final TermOrder REVITDEG = new TermOrder(TermOrder.REVITDEG);
+
+
+    /**
+     * Default TermOrder.
+     */
+    public final static TermOrder DEFAULT = new TermOrder(TermOrder.DEFAULT_EVORD);
+
+
+    // Math like term orders:
+
+    /**
+     * TermOrder name Lexicographic of Math like CAS.
+     */
+    public final static TermOrder Lexicographic = REVILEX;
+
+
+    /**
+     * TermOrder name NegativeLexicographic of Math like CAS.
+     */
+    public final static TermOrder NegativeLexicographic = REVLEX;
+
+
+    /**
+     * TermOrder name DegreeLexicographic of Math like CAS.
+     */
+    public final static TermOrder DegreeLexicographic = REVITDG;
+
+
+    /**
+     * TermOrder name NegativeDegreeLexicographic of Math like CAS.
+     */
+    public final static TermOrder NegativeDegreeLexicographic = REVITDEG; // was REVTDEG;
+
+
+    /**
+     * TermOrder name ReverseLexicographic of Math like CAS.
+     */
+    public final static TermOrder ReverseLexicographic = INVLEX;
+
+
+    /**
+     * TermOrder name DegreeReverseLexicographic of Math like CAS.
+     */
+    public final static TermOrder DegreeReverseLexicographic = ITDEGLEX; // was IGRLEX;
+
+
+    /**
+     * TermOrder name NegativeReverseLexicographic of Math like CAS.
+     */
+    public final static TermOrder NegativeReverseLexicographic = LEX;
+
+
+    /**
+     * TermOrder name NegativeDegreeReverseLexicographic of Math like CAS.
+     */
+    public final static TermOrder NegativeDegreeReverseLexicographic = GRLEX;
+
+
+    // Sage term orders:
+
+    /**
+     * TermOrder name lex of Sage.
+     */
+    public final static TermOrder lex = Lexicographic; // = REVILEX; 
+
+
+    /**
+     * TermOrder name degrevlex of Sage.
+     */
+    public final static TermOrder degrevlex = DegreeReverseLexicographic; // = IGRLEX; 
+
+
+    /**
+     * TermOrder name deglex of Sage.
+     */
+    public final static TermOrder deglex = DegreeLexicographic; // = REVITDG; 
+
+
+    /**
+     * TermOrder name invlex of Sage.
+     */
+    public final static TermOrder invlex = INVLEX; //ReverseLexicographic  
+
+
+    /**
+     * TermOrder name neglex of Sage.
+     */
+    public final static TermOrder neglex = NegativeLexicographic; // = REVLEX; 
+
+
+    /**
+     * TermOrder name negdegrevlex of Sage.
+     */
+    public final static TermOrder negdegrevlex = NegativeDegreeReverseLexicographic; // = GRLEX;
+
+
+    /**
+     * TermOrder name negdeglex of Sage.
+     */
+    public final static TermOrder negdeglex = NegativeDegreeLexicographic; // = REVTDEG; 
+
+
+    /**
+     * TermOrder name negrevlex of Sage.
+     */
+    public final static TermOrder negrevlex = NegativeReverseLexicographic; // = LEX; 
+
+
+    // Singular term orders:
+
+    /**
+     * TermOrder name lp of Singular.
+     */
+    public final static TermOrder lp = lex; // = REVILEX; 
+
+
+    /**
+     * TermOrder name dp of Singular.
+     */
+    public final static TermOrder dp = degrevlex; // = IGRLEX; 
+
+
+    /**
+     * TermOrder name Dp of Singular.
+     */
+    public final static TermOrder Dp = deglex; // = REVITDG; 
+
+
+    /**
+     * TermOrder name rp of Singular.
+     */
+    public final static TermOrder rp = invlex; // = INVLEX;  
+
+
+    /**
+     * TermOrder name ls of Singular.
+     */
+    public final static TermOrder ls = neglex; // = REVLEX; 
+
+
+    /**
+     * TermOrder name ds of Singular.
+     */
+    public final static TermOrder ds = negdegrevlex; // = GRLEX;
+
+
+    /**
+     * TermOrder name Ds of Singular.
+     */
+    public final static TermOrder Ds = negdeglex; // = REVTDEG; 
+
+
+    // missing: public final static TermOrder negrevlex; // = LEX; 
+
+
+    /**
+     * Construct elimination block TermOrder. Variables {x<sub>1</sub>, ..., x
+     * <sub>s-1</sub>} &lt; {x<sub>s</sub>, ..., x<sub>r</sub>}
+     * 
+     * @param t1 term order for both blocks
+     * @param s split index
+     * @return constructed term order
+     */
+    public final static TermOrder blockOrder(TermOrder t1, int s) {
+        return t1.blockOrder(s);
+    }
+
+
+    /**
+     * Construct elimination block TermOrder. Variables {x<sub>1</sub>, ..., x
+     * <sub>s-1</sub>} &lt; {x<sub>s</sub>, ..., x<sub>r</sub>}
+     * 
+     * @param t1 term order for both blocks
+     * @param e exponent vector of desired length, r = length(e)
+     * @param s split index
+     * @return constructed term order
+     */
+    public final static TermOrder blockOrder(TermOrder t1, ExpVector e, int s) {
+        return t1.blockOrder(s, e.length());
+    }
+
+
+    /**
+     * Construct elimination block TermOrder. Variables {x<sub>1</sub>, ..., x
+     * <sub>s-1</sub>} &lt; {x<sub>s</sub>, ..., x<sub>r</sub>}
+     * 
+     * @param t1 term order for lower valiables
+     * @param t2 term order for higher variables
+     * @param s split index
+     * @return constructed term order
+     */
+    public final static TermOrder blockOrder(TermOrder t1, TermOrder t2, int s) {
+        return new TermOrder(t1.getEvord(), t2.getEvord(), Integer.MAX_VALUE, s);
+    }
+
+
+    /**
+     * Construct elimination block TermOrder. Variables {x<sub>1</sub>, ..., x
+     * <sub>s-1</sub>} &lt; {x<sub>s</sub>, ..., x<sub>r</sub>}
+     * 
+     * @param t1 term order for lower valiables
+     * @param t2 term order for higher variables
+     * @param e exponent vector of desired length, r = length(e)
+     * @param s split index
+     * @return constructed term order
+     */
+    public final static TermOrder blockOrder(TermOrder t1, TermOrder t2, ExpVector e, int s) {
+        return new TermOrder(t1.getEvord(), t2.getEvord(), e.length(), s);
+    }
+
+
+    /**
+     * Construct weight TermOrder.
+     * 
+     * @param v weight vector
+     * @return constructed term order
+     */
+    public final static TermOrder weightOrder(long[] v) {
+        return TermOrder.reverseWeight(new long[][] { v });
+    }
+
+
+    /**
+     * Construct weight TermOrder.
+     * 
+     * @param w weight matrix
+     * @return constructed term order
+     */
+    public final static TermOrder weightOrder(long[][] w) {
+        return TermOrder.reverseWeight(w);
+    }
+
+
+    /**
+     * Construct weight TermOrder.
+     * 
+     * @param wa weight matrix as List
+     * @return constructed term order
+     */
+    public final static TermOrder weightOrder(List<List<Long>> wa) {
+        int n = wa.size();
+        long[][] w = new long[n][];
+        for (int i = 0; i < n; i++) {
+            List<Long> row = wa.get(i);
+            int m = row.size();
+            long[] wi = new long[m];
+            for (int j = 0; j < m; j++) {
+                wi[j] = row.get(j);
+            }
+            w[i] = wi;
+        }
+        //return TermOrder.reverseWeight(w);
+        return weightOrder(w);
+    }
+
+
+    /**
+     * Construct weight for term order.
+     * @param to term order
+     * @param n exponent vector size
+     * @return weight matrix
+     */
+    public final static long[][] weightForOrder(TermOrder to, int n) {
+        if (to.isSplit()) {
+            return weightForSplitOrder(to.getEvord(), to.getEvord2(), n, to.getSplit());
+        }
+        return weightForOrder(to.getEvord(), n);
+    }
+
+
+    /**
+     * Construct weight for term order.
+     * @param to term order indicator
+     * @param n exponent vector size
+     * @return weight matrix
+     */
+    /*public*/ final static long[][] weightForOrder(int to, int n) {
+        int k = 0;
+        switch (to) {
+        case TermOrder.IGRLEX:
+            k = n + 1;
+            break;
+        case TermOrder.REVILEX:
+            // no break
+        case TermOrder.INVLEX:
+            k = n;
+            break;
+        default:
+        }
+        logger.info("to = " + to + ", k = " + k);
+        long[][] w = new long[k][];
+        long[] wi;
+        switch (to) {
+        case TermOrder.INVLEX:
+            for (int i = 0; i < n; i++) {
+                w[i] = new long[n];
+                wi = w[i];
+                for (int j = 0; j < n; j++) {
+                    if (i == j) { //n - 1 -
+                        wi[j] = 1L;
+                    } else {
+                        wi[j] = 0L;
+                    }
+                }
+            }
+            break;
+        case TermOrder.IGRLEX:
+            w[0] = new long[n];
+            wi = w[0];
+            for (int j = 0; j < n; j++) {
+                wi[j] = 1L;
+            }
+            for (int i = 0; i < n; i++) {
+                w[i + 1] = new long[n];
+                wi = w[i + 1];
+                for (int j = 0; j < n; j++) {
+                    if (i == j) { //n - 1 -
+                        wi[j] = 1L;
+                    } else {
+                        wi[j] = 0L;
+                    }
+                }
+            }
+            break;
+        case TermOrder.REVILEX:
+            for (int i = 0; i < n; i++) {
+                w[i] = new long[n];
+                wi = w[i];
+                for (int j = 0; j < n; j++) {
+                    if ((n - 1 - i) == j) {
+                        wi[j] = 1L;
+                    } else {
+                        wi[j] = 0L;
+                    }
+                }
+            }
+            break;
+        default:
+            throw new UnsupportedOperationException("case " + to + " not implemented for weightForOrder");
+        }
+        return w;
+    }
+
+
+    /**
+     * Construct weight for split term order.
+     * @param to first term order indicator
+     * @param to2 second term order indicator
+     * @param n exponent vector size
+     * @param s slpit index
+     * @return weight matrix
+     */
+    /*public*/ final static long[][] weightForSplitOrder(int to, int to2, int n, int s) {
+        int k = 0;
+        switch (to) {
+        case TermOrder.IGRLEX:
+            k += 1;
+            break;
+        case TermOrder.INVLEX:
+            k += s;
+            break;
+        default:
+        }
+        //System.out.println("to = " + to + ", k = " + k);
+        switch (to2) {
+        case TermOrder.IGRLEX:
+            k += 1;
+            break;
+        case TermOrder.INVLEX:
+            k += n - s;
+            break;
+        default:
+        }
+        logger.info("to = " + to + ", k = " + k);
+        //System.out.println("to = " + to + ", k = " + k);
+        long[][] w = new long[k + n][];
+        boolean done = true;
+        switch (to) {
+        case TermOrder.IGRLEX:
+            w[0] = new long[n];
+            long[] wi = w[0];
+            int j;
+            for (j = 0; j < s; j++) {
+                wi[j] = 1L;
+            }
+            for (; j < n; j++) {
+                wi[j] = 0L;
+            }
+            break;
+        case TermOrder.INVLEX:
+            for (int i = 0; i < s; i++) {
+                w[i] = new long[n];
+                wi = w[i]; // long[]
+                for (j = 0; j < n; j++) {
+                    if ((n - 1 - i) == j) {
+                        wi[j] = 1L;
+                    } else {
+                        wi[j] = 0L;
+                    }
+                }
+            }
+            break;
+        default:
+            done = false;
+            // compiler/run time error:
+            //throw new UnsupportedOperationException("case " + to + "/" + to2 + " not implemented for weightForOrder");
+            break;
+        }
+        switch (to2) {
+        case TermOrder.IGRLEX:
+            w[k - 1] = new long[n];
+            long[] wi = w[k - 1];
+            int j;
+            for (j = 0; j < s; j++) {
+                wi[j] = 0L;
+            }
+            for (; j < n; j++) {
+                wi[j] = 1L;
+            }
+            break;
+        case TermOrder.INVLEX:
+            for (int i = 0; i < s; i++) {
+                w[s + i] = new long[n];
+                wi = w[s + i]; // long[]
+                for (j = 0; j < n; j++) {
+                    if ((n - 1 - i) == (s + j)) {
+                        wi[j] = 1L;
+                    } else {
+                        wi[j] = 0L;
+                    }
+                }
+            }
+            break;
+        default:
+            done = false;
+            break;
+        }
+        if (!done) {
+            //System.out.println("weightForSplitOrder case " + to + "/" + to2);
+            throw new UnsupportedOperationException(
+                            "case " + to + "/" + to2 + " not implemented for weightForOrder");
+        }
+        //System.out.println("weight: " + Arrays.toString(w));
+        // break ties by inv lex term order
+        for (int i = 0; i < n; i++) {
+            w[k + i] = new long[n];
+            long[] wi = w[k + i];
+            for (int j = 0; j < n; j++) {
+                if ((i) == j) { //n - 1 - 
+                    wi[j] = 1L;
+                } else {
+                    wi[j] = 0L;
+                }
+            }
+        }
+        return w;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/TermOrderOptimization.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/TermOrderOptimization.java
@@ -1,0 +1,605 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.arith.BigInteger;
+import edu.jas.structure.RingElem;
+import edu.jas.vector.GenVector;
+import edu.jas.vector.GenVectorModul;
+
+
+/**
+ * Term order optimization. See mas10/maspoly/DIPTOO.m{di}.
+ * @author Heinz Kredel
+ */
+
+public class TermOrderOptimization {
+
+
+    private static final Logger logger = LogManager.getLogger(TermOrderOptimization.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Degree matrix.
+     * @param A polynomial to be considered.
+     * @return degree matrix.
+     */
+    public static <C extends RingElem<C>> List<GenPolynomial<BigInteger>> degreeMatrix(GenPolynomial<C> A) {
+
+        List<GenPolynomial<BigInteger>> dem = null;
+        if (A == null) {
+            return dem;
+        }
+
+        BigInteger cfac = new BigInteger();
+        GenPolynomialRing<BigInteger> ufac = new GenPolynomialRing<BigInteger>(cfac, new String[] {"dm"} );
+
+        int nvar = A.numberOfVariables();
+        dem = new ArrayList<GenPolynomial<BigInteger>>(nvar);
+
+        for (int i = 0; i < nvar; i++) {
+            dem.add(ufac.getZERO());
+        }
+        if (A.isZERO()) {
+            return dem;
+        }
+
+        for (ExpVector e : A.getMap().keySet()) {
+            dem = expVectorAdd(dem, e);
+        }
+        return dem;
+    }
+
+
+    /**
+     * Degree matrix exponent vector add.
+     * @param dm degree matrix.
+     * @param e exponent vector.
+     * @return degree matrix + e.
+     */
+    public static List<GenPolynomial<BigInteger>> expVectorAdd(List<GenPolynomial<BigInteger>> dm, ExpVector e) {
+        for (int i = 0; i < dm.size() && i < e.length(); i++) {
+            GenPolynomial<BigInteger> p = dm.get(i);
+            long u = e.getVal(i);
+            ExpVector f = ExpVector.create(1, 0, u);
+            p = p.sum(p.ring.getONECoefficient(), f);
+            dm.set(i, p);
+        }
+        return dm;
+    }
+
+
+    /**
+     * Degree matrix of coefficient polynomials.
+     * @param A polynomial to be considered.
+     * @return degree matrix for the coeficients.
+     */
+    public static <C extends RingElem<C>> List<GenPolynomial<BigInteger>> degreeMatrixOfCoefficients(
+                    GenPolynomial<GenPolynomial<C>> A) {
+        if (A == null) {
+            throw new IllegalArgumentException("polynomial must not be null");
+        }
+        return degreeMatrix(A.getMap().values());
+    }
+
+
+    /**
+     * Degree matrix.
+     * @param L list of polynomial to be considered.
+     * @return degree matrix.
+     */
+    public static <C extends RingElem<C>> List<GenPolynomial<BigInteger>> degreeMatrix(
+                    Collection<GenPolynomial<C>> L) {
+        if (L == null) {
+            throw new IllegalArgumentException("list must be non null");
+        }
+        GenVectorModul<GenPolynomial<BigInteger>> vmblas = null;
+        GenVector<GenPolynomial<BigInteger>> vdem = null;
+        for (GenPolynomial<C> p : L) {
+            List<GenPolynomial<BigInteger>> dm = degreeMatrix(p);
+            if (vdem == null) {
+                vmblas = new GenVectorModul<GenPolynomial<BigInteger>>(dm.get(0).ring, dm.size());
+                vdem = new GenVector<GenPolynomial<BigInteger>>(vmblas, dm);
+            } else {
+                vdem = vdem.sum(new GenVector<GenPolynomial<BigInteger>>(vmblas, dm));
+            }
+        }
+        return vdem.val;
+    }
+
+
+    /**
+     * Degree matrix of coefficient polynomials.
+     * @param L list of polynomial to be considered.
+     * @return degree matrix for the coeficients.
+     */
+    public static <C extends RingElem<C>> List<GenPolynomial<BigInteger>> degreeMatrixOfCoefficients(
+                    Collection<GenPolynomial<GenPolynomial<C>>> L) {
+        if (L == null) {
+            throw new IllegalArgumentException("list must not be null");
+        }
+        GenVectorModul<GenPolynomial<BigInteger>> vmblas = null;
+        GenVector<GenPolynomial<BigInteger>> vdem = null;
+        for (GenPolynomial<GenPolynomial<C>> p : L) {
+            List<GenPolynomial<BigInteger>> dm = degreeMatrixOfCoefficients(p);
+            if (vdem == null) {
+                vmblas = new GenVectorModul<GenPolynomial<BigInteger>>(dm.get(0).ring, dm.size());
+                vdem = new GenVector<GenPolynomial<BigInteger>>(vmblas, dm);
+            } else {
+                vdem = vdem.sum(new GenVector<GenPolynomial<BigInteger>>(vmblas, dm));
+            }
+        }
+        return vdem.val;
+    }
+
+
+    /**
+     * Optimal permutation for the Degree matrix.
+     * @param D degree matrix.
+     * @return optimal permutation for D.
+     */
+    public static List<Integer> optimalPermutation(List<GenPolynomial<BigInteger>> D) {
+        if (D == null) {
+            throw new IllegalArgumentException("list must be non null");
+        }
+        List<Integer> P = new ArrayList<Integer>(D.size());
+        if (D.size() == 0) {
+            return P;
+        }
+        if (D.size() == 1) {
+            P.add(0);
+            return P;
+        }
+        SortedMap<GenPolynomial<BigInteger>, List<Integer>> map = new TreeMap<GenPolynomial<BigInteger>, List<Integer>>();
+        int i = 0;
+        for (GenPolynomial<BigInteger> p : D) {
+            List<Integer> il = map.get(p);
+            if (il == null) {
+                il = new ArrayList<Integer>(3);
+            }
+            il.add(i);
+            map.put(p, il);
+            i++;
+        }
+        List<List<Integer>> V = new ArrayList<List<Integer>>(map.values());
+        //System.out.println("V = " + V);
+        if (logger.isDebugEnabled()) {
+            logger.info("V = " + V);
+        }
+        //for ( int j = V.size()-1; j >= 0; j-- ) {
+        for (int j = 0; j < V.size(); j++) {
+            List<Integer> v = V.get(j);
+            for (Integer k : v) {
+                P.add(k);
+            }
+        }
+        return P;
+    }
+
+
+    /**
+     * Inverse of a permutation.
+     * @param P permutation.
+     * @return S with S*P = id.
+     */
+    public static List<Integer> inversePermutation(List<Integer> P) {
+        if (P == null || P.size() <= 1) {
+            return P;
+        }
+        List<Integer> ip = new ArrayList<Integer>(P); // ensure size and content
+        for (int i = 0; i < P.size(); i++) {
+            ip.set(P.get(i), i); // inverse
+        }
+        return ip;
+    }
+
+
+    /**
+     * Test for identity permutation.
+     * @param P permutation.
+     * @return true , if P = id, else false.
+     */
+    public static boolean isIdentityPermutation(List<Integer> P) {
+        if (P == null || P.size() <= 1) {
+            return true;
+        }
+        for (int i = 0; i < P.size(); i++) {
+            if (P.get(i).intValue() != i) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Multiplication permutations.
+     * @param P permutation.
+     * @param S permutation.
+     * @return P*S.
+     */
+    public static List<Integer> multiplyPermutation(List<Integer> P, List<Integer> S) {
+        if (P == null || S == null) {
+            return null;
+        }
+        if (P.size() != S.size()) {
+            throw new IllegalArgumentException("#P != #S: P =" + P + ", S = " + S);
+        }
+        List<Integer> ip = new ArrayList<Integer>(P); // ensure size and content
+        for (int i = 0; i < P.size(); i++) {
+            ip.set(i, S.get(P.get(i)));
+        }
+        return ip;
+    }
+
+
+    /**
+     * Permutation of a list.
+     * @param L list.
+     * @param P permutation.
+     * @return P(L).
+     */
+    @SuppressWarnings("cast")
+    public static <T> List<T> listPermutation(List<Integer> P, List<T> L) {
+        if (L == null || L.size() <= 1) {
+            return L;
+        }
+        List<T> pl = new ArrayList<T>(L.size());
+        for (Integer i : P) {
+            pl.add(L.get((int) i));
+        }
+        return pl;
+    }
+
+
+    /**
+     * Permutation of an array. Compiles, but does not work, requires JDK 1.6 to
+     * work.
+     * @param a array.
+     * @param P permutation.
+     * @return P(a).
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    public static <T> T[] arrayPermutation(List<Integer> P, T[] a) {
+        if (a == null || a.length <= 1) {
+            return a;
+        }
+        //T[] b = (T[]) new Object[a.length]; // jdk 1.5 
+        T[] b = Arrays.<T> copyOf( a, a.length ); // jdk 1.6, works
+        int j = 0;
+        for (Integer i : P) {
+            b[j] = a[(int) i];
+            j++;
+        }
+        return b;
+    }
+
+
+    /**
+     * Permutation of polynomial exponent vectors.
+     * @param A polynomial.
+     * @param R polynomial ring.
+     * @param P permutation.
+     * @return P(A).
+     */
+    public static <C extends RingElem<C>> GenPolynomial<C> permutation(List<Integer> P,
+                    GenPolynomialRing<C> R, GenPolynomial<C> A) {
+        if (A == null) {
+            return A;
+        }
+        GenPolynomial<C> B = R.getZERO().copy();
+        Map<ExpVector, C> Bv = B.val; //getMap();
+        for (Map.Entry<ExpVector, C> y : A.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            C a = y.getValue();
+            //System.out.println("e = " + e);
+            ExpVector f = e.permutation(P);
+            //System.out.println("f = " + f);
+            Bv.put(f, a); // assert f not in Bv
+        }
+        return B;
+    }
+
+
+    /**
+     * Permutation of polynomial exponent vectors.
+     * @param L list of polynomials.
+     * @param R polynomial ring.
+     * @param P permutation.
+     * @return P(L).
+     */
+    public static <C extends RingElem<C>> List<GenPolynomial<C>> permutation(List<Integer> P,
+                    GenPolynomialRing<C> R, List<GenPolynomial<C>> L) {
+        if (L == null || L.size() == 0) {
+            return L;
+        }
+        List<GenPolynomial<C>> K = new ArrayList<GenPolynomial<C>>(L.size());
+        for (GenPolynomial<C> a : L) {
+            GenPolynomial<C> b = permutation(P, R, a);
+            K.add(b);
+        }
+        return K;
+    }
+
+
+    /**
+     * Permutation of solvable polynomial exponent vectors.
+     * @param L list of solvable polynomials.
+     * @param R solvable polynomial ring.
+     * @param P permutation, must be compatible with the commutator relations.
+     * @return P(L).
+     */
+    public static <C extends RingElem<C>> List<GenSolvablePolynomial<C>> permutation(List<Integer> P,
+                    GenSolvablePolynomialRing<C> R, List<GenSolvablePolynomial<C>> L) {
+        if (L == null || L.size() == 0) {
+            return L;
+        }
+        List<GenSolvablePolynomial<C>> K = new ArrayList<GenSolvablePolynomial<C>>(L.size());
+        for (GenSolvablePolynomial<C> a : L) {
+            GenSolvablePolynomial<C> b;
+            b = (GenSolvablePolynomial<C>) permutation(P, (GenPolynomialRing<C>) R, (GenPolynomial<C>) a);
+            K.add(b);
+        }
+        return K;
+    }
+
+
+    /**
+     * Permutation of polynomial exponent vectors of coefficient polynomials.
+     * @param A polynomial.
+     * @param R polynomial ring.
+     * @param P permutation.
+     * @return P(A).
+     */
+    public static <C extends RingElem<C>> GenPolynomial<GenPolynomial<C>> permutationOnCoefficients(
+                    List<Integer> P, GenPolynomialRing<GenPolynomial<C>> R, GenPolynomial<GenPolynomial<C>> A) {
+        if (A == null) {
+            return A;
+        }
+        GenPolynomial<GenPolynomial<C>> B = R.getZERO().copy();
+        GenPolynomialRing<C> cf = (GenPolynomialRing<C>) R.coFac;
+        Map<ExpVector, GenPolynomial<C>> Bv = B.val; //getMap();
+        for (Map.Entry<ExpVector, GenPolynomial<C>> y : A.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            GenPolynomial<C> a = y.getValue();
+            //System.out.println("e = " + e);
+            GenPolynomial<C> b = permutation(P, cf, a);
+            //System.out.println("b = " + b);
+            Bv.put(e, b); // assert e not in Bv
+        }
+        return B;
+    }
+
+
+    /**
+     * Permutation of polynomial exponent vectors of coefficients.
+     * @param L list of polynomials.
+     * @param R polynomial ring.
+     * @param P permutation.
+     * @return P(L).
+     */
+    public static <C extends RingElem<C>> List<GenPolynomial<GenPolynomial<C>>> permutationOnCoefficients(
+                    List<Integer> P, GenPolynomialRing<GenPolynomial<C>> R,
+                    List<GenPolynomial<GenPolynomial<C>>> L) {
+        if (L == null || L.size() == 0) {
+            return L;
+        }
+        List<GenPolynomial<GenPolynomial<C>>> K = new ArrayList<GenPolynomial<GenPolynomial<C>>>(L.size());
+        for (GenPolynomial<GenPolynomial<C>> a : L) {
+            GenPolynomial<GenPolynomial<C>> b = permutationOnCoefficients(P, R, a);
+            K.add(b);
+        }
+        return K;
+    }
+
+
+    /**
+     * Permutation of polynomial ring variables.
+     * @param R polynomial ring.
+     * @param P permutation.
+     * @return P(R).
+     */
+    public static <C extends RingElem<C>> GenPolynomialRing<C> permutation(List<Integer> P,
+                    GenPolynomialRing<C> R) {
+        return R.permutation(P);
+    }
+
+
+    /**
+     * Optimize variable order.
+     * @param R polynomial ring.
+     * @param L list of polynomials.
+     * @return optimized polynomial list.
+     */
+    public static <C extends RingElem<C>> OptimizedPolynomialList<C> optimizeTermOrder(
+                    GenPolynomialRing<C> R, List<GenPolynomial<C>> L) {
+        List<GenPolynomial<C>> Lp = new ArrayList<GenPolynomial<C>>(L);
+        if (R instanceof GenSolvablePolynomialRing) { // look also on solvable relations
+            GenSolvablePolynomialRing<C> Rs = (GenSolvablePolynomialRing<C>) R;
+            Lp.addAll(Rs.table.relationList());
+        }
+        List<Integer> perm = optimalPermutation(degreeMatrix(Lp));
+        GenPolynomialRing<C> pring = R.permutation(perm);
+        List<GenPolynomial<C>> ppolys = permutation(perm, pring, L);
+        OptimizedPolynomialList<C> op = new OptimizedPolynomialList<C>(perm, pring, ppolys);
+        return op;
+    }
+
+
+    /**
+     * Optimize variable order.
+     * @param P polynomial list.
+     * @return optimized polynomial list.
+     */
+    public static <C extends RingElem<C>> OptimizedPolynomialList<C> optimizeTermOrder(PolynomialList<C> P) {
+        if (P == null) {
+            return null;
+        }
+        return optimizeTermOrder(P.ring, P.list);
+    }
+
+
+    /**
+     * Optimize variable order on coefficients.
+     * @param P polynomial list.
+     * @return optimized polynomial list.
+     */
+    public static <C extends RingElem<C>> OptimizedPolynomialList<GenPolynomial<C>> optimizeTermOrderOnCoefficients(
+                    PolynomialList<GenPolynomial<C>> P) {
+        return optimizeTermOrderOnCoefficients(P.ring, P.list);
+    }
+
+
+    /**
+     * Optimize variable order on coefficients.
+     * @param ring polynomial ring.
+     * @param L list of polynomials.
+     * @return optimized polynomial list.
+     */
+    @SuppressWarnings("cast")
+    public static <C extends RingElem<C>> OptimizedPolynomialList<GenPolynomial<C>> optimizeTermOrderOnCoefficients(
+                    GenPolynomialRing<GenPolynomial<C>> ring, List<GenPolynomial<GenPolynomial<C>>> L) {
+        if (L == null) {
+            return null;
+        }
+        List<GenPolynomial<GenPolynomial<C>>> Lp = new ArrayList<GenPolynomial<GenPolynomial<C>>>(L);
+        //GenPolynomialRing<GenPolynomial<C>> ring = P.ring;
+        if (ring instanceof GenSolvablePolynomialRing) { // look also on solvable relations
+            GenSolvablePolynomialRing<GenPolynomial<C>> Rs = (GenSolvablePolynomialRing<GenPolynomial<C>>) ring;
+            Lp.addAll(Rs.table.relationList());
+        }
+        List<Integer> perm = optimalPermutation(degreeMatrixOfCoefficients(Lp));
+
+        GenPolynomialRing<C> coFac = (GenPolynomialRing<C>) ring.coFac;
+        GenPolynomialRing<C> pFac = coFac.permutation(perm);
+        GenSolvablePolynomialRing<GenPolynomial<C>> sring, psring;
+        GenPolynomialRing<GenPolynomial<C>> pring;
+        if (ring instanceof GenSolvablePolynomialRing) { // permute also solvable relations
+            sring = (GenSolvablePolynomialRing<GenPolynomial<C>>) ring;
+            psring = new GenSolvablePolynomialRing<GenPolynomial<C>>(pFac, sring);
+            List<GenPolynomial<GenPolynomial<C>>> ir = PolynomialList
+                            .<GenPolynomial<C>> castToList(sring.table.relationList());
+            ir = permutationOnCoefficients(perm, psring, ir);
+            psring.addRelations(ir);
+            pring = (GenPolynomialRing<GenPolynomial<C>>) psring;
+        } else {
+            pring = new GenPolynomialRing<GenPolynomial<C>>(pFac, ring);
+        }
+        List<GenPolynomial<GenPolynomial<C>>> ppolys;
+        ppolys = permutationOnCoefficients(perm, pring, L);
+
+        OptimizedPolynomialList<GenPolynomial<C>> op;
+        op = new OptimizedPolynomialList<GenPolynomial<C>>(perm, pring, ppolys);
+        return op;
+    }
+
+
+    /**
+     * Optimize variable order.
+     * @param P module list.
+     * @return optimized module list.
+     */
+    public static <C extends RingElem<C>> OptimizedModuleList<C> optimizeTermOrder(ModuleList<C> P) {
+        if (P == null) {
+            return null;
+        }
+        return optimizeTermOrderModule(P.ring, P.list);
+    }
+
+
+    /**
+     * Optimize variable order.
+     * @param R polynomial ring.
+     * @param L list of lists of polynomials.
+     * @return optimized module list.
+     */
+    public static <C extends RingElem<C>> OptimizedModuleList<C> optimizeTermOrderModule(
+                    GenPolynomialRing<C> R, List<List<GenPolynomial<C>>> L) {
+        List<GenPolynomial<C>> M = new ArrayList<GenPolynomial<C>>();
+        for (List<GenPolynomial<C>> ll : L) {
+            M.addAll(ll);
+        }
+        if (R instanceof GenSolvablePolynomialRing) { // look also on solvable relations
+            GenSolvablePolynomialRing<C> Rs = (GenSolvablePolynomialRing<C>) R;
+            M.addAll(Rs.table.relationList());
+        }
+        List<Integer> perm = optimalPermutation(degreeMatrix(M));
+        GenPolynomialRing<C> pring = R.permutation(perm);
+        List<List<GenPolynomial<C>>> mpolys = new ArrayList<List<GenPolynomial<C>>>();
+        List<GenPolynomial<C>> pp;
+        for (List<GenPolynomial<C>> ll : L) {
+            pp = permutation(perm, pring, ll);
+            mpolys.add(pp);
+        }
+        OptimizedModuleList<C> op = new OptimizedModuleList<C>(perm, pring, mpolys);
+        return op;
+    }
+
+
+    /**
+     * Optimize variable order on coefficients.
+     * @param P module list.
+     * @return optimized module list.
+     */
+    @SuppressWarnings("cast")
+    public static <C extends RingElem<C>> OptimizedModuleList<GenPolynomial<C>> optimizeTermOrderOnCoefficients(
+                    ModuleList<GenPolynomial<C>> P) {
+        if (P == null) {
+            return null;
+        }
+        GenPolynomialRing<GenPolynomial<C>> ring = P.ring;
+        List<GenPolynomial<GenPolynomial<C>>> M = new ArrayList<GenPolynomial<GenPolynomial<C>>>();
+        for (List<GenPolynomial<GenPolynomial<C>>> ll : P.list) {
+            M.addAll(ll);
+        }
+        if (ring instanceof GenSolvablePolynomialRing) { // look also on solvable relations
+            GenSolvablePolynomialRing<GenPolynomial<C>> Rs = (GenSolvablePolynomialRing<GenPolynomial<C>>) ring;
+            M.addAll(Rs.table.relationList());
+        }
+        List<Integer> perm = optimalPermutation(degreeMatrixOfCoefficients(M));
+
+        GenPolynomialRing<C> coFac = (GenPolynomialRing<C>) ring.coFac;
+        GenPolynomialRing<C> pFac = coFac.permutation(perm);
+        GenSolvablePolynomialRing<GenPolynomial<C>> sring, psring;
+        GenPolynomialRing<GenPolynomial<C>> pring;
+        if (ring instanceof GenSolvablePolynomialRing) { // permute also solvable relations
+            sring = (GenSolvablePolynomialRing<GenPolynomial<C>>) ring;
+            psring = new GenSolvablePolynomialRing<GenPolynomial<C>>(pFac, sring);
+            List<GenPolynomial<GenPolynomial<C>>> ir = PolynomialList
+                            .<GenPolynomial<C>> castToList(sring.table.relationList());
+            ir = permutationOnCoefficients(perm, psring, ir);
+            psring.addRelations(ir);
+            pring = (GenPolynomialRing<GenPolynomial<C>>) psring;
+        } else {
+            pring = new GenPolynomialRing<GenPolynomial<C>>(pFac, ring);
+        }
+        List<GenPolynomial<GenPolynomial<C>>> pp;
+        List<List<GenPolynomial<GenPolynomial<C>>>> mpolys;
+        mpolys = new ArrayList<List<GenPolynomial<GenPolynomial<C>>>>();
+        for (List<GenPolynomial<GenPolynomial<C>>> ll : P.list) {
+            pp = permutationOnCoefficients(perm, pring, ll);
+            mpolys.add(pp);
+        }
+        OptimizedModuleList<GenPolynomial<C>> op = new OptimizedModuleList<GenPolynomial<C>>(perm, pring,
+                        mpolys);
+        return op;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/WeylRelations.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/WeylRelations.java
@@ -1,0 +1,118 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Generate Relation Table for Weyl Algebras Adds the respective relations to
+ * the relation table of the given solvable ring factory. Relations are of the
+ * form x<sub>j</sub> * x<sub>i</sub> = x<sub>i</sub> x<sub>j</sub> + 1.
+ * Block form: R{x1,...,xn,y1,...,yn; yi*xi = xi yi + 1}.
+ * @author Heinz Kredel
+ */
+
+public class WeylRelations<C extends RingElem<C>> implements RelationGenerator<C> {
+
+
+    /**
+     * The factory for the solvable polynomial ring.
+     */
+    private final GenSolvablePolynomialRing<C> ring;
+
+
+    private static final Logger logger = LogManager.getLogger(WeylRelations.class);
+
+
+    /**
+     * The no argument constructor. The relation table of this ring is setup to
+     * a Weyl Algebra.
+     */
+    public WeylRelations() {
+        ring = null;
+    }
+
+
+    /**
+     * The constructor requires a ring factory. The relation table of this ring
+     * is setup to a Weyl Algebra.
+     * @param r solvable polynomial ring factory, r must have even number of
+     *            variables.
+     */
+    public WeylRelations(GenSolvablePolynomialRing<C> r) {
+        if (r == null) {
+            throw new IllegalArgumentException("WeylRelations, ring == null");
+        }
+        ring = r;
+        if (ring.nvar <= 1 || (ring.nvar % 2) != 0) {
+            throw new IllegalArgumentException("WeylRelations, wrong nvar = " + ring.nvar);
+        }
+    }
+
+
+    /**
+     * Generates the relation table of this ring. Block form:
+     * R{x1,...,xn,y1,...,yn; yi*xi = xi yi + 1}.
+     */
+    public void generate() {
+        if (ring == null) {
+            throw new IllegalArgumentException("WeylRelations, ring == null");
+        }
+        generate(ring);
+    }
+
+
+    /**
+     * Generates the relation table of this ring. Block form:
+     * R{x1,...,xn,y1,...,yn; yi*xi = xi yi + 1}.
+     * @param ring solvable polynomial ring factory, ring must have even number
+     *            of variables.
+     * @see edu.jas.poly.RelationGenerator#generate(edu.jas.poly.GenSolvablePolynomialRing)
+     */
+    @Override
+    public void generate(GenSolvablePolynomialRing<C> ring) {
+        if (ring == null) {
+            throw new IllegalArgumentException("WeylRelations, ring == null");
+        }
+        if (ring.nvar <= 1 || (ring.nvar % 2) != 0) {
+            throw new IllegalArgumentException("WeylRelations, wrong nvar = " + ring.nvar);
+        }
+        RelationTable<C> table = ring.table;
+        int r = ring.nvar;
+        int m = r / 2;
+        GenSolvablePolynomial<C> one = ring.getONE().copy();
+        GenSolvablePolynomial<C> zero = ring.getZERO().copy();
+        for (int i = m; i < r; i++) {
+            ExpVector f = ExpVector.create(r, i, 1);
+            int j = i - m;
+            ExpVector e = ExpVector.create(r, j, 1);
+            ExpVector ef = e.sum(f);
+            GenSolvablePolynomial<C> b = one.multiply(ef);
+            GenSolvablePolynomial<C> rel = (GenSolvablePolynomial<C>) b.sum(one);
+            //  = (GenSolvablePolynomial<C>)b.subtract(one);
+            if (rel.isZERO()) {
+                logger.info("ring = " + ring);
+                logger.info("one  = " + one);
+                logger.info("zero = " + zero);
+                logger.info("b    = " + b);
+                logger.info("rel  = " + rel);
+                //System.exit(1);
+                throw new RuntimeException("rel.isZERO()");
+            }
+            //System.out.println("rel = " + rel.toString(ring.vars));
+            table.update(e, f, rel);
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug("\nWeyl relations = " + table);
+        }
+        return;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/WeylRelationsIterated.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/WeylRelationsIterated.java
@@ -1,0 +1,116 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Generate Relation Table for Weyl Algebras Adds the respective relations to
+ * the relation table of the given solvable ring factory. Relations are of the
+ * form x<sub>j</sub> * x<sub>i</sub> = x<sub>i</sub> x<sub>j</sub> + 1.
+ * Iterated form: R{x1,y1,...,xn,yn; yi*xi = xi yi + 1}.
+ * @author Heinz Kredel
+ */
+
+public class WeylRelationsIterated<C extends RingElem<C>> implements RelationGenerator<C> {
+
+
+    /**
+     * The factory for the solvable polynomial ring.
+     */
+    private final GenSolvablePolynomialRing<C> ring;
+
+
+    private static final Logger logger = LogManager.getLogger(WeylRelationsIterated.class);
+
+
+    /**
+     * The no argument constructor. The relation table of this ring is setup to
+     * a Weyl Algebra.
+     */
+    public WeylRelationsIterated() {
+        ring = null;
+    }
+
+
+    /**
+     * The constructor requires a ring factory. The relation table of this ring
+     * is setup to a Weyl Algebra.
+     * @param r solvable polynomial ring factory, r must have even number of
+     *            variables.
+     */
+    public WeylRelationsIterated(GenSolvablePolynomialRing<C> r) {
+        if (r == null) {
+            throw new IllegalArgumentException("WeylRelations, ring == null");
+        }
+        ring = r;
+        if (ring.nvar <= 1 || (ring.nvar % 2) != 0) {
+            throw new IllegalArgumentException("WeylRelations, wrong nvar = " + ring.nvar);
+        }
+    }
+
+
+    /**
+     * Generates the relation table of this ring. Iterated form:
+     * R{x1,y1,...,xn,yn; yi*xi = xi yi + 1}.
+     */
+    public void generate() {
+        if (ring == null) {
+            throw new IllegalArgumentException("WeylRelations, ring == null");
+        }
+        generate(ring);
+    }
+
+
+    /**
+     * Generates the relation table of this ring. Iterated form:
+     * R{x1,y1,...,xn,yn; yi*xi = xi yi + 1}.
+     * @param ring solvable polynomial ring factory, ring must have even number
+     *            of variables.
+     */
+    public void generate(GenSolvablePolynomialRing<C> ring) {
+        if (ring == null) {
+            throw new IllegalArgumentException("WeylRelations, ring == null");
+        }
+        if (ring.nvar <= 1 || (ring.nvar % 2) != 0) {
+            throw new IllegalArgumentException("WeylRelations, wrong nvar = " + ring.nvar);
+        }
+        RelationTable<C> table = ring.table;
+        int r = ring.nvar;
+        //int m =  r / 2;
+        GenSolvablePolynomial<C> one = ring.getONE().copy();
+        GenSolvablePolynomial<C> zero = ring.getZERO().copy();
+        for (int i = 1; i <= r; i += 2) {
+            ExpVector f = ExpVector.create(r, i, 1);
+            int j = i - 1;
+            ExpVector e = ExpVector.create(r, j, 1);
+            ExpVector ef = e.sum(f);
+            GenSolvablePolynomial<C> b = one.multiply(ef);
+            GenSolvablePolynomial<C> rel = (GenSolvablePolynomial<C>) b.sum(one);
+            //  = (GenSolvablePolynomial<C>)b.subtract(one);
+            if (rel.isZERO()) {
+                logger.info("ring = " + ring);
+                logger.info("one  = " + one);
+                logger.info("zero = " + zero);
+                logger.info("b    = " + b);
+                logger.info("rel  = " + rel);
+                //System.exit(1);
+                throw new RuntimeException("rel.isZERO()");
+            }
+            //System.out.println("rel = " + rel.toString(ring.vars));
+            table.update(e, f, rel);
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug("\nWeyl relations = " + table);
+        }
+        return;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/Word.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/Word.java
@@ -1,0 +1,672 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import edu.jas.structure.MonoidElem;
+import edu.jas.structure.MonoidFactory;
+import edu.jas.structure.NotInvertibleException;
+
+
+/**
+ * Word implements strings of letters for polynomials.
+ * @author Heinz Kredel
+ */
+
+public final class Word implements MonoidElem<Word> {
+
+
+    /**
+     * Defining alphabet in WordFactory.
+     */
+    public final WordFactory mono;
+
+
+    /**
+     * The data structure is a String of characters.
+     */
+    /*package*/final String val;
+
+
+    /**
+     * Stored hash code.
+     */
+    protected int hash = 0;
+
+
+    /**
+     * Constructor for Word.
+     * @param m factory for words.
+     */
+    public Word(WordFactory m) {
+        this(m, "");
+    }
+
+
+    /**
+     * Constructor for Word.
+     * @param m factory for words.
+     * @param s String
+     */
+    public Word(WordFactory m, String s) {
+        this(m, s, true);
+    }
+
+
+    /**
+     * Constructor for Word.
+     * @param m factory for words.
+     * @param s String
+     * @param translate indicator if s needs translation
+     */
+    public Word(WordFactory m, String s, boolean translate) {
+        mono = m;
+        hash = 0;
+        if (s == null) {
+            throw new IllegalArgumentException("null string not allowed");
+        }
+        if (translate) {
+            if (mono.translation != null) {
+                //System.out.println("s = " + s);
+                String[] S = GenPolynomialTokenizer.variableList(s);
+                //System.out.println("S = " + Arrays.toString(S));
+                val = mono.translate(S);
+                //System.out.println("val = " + val);
+            } else {
+                val = WordFactory.cleanSpace(s); //??
+            }
+        } else {
+            val = s;
+        }
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public MonoidFactory<Word> factory() {
+        return mono;
+    }
+
+
+    /**
+     * Copy this.
+     * @return copy of this.
+     */
+    @Override
+    public Word copy() {
+        return new Word(mono, val, false);
+    }
+
+
+    /**
+     * Get the word String.
+     * @return val.
+     */
+    /*package*/String getVal() {
+        return val;
+    }
+
+
+    /**
+     * Get the letter at position i.
+     * @param i position.
+     * @return val[i].
+     */
+    public char getVal(int i) {
+        return val.charAt(i);
+    }
+
+
+    /**
+     * Get the length of this word.
+     * @return val.length.
+     */
+    public int length() {
+        return val.length();
+    }
+
+
+    /**
+     * Get the string representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        if (val.length() == 0) {
+            return "";
+        }
+        StringBuffer s = new StringBuffer("\"");
+        if (mono.translation == null) {
+            for (int i = 0; i < length(); i++) {
+                if (i != 0) {
+                    s.append(" ");
+                }
+                s.append(getVal(i));
+            }
+        } else {
+            for (int i = 0; i < length(); i++) {
+                if (i != 0) {
+                    s.append(" ");
+                }
+                s.append(mono.transVar(getVal(i)));
+            }
+        }
+        s.append("\"");
+        return s.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        if (val.length() == 0) {
+            return "";
+        }
+        StringBuffer s = new StringBuffer("");
+        if (mono.translation == null) {
+            for (int i = 0; i < length(); i++) {
+                if (i != 0) {
+                    s.append("*"); // checked for python vs ruby
+                }
+                s.append(getVal(i));
+            }
+        } else {
+            for (int i = 0; i < length(); i++) {
+                if (i != 0) {
+                    s.append("*"); // checked for python vs ruby
+                }
+                s.append(mono.transVar(getVal(i)));
+            }
+        }
+        s.append("");
+        return s.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python case
+        return mono.toString();
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object B) {
+        if (!(B instanceof Word)) {
+            return false;
+        }
+        Word b = (Word) B;
+        // mono == b.mono ??
+        int t = this.compareTo(b);
+        //System.out.println("equals: this = " + this.val + " b = " + b.val + " t = " + t);
+        return (0 == t);
+    }
+
+
+    /**
+     * hashCode.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        if (hash == 0) {
+            hash = val.hashCode();
+        }
+        return hash;
+    }
+
+
+    /**
+     * Is Word one.
+     * @return If this is the empty word then true is returned, else false.
+     */
+    public boolean isONE() {
+        return val.isEmpty();
+    }
+
+
+    /**
+     * Is Word unit.
+     * @return If this is a unit then true is returned, else false.
+     */
+    public boolean isUnit() {
+        return isONE();
+    }
+
+
+    /**
+     * Word multiplication.
+     * @param V other word.
+     * @return this * V.
+     */
+    public Word multiply(Word V) {
+        return new Word(mono, this.val + V.val, false);
+    }
+
+
+    /**
+     * Word divide.
+     * @param V other word.
+     * @return this / V.
+     */
+    public Word divide(Word V) {
+        return divideLeft(V);
+    }
+
+
+    /**
+     * Word divide left.
+     * @param V other word.
+     * @return this / V = left, with left * V = this.
+     */
+    public Word divideLeft(Word V) {
+        Word[] ret = divideWord(V,false);
+        // fail if right is non zero
+        if (!ret[1].isONE()) {
+            throw new IllegalArgumentException("not simple left dividable: left = " + ret[0] + ", right = "
+                            + ret[1] + ", use divideWord");
+        }
+        return ret[0];
+    }
+
+
+    /**
+     * Word divide right.
+     * @param V other word.
+     * @return this / V = right, with V * right = this.
+     */
+    public Word divideRight(Word V) {
+        Word[] ret = divideWord(V,true);
+        // fail if left is non zero
+        if (!ret[0].isONE()) {
+            throw new IllegalArgumentException("not simple right dividable: left = " + ret[0] + ", right = "
+                            + ret[1] + ", use divideWord");
+        }
+        return ret[1];
+    }
+
+
+    /**
+     * Word divide with prefix and suffix.
+     * @param V other word.
+     * @return [left,right] with left * V * right = this.
+     */
+    public Word[] divideWord(Word V) {
+        return divideWord(V,true); 
+    }
+
+    /**
+     * Word divide with prefix and suffix.
+     * @param V other word.
+     * @param first is true for first index, false for last index.
+     * @return [left,right] with left * V * right = this.
+     */
+    public Word[] divideWord(Word V, boolean first) {
+        int i;
+        if (first) {
+            i = this.val.indexOf(V.val);
+        } else {
+            i = this.val.lastIndexOf(V.val);
+        }
+        if (i < 0) {
+            throw new NotInvertibleException("not dividable: " + this + ", other " + V);
+        }
+        int len = V.val.length();
+        String pre = this.val.substring(0, i);
+        String suf = this.val.substring(i + len);
+        Word[] ret = new Word[2];
+        ret[0] = new Word(mono, pre, false);
+        ret[1] = new Word(mono, suf, false);
+        return ret;
+    }
+
+
+    /**
+     * Word remainder.
+     * @param V other word.
+     * @return this (this/V). <b>Note:</b> not useful.
+     */
+    public Word remainder(Word V) {
+        int i = this.val.indexOf(V.val);
+        if (i < 0) {
+            throw new NotInvertibleException("not dividable: " + this + ", other " + V);
+        }
+        return V;
+    }
+
+
+    /**
+     * Quotient and remainder by division of this by S.
+     * @param S a Word
+     * @return [this/S, this - (this/S)*S]. <b>Note:</b> not useful.
+     */
+    public Word[] quotientRemainder(Word S) {
+        return new Word[] { divide(S), remainder(S) };
+    }
+
+
+    /**
+     * Word inverse.
+     * @return 1 / this.
+     */
+    public Word inverse() {
+        if (val.length() == 0) {
+            return this;
+        }
+        throw new NotInvertibleException("not inversible " + this);
+    }
+
+
+    /**
+     * Word signum.
+     * @return 0 if this is one, 1 if it is non empty.
+     */
+    public int signum() {
+        int i = val.length();
+        if (i > 0) {
+            i = 1;
+        }
+        assert i >= 0;
+        return i;
+    }
+
+
+    /**
+     * Word degree.
+     * @return total degree of all letters.
+     */
+    public long degree() {
+        return val.length();
+    }
+
+
+    /**
+     * Word dependency on letters.
+     * @return sorted map of letters and the number of its occurences.
+     */
+    public SortedMap<String, Integer> dependencyOnVariables() {
+        return histogram(val);
+    }
+
+
+    /**
+     * String dependency on letters.
+     * @param v string.
+     * @return sorted map of letters and the number of its occurences.
+     */
+    public static SortedMap<String, Integer> histogram(String v) {
+        SortedMap<String, Integer> map = new TreeMap<String, Integer>();
+        for (int i = 0; i < v.length(); i++) {
+            String s = String.valueOf(v.charAt(i));
+            Integer n = map.get(s);
+            if (n == null) {
+                n = 0;
+            }
+            n = n + 1;
+            map.put(s, n);
+        }
+        return map;
+    }
+
+
+    /**
+     * Word leading exponent vector.
+     * @return an ExpVector for the first power of a letter.
+     */
+    public ExpVector leadingExpVector() {
+        long n = 0;
+        char letter = ' ';
+        for (int i = 0; i < val.length(); i++) {
+            char s = val.charAt(i);
+            if (n == 0) {
+                letter = s;
+                n++;
+            } else if (letter == s) {
+                n++;
+            } else {
+                break;
+            }
+        }
+        int k = mono.length();
+        if (n == 0L){ // == isONE()
+            return ExpVector.create(k);
+        }
+        int j = k - mono.indexOf(letter) - 1;
+        return ExpVector.create(k,j,n);
+    }
+
+
+    /**
+     * Word without leading exponent vector.
+     * @return an Word without the first power of a letter.
+     */
+    public Word reductum() {
+        if (isONE()) {
+            return this;
+        }
+        int n = 0;
+        char letter = ' ';
+        for (int i = 0; i < val.length(); i++) {
+            char s = val.charAt(i);
+            if (n == 0) {
+                letter = s;
+                n++;
+            } else if (letter == s) {
+                n++;
+            } else {
+                break;
+            }
+        }
+        // n != 0
+        String r = val.substring(n); // n-1+1
+        return new Word(mono, r, false);
+    }
+
+
+    /**
+     * Word multiple test.
+     * @param V other word.
+     * @return true if this is a multiple of V, else false.
+     */
+    public boolean multipleOf(Word V) {
+        return this.val.contains(V.val);
+    }
+
+
+    /**
+     * Word divides test.
+     * @param V other word.
+     * @return true if this divides V, else false.
+     */
+    public boolean divides(Word V) {
+        return V.val.contains(this.val);
+    }
+
+
+    /**
+     * Word compareTo. Uses <code>String.compareTo</code>.
+     * @param V other word.
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    @Override
+    public int compareTo(Word V) {
+        if (mono == V.mono) {
+            return val.compareTo(V.val);
+        }
+        //System.out.println("compareTo: mono " + mono + ", V = " + V.mono);
+        return toString().compareTo(V.toString());
+    }
+
+
+    /**
+     * Word graded comparison. Compares first be degree, then lexicographical.
+     * @param V other word.
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    public int gradCompareTo(Word V) {
+        long e = this.degree();
+        long f = V.degree();
+        if (e < f) {
+            return 1;
+        } else if (e > f) {
+            return -1;
+        }
+        return this.compareTo(V);
+    }
+
+
+    /**
+     * Word graded comparison. Compares first be degree, then inverse
+     * lexicographical.
+     * @param V other word.
+     * @return 0 if U == V, -1 if U &lt; V, 1 if U &gt; V.
+     */
+    public int gradInvlexCompareTo(Word V) {
+        long e = this.degree();
+        long f = V.degree();
+        if (e < f) {
+            return 1;
+        } else if (e > f) {
+            return -1;
+        }
+        return -this.compareTo(V);
+    }
+
+
+    /**
+     * Is word overlap.
+     * @param ol = [l1,r1,l2,r2] an Overlap container of four words
+     * @param V word
+     * @return true if l1 * this * r1 = l2 * V * r2, else false.
+     */
+    public boolean isOverlap(Overlap ol, Word V) {
+        return ol.isOverlap(this, V);
+    }
+
+
+    /**
+     * Word overlap list.
+     * @param V other word.
+     * @return list of overlaps [l1,r1,l2,r2] with l1 * this * r1 = l2 * V * r2.
+     *         If no such overlaps exist the empty overlap list is returned.
+     */
+    public OverlapList overlap(Word V) {
+        OverlapList ret = new OverlapList();
+        Word wone = mono.getONE();
+        String a = this.val;
+        String b = V.val;
+        int ai = a.length();
+        int bi = b.length();
+        int j = b.indexOf(a);
+        if (j >= 0) {
+            while (j >= 0) {
+                String pre = b.substring(0, j);
+                String suf = b.substring(j + ai);
+                Word wpre = new Word(mono, pre, false);
+                Word wsuf = new Word(mono, suf, false);
+                ret.add(new Overlap(wpre, wsuf, wone, wone));
+                j = b.indexOf(a, j + ai); // +1 also inner overlaps ?
+            }
+            return ret;
+        }
+        j = a.indexOf(b);
+        if (j >= 0) {
+            while (j >= 0) {
+                String pre = a.substring(0, j);
+                String suf = a.substring(j + bi);
+                Word wpre = new Word(mono, pre, false);
+                Word wsuf = new Word(mono, suf, false);
+                ret.add(new Overlap(wone, wone, wpre, wsuf));
+                j = a.indexOf(b, j + bi); // +1 also inner overlaps ?
+            }
+            return ret;
+        }
+        if (ai >= bi) {
+            for (int i = 0; i < bi; i++) {
+                String as = a.substring(0, i + 1);
+                String bs = b.substring(bi - i - 1, bi);
+                //System.out.println("i = " + i + ", bs = " + bs + ", as = " + as);
+                if (as.equals(bs)) {
+                    Word w1 = new Word(mono, b.substring(0, bi - i - 1), false);
+                    Word w2 = new Word(mono, a.substring(i + 1), false);
+                    ret.add(new Overlap(w1, wone, wone, w2));
+                    break;
+                }
+            }
+            for (int i = 0; i < bi; i++) {
+                String as = a.substring(ai - i - 1, ai);
+                String bs = b.substring(0, i + 1);
+                //System.out.println("i = " + i + ", bs = " + bs + ", as = " + as);
+                if (as.equals(bs)) {
+                    Word w1 = new Word(mono, b.substring(i + 1), false);
+                    Word w2 = new Word(mono, a.substring(0, ai - i - 1), false);
+                    ret.add(new Overlap(wone, w1, w2, wone));
+                    break;
+                }
+            }
+        } else { // ai < bi
+            for (int i = 0; i < ai; i++) {
+                String as = a.substring(ai - i - 1, ai);
+                String bs = b.substring(0, i + 1);
+                //System.out.println("i = " + i + ", bs = " + bs + ", as = " + as);
+                if (as.equals(bs)) {
+                    Word w1 = new Word(mono, b.substring(i + 1), false);
+                    Word w2 = new Word(mono, a.substring(0, ai - i - 1), false);
+                    ret.add(new Overlap(wone, w1, w2, wone));
+                    break;
+                }
+            }
+            for (int i = 0; i < ai; i++) {
+                String as = a.substring(0, i + 1);
+                String bs = b.substring(bi - i - 1, bi);
+                //System.out.println("i = " + i + ", bs = " + bs + ", as = " + as);
+                if (as.equals(bs)) {
+                    Word w1 = new Word(mono, b.substring(0, bi - i - 1), false);
+                    Word w2 = new Word(mono, a.substring(i + 1), false);
+                    ret.add(new Overlap(w1, wone, wone, w2));
+                    break;
+                }
+            }
+        }
+        return ret;
+    }
+
+
+    /**
+     * Word pseudo least common multiple.
+     * @param V other word.
+     * @return w = l1*this*r1, with l1*this*r1 == l2*V*r2, if l1, r1, l2, r2
+     *         exist, else null is returned.
+     */
+    public Word lcm(Word V) {
+        OverlapList oll = overlap(V);
+        if (oll.ols.isEmpty()) {
+            return null;
+        }
+        Overlap ol = oll.ols.get(0);
+        Word w = ol.l1.multiply(this).multiply(ol.r1);
+        return w;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/WordFactory.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/WordFactory.java
@@ -1,0 +1,701 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+
+import java.io.Reader;
+import java.io.Serializable;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+//import java.util.Set;
+import java.util.Random;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.kern.StringUtil;
+import edu.jas.structure.MonoidFactory;
+
+
+/**
+ * WordFactory implements alphabet related methods.
+ * @author Heinz Kredel
+ */
+
+public final class WordFactory implements MonoidFactory<Word> {
+
+
+    /**
+     * The data structure is a String of characters which defines the alphabet.
+     */
+    /*package*/final String alphabet;
+
+
+    /**
+     * The empty word for this monoid.
+     */
+    public final Word ONE;
+
+
+    /**
+     * The translation reference string.
+     */
+    public static final String transRef = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+
+    /**
+     * The translation array of Strings.
+     */
+    public final String[] translation;
+
+
+    /**
+     * Random number generator.
+     */
+    private final static Random random = new Random();
+
+
+    /**
+     * Log4j logger object.
+     */
+    private static final Logger logger = LogManager.getLogger(WordFactory.class);
+
+
+    /**
+     * Comparator for Words.
+     */
+    public static abstract class WordComparator implements Comparator<Word>, Serializable {
+
+
+        public abstract int compare(Word e1, Word e2);
+    }
+
+
+    /**
+     * Defined descending order comparator. Sorts the highest terms first.
+     */
+    private static final WordComparator horder = new WordComparator() {
+
+
+        @Override
+        public int compare(Word e1, Word e2) {
+            //return e1.gradCompareTo(e2);
+            return e1.gradInvlexCompareTo(e2);
+        }
+    };
+
+
+    /**
+     * Defined ascending order comparator. Sorts the lowest terms first.
+     */
+    private static final WordComparator lorder = new WordComparator() {
+
+
+        @Override
+        public int compare(Word e1, Word e2) {
+            //return -e1.gradCompareTo(e2);
+            return -e1.gradInvlexCompareTo(e2);
+        }
+    };
+
+
+    /**
+     * Constructor for WordFactory.
+     */
+    public WordFactory() {
+        this("");
+    }
+
+
+    /**
+     * Constructor for WordFactory.
+     * @param s String of single letters for alphabet
+     */
+    public WordFactory(String s) {
+        if (s == null) {
+            throw new IllegalArgumentException("null string not allowed");
+        }
+        String alp = cleanSpace(s);
+        translation = null;
+        Map<String, Integer> hist = Word.histogram(alp);
+        if (hist.size() != alp.length()) {
+            logger.warn("multiple characters in String: " + hist);
+            //Set<String> k = hist.keySet();
+            String[] ka = hist.keySet().toArray(new String[hist.size()]);
+            alphabet = concat(ka);
+        } else {
+            alphabet = alp;
+        }
+        //System.out.println("hist = " + hist);
+        ONE = new Word(this, "", false);
+    }
+
+
+    /**
+     * Constructor for WordFactory.
+     * @param S String array for alphabet
+     */
+    public WordFactory(String[] S) {
+        String[] V = cleanAll(S);
+        if (isSingleLetters(V)) {
+            alphabet = concat(V);
+            translation = null;
+        } else {
+            alphabet = transRef.substring(0, V.length);
+            translation = V;
+            logger.info("alphabet = " + alphabet + ", translation = " + Arrays.toString(translation));
+        }
+        ONE = new Word(this, "", false);
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite()
+     */
+    public boolean isFinite() {
+        if (alphabet.length() == 0) {
+            return true;
+        }
+        return false;
+    }
+
+
+    /**
+     * Query if this monoid is commutative.
+     * @return true if this monoid is commutative, else false.
+     */
+    public boolean isCommutative() {
+        if (alphabet.length() == 0) {
+            return true;
+        }
+        return false;
+    }
+
+
+    /**
+     * Query if this monoid is associative.
+     * @return true if this monoid is associative, else false.
+     */
+    public boolean isAssociative() {
+        return true;
+    }
+
+
+    /**
+     * Get the one element, the empty word.
+     * @return 1 as Word.
+     */
+    public Word getONE() {
+        return ONE;
+    }
+
+
+    /**
+     * Copy word.
+     * @param w word to copy.
+     * @return copy of w.
+     */
+    @Override
+    public Word copy(Word w) {
+        return new Word(this, w.getVal(), false);
+    }
+
+
+    /**
+     * Get the alphabet length.
+     * @return alphabet.length.
+     */
+    public int length() {
+        return alphabet.length();
+    }
+
+
+    /**
+     * Get the alphabet String.
+     * @return alphabet.
+     */
+    /*package*/String getVal() {
+        return alphabet;
+    }
+
+
+    /**
+     * Get the translation array of Strings.
+     * @return alphabet.
+     */
+    /*package*/String[] getTrans() {
+        return translation;
+    }
+
+
+    /**
+     * Get the alphabet letter at position i.
+     * @param i position.
+     * @return val[i].
+     */
+    public char getVal(int i) {
+        return alphabet.charAt(i);
+    }
+
+
+    /**
+     * Get the variable names.
+     * @return array of variable names
+     */
+    public String[] getVars() {
+        String[] vars = new String[alphabet.length()];
+        if (translation == null) {
+            for (int i = 0; i < alphabet.length(); i++) {
+                vars[i] = String.valueOf(getVal(i));
+            }
+        } else {
+            for (int i = 0; i < alphabet.length(); i++) {
+                vars[i] = translation[i];
+            }
+        }
+        return vars;
+    }
+
+
+    /**
+     * Extend variables. Extend number of variables by length(vn). 
+     * @param vn names for extended variables.
+     * @return extended word ring factory.
+     */
+    public WordFactory extend(String[] vn) {
+        String[] vars = new String[length() + vn.length];
+        int i = 0;
+        for (String v : getVars()) {
+            vars[i++] = v;
+        }
+        for (String v : vn) {
+            vars[i++] = v;
+        }
+        return new WordFactory(vars);
+    }
+
+    
+    /**
+     * Get the string representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer s = new StringBuffer("\"");
+        if (translation == null) {
+            for (int i = 0; i < alphabet.length(); i++) {
+                if (i != 0) {
+                    s.append(",");
+                }
+                s.append(getVal(i));
+            }
+        } else {
+            for (int i = 0; i < alphabet.length(); i++) {
+                if (i != 0) {
+                    s.append(",");
+                }
+                s.append(translation[i]);
+            }
+        }
+        s.append("\"");
+        return s.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        return toString();
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object B) {
+        if (!(B instanceof WordFactory)) {
+            return false;
+        }
+        WordFactory b = (WordFactory) B;
+        return alphabet.equals(b.alphabet);
+    }
+
+
+    /**
+     * hashCode.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return alphabet.hashCode();
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     */
+    public List<Word> generators() {
+        int len = alphabet.length();
+        List<Word> gens = new ArrayList<Word>(len);
+        // ONE is not a word generator
+        for (int i = 0; i < len; i++) {
+            Word w = new Word(this, String.valueOf(alphabet.charAt(i)), false);
+            gens.add(w);
+        }
+        return gens;
+    }
+
+
+    /**
+     * Get the Element for a.
+     * @param a long
+     * @return element corresponding to a.
+     */
+    public Word fromInteger(long a) {
+        throw new UnsupportedOperationException("not implemented for WordFactory");
+    }
+
+
+    /**
+     * Get the Element for a.
+     * @param a java.math.BigInteger.
+     * @return element corresponding to a.
+     */
+    public Word fromInteger(BigInteger a) {
+        throw new UnsupportedOperationException("not implemented for WordFactory");
+    }
+
+
+    /**
+     * Get the Element for an ExpVector.
+     * @param e ExpVector.
+     * @return element corresponding to e.
+     */
+    public Word valueOf(ExpVector e) {
+        Word w = ONE;
+        List<Word> gens = generators();
+        int n = alphabet.length();
+        int m = e.length();
+        if (m > n) {
+            throw new IllegalArgumentException("alphabet to short for exponent " + e + ", alpahbet = "
+                            + alphabet);
+        }
+        for (int i = 0; i < m; i++) {
+            int x = (int) e.getVal(m - i - 1);
+            Word y = gens.get(i);
+            Word u = ONE;
+            for (int j = 0; j < x; j++) {
+                u = u.multiply(y);
+            }
+            w = w.multiply(u);
+        }
+        return w;
+    }
+
+
+    /**
+     * Get the element from an other word.
+     * @param w other word.
+     * @return w in this word factory.
+     */
+    public Word valueOf(Word w) {
+        String s = w.toString();
+        return parse(s);
+    }
+
+    
+    /**
+     * IndexOf for letter in alphabet.
+     * @param s letter character.
+     * @return index of s in the alphabet, or -1 if s is not contained in the alphabet.
+     */
+    public int indexOf(char s) {
+        return alphabet.indexOf(s);
+    }
+
+
+    /**
+     * Generate a random Element with size less equal to n.
+     * @param n
+     * @return a random element.
+     */
+    public Word random(int n) {
+        return random(n, random);
+    }
+
+
+    /**
+     * Generate a random Element with size less equal to n.
+     * @param n
+     * @param random is a source for random bits.
+     * @return a random element.
+     */
+    public Word random(int n, Random random) {
+        StringBuffer sb = new StringBuffer();
+        int len = alphabet.length();
+        for (int i = 0; i < n; i++) {
+            int r = Math.abs(random.nextInt() % len);
+            sb.append(alphabet.charAt(r));
+        }
+        return new Word(this, sb.toString(), false);
+    }
+
+
+    /**
+     * Parse from String.
+     * @param s String.
+     * @return a Element corresponding to s.
+     */
+    public Word parse(String s) {
+        String st = clean(s);
+        String regex;
+        if (translation == null) {
+            regex = "[" + alphabet + " ]*";
+        } else {
+            regex = "[" + concat(translation) + " ]*";
+        }
+        if (!st.matches(regex)) {
+            throw new IllegalArgumentException("word '" + st + "' contains letters not from: " + alphabet
+                            + " or from " + concat(translation));
+        }
+        // now only alphabet or translation chars are contained in st
+        return new Word(this, st, true);
+    }
+
+
+    /**
+     * Parse from Reader. White space is delimiter for word.
+     * @param r Reader.
+     * @return the next Element found on r.
+     */
+    public Word parse(Reader r) {
+        return parse(StringUtil.nextString(r));
+    }
+
+
+    /**
+     * Test if the alphabet of w is a subalphabet of this.
+     * @param w other word factory to test.
+     * @return true, if w is a subalphabet of this, else false.
+     */
+    public boolean isSubFactory(WordFactory w) {
+        if (w == null) {
+            throw new IllegalArgumentException("w may not be null");
+        }
+        String s = w.toString().replace(",", " ");
+        Word c = null;
+        try {
+            c = parse(s);
+        } catch (IllegalArgumentException ignored) {
+            // ignore
+        }
+        //System.out.println("c: " + c + ", s = " + s);
+        if (c != null) {
+            return true;
+        }
+        return false;
+    }
+
+
+    /**
+     * Contract word to this word factory.
+     * <code>this.isSubFactory(w.mono)</code> must be true, otherwise null is returned.
+     * @param w other word to contract.
+     * @return w with this factory, or null if not contractable.
+     */
+    public Word contract(Word w) {
+        if (w == null) {
+            throw new IllegalArgumentException("w may not be null");
+        }
+        Word c = null;
+        try {
+            c = parse(w.toString());
+        } catch (IllegalArgumentException ignored) {
+            // ignore
+        }
+        return c;
+    }
+
+    
+    /**
+     * Get the descending order comparator. Sorts the highest terms first.
+     * @return horder.
+     */
+    public WordComparator getDescendComparator() {
+        return horder;
+    }
+
+
+    /**
+     * Get the ascending order comparator. Sorts the lowest terms first.
+     * @return lorder.
+     */
+    public WordComparator getAscendComparator() {
+        return lorder;
+    }
+
+
+    /**
+     * Prepare parse from String.
+     * @param s String.
+     * @return a Element corresponding to s.
+     */
+    public static String cleanSpace(String s) {
+        String st = s.trim();
+        st = st.replaceAll("\\*", "");
+        st = st.replaceAll("\\s", "");
+        st = st.replaceAll("\\(", "");
+        st = st.replaceAll("\\)", "");
+        st = st.replaceAll("\\\"", "");
+        return st;
+    }
+
+
+    /**
+     * Prepare parse from String.
+     * @param s String.
+     * @return a Element corresponding to s.
+     */
+    public static String clean(String s) {
+        String st = s.trim();
+        st = st.replaceAll("\\*", " ");
+        //st = st.replaceAll("\\s", "");
+        st = st.replaceAll("\\(", "");
+        st = st.replaceAll("\\)", "");
+        st = st.replaceAll("\\\"", "");
+        return st;
+    }
+
+
+    /**
+     * Prepare parse from String array.
+     * @param v String array.
+     * @return an array of cleaned strings.
+     */
+    public static String[] cleanAll(String[] v) {
+        String[] t = new String[v.length];
+        for (int i = 0; i < v.length; i++) {
+            t[i] = cleanSpace(v[i]);
+            if (t[i].length() == 0) {
+                logger.error("empty v[i]: '" + v[i] + "'");
+            }
+            //System.out.println("clean all: " + v[i] + " --> " + t[i]);
+        }
+        return t;
+    }
+
+
+    /**
+     * Concat variable names.
+     * @param v an array of strings.
+     * @return the concatination of the strings in v.
+     */
+    public static String concat(String[] v) {
+        StringBuffer s = new StringBuffer();
+        if (v == null) {
+            return s.toString();
+        }
+        for (int i = 0; i < v.length; i++) {
+            s.append(v[i]);
+        }
+        return s.toString();
+    }
+
+
+    /**
+     * Trim all variable names.
+     * @param v an array of strings.
+     * @return an array of strings with all elements trimmed.
+     */
+    public static String[] trimAll(String[] v) {
+        String[] t = new String[v.length];
+        for (int i = 0; i < v.length; i++) {
+            t[i] = v[i].trim();
+            if (t[i].length() == 0) {
+                logger.error("empty v[i]: '" + v[i] + "'");
+            }
+        }
+        return t;
+    }
+
+
+    /**
+     * IndexOf for String array.
+     * @param v an array of strings.
+     * @param s string.
+     * @return index of s in v, or -1 if s is not contained in v.
+     */
+    public static int indexOf(String[] v, String s) {
+        for (int i = 0; i < v.length; i++) {
+            if (s.equals(v[i])) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+
+    /**
+     * Test if all variables are single letters.
+     * @param v an array of strings.
+     * @return true, if all variables have length 1, else false.
+     */
+    public static boolean isSingleLetters(String[] v) {
+        for (int i = 0; i < v.length; i++) {
+            if (v[i].length() != 1) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Translate variable names.
+     * @param v an array of strings.
+     * @return the translated string of v with respect to t.
+     */
+    public String translate(String[] v) {
+        StringBuffer s = new StringBuffer();
+        for (int i = 0; i < v.length; i++) {
+            String a = v[i];
+            int k = indexOf(translation, a);
+            if (k < 0) {
+                System.out.println("t = " + Arrays.toString(translation));
+                System.out.println("v = " + Arrays.toString(v));
+                logger.error("v[i] not found in t: " + a);
+                //continue;
+                throw new IllegalArgumentException("v[i] not found in t: " + a);
+            }
+            s.append(transRef.charAt(k));
+        }
+        return s.toString();
+    }
+
+
+    /**
+     * Translate variable name.
+     * @param c internal char.
+     * @return the extenal translated string.
+     */
+    public String transVar(char c) {
+        int k = alphabet.indexOf(c);
+        return translation[k];
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/WordMonomial.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/WordMonomial.java
@@ -1,0 +1,84 @@
+
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.Iterator;
+
+import edu.jas.structure.RingElem;
+
+import edu.jas.poly.ExpVector;
+
+
+/**
+ * WordMonomial class. 
+ * Represents pairs of words and coefficients.
+ * Adaptor for Map.Entry.
+ * @author Heinz Kredel
+ */
+
+public final class WordMonomial<C extends RingElem<C> > {
+
+    /** 
+     * Word of monomial.
+     */
+    public final Word e;
+
+
+    /** 
+     * Coefficient of monomial.
+     */
+    public final C c;
+
+
+    /** 
+     * Constructor of word monomial.
+     * @param me a MapEntry.
+     */
+    public WordMonomial(Map.Entry<Word,C> me){
+        this( me.getKey(), me.getValue() );
+    }
+
+
+    /** 
+     * Constructor of word monomial.
+     * @param e word.
+     * @param c coefficient.
+     */
+    public WordMonomial(Word e, C c) {
+        this.e = e;
+        this.c = c;
+    }
+
+
+    /** 
+     * Getter for word.
+     * @return word.
+     */
+    public Word word() {
+        return e;
+    }
+
+
+    /** 
+     * Getter for coefficient.
+     * @return coefficient.
+     */
+    public C coefficient() {
+        return c;
+    }
+
+    /**
+     * String representation of Monomial.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return c.toString() + " " + e.toString();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/WordPolyIterator.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/WordPolyIterator.java
@@ -1,0 +1,67 @@
+
+/*
+ * $Id$
+ */
+
+package edu.jas.poly;
+
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.Iterator;
+
+import edu.jas.structure.RingElem;
+
+import edu.jas.poly.Word;
+
+
+/**
+ * Iterator over monomials of a polynomial. 
+ * Adaptor for val.entrySet().iterator().
+ * @author Heinz Kredel
+ */
+
+public class WordPolyIterator<C extends RingElem<C> > 
+             implements Iterator< WordMonomial<C> > {
+
+
+    /** 
+     * Internal iterator over polynomial map.
+     */
+    protected final Iterator< Map.Entry<Word,C> > ms;
+
+
+    /** 
+     * Constructor of polynomial iterator.
+     * @param m SortetMap of a polynomial.
+     */
+    public WordPolyIterator( SortedMap<Word,C> m ) {
+        ms = m.entrySet().iterator();
+    }
+
+
+    /** 
+     * Test for availability of a next monomial.
+     * @return true if the iteration has more monomials, else false.
+     */
+    public boolean hasNext() {
+        return ms.hasNext();
+    }
+
+
+    /** 
+     * Get next monomial element.
+     * @return next monomial.
+     */
+    public WordMonomial<C> next() {
+        return new WordMonomial<C>( ms.next() );
+    }
+
+
+    /** 
+     * Remove the last monomial returned from underlying set if allowed.
+     */
+    public void remove() {
+        ms.remove();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/package.html
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/poly/package.html
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "../DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>Generic coefficients polynomial package</title>
+  </head>
+
+  <body>
+    <h1>Generic coefficients polynomial package.</h1>
+
+<p>
+  This package contains classes for polynomial, solvable polynomial
+  and free non-commutative polynomial arithmetic,
+  e.g. <code>GenPolynomial</code>, <code>GenSolvablePolynomial</code>
+  or <code>GenWordPolynomial</code> over coefficient rings which
+  implement the <code>RingElem</code> interface.  For arithmetic of
+  commutative exponents and words over arbitrary alphabets are the
+  classes <code>ExpVector</code> and <code>Word</code> with
+  <code>WordFactory</code>.  Other classes contained in this package
+  are <code>AlgebraicNumber</code>, <code>PolyUtil</code> and a
+  polynomial parser <code>GenPolynomialTokenizer</code>.  Some classes
+  implement quotient rings or residue class rings, etc., based only on
+  the interfaces in the <code>edu.jas.structure</code> package.
+</p>
+
+<p align="center">
+<img src="../../../../../images/poly-over.png" width="80%" 
+     alt="Polynomial overview" />
+<br />
+<b>Polynomial overview</b>
+</p>
+<p align="center">
+<img src="../../../../../images/poly-ring-over.png" width="80%" 
+     alt="Polynomial ring overview" />
+<br />
+<b>Polynomial ring overview</b>
+</p>
+
+    <hr />
+    <address><a href="mailto:kredel at rz.uni-mannheim.de">Heinz Kredel</a></address>
+<p>
+<!-- Created: Wed Mar  1 12:29:04 CET 2006 -->
+<!-- hhmts start -->
+Last modified: Mon Sep 22 00:25:48 CEST 2014
+<!-- hhmts end -->
+</p>
+<p>$Id$ 
+</p>
+  </body>
+</html>

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/Coefficients.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/Coefficients.java
@@ -1,0 +1,74 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ps;
+
+
+import java.io.Serializable;
+import java.util.HashMap;
+
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Abstract class for generating functions for coefficients of power series. Was
+ * an interface, now this class handles the caching itself.
+ * @param <C> ring element type
+ * @author Heinz Kredel
+ */
+
+public abstract class Coefficients<C extends RingElem<C>> implements Serializable {
+
+
+    /**
+     * Cache for already computed coefficients.
+     */
+    public final HashMap<Integer, C> coeffCache;
+
+
+    /**
+     * Public no arguments constructor.
+     */
+    public Coefficients() {
+        this(new HashMap<Integer, C>());
+    }
+
+
+    /**
+     * Public constructor with pre-filled cache.
+     * @param cache pre-filled coefficient cache.
+     */
+    public Coefficients(HashMap<Integer, C> cache) {
+        coeffCache = cache;
+    }
+
+
+    /**
+     * Get cached coefficient or generate coefficient.
+     * @param index of requested coefficient.
+     * @return coefficient at index.
+     */
+    public C get(int index) {
+        if (coeffCache == null) {
+            return generate(index);
+        }
+        Integer i = index;
+        C c = coeffCache.get(i);
+        if (c != null) {
+            return c;
+        }
+        c = generate(index);
+        coeffCache.put(i, c);
+        return c;
+    }
+
+
+    /**
+     * Generate coefficient.
+     * @param index of requested coefficient.
+     * @return coefficient at index.
+     */
+    protected abstract C generate(int index);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/Examples.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/Examples.java
@@ -1,0 +1,517 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ps;
+
+import java.util.List;
+
+import edu.jas.arith.BigComplex;
+import edu.jas.arith.BigDecimal;
+import edu.jas.arith.BigInteger;
+import edu.jas.arith.BigRational;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.structure.BinaryFunctor;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.structure.Selector;
+import edu.jas.structure.UnaryFunctor;
+
+
+/**
+ * Examples for univariate power series implementations.
+ * @author Heinz Kredel
+ */
+
+public class Examples {
+
+
+    public static void main(String[] args) {
+        example2();
+        example4();
+        example6();
+        example8();
+        example9();
+        example10();
+        example11();
+        example1();
+        example3();
+        example5();
+        example7();
+        if ( args.length > 0 ) {
+            example12();
+        }
+        example13();
+        example14();
+    }
+
+
+    static UnivPowerSeries<BigInteger> integersFrom(final int start) {
+        UnivPowerSeriesRing<BigInteger> pfac = new UnivPowerSeriesRing<BigInteger>(new BigInteger());
+        return new UnivPowerSeries<BigInteger>(pfac, new Coefficients<BigInteger>() {
+
+
+            @Override
+            public BigInteger generate(int i) {
+                return new BigInteger(start + i);
+            }
+        });
+    }
+
+
+    //----------------------
+
+
+    static class Sum<C extends RingElem<C>> implements BinaryFunctor<C, C, C> {
+
+
+        public C eval(C c1, C c2) {
+            return c1.sum(c2);
+        }
+    }
+
+
+    static class Odds<C extends RingElem<C>> implements Selector<C> {
+
+
+        C two;
+
+
+        RingFactory<C> fac;
+
+
+        public Odds(RingFactory<C> fac) {
+            this.fac = fac;
+            two = this.fac.fromInteger(2);
+            //System.out.println("two = " + two);
+        }
+
+
+        public boolean select(C c) {
+            //System.out.print("c = " + c);
+            if (c.remainder(two).isONE()) {
+                //System.out.println(" odd");
+                return true;
+            }
+            //System.out.println(" even");
+            return false;
+        }
+    }
+
+
+    //----------------------
+
+
+    public static void example1() {
+        UnivPowerSeries<BigInteger> integers = integersFrom(0);
+
+        BigInteger e = new BigInteger(1);
+        BigInteger v = integers.evaluate(e);
+        System.out.println("integers(" + e + ") = " + v);
+        e = new BigInteger(0);
+        v = integers.evaluate(e);
+        System.out.println("integers(" + e + ") = " + v);
+        e = new BigInteger(2);
+        v = integers.evaluate(e);
+        System.out.println("integers(" + e + ") = " + v);
+    }
+
+
+    public static void example2() {
+        UnivPowerSeries<BigInteger> integers = integersFrom(0);
+
+        System.out.print("integer coefficients = ");
+        UnivPowerSeries<BigInteger> s = integers;
+        for (int i = 0; i < 20; i++) {
+            BigInteger c = s.leadingCoefficient();
+            System.out.print(c.toString() + ", ");
+            s = s.reductum();
+        }
+        System.out.println("...");
+    }
+
+
+    public static void example3() {
+        RingFactory<BigInteger> fac = new BigInteger(1);
+        UnivPowerSeriesRing<BigInteger> ups = new UnivPowerSeriesRing<BigInteger>(fac);
+        System.out.println("ups = " + ups);
+        System.out.println("ups.isCommutative() = " + ups.isCommutative());
+        System.out.println("ups.isAssociative() = " + ups.isAssociative());
+        System.out.println("ups.isField()       = " + ups.isField());
+
+        System.out.println("ups.getZERO()       = " + ups.getZERO());
+        System.out.println("ups.getONE()        = " + ups.getONE());
+
+        UnivPowerSeries<BigInteger> rnd = ups.random();
+        System.out.println("rnd = " + rnd);
+        System.out.println("rnd = " + rnd);
+        System.out.println("rnd.isUnit()       = " + rnd.isUnit());
+    }
+
+
+    public static void example4() {
+        UnivPowerSeries<BigInteger> integers = integersFrom(0);
+        System.out.println("integers = " + integers);
+    }
+
+
+    public static void example6() {
+        UnivPowerSeriesRing<BigInteger> pfac = new UnivPowerSeriesRing<BigInteger>(new BigInteger());
+        UnivPowerSeries<BigInteger> integers;
+        integers = pfac.fixPoint(new UnivPowerSeriesMap<BigInteger>() {
+
+
+            public UnivPowerSeries<BigInteger> map(UnivPowerSeries<BigInteger> ps) {
+                return ps.map(new UnaryFunctor<BigInteger, BigInteger>() {
+
+
+                    public BigInteger eval(BigInteger s) {
+                        return s.sum(new BigInteger(1));
+                    }
+                }).prepend(new BigInteger(0));
+            }
+        });
+        System.out.println("integers1 = " + integers);
+        System.out.println("integers2 = " + integers);
+    }
+
+
+    public static void example8() {
+        final BigInteger z = new BigInteger(0);
+        final BigInteger one = new BigInteger(1);
+        UnivPowerSeriesRing<BigInteger> pfac = new UnivPowerSeriesRing<BigInteger>(z);
+        UnivPowerSeries<BigInteger> fibs;
+        fibs = pfac.fixPoint(new UnivPowerSeriesMap<BigInteger>() {
+
+
+            public UnivPowerSeries<BigInteger> map(UnivPowerSeries<BigInteger> ps) {
+                return ps.zip(new Sum<BigInteger>(), ps.prepend(one)).prepend(z);
+            }
+        });
+        System.out.println("fibs1 = " + fibs.toString(/*20*/));
+        System.out.println("fibs2 = " + fibs.toString(/*20*/));
+    }
+
+
+    public static void example9() {
+        UnivPowerSeries<BigInteger> integers = integersFrom(0);
+        System.out.println("      integers = " + integers);
+        UnivPowerSeries<BigInteger> doubleintegers = integers.sum(integers);
+        System.out.println("doubleintegers = " + doubleintegers);
+        UnivPowerSeries<BigInteger> nulls = integers.subtract(integers);
+        System.out.println("null  integers = " + nulls);
+        doubleintegers = integers.multiply(new BigInteger(2));
+        System.out.println("doubleintegers = " + doubleintegers);
+        nulls = integers.multiply(new BigInteger(0));
+        System.out.println("null  integers = " + nulls);
+        UnivPowerSeries<BigInteger> odds = integers.select(new Odds<BigInteger>(new BigInteger()));
+        System.out.println("odd   integers = " + odds);
+    }
+
+
+    public static void example10() {
+        final BigInteger fac = new BigInteger();
+        UnivPowerSeriesRing<BigInteger> pfac = new UnivPowerSeriesRing<BigInteger>(fac);
+        UnivPowerSeries<BigInteger> integers = integersFrom(0);
+        System.out.println("      integers = " + integers);
+        UnivPowerSeries<BigInteger> ONE = new UnivPowerSeries<BigInteger>(pfac,
+                new Coefficients<BigInteger>() {
+
+
+                    @Override
+                    public BigInteger generate(int i) {
+                        if (i == 0) {
+                            return fac.getONE();
+                        }
+                        return fac.getZERO();
+                    }
+                }//, null
+        );
+        System.out.println("ONE  = " + ONE);
+        UnivPowerSeries<BigInteger> ZERO = new UnivPowerSeries<BigInteger>(pfac,
+                new Coefficients<BigInteger>() {
+
+
+                    @Override
+                    public BigInteger generate(int i) {
+                        return fac.getZERO();
+                    }
+                }//, null
+        );
+        System.out.println("ZERO = " + ZERO);
+        UnivPowerSeries<BigInteger> ints = integers.multiply(ONE);
+        System.out.println("integers       = " + ints);
+        UnivPowerSeries<BigInteger> nulls = integers.multiply(ZERO);
+        System.out.println("null  integers = " + nulls);
+        UnivPowerSeries<BigInteger> nints = integers.negate();
+        System.out.println("-integers      = " + nints);
+        UnivPowerSeries<BigInteger> one = ONE.multiply(ONE);
+        System.out.println("integers one   = " + one);
+        UnivPowerSeries<BigInteger> ints2 = integers.multiply(integers);
+        System.out.println("integers 2     = " + ints2);
+        UnivPowerSeries<BigInteger> inv1 = ONE.inverse();
+        System.out.println("integers inv1  = " + inv1);
+        UnivPowerSeries<BigInteger> int1 = integers.reductum();
+        System.out.println("integers int1  = " + int1);
+        UnivPowerSeries<BigInteger> intinv = int1.inverse();
+        System.out.println("integers intinv = " + intinv);
+        UnivPowerSeries<BigInteger> one1 = int1.multiply(intinv);
+        System.out.println("integers one1  = " + one1);
+        UnivPowerSeries<BigInteger> ii = intinv.inverse();
+        System.out.println("integers ii    = " + ii);
+        UnivPowerSeries<BigInteger> rem = integers.subtract(integers.divide(int1).multiply(int1));
+        System.out.println("integers rem   = " + rem);
+    }
+
+
+    public static void example11() {
+        //final BigInteger fac = new BigInteger();
+        UnivPowerSeries<BigInteger> integers = integersFrom(0);
+        System.out.println("      integers = " + integers);
+        UnivPowerSeries<BigInteger> int2 = integers.multiply(new BigInteger(2));
+        System.out.println("    2*integers = " + int2);
+        System.out.println("integers < 2*integers  = " + integers.compareTo(int2));
+        System.out.println("2*integers > integers  = " + int2.compareTo(integers));
+        System.out.println("2*integers == integers = " + int2.equals(integers));
+        System.out.println("integers == integers   = " + integers.equals(integers.copy()));
+        System.out.println("integers.hashCode()    = " + integers.hashCode());
+    }
+
+
+    public static void example5() {
+        //final BigInteger fac = new BigInteger();
+        //UnivPowerSeriesRing<BigInteger> pfac = new UnivPowerSeriesRing<BigInteger>(fac);
+        UnivPowerSeries<BigInteger> integers = integersFrom(0);
+        System.out.println("      integers = " + integers);
+        UnivPowerSeries<BigInteger> ints2 = integers.multiply(integers);
+        System.out.println("integers 2     = " + ints2);
+
+        UnivPowerSeries<BigInteger> q1 = ints2.divide(integers);
+        System.out.println("q1             = " + q1);
+        UnivPowerSeries<BigInteger> q2 = integers.divide(ints2);
+        System.out.println("q2             = " + q2);
+
+        UnivPowerSeries<BigInteger> r1 = ints2.remainder(integers);
+        System.out.println("r1             = " + r1);
+        UnivPowerSeries<BigInteger> r2 = integers.remainder(ints2);
+        System.out.println("r2             = " + r2);
+
+        UnivPowerSeries<BigInteger> qr1 = q1.multiply(integers).sum(r1);
+        System.out.println("qr1            = " + qr1);
+        UnivPowerSeries<BigInteger> qr2 = q2.multiply(ints2).sum(r2);
+        System.out.println("qr2            = " + qr2);
+
+        System.out.println("sign(qr1-ints2) = " + qr1.compareTo(ints2));
+        System.out.println("sign(qr2-integers) = " + qr2.compareTo(integers));
+
+        UnivPowerSeries<BigInteger> g = ints2.gcd(integers);
+        System.out.println("g               = " + g);
+    }
+
+
+    public static void example7() {
+        final BigRational fac = new BigRational();
+        final UnivPowerSeriesRing<BigRational> pfac = new UnivPowerSeriesRing<BigRational>(fac, 11, "y");
+        UnivPowerSeries<BigRational> exp = pfac.fixPoint(new UnivPowerSeriesMap<BigRational>() {
+
+
+            public UnivPowerSeries<BigRational> map(UnivPowerSeries<BigRational> e) {
+                return e.integrate(fac.getONE());
+            }
+        });
+        System.out.println("exp = " + exp);
+        UnivPowerSeries<BigRational> tan = pfac.fixPoint(new UnivPowerSeriesMap<BigRational>() {
+
+
+            public UnivPowerSeries<BigRational> map(UnivPowerSeries<BigRational> t) {
+                return t.multiply(t).sum(pfac.getONE()).integrate(fac.getZERO());
+            }
+        });
+        System.out.println("tan = " + tan);
+        UnivPowerSeries<BigRational> sin = new UnivPowerSeries<BigRational>(pfac,
+                new Coefficients<BigRational>() {
+
+
+                    @Override
+                    public BigRational generate(int i) {
+                        BigRational c;
+                        if (i == 0) {
+                            c = fac.getZERO();
+                        } else if (i == 1) {
+                            c = fac.getONE();
+                        } else {
+                            c = get(i - 2).negate();
+                            c = c.divide(fac.fromInteger(i)).divide(fac.fromInteger(i - 1));
+                        }
+                        return c;
+                    }
+                });
+        System.out.println("sin = " + sin);
+        UnivPowerSeries<BigRational> sin1 = pfac.fixPoint(new UnivPowerSeriesMap<BigRational>() {
+
+
+            public UnivPowerSeries<BigRational> map(UnivPowerSeries<BigRational> e) {
+                return e.negate().integrate(fac.getONE()).integrate(fac.getZERO());
+            }
+        });
+        System.out.println("sin1 = " + sin1);
+
+        UnivPowerSeries<BigRational> cos = new UnivPowerSeries<BigRational>(pfac,
+                new Coefficients<BigRational>() {
+
+
+                    @Override
+                    public BigRational generate(int i) {
+                        BigRational c;
+                        if (i == 0) {
+                            c = fac.getONE();
+                        } else if (i == 1) {
+                            c = fac.getZERO();
+                        } else {
+                            c = get(i - 2).negate();
+                            c = c.divide(fac.fromInteger(i)).divide(fac.fromInteger(i - 1));
+                        }
+                        return c;
+                    }
+                });
+        System.out.println("cos = " + cos);
+        UnivPowerSeries<BigRational> cos1 = pfac.fixPoint(new UnivPowerSeriesMap<BigRational>() {
+
+
+            public UnivPowerSeries<BigRational> map(UnivPowerSeries<BigRational> e) {
+                return e.negate().integrate(fac.getZERO()).integrate(fac.getONE());
+            }
+        });
+        System.out.println("cos1 = " + cos1);
+
+        UnivPowerSeries<BigRational> cos2 = pfac.solveODE(sin1.negate(), fac.getONE());
+        System.out.println("cos2 = " + cos2);
+
+        UnivPowerSeries<BigRational> sin2 = pfac.solveODE(cos1, fac.getZERO());
+        System.out.println("sin2 = " + sin2);
+
+        UnivPowerSeries<BigRational> sinh = new UnivPowerSeries<BigRational>(pfac,
+                new Coefficients<BigRational>() {
+
+
+                    @Override
+                    public BigRational generate(int i) {
+                        BigRational c;
+                        if (i == 0) {
+                            c = fac.getZERO();
+                        } else if (i == 1) {
+                            c = fac.getONE();
+                        } else {
+                            c = get(i - 2);
+                            c = c.divide(fac.fromInteger(i)).divide(fac.fromInteger(i - 1));
+                        }
+                        return c;
+                    }
+                });
+        System.out.println("sinh = " + sinh);
+        UnivPowerSeries<BigRational> cosh = new UnivPowerSeries<BigRational>(pfac,
+                new Coefficients<BigRational>() {
+
+
+                    @Override
+                    public BigRational generate(int i) {
+                        BigRational c;
+                        if (i == 0) {
+                            c = fac.getONE();
+                        } else if (i == 1) {
+                            c = fac.getZERO();
+                        } else {
+                            c = get(i - 2);
+                            c = c.divide(fac.fromInteger(i)).divide(fac.fromInteger(i - 1));
+                        }
+                        return c;
+                    }
+                }//, null
+        );
+        System.out.println("cosh = " + cosh);
+
+        UnivPowerSeries<BigRational> sinhcosh = sinh.sum(cosh);
+        System.out.println("sinh+cosh = " + sinhcosh);
+        System.out.println("sinh+cosh == exp: " + sinhcosh.equals(exp));
+    }
+
+
+    public static void example12() {
+        final BigComplex fac = new BigComplex();
+        final BigComplex I = BigComplex.I;
+        final UnivPowerSeriesRing<BigComplex> pfac = new UnivPowerSeriesRing<BigComplex>(fac);
+        UnivPowerSeries<BigComplex> exp = pfac.fixPoint(new UnivPowerSeriesMap<BigComplex>() {
+
+
+            public UnivPowerSeries<BigComplex> map(UnivPowerSeries<BigComplex> e) {
+                return e.integrate(I);
+            }
+        });
+        System.out.println("exp = " + exp);
+
+        UnivPowerSeries<BigComplex> sin = pfac.fixPoint(new UnivPowerSeriesMap<BigComplex>() {
+
+
+            public UnivPowerSeries<BigComplex> map(UnivPowerSeries<BigComplex> e) {
+                return e.negate().integrate(fac.getONE()).integrate(fac.getZERO());
+            }
+        });
+        System.out.println("sin = " + sin);
+
+        UnivPowerSeries<BigComplex> cos = pfac.fixPoint(new UnivPowerSeriesMap<BigComplex>() {
+
+
+            public UnivPowerSeries<BigComplex> map(UnivPowerSeries<BigComplex> e) {
+                return e.negate().integrate(fac.getZERO()).integrate(fac.getONE());
+            }
+        });
+        System.out.println("cos = " + cos);
+
+        UnivPowerSeries<BigComplex> cpis = cos.sum(sin.multiply(I));
+        System.out.println("cpis = " + cpis);
+    }
+
+
+    public static void example13() {
+        BigRational fac = new BigRational();
+        UnivPowerSeriesRing<BigRational> pfac = new UnivPowerSeriesRing<BigRational>(fac, 11, "y");
+        UnivPowerSeries<BigRational> exp = pfac.getEXP();
+        System.out.println("exp = " + exp);
+        System.out.println("exp(1) = " + exp.evaluate(fac.getONE()));
+        System.out.println("exp(0) = " + exp.evaluate(fac.getZERO()));
+
+        BigDecimal dfac = new BigDecimal();
+        UnivPowerSeriesRing<BigDecimal> dpfac = new UnivPowerSeriesRing<BigDecimal>(dfac, 11, "z");
+        UnivPowerSeries<BigDecimal> dexp = dpfac.getEXP();
+        System.out.println("exp = " + dexp);
+        System.out.println("exp(1) = " + dexp.evaluate(dfac.getONE()));
+        System.out.println("exp(0) = " + dexp.evaluate(dfac.getZERO()));
+    }
+
+
+    public static void example14() {
+        BigRational cfac = new BigRational();
+        UnivPowerSeriesRing<BigRational> pfac = new UnivPowerSeriesRing<BigRational>(cfac, 11, "t");
+        System.out.println("pfac = " + pfac);
+        System.out.println("pfac = " + pfac.toScript());
+
+        GenPolynomialRing<UnivPowerSeries<BigRational>> fac = new GenPolynomialRing<UnivPowerSeries<BigRational>>(pfac,new String[] { "x"} ); 
+        System.out.println("fac = " + fac);
+        System.out.println("fac = " + fac.toScript());
+        List<UnivPowerSeries<BigRational>> gens = pfac.generators();
+        System.out.println("gens = " + gens);
+
+        GenPolynomial<UnivPowerSeries<BigRational>> p = fac.parse("x^2 - x");
+        System.out.println("p = " + p);
+        GenPolynomial<UnivPowerSeries<BigRational>> s = p.sum(gens.get(1).multiply(gens.get(1)));
+        System.out.println("s = " + s);
+
+        GenPolynomial<UnivPowerSeries<BigRational>> q = p.multiply(s);
+        System.out.println("q = " + q);
+
+        GenPolynomial<UnivPowerSeries<BigRational>> r = q.gcd(s);
+        System.out.println("r = " + r);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/ExamplesMulti.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/ExamplesMulti.java
@@ -1,0 +1,507 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ps;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.jas.arith.BigRational;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+
+
+/**
+ * Examples for multivariate power series implementations.
+ * @author Heinz Kredel
+ */
+
+public class ExamplesMulti {
+
+
+    public static void main(String[] args) {
+        if ( args.length > 0 ) {
+            example1();
+            example2();
+            example3();
+            example4();
+            example5();
+            example6();
+            example7();
+            example8();
+            example9();
+            example10();
+        }
+        example11();
+    }
+
+
+    public static void example1() {
+        BigRational br = new BigRational(1);
+        String[] vars = new String[] { "x", "y" };
+        GenPolynomialRing<BigRational> pfac = new GenPolynomialRing<BigRational>(br, vars);
+        System.out.println("pfac = " + pfac.toScript());
+
+        GenPolynomial<BigRational> a = pfac.parse("x^2  + x y");
+        GenPolynomial<BigRational> b = pfac.parse("y^2  + x y");
+        GenPolynomial<BigRational> c = pfac.parse("x^3  + x^2");
+        System.out.println("a = " + a);
+        System.out.println("b = " + b);
+        System.out.println("c = " + c);
+
+        MultiVarPowerSeriesRing<BigRational> fac = new MultiVarPowerSeriesRing<BigRational>(pfac);
+        System.out.println("fac = " + fac.toScript());
+
+        MultiVarPowerSeries<BigRational> ap = fac.fromPolynomial(a);
+        MultiVarPowerSeries<BigRational> bp = fac.fromPolynomial(b);
+        MultiVarPowerSeries<BigRational> cp = fac.fromPolynomial(c);
+        System.out.println("ap = " + ap);
+        System.out.println("bp = " + bp);
+        System.out.println("cp = " + cp);
+
+        List<MultiVarPowerSeries<BigRational>> L = new ArrayList<MultiVarPowerSeries<BigRational>>();
+        L.add(ap);
+        L.add(bp);
+        ReductionSeq<BigRational> red = new ReductionSeq<BigRational>();
+
+        MultiVarPowerSeries<BigRational> dp = red.normalform(L, cp);
+        System.out.println("dp = " + dp);
+    }
+
+
+    public static void example2() {
+        BigRational br = new BigRational(1);
+        String[] vars = new String[] { "x", "y" };
+        GenPolynomialRing<BigRational> pfac = new GenPolynomialRing<BigRational>(br, vars);
+        System.out.println("pfac = " + pfac.toScript());
+
+        GenPolynomial<BigRational> a = pfac.parse("x - x y");
+        GenPolynomial<BigRational> b = pfac.parse("y^2  + x^3");
+        GenPolynomial<BigRational> c = pfac.parse("x^2  + y^2");
+        System.out.println("a = " + a);
+        System.out.println("b = " + b);
+        System.out.println("c = " + c);
+
+        MultiVarPowerSeriesRing<BigRational> fac = new MultiVarPowerSeriesRing<BigRational>(pfac);
+        System.out.println("fac = " + fac.toScript());
+
+        MultiVarPowerSeries<BigRational> ap = fac.fromPolynomial(a);
+        MultiVarPowerSeries<BigRational> bp = fac.fromPolynomial(b);
+        MultiVarPowerSeries<BigRational> cp = fac.fromPolynomial(c);
+        System.out.println("ap = " + ap);
+        System.out.println("bp = " + bp);
+        System.out.println("cp = " + cp);
+
+        List<MultiVarPowerSeries<BigRational>> L = new ArrayList<MultiVarPowerSeries<BigRational>>();
+        L.add(ap);
+        L.add(bp);
+        ReductionSeq<BigRational> red = new ReductionSeq<BigRational>();
+
+        MultiVarPowerSeries<BigRational> dp = red.normalform(L, cp);
+        System.out.println("dp = " + dp);
+    }
+
+
+    public static void example3() {
+        BigRational br = new BigRational(1);
+        String[] vars = new String[] { "x", "y", "z" };
+        GenPolynomialRing<BigRational> pfac = new GenPolynomialRing<BigRational>(br, vars);
+        System.out.println("pfac = " + pfac.toScript());
+
+        GenPolynomial<BigRational> a = pfac.parse("x");
+        GenPolynomial<BigRational> b = pfac.parse("y");
+        GenPolynomial<BigRational> c = pfac.parse("x^2 + y^2 + z^3 + x^4 + y^5");
+        System.out.println("a = " + a);
+        System.out.println("b = " + b);
+        System.out.println("c = " + c);
+
+        MultiVarPowerSeriesRing<BigRational> fac = new MultiVarPowerSeriesRing<BigRational>(pfac);
+        System.out.println("fac = " + fac.toScript());
+
+        MultiVarPowerSeries<BigRational> ap = fac.fromPolynomial(a);
+        MultiVarPowerSeries<BigRational> bp = fac.fromPolynomial(b);
+        MultiVarPowerSeries<BigRational> cp = fac.fromPolynomial(c);
+        System.out.println("ap = " + ap);
+        System.out.println("bp = " + bp);
+        System.out.println("cp = " + cp);
+
+        List<MultiVarPowerSeries<BigRational>> L = new ArrayList<MultiVarPowerSeries<BigRational>>();
+        L.add(ap);
+        L.add(bp);
+        ReductionSeq<BigRational> red = new ReductionSeq<BigRational>();
+
+        MultiVarPowerSeries<BigRational> dp = red.normalform(L, cp);
+        System.out.println("dp = " + dp);
+    }
+
+
+    public static void example4() {
+        BigRational br = new BigRational(1);
+        String[] vars = new String[] { "x" };
+        GenPolynomialRing<BigRational> pfac = new GenPolynomialRing<BigRational>(br, vars);
+        System.out.println("pfac = " + pfac.toScript());
+
+        GenPolynomial<BigRational> a = pfac.parse("x + x^3 + x^5");
+        GenPolynomial<BigRational> c = pfac.parse("x + x^2");
+        System.out.println("a = " + a);
+        System.out.println("c = " + c);
+
+        MultiVarPowerSeriesRing<BigRational> fac = new MultiVarPowerSeriesRing<BigRational>(pfac);
+        //fac.setTruncate(11);
+        System.out.println("fac = " + fac.toScript());
+
+        MultiVarPowerSeries<BigRational> ap = fac.fromPolynomial(a);
+        MultiVarPowerSeries<BigRational> cp = fac.fromPolynomial(c);
+        System.out.println("ap = " + ap);
+        System.out.println("cp = " + cp);
+
+        List<MultiVarPowerSeries<BigRational>> L = new ArrayList<MultiVarPowerSeries<BigRational>>();
+        L.add(ap);
+        ReductionSeq<BigRational> red = new ReductionSeq<BigRational>();
+
+        MultiVarPowerSeries<BigRational> dp = red.normalform(L, cp);
+        System.out.println("dp = " + dp);
+    }
+
+
+    public static void example5() {
+        BigRational br = new BigRational(1);
+        String[] vars = new String[] { "x", "y" };
+        GenPolynomialRing<BigRational> pfac = new GenPolynomialRing<BigRational>(br, vars);
+        System.out.println("pfac = " + pfac.toScript());
+
+        GenPolynomial<BigRational> c = pfac.parse("x^2  + y^2 - 1");
+        System.out.println("c = " + c);
+
+        MultiVarPowerSeriesRing<BigRational> fac = new MultiVarPowerSeriesRing<BigRational>(pfac);
+        //fac.setTruncate(19);
+        System.out.println("fac = " + fac.toScript());
+
+        MultiVarPowerSeries<BigRational> ap = fac.getSIN(0);
+        MultiVarPowerSeries<BigRational> bp = fac.getCOS(1);
+        MultiVarPowerSeries<BigRational> ep = fac.getCOS(0);
+        MultiVarPowerSeries<BigRational> cp = fac.fromPolynomial(c);
+        System.out.println("ap = " + ap);
+        System.out.println("bp = " + bp);
+        System.out.println("ep = " + ep);
+        System.out.println("cp = " + cp);
+        System.out.println("ap^2 + ep^2 = " + ap.multiply(ap).sum(ep.multiply(ep)));
+
+        List<MultiVarPowerSeries<BigRational>> L = new ArrayList<MultiVarPowerSeries<BigRational>>();
+        L.add(ap);
+        L.add(bp);
+        ReductionSeq<BigRational> red = new ReductionSeq<BigRational>();
+
+        MultiVarPowerSeries<BigRational> dp = red.normalform(L, cp);
+        System.out.println("dp = " + dp);
+    }
+
+
+    public static void example6() {
+        BigRational br = new BigRational(1);
+        String[] vars = new String[] { "x", "y", "z" };
+        GenPolynomialRing<BigRational> pfac = new GenPolynomialRing<BigRational>(br, vars);
+        System.out.println("pfac = " + pfac.toScript());
+
+        GenPolynomial<BigRational> a = pfac.parse("x^5 - x y^6 + z^7");
+        GenPolynomial<BigRational> b = pfac.parse("x y + y^3 + z^3");
+        GenPolynomial<BigRational> c = pfac.parse("x^2 + y^2 - z^2");
+        System.out.println("a = " + a);
+        System.out.println("b = " + b);
+        System.out.println("c = " + c);
+
+        MultiVarPowerSeriesRing<BigRational> fac = new MultiVarPowerSeriesRing<BigRational>(pfac);
+        //fac.setTruncate(11);
+        System.out.println("fac = " + fac.toScript());
+
+        MultiVarPowerSeries<BigRational> ap = fac.fromPolynomial(a);
+        MultiVarPowerSeries<BigRational> bp = fac.fromPolynomial(b);
+        MultiVarPowerSeries<BigRational> cp = fac.fromPolynomial(c);
+        System.out.println("ap = " + ap);
+        System.out.println("bp = " + bp);
+        System.out.println("cp = " + cp);
+
+        List<MultiVarPowerSeries<BigRational>> L = new ArrayList<MultiVarPowerSeries<BigRational>>();
+        L.add(ap);
+        L.add(bp);
+        L.add(cp);
+        StandardBaseSeq<BigRational> tm = new StandardBaseSeq<BigRational>();
+
+        List<MultiVarPowerSeries<BigRational>> S = tm.STD(L);
+        for (MultiVarPowerSeries<BigRational> ps : S) {
+            System.out.println("ps = " + ps);
+        }
+        System.out.println("\nS = " + S);
+
+        boolean s = tm.isSTD(S);
+        System.out.println("\nisSTD = " + s);
+
+        ReductionSeq<BigRational> red = new ReductionSeq<BigRational>();
+        s = red.contains(S, L);
+        System.out.println("S contains L = " + s);
+    }
+
+
+    public static void example7() {
+        BigRational br = new BigRational(1);
+        String[] vars = new String[] { "x", "y" };
+        GenPolynomialRing<BigRational> pfac = new GenPolynomialRing<BigRational>(br, vars);
+        System.out.println("pfac = " + pfac.toScript());
+
+        GenPolynomial<BigRational> a = pfac.parse("x^10 + x^9 y^2");
+        GenPolynomial<BigRational> b = pfac.parse("y^8 - x^2 y^7");
+        System.out.println("a = " + a);
+        System.out.println("b = " + b);
+
+        MultiVarPowerSeriesRing<BigRational> fac = new MultiVarPowerSeriesRing<BigRational>(pfac);
+        fac.setTruncate(12);
+        System.out.println("fac = " + fac.toScript());
+
+        MultiVarPowerSeries<BigRational> ap = fac.fromPolynomial(a);
+        MultiVarPowerSeries<BigRational> bp = fac.fromPolynomial(b);
+        System.out.println("ap = " + ap);
+        System.out.println("bp = " + bp);
+
+        List<MultiVarPowerSeries<BigRational>> L = new ArrayList<MultiVarPowerSeries<BigRational>>();
+        L.add(ap);
+        L.add(bp);
+
+        StandardBaseSeq<BigRational> tm = new StandardBaseSeq<BigRational>();
+        List<MultiVarPowerSeries<BigRational>> S = tm.STD(L);
+        for (MultiVarPowerSeries<BigRational> ps : S) {
+            System.out.println("ps = " + ps);
+        }
+        System.out.println("\nS = " + S);
+
+        boolean s = tm.isSTD(S);
+        System.out.println("\nisSTD = " + s);
+
+        ReductionSeq<BigRational> red = new ReductionSeq<BigRational>();
+        s = red.contains(S, L);
+        System.out.println("\nS contains L = " + s);
+    }
+
+
+    public static void example8() {
+        BigRational br = new BigRational(1);
+        String[] vars = new String[] { "x", "y" };
+        GenPolynomialRing<BigRational> pfac = new GenPolynomialRing<BigRational>(br, vars);
+        System.out.println("pfac = " + pfac.toScript());
+
+        GenPolynomial<BigRational> c = pfac.parse("x^2  + y^2");
+        System.out.println("c = " + c);
+
+        MultiVarPowerSeriesRing<BigRational> fac = new MultiVarPowerSeriesRing<BigRational>(pfac);
+        //fac.setTruncate(19);
+        System.out.println("fac = " + fac.toScript());
+
+        MultiVarPowerSeries<BigRational> ap = fac.getSIN(0);
+        MultiVarPowerSeries<BigRational> bp = fac.getTAN(0);
+        MultiVarPowerSeries<BigRational> cp = fac.fromPolynomial(c);
+        System.out.println("ap = " + ap);
+        System.out.println("bp = " + bp);
+        System.out.println("cp = " + cp);
+
+        List<MultiVarPowerSeries<BigRational>> L = new ArrayList<MultiVarPowerSeries<BigRational>>();
+        L.add(ap);
+        L.add(bp);
+        //L.add(cp);
+        System.out.println("\nL = " + L);
+
+        StandardBaseSeq<BigRational> tm = new StandardBaseSeq<BigRational>();
+
+        List<MultiVarPowerSeries<BigRational>> S = tm.STD(L);
+        for (MultiVarPowerSeries<BigRational> ps : S) {
+            System.out.println("ps = " + ps);
+        }
+        System.out.println("\nS = " + S);
+
+        boolean s = tm.isSTD(S);
+        System.out.println("\nisSTD = " + s);
+
+        ReductionSeq<BigRational> red = new ReductionSeq<BigRational>();
+        s = red.contains(S, L);
+        System.out.println("S contains L = " + s);
+    }
+
+
+    public static void example9() {
+        BigRational br = new BigRational(1);
+        String[] vars = new String[] { "x", "y", "z" };
+        GenPolynomialRing<BigRational> pfac = new GenPolynomialRing<BigRational>(br, vars);
+        System.out.println("pfac = " + pfac.toScript());
+
+        GenPolynomial<BigRational> a = pfac.parse("x z - y z - y^2 z");
+        GenPolynomial<BigRational> b = pfac.parse("x z - y z + y^2 z");
+        GenPolynomial<BigRational> c = pfac.parse("z + y^2 z");
+        System.out.println("a = " + a);
+        System.out.println("b = " + b);
+        System.out.println("c = " + c);
+
+        MultiVarPowerSeriesRing<BigRational> fac = new MultiVarPowerSeriesRing<BigRational>(pfac);
+        fac.setTruncate(11);
+        System.out.println("fac = " + fac.toScript());
+
+        MultiVarPowerSeries<BigRational> ap = fac.fromPolynomial(a);
+        MultiVarPowerSeries<BigRational> bp = fac.fromPolynomial(b);
+        MultiVarPowerSeries<BigRational> cp = fac.fromPolynomial(c);
+        System.out.println("ap = " + ap);
+        System.out.println("bp = " + bp);
+        System.out.println("cp = " + cp);
+
+        List<MultiVarPowerSeries<BigRational>> L = new ArrayList<MultiVarPowerSeries<BigRational>>();
+        L.add(ap);
+        L.add(bp);
+        L.add(cp);
+        StandardBaseSeq<BigRational> tm = new StandardBaseSeq<BigRational>();
+
+        List<MultiVarPowerSeries<BigRational>> S = tm.STD(L);
+        for (MultiVarPowerSeries<BigRational> ps : S) {
+            System.out.println("ps = " + ps);
+        }
+        System.out.println("\nS = " + S);
+
+        boolean s = tm.isSTD(S);
+        System.out.println("\nisSTD = " + s);
+
+        ReductionSeq<BigRational> red = new ReductionSeq<BigRational>();
+        s = red.contains(S, L);
+        System.out.println("S contains L = " + s);
+    }
+
+
+    public static void example10() {
+        BigRational br = new BigRational(1);
+        String[] vars = new String[] { "x", "y", "z" };
+        GenPolynomialRing<BigRational> pfac = new GenPolynomialRing<BigRational>(br, vars);
+        System.out.println("pfac = " + pfac.toScript());
+
+        GenPolynomial<BigRational> a = pfac.parse("x^2 z^2 - y^6");
+        GenPolynomial<BigRational> b = pfac.parse("x y z^2 + y^4 z - x^5 z - x^4 y^3");
+        GenPolynomial<BigRational> c = pfac.parse("x z - y^3 + x^2 z - x y^3");
+        GenPolynomial<BigRational> d = pfac.parse("y z + x y z - x^4 - x^5");
+        System.out.println("a = " + a);
+        System.out.println("b = " + b);
+        System.out.println("c = " + c);
+        System.out.println("d = " + d);
+
+        MultiVarPowerSeriesRing<BigRational> fac = new MultiVarPowerSeriesRing<BigRational>(pfac);
+        fac.setTruncate(9);
+        System.out.println("fac = " + fac.toScript());
+
+        MultiVarPowerSeries<BigRational> ap = fac.fromPolynomial(a);
+        MultiVarPowerSeries<BigRational> bp = fac.fromPolynomial(b);
+        MultiVarPowerSeries<BigRational> cp = fac.fromPolynomial(c);
+        MultiVarPowerSeries<BigRational> dp = fac.fromPolynomial(d);
+        System.out.println("ap = " + ap);
+        System.out.println("bp = " + bp);
+        System.out.println("cp = " + cp);
+        System.out.println("dp = " + dp);
+
+        List<MultiVarPowerSeries<BigRational>> L = new ArrayList<MultiVarPowerSeries<BigRational>>();
+        L.add(ap);
+        L.add(bp);
+        L.add(cp);
+        L.add(dp);
+        StandardBaseSeq<BigRational> tm = new StandardBaseSeq<BigRational>();
+
+        List<MultiVarPowerSeries<BigRational>> S = tm.STD(L);
+        for (MultiVarPowerSeries<BigRational> ps : S) {
+            System.out.println("ps = " + ps);
+        }
+        System.out.println("\nS = " + S);
+
+        boolean s = tm.isSTD(S);
+        System.out.println("\nisSTD = " + s);
+
+        ReductionSeq<BigRational> red = new ReductionSeq<BigRational>();
+        s = red.contains(S, L);
+        System.out.println("S contains L = " + s);
+
+        List<MultiVarPowerSeries<BigRational>> R = red.totalNormalform(S);
+        System.out.println("R = " + R);
+        s = red.contains(R, L);
+        System.out.println("R contains L = " + s);
+        s = red.contains(R, S);
+        System.out.println("R contains S = " + s);
+    }
+
+
+    public static void example11() {
+        BigRational br = new BigRational(1);
+        String[] vars = new String[] { "x", "y", "z" };
+        GenPolynomialRing<BigRational> pfac = new GenPolynomialRing<BigRational>(br, vars);
+        System.out.println("pfac = " + pfac.toScript());
+
+        GenPolynomial<BigRational> a = pfac.parse("x^5 - x y^6 - z^7");
+        GenPolynomial<BigRational> b = pfac.parse("x y + y^3 + z^3");
+        GenPolynomial<BigRational> c = pfac.parse("x^2 + y^2 - z^2");
+        System.out.println("a = " + a);
+        System.out.println("b = " + b);
+        System.out.println("c = " + c);
+
+        MultiVarPowerSeriesRing<BigRational> fac = new MultiVarPowerSeriesRing<BigRational>(pfac);
+        //fac.setTruncate(9);
+        System.out.println("fac = " + fac.toScript());
+
+        MultiVarPowerSeries<BigRational> ap = fac.fromPolynomial(a);
+        MultiVarPowerSeries<BigRational> bp = fac.fromPolynomial(b);
+        MultiVarPowerSeries<BigRational> cp = fac.fromPolynomial(c);
+        System.out.println("ap = " + ap);
+        System.out.println("bp = " + bp);
+        System.out.println("cp = " + cp);
+
+        List<MultiVarPowerSeries<BigRational>> L = new ArrayList<MultiVarPowerSeries<BigRational>>();
+        L.add(ap);
+        L.add(bp);
+        L.add(cp);
+        StandardBaseSeq<BigRational> tm = new StandardBaseSeq<BigRational>();
+
+        List<MultiVarPowerSeries<BigRational>> S = tm.STD(L);
+        for (MultiVarPowerSeries<BigRational> ps : S) {
+            System.out.println("ps = " + ps);
+        }
+        System.out.println("\nS = " + S);
+
+        boolean s = tm.isSTD(S);
+        System.out.println("\nisSTD = " + s);
+
+        ReductionSeq<BigRational> red = new ReductionSeq<BigRational>();
+        s = red.contains(S, L);
+        System.out.println("S contains L = " + s);
+
+        List<MultiVarPowerSeries<BigRational>> R = red.totalNormalform(S);
+        for (MultiVarPowerSeries<BigRational> ps : R) {
+            System.out.println("ps = " + ps);
+        }
+        System.out.println("\nR = " + R);
+        s = tm.isSTD(R);
+        System.out.println("\nisSTD = " + s);
+
+        s = red.contains(R, L);
+        System.out.println("R contains L = " + s);
+        s = red.contains(R, S);
+        System.out.println("R contains S = " + s);
+        s = red.contains(S,R);
+        System.out.println("S contains R = " + s);
+        s = red.contains(S,L);
+        System.out.println("S contains L = " + s);
+
+        List<MultiVarPowerSeries<BigRational>> Rs = tm.STD(R);
+        for (MultiVarPowerSeries<BigRational> ps : Rs) {
+            System.out.println("ps = " + ps);
+        }
+        System.out.println("\nRs = " + Rs);
+        s = tm.isSTD(Rs);
+        System.out.println("\nisSTD = " + s);
+
+        s = red.contains(Rs, R);
+        System.out.println("Rs contains R = " + s);
+
+        s = red.contains(Rs, S);
+        System.out.println("Rs contains S = " + s);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/ExpVectorIterable.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/ExpVectorIterable.java
@@ -1,0 +1,235 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ps;
+
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.List;
+import java.util.ArrayList;
+
+
+import edu.jas.poly.ExpVector;
+import edu.jas.util.CartesianProductLong;
+import edu.jas.util.LongIterable;
+
+
+/**
+ * Iterable for ExpVector, using total degree enumeration.
+ * @author Heinz Kredel
+ */
+public class ExpVectorIterable implements Iterable<ExpVector> {
+
+
+    protected long upperBound;
+
+
+    final boolean infinite;
+
+
+    final int nvar;
+
+
+    /**
+     * Constructor.
+     * @param nv number of variables.
+     */
+    public ExpVectorIterable(int nv) {
+        this(nv,true,Long.MAX_VALUE);
+    }
+
+
+    /**
+     * Constructor.
+     * @param nv number of variables.
+     * @param ub upper bound for the components.
+     */
+    public ExpVectorIterable(int nv, long ub) {
+        this(nv,false,ub);
+    }
+
+
+    /**
+     * Constructor.
+     * @param nv number of variables.
+     * @param all true, if all elements between 0 and upper bound are enumerated, 
+                  false, if only elements of exact upper bund are to be processed.
+     * @param ub upper bound for the components.
+     */
+    public ExpVectorIterable(int nv, boolean all, long ub) {
+        upperBound = ub;
+        infinite = all;
+        nvar = nv;
+    }
+
+
+    /** Set the upper bound for the iterator.
+     * @param ub an upper bound for the iterator elements. 
+     */
+    public void setUpperBound(long ub) {
+        upperBound = ub;
+    }
+
+
+    /** Get the upper bound for the iterator.
+     * @return the upper bound for the iterator elements. 
+     */
+    public long getUpperBound() {
+        return upperBound;
+    }
+
+
+    /**
+     * Get an iterator over ExpVector.
+     * @return an iterator.
+     */
+    public Iterator<ExpVector> iterator() {
+        return new ExpVectorIterator(nvar,infinite,upperBound);
+    }
+
+}
+
+
+/**
+ * ExpVector iterator using CartesianProductLongIterator.
+ * @author Heinz Kredel
+ */
+class ExpVectorIterator implements Iterator<ExpVector> {
+
+
+    /**
+     * data structure.
+     */
+    ExpVector current;
+
+
+    Iterator<List<Long>> liter;
+
+
+    protected int totalDegree;
+
+
+    protected boolean empty;
+
+
+    final long upperBound;
+
+
+    final boolean infinite;
+
+
+    final int nvar;
+
+
+    /**
+     * ExpVector iterator constructor.
+     * @param nv number of variables.
+     */
+    public ExpVectorIterator(int nv) {
+        this(nv,true,Long.MAX_VALUE);
+    }
+
+
+    /**
+     * ExpVector iterator constructor.
+     * @param nv number of variables.
+     * @param ub upper bound for the components.
+     */
+    public ExpVectorIterator(int nv,long ub) {
+        this(nv,false,ub);
+    }
+
+
+    /**
+     * ExpVector iterator constructor.
+     * @param nv number of variables.
+     * @param inf true, if all elements between 0 and upper bound are enumerated, 
+                  false, if only elements of exact upper bund are to be processed.
+     * @param ub an upper bound for the entrys.
+     */
+    protected ExpVectorIterator(int nv, boolean inf, long ub) {
+        infinite = inf; 
+        upperBound = ub;
+        if (upperBound < 0L) {
+            throw new IllegalArgumentException("negative upper bound not allowed");
+        }
+        totalDegree = 0;
+        if ( !infinite ) {
+            totalDegree = (int)upperBound;
+        }
+        //System.out.println("totalDegree = " + totalDegree + ", upperBound = " + upperBound);
+        LongIterable li = new LongIterable();
+        li.setNonNegativeIterator();
+        li.setUpperBound(totalDegree);
+        List<LongIterable> tlist = new ArrayList<LongIterable>(nv);
+        for (int i = 0; i < nv; i++) {
+            tlist.add(li); // can reuse li
+        }
+        Iterable<List<Long>> ib = new CartesianProductLong(tlist,totalDegree);
+        liter = ib.iterator();
+        empty = (totalDegree > upperBound) || !liter.hasNext();
+        current = ExpVector.create(nv);
+        if ( !empty ) {
+            List<Long> el = liter.next();
+            current = ExpVector.create(el);
+            //System.out.println("current = " + current);
+        }
+        nvar = nv;
+    }
+
+
+    /**
+     * Test for availability of a next long.
+     * @return true if the iteration has more ExpVectors, else false.
+     */
+    public synchronized boolean hasNext() {
+        return !empty;
+    }
+
+
+    /**
+     * Get next ExpVector.
+     * @return next ExpVector.
+     */
+    public synchronized ExpVector next() {
+        ExpVector res = current;
+        if ( liter.hasNext() ) {
+            List<Long> el = liter.next();
+            current = ExpVector.create(el);
+            //System.out.println("current, liter = " + current);
+            return res;
+        } 
+        if ( totalDegree >= upperBound ) {
+            empty = true;
+            return res;
+        }
+        totalDegree++;
+        //System.out.println("totalDegree,b = " + totalDegree);
+        if ( totalDegree >= upperBound && !infinite ) {
+            throw new NoSuchElementException("invalid call of next()");
+        }
+        LongIterable li = new LongIterable();
+        li.setNonNegativeIterator();
+        li.setUpperBound(totalDegree);
+        List<LongIterable> tlist = new ArrayList<LongIterable>(nvar);
+        for (int i = 0; i < nvar; i++) {
+            tlist.add(li); // can reuse li
+        }
+        Iterable<List<Long>> ib = new CartesianProductLong(tlist,totalDegree);
+        liter = ib.iterator();
+        List<Long> el = liter.next();
+        current = ExpVector.create(el);
+        return res;
+    }
+
+
+    /**
+     * Remove a tuple if allowed.
+     */
+    public void remove() {
+        throw new UnsupportedOperationException("cannnot remove elements");
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/MultiVarCoefficients.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/MultiVarCoefficients.java
@@ -1,0 +1,229 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ps;
+
+
+import java.io.Serializable;
+import java.util.BitSet;
+import java.util.HashMap;
+import java.util.HashSet;
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Abstract class for generating functions for coefficients of multivariate
+ * power series. This class handles the caching itself.
+ * @param <C> ring element type
+ * @author Heinz Kredel
+ */
+
+public abstract class MultiVarCoefficients<C extends RingElem<C>> implements Serializable {
+
+
+    /**
+     * Ring factory for polynomials.
+     */
+    public final GenPolynomialRing<C> pfac;
+
+
+    /**
+     * Cache for already computed coefficients.
+     */
+    public final HashMap<Long, GenPolynomial<C>> coeffCache;
+
+
+    /**
+     * Indicator if all coefficients of a homogeneous degree have been
+     * constructed.
+     */
+    public final BitSet homCheck;
+
+
+    /**
+     * Cache for known zero coefficients. Required because zero coefficients are
+     * not stored in the polynomials.
+     */
+    public final HashSet<ExpVector> zeroCache;
+
+
+    /**
+     * Public constructor.
+     * @param pf multivariate power series ring factory.
+     */
+    public MultiVarCoefficients(MultiVarPowerSeriesRing<C> pf) {
+        this(pf.polyRing(), new HashMap<Long, GenPolynomial<C>>(), new HashSet<ExpVector>());
+    }
+
+
+    /*
+     * Public constructor with some pre-filled caches.
+     * @param pf multivariate power series ring factory.
+     * @param hc pre-filled homogeneous check bit-set.
+    public MultiVarCoefficients(MultiVarPowerSeriesRing<C> pf, BitSet hc) {
+        this(pf.polyRing(), new HashMap<Long, GenPolynomial<C>>(), new HashSet<ExpVector>(), hc);
+    }
+     */
+
+
+    /**
+     * Public constructor.
+     * @param pf polynomial ring factory.
+     */
+    public MultiVarCoefficients(GenPolynomialRing<C> pf) {
+        this(pf, new HashMap<Long, GenPolynomial<C>>(), new HashSet<ExpVector>());
+    }
+
+
+    /**
+     * Public with pre-filled coefficient cache.
+     * @param pf polynomial ring factory.
+     * @param cache pre-filled coefficient cache.
+     */
+    public MultiVarCoefficients(GenPolynomialRing<C> pf, HashMap<Long, GenPolynomial<C>> cache) {
+        this(pf, cache, new HashSet<ExpVector>());
+    }
+
+
+    /**
+     * Public constructor with pre-filled caches.
+     * @param pf polynomial ring factory.
+     * @param cache pre-filled coefficient cache.
+     * @param zeros pre-filled zero coefficient cache.
+     */
+    public MultiVarCoefficients(GenPolynomialRing<C> pf, HashMap<Long, GenPolynomial<C>> cache,
+            HashSet<ExpVector> zeros) {
+        this(pf, cache, zeros, new BitSet());
+    }
+
+
+    /*
+     * Public constructor with pre-filled caches.
+     * @param pf polynomial ring factory.
+     * @param hc pre-filled homogeneous check bit-set.
+    public MultiVarCoefficients(GenPolynomialRing<C> pf, BitSet hc) {
+        this(pf, new HashMap<Long, GenPolynomial<C>>(), new HashSet<ExpVector>(), hc);
+    }
+     */
+
+
+    /**
+     * Public constructor with pre-filled caches.
+     * @param pf polynomial ring factory.
+     * @param cache pre-filled coefficient cache.
+     * @param hc pre-filled homogeneous check bit-set.
+     */
+    public MultiVarCoefficients(GenPolynomialRing<C> pf, HashMap<Long, GenPolynomial<C>> cache, BitSet hc) {
+        this(pf, cache, new HashSet<ExpVector>(), hc);
+    }
+
+
+    /**
+     * Public constructor with pre-filled caches.
+     * @param pf polynomial ring factory.
+     * @param cache pre-filled coefficient cache.
+     * @param zeros pre-filled zero coefficient cache.
+     * @param hc pre-filled homogeneous check bit-set.
+     */
+    public MultiVarCoefficients(GenPolynomialRing<C> pf, HashMap<Long, GenPolynomial<C>> cache,
+            HashSet<ExpVector> zeros, BitSet hc) {
+        pfac = pf;
+        coeffCache = cache;
+        zeroCache = zeros;
+        homCheck = hc;
+    }
+
+
+    /**
+     * Get cached coefficient or generate coefficient.
+     * @param index of requested coefficient.
+     * @return coefficient at index.
+     */
+    public C get(ExpVector index) {
+        //if (index.signum() < 0) { // better assert
+        //    throw new IllegalArgumentException("negative signum not allowed " + index);
+        //}
+        //if (coeffCache == null) { // not possible
+        //    return generate(index);
+        //}
+        long tdeg = index.totalDeg();
+        GenPolynomial<C> p = coeffCache.get(tdeg);
+        if (p == null) {
+            p = pfac.getZERO().copy();
+            coeffCache.put(tdeg, p);
+        }
+        C c = p.coefficient(index);
+        if (!c.isZERO()) {
+            return c;
+        }
+        if (homCheck.get((int) tdeg)) { // rely on p
+            return c;
+        }
+        if (zeroCache.contains(index)) {
+            return c;
+        }
+        C g = generate(index);
+        if (g.isZERO()) {
+            zeroCache.add(index);
+        } else {
+            p.doPutToMap(index, g);
+        }
+        return g;
+    }
+
+
+    /**
+     * Homogeneous part.
+     * @param tdeg requested degree.
+     * @return polynomial part of given degree.
+     */
+    public GenPolynomial<C> getHomPart(long tdeg) {
+        if (coeffCache == null) {
+            throw new IllegalArgumentException("null cache not allowed");
+        }
+        GenPolynomial<C> p = coeffCache.get(tdeg);
+        if (p == null) {
+            p = pfac.getZERO().copy();
+            coeffCache.put(tdeg, p);
+        } 
+        // trust contents?
+        if (homCheck.get((int) tdeg)) {
+            return p;
+        }
+        // check correct contents or generate coefficients
+        ExpVectorIterable eiter = new ExpVectorIterable(pfac.nvar, tdeg);
+        for (ExpVector e : eiter) {
+            if (zeroCache.contains(e)) {
+                if ( !zeroCache.remove(e) ) { // clean-up unused
+                    System.out.println("not removed e = " + e); // cannot happen
+                }
+                continue;
+            }
+            if (!p.coefficient(e).isZERO()) {
+                continue;
+            }
+            C g = generate(e);
+            if (!g.isZERO()) {
+                p.doPutToMap(e, g);
+            }
+        }
+        homCheck.set((int) tdeg);
+        //System.out.println("homCheck = " + homCheck);
+        //System.out.println("coeffCache = " + coeffCache.keySet());
+        return p;
+    }
+
+
+    /**
+     * Generate coefficient.
+     * @param index of requested coefficient.
+     * @return coefficient at index.
+     */
+    protected abstract C generate(ExpVector index);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/MultiVarPowerSeries.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/MultiVarPowerSeries.java
@@ -1,0 +1,1389 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ps;
+
+
+import java.util.BitSet;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.BinaryFunctor;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.Selector;
+import edu.jas.structure.UnaryFunctor;
+import edu.jas.util.MapEntry;
+
+
+/**
+ * Multivariate power series implementation. Uses inner classes and lazy
+ * evaluated generating function for coefficients. All ring element methods use
+ * lazy evaluation except where noted otherwise. Eager evaluated methods are
+ * <code>toString()</code>, <code>compareTo()</code>, <code>equals()</code>,
+ * <code>evaluate()</code>, or methods which use the <code>order()</code> or
+ * <code>orderExpVector()</code> methods, like <code>signum()</code>,
+ * <code>abs()</code>, <code>divide()</code>, <code>remainder()</code> and
+ * <code>gcd()</code>. <b>Note: </b> Currently the term order is fixed to the
+ * order defined by the iterator over exponent vectors in class
+ * <code>ExpVectorIterator</code>.
+ * @param <C> ring element type
+ * @author Heinz Kredel
+ */
+
+public class MultiVarPowerSeries<C extends RingElem<C>> implements RingElem<MultiVarPowerSeries<C>> {
+
+
+    /**
+     * Power series ring factory.
+     */
+    public final MultiVarPowerSeriesRing<C> ring;
+
+
+    /**
+     * Data structure / generating function for coeffcients. Cannot be final
+     * because of fixPoint, must be accessible in factory.
+     */
+    /*package*/MultiVarCoefficients<C> lazyCoeffs;
+
+
+    /**
+     * Truncation of computations.
+     */
+    private int truncate;
+
+
+    /**
+     * Order of power series.
+     */
+    private int order = -1; // == unknown
+
+
+    /**
+     * ExpVector of order of power series.
+     */
+    private ExpVector evorder = null; // == unknown
+
+
+    /**
+     * Private constructor.
+     */
+    @SuppressWarnings("unused")
+    private MultiVarPowerSeries() {
+        throw new IllegalArgumentException("do not use no-argument constructor");
+    }
+
+
+    /**
+     * Package constructor. Use in fixPoint only, must be accessible in factory.
+     * @param ring power series ring.
+     */
+    /*package*/ MultiVarPowerSeries(MultiVarPowerSeriesRing<C> ring) {
+        this.ring = ring;
+        this.lazyCoeffs = null;
+        this.truncate = ring.truncate;
+    }
+
+
+    /**
+     * Constructor.
+     * @param ring power series ring.
+     * @param lazyCoeffs generating function for coefficients.
+     */
+    public MultiVarPowerSeries(MultiVarPowerSeriesRing<C> ring, MultiVarCoefficients<C> lazyCoeffs) {
+        this(ring, lazyCoeffs, ring.truncate);
+    }
+
+
+    /**
+     * Constructor.
+     * @param ring power series ring.
+     * @param lazyCoeffs generating function for coefficients.
+     * @param trunc truncate parameter for this power series.
+     */
+    public MultiVarPowerSeries(MultiVarPowerSeriesRing<C> ring, MultiVarCoefficients<C> lazyCoeffs,
+                    int trunc) {
+        if (lazyCoeffs == null || ring == null) {
+            throw new IllegalArgumentException(
+                            "null not allowed: ring = " + ring + ", lazyCoeffs = " + lazyCoeffs);
+        }
+        this.ring = ring;
+        this.lazyCoeffs = lazyCoeffs;
+        this.truncate = Math.min(trunc, ring.truncate);
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public MultiVarPowerSeriesRing<C> factory() {
+        return ring;
+    }
+
+
+    /**
+     * Clone this power series.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public MultiVarPowerSeries<C> copy() {
+        return new MultiVarPowerSeries<C>(ring, lazyCoeffs);
+    }
+
+
+    /**
+     * String representation of power series.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return toString(truncate);
+    }
+
+
+    /**
+     * To String with given truncate.
+     * @param trunc truncate parameter for this power series.
+     * @return string representation of this to given truncate.
+     */
+    public String toString(int trunc) {
+        StringBuffer sb = new StringBuffer();
+        MultiVarPowerSeries<C> s = this;
+        String[] vars = ring.vars;
+        //System.out.println("cache1 = " + s.lazyCoeffs.coeffCache);
+        for (ExpVector i : new ExpVectorIterable(ring.nvar, true, trunc)) {
+            C c = s.coefficient(i);
+            //System.out.println("i = " + i + ", c = " +c);
+            int si = c.signum();
+            if (si != 0) {
+                if (si > 0) {
+                    if (sb.length() > 0) {
+                        sb.append(" + ");
+                    }
+                } else {
+                    c = c.negate();
+                    sb.append(" - ");
+                }
+                if (!c.isONE() || i.isZERO()) {
+                    if (c instanceof GenPolynomial || c instanceof AlgebraicNumber) {
+                        sb.append("{ ");
+                    }
+                    sb.append(c.toString());
+                    if (c instanceof GenPolynomial || c instanceof AlgebraicNumber) {
+                        sb.append(" }");
+                    }
+                    if (!i.isZERO()) {
+                        sb.append(" * ");
+                    }
+                }
+                if (i.isZERO()) {
+                    //skip; sb.append(" ");
+                } else {
+                    sb.append(i.toString(vars));
+                }
+                //sb.append(c.toString() + ", ");
+            }
+            //System.out.println("cache = " + s.coeffCache);
+        }
+        if (sb.length() == 0) {
+            sb.append("0");
+        }
+        sb.append(" + BigO( (" + ring.varsToString() + ")^" + (trunc + 1) + "(" + (ring.truncate + 1)
+                        + ") )");
+        //sb.append("...");
+        //System.out.println("cache2 = " + s.lazyCoeffs.coeffCache);
+        return sb.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        StringBuffer sb = new StringBuffer("");
+        MultiVarPowerSeries<C> s = this;
+        String[] vars = ring.vars;
+        //System.out.println("cache = " + s.coeffCache);
+        for (ExpVector i : new ExpVectorIterable(ring.nvar, true, truncate)) {
+            C c = s.coefficient(i);
+            int si = c.signum();
+            if (si != 0) {
+                if (si > 0) {
+                    if (sb.length() > 0) {
+                        sb.append(" + ");
+                    }
+                } else {
+                    c = c.negate();
+                    sb.append(" - ");
+                }
+                if (!c.isONE() || i.isZERO()) {
+                    if (c instanceof GenPolynomial || c instanceof AlgebraicNumber) {
+                        sb.append("( ");
+                    }
+                    sb.append(c.toScript());
+                    if (c instanceof GenPolynomial || c instanceof AlgebraicNumber) {
+                        sb.append(" )");
+                    }
+                    if (!i.isZERO()) {
+                        sb.append(" * ");
+                    }
+                }
+                if (i.isZERO()) {
+                    //skip; sb.append(" ");
+                } else {
+                    sb.append(i.toScript(vars));
+                }
+                //sb.append(c.toString() + ", ");
+            }
+            //System.out.println("cache = " + s.coeffCache);
+        }
+        if (sb.length() == 0) {
+            sb.append("0");
+        }
+        sb.append(" + BigO( (" + ring.varsToString() + ")**" + (truncate + 1) + " )");
+        // sb.append("," + truncate + "");
+        return sb.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python case
+        return factory().toScript();
+    }
+
+
+    /**
+     * Get coefficient.
+     * @param index number of requested coefficient.
+     * @return coefficient at index.
+     */
+    public C coefficient(ExpVector index) {
+        if (index == null) {
+            throw new IndexOutOfBoundsException("null index not allowed");
+        }
+        return lazyCoeffs.get(index);
+    }
+
+
+    /**
+     * Homogeneous part.
+     * @param tdeg requested degree.
+     * @return polynomial part of given degree.
+     */
+    public GenPolynomial<C> homogeneousPart(long tdeg) {
+        return lazyCoeffs.getHomPart(tdeg);
+    }
+
+
+    /**
+     * Get a GenPolynomial&lt;C&gt; from this.
+     * @return a GenPolynomial&lt;C&gt; from this up to truncate homogeneous
+     *         parts.
+     */
+    public GenPolynomial<C> asPolynomial() {
+        GenPolynomial<C> p = homogeneousPart(0L);
+        for (int i = 1; i <= truncate; i++) {
+            p = p.sum(homogeneousPart(i));
+        }
+        return p;
+    }
+
+
+    /**
+     * Leading base coefficient.
+     * @return first coefficient.
+     */
+    public C leadingCoefficient() {
+        return coefficient(ring.EVZERO);
+    }
+
+
+    /**
+     * Reductum.
+     * @param r variable for taking the reductum.
+     * @return this - leading monomial in the direction of r.
+     */
+    public MultiVarPowerSeries<C> reductum(final int r) {
+        if (r < 0 || ring.nvar < r) {
+            throw new IllegalArgumentException("variable index out of bound");
+        }
+        return new MultiVarPowerSeries<C>(ring, new MultiVarCoefficients<C>(ring) {
+
+
+            @Override
+            public C generate(ExpVector i) {
+                ExpVector e = i.subst(r, i.getVal(r) + 1);
+                return coefficient(e);
+            }
+        });
+    }
+
+
+    /**
+     * Prepend a new leading coefficient.
+     * @param r variable for the direction.
+     * @param h new coefficient.
+     * @return new power series.
+     */
+    public MultiVarPowerSeries<C> prepend(final C h, final int r) {
+        if (r < 0 || ring.nvar < r) {
+            throw new IllegalArgumentException("variable index out of bound");
+        }
+        return new MultiVarPowerSeries<C>(ring, new MultiVarCoefficients<C>(ring) {
+
+
+            @Override
+            public C generate(ExpVector i) {
+                if (i.isZERO()) {
+                    return h;
+                }
+                ExpVector e = i.subst(r, i.getVal(r) - 1);
+                if (e.signum() < 0) {
+                    return pfac.coFac.getZERO();
+                }
+                return coefficient(e);
+            }
+        });
+    }
+
+
+    /**
+     * Shift coefficients.
+     * @param k shift index.
+     * @param r variable for the direction.
+     * @return new power series with coefficient(i) = old.coefficient(i-k).
+     */
+    public MultiVarPowerSeries<C> shift(final int k, final int r) {
+        if (r < 0 || ring.nvar < r) {
+            throw new IllegalArgumentException("variable index out of bound");
+        }
+        int nt = Math.min(truncate + k, ring.truncate);
+        return new MultiVarPowerSeries<C>(ring, new MultiVarCoefficients<C>(ring) {
+
+
+            @Override
+            public C generate(ExpVector i) {
+                long d = i.getVal(r);
+                if (d - k < 0) {
+                    return ring.coFac.getZERO();
+                }
+                ExpVector e = i.subst(r, i.getVal(r) - k);
+                return coefficient(e);
+            }
+        }, nt);
+    }
+
+
+    /**
+     * Reductum.
+     * @return this - leading monomial.
+     */
+    public MultiVarPowerSeries<C> reductum() {
+        Map.Entry<ExpVector, C> m = orderMonomial();
+        if (m == null) {
+            return ring.getZERO();
+        }
+        ExpVector e = m.getKey();
+        long d = e.totalDeg();
+        MultiVarCoefficients<C> mc = lazyCoeffs;
+        HashMap<Long, GenPolynomial<C>> cc = new HashMap<Long, GenPolynomial<C>>(mc.coeffCache);
+        GenPolynomial<C> p = cc.get(d);
+        if (p != null && !p.isZERO()) {
+            p = p.subtract(m.getValue(), e); // p contains this term after orderMonomial()
+            cc.put(d, p);
+        }
+        HashSet<ExpVector> z = new HashSet<ExpVector>(mc.zeroCache);
+        if (!mc.homCheck.get((int) d)) {
+            z.add(e);
+            //System.out.println("e = " + e);
+        }
+
+        return new MultiVarPowerSeries<C>(ring, new MultiVarCoefficients<C>(mc.pfac, cc, z, mc.homCheck) {
+
+
+            @Override
+            public C generate(ExpVector i) {
+                return coefficient(i);
+            }
+        });
+    }
+
+
+    /**
+     * Shift coefficients. Multiply by exponent vector.
+     * @param k shift ExpVector.
+     * @return new power series with coefficient(i) = old.coefficient(i-k).
+     */
+    public MultiVarPowerSeries<C> shift(final ExpVector k) {
+        if (k == null) {
+            throw new IllegalArgumentException("null ExpVector not allowed");
+        }
+        if (k.signum() == 0) {
+            return this;
+        }
+        int nt = Math.min(truncate + (int) k.totalDeg(), ring.truncate);
+        return new MultiVarPowerSeries<C>(ring, new MultiVarCoefficients<C>(ring) {
+
+
+            @Override
+            public C generate(ExpVector i) {
+                ExpVector d = i.subtract(k);
+                if (d.signum() < 0) {
+                    return ring.coFac.getZERO();
+                }
+                return coefficient(d);
+            }
+        }, nt);
+    }
+
+
+    /**
+     * Multiply by exponent vector and coefficient.
+     * @param k shift ExpVector.
+     * @param c coefficient multiplier.
+     * @return new power series with coefficient(i) = old.coefficient(i-k)*c.
+     */
+    public MultiVarPowerSeries<C> multiply(final C c, final ExpVector k) {
+        if (k == null) {
+            throw new IllegalArgumentException("null ExpVector not allowed");
+        }
+        if (k.signum() == 0) {
+            return this.multiply(c);
+        }
+        if (c.signum() == 0) {
+            return ring.getZERO();
+        }
+        int nt = Math.min(ring.truncate, truncate + (int) k.totalDeg());
+
+        return new MultiVarPowerSeries<C>(ring, new MultiVarCoefficients<C>(ring) {
+
+
+            @Override
+            public C generate(ExpVector i) {
+                ExpVector d = i.subtract(k);
+                if (d.signum() < 0) {
+                    return ring.coFac.getZERO();
+                }
+                long tdegd = d.totalDeg();
+                if (lazyCoeffs.homCheck.get((int) tdegd)) {
+                    GenPolynomial<C> p = homogeneousPart(tdegd).multiply(c, k);
+                    long tdegi = i.totalDeg();
+                    coeffCache.put(tdegi, p); // overwrite
+                    homCheck.set((int) tdegi);
+                    C b = p.coefficient(i);
+                    //System.out.println("b = " + b + ", i = " + i + ", tdegi = " + tdegi+ ", tdegd = " + tdegd);
+                    //System.out.println("p = " + p + ", i = " + i);
+                    return b;
+                }
+                return coefficient(d).multiply(c);
+            }
+        }, nt);
+    }
+
+
+    /**
+     * Sum monomial.
+     * @param m ExpVector , coeffcient pair
+     * @return this + ONE.multiply(m.coefficient,m.exponent).
+     */
+    public MultiVarPowerSeries<C> sum(Map.Entry<ExpVector, C> m) {
+        if (m == null) {
+            throw new IllegalArgumentException("null Map.Entry not allowed");
+        }
+        return sum(m.getValue(), m.getKey());
+    }
+
+
+    /**
+     * Sum exponent vector and coefficient.
+     * @param k ExpVector.
+     * @param c coefficient.
+     * @return this + ONE.multiply(c,k).
+     */
+    public MultiVarPowerSeries<C> sum(final C c, final ExpVector k) {
+        if (k == null) {
+            throw new IllegalArgumentException("null ExpVector not allowed");
+        }
+        if (c.signum() == 0) {
+            return this;
+        }
+        long d = k.totalDeg();
+        MultiVarCoefficients<C> mc = lazyCoeffs;
+        HashMap<Long, GenPolynomial<C>> cc = new HashMap<Long, GenPolynomial<C>>(mc.coeffCache);
+        GenPolynomial<C> p = cc.get(d);
+        if (p == null) {
+            p = mc.pfac.getZERO();
+        }
+        p = p.sum(c, k);
+        //System.out.println("p = " + p);
+        cc.put(d, p);
+        HashSet<ExpVector> z = new HashSet<ExpVector>(mc.zeroCache);
+        //System.out.println("z = " + z);
+        if (p.coefficient(k).isZERO() && !mc.homCheck.get((int) d)) {
+            z.add(k);
+        }
+
+        return new MultiVarPowerSeries<C>(ring, new MultiVarCoefficients<C>(mc.pfac, cc, z, mc.homCheck) {
+
+
+            @Override
+            public C generate(ExpVector i) {
+                return coefficient(i);
+            }
+        });
+    }
+
+
+    /**
+     * Subtract exponent vector and coefficient.
+     * @param k ExpVector.
+     * @param c coefficient.
+     * @return this - ONE.multiply(c,k).
+     */
+    public MultiVarPowerSeries<C> subtract(final C c, final ExpVector k) {
+        if (k == null) {
+            throw new IllegalArgumentException("null ExpVector not allowed");
+        }
+        if (c.signum() == 0) {
+            return this;
+        }
+        long d = k.totalDeg();
+        MultiVarCoefficients<C> mc = lazyCoeffs;
+        HashMap<Long, GenPolynomial<C>> cc = new HashMap<Long, GenPolynomial<C>>(mc.coeffCache);
+        GenPolynomial<C> p = cc.get(d);
+        if (p == null) {
+            p = mc.pfac.getZERO();
+        }
+        p = p.subtract(c, k);
+        cc.put(d, p);
+        HashSet<ExpVector> z = new HashSet<ExpVector>(mc.zeroCache);
+        //System.out.println("z = " + z);
+        if (p.coefficient(k).isZERO() && !mc.homCheck.get((int) d)) {
+            z.add(k);
+        }
+        return new MultiVarPowerSeries<C>(ring, new MultiVarCoefficients<C>(mc.pfac, cc, z, mc.homCheck) {
+
+
+            @Override
+            public C generate(ExpVector i) {
+                return coefficient(i);
+            }
+        });
+    }
+
+
+    /**
+     * Sum exponent vector and coefficient.
+     * @param mvc cached coefficients.
+     * @return this + mvc.
+     */
+    public MultiVarPowerSeries<C> sum(MultiVarCoefficients<C> mvc) {
+        MultiVarCoefficients<C> mc = lazyCoeffs;
+        TreeMap<Long, GenPolynomial<C>> cc = new TreeMap<Long, GenPolynomial<C>>(mc.coeffCache);
+        TreeMap<Long, GenPolynomial<C>> ccv = new TreeMap<Long, GenPolynomial<C>>(mvc.coeffCache);
+        long d1 = (cc.size() > 0 ? cc.lastKey() : 0);
+        long d2 = (ccv.size() > 0 ? ccv.lastKey() : 0);
+        HashSet<ExpVector> z = new HashSet<ExpVector>(mc.zeroCache);
+        z.addAll(mvc.zeroCache);
+        long d = Math.max(d1, d2);
+        BitSet hc = new BitSet((int) d);
+        for (long i = 0; i <= d; i++) {
+            GenPolynomial<C> p1 = cc.get(i);
+            GenPolynomial<C> p2 = mvc.coeffCache.get(i);
+            if (p1 == null) {
+                p1 = mc.pfac.getZERO();
+            }
+            if (p2 == null) {
+                p2 = mc.pfac.getZERO();
+            }
+            GenPolynomial<C> p = p1.sum(p2);
+            //System.out.println("p = " + p);
+            cc.put(i, p);
+            if (mc.homCheck.get((int) i) && mvc.homCheck.get((int) i)) {
+                hc.set((int) i);
+            } else {
+                Set<ExpVector> ev = new HashSet<ExpVector>(p1.getMap().keySet());
+                ev.addAll(p2.getMap().keySet());
+                ev.removeAll(p.getMap().keySet());
+                z.addAll(ev);
+            }
+        }
+        //System.out.println("cc = " + cc);
+
+        return new MultiVarPowerSeries<C>(ring,
+                        new MultiVarCoefficients<C>(mc.pfac, new HashMap<Long, GenPolynomial<C>>(cc), z, hc) {
+
+
+                            @Override
+                            public C generate(ExpVector i) {
+                                return coefficient(i);
+                            }
+                        });
+    }
+
+
+    /**
+     * Select coefficients.
+     * @param sel selector functor.
+     * @return new power series with selected coefficients.
+     */
+    public MultiVarPowerSeries<C> select(final Selector<? super C> sel) {
+        return new MultiVarPowerSeries<C>(ring, new MultiVarCoefficients<C>(ring) {
+
+
+            @Override
+            public C generate(ExpVector i) {
+                C c = coefficient(i);
+                if (sel.select(c)) {
+                    return c;
+                }
+                return ring.coFac.getZERO();
+            }
+        });
+    }
+
+
+    /**
+     * Shift select coefficients. Not selected coefficients are removed from the
+     * result series.
+     * @param sel selector functor.
+     * @return new power series with shifted selected coefficients.
+     */
+    public MultiVarPowerSeries<C> shiftSelect(final Selector<? super C> sel) {
+        return new MultiVarPowerSeries<C>(ring, new MultiVarCoefficients<C>(ring) {
+
+
+            ExpVectorIterable ib = new ExpVectorIterable(ring.nvar, true, truncate);
+
+
+            Iterator<ExpVector> pos = ib.iterator();
+
+
+            @Override
+            public C generate(ExpVector i) {
+                C c;
+                if (i.signum() > 0) {
+                    int[] deps = i.dependencyOnVariables();
+                    ExpVector x = i.subst(deps[0], i.getVal(deps[0]) - 1L);
+                    c = get(x); // ensure all coefficients are generated
+                }
+                do {
+                    c = null;
+                    if (pos.hasNext()) {
+                        ExpVector e = pos.next();
+                        c = coefficient(e);
+                    } else {
+                        break;
+                    }
+                } while (!sel.select(c));
+                if (c == null) { // not correct because not known
+                    c = ring.coFac.getZERO();
+                }
+                return c;
+            }
+        });
+    }
+
+
+    /**
+     * Map a unary function to this power series.
+     * @param f evaluation functor.
+     * @return new power series with coefficients f(this(i)).
+     */
+    public MultiVarPowerSeries<C> map(final UnaryFunctor<? super C, C> f) {
+        return new MultiVarPowerSeries<C>(ring, new MultiVarCoefficients<C>(ring) {
+
+
+            @Override
+            public C generate(ExpVector i) {
+                return f.eval(coefficient(i));
+            }
+        });
+    }
+
+
+    /**
+     * Map a binary function to this and another power series.
+     * @param f evaluation functor with coefficients f(this(i),other(i)).
+     * @param ps other power series.
+     * @return new power series.
+     */
+    public MultiVarPowerSeries<C> zip(final BinaryFunctor<? super C, ? super C, C> f,
+                    final MultiVarPowerSeries<C> ps) {
+        int m = Math.min(ring.truncate, Math.max(truncate, ps.truncate()));
+
+        return new MultiVarPowerSeries<C>(ring, new MultiVarCoefficients<C>(ring) {
+
+
+            @Override
+            public C generate(ExpVector i) {
+                return f.eval(coefficient(i), ps.coefficient(i));
+            }
+        }, m);
+    }
+
+
+    /**
+     * Sum of two power series, using zip().
+     * @param ps other power series.
+     * @return this + ps.
+     */
+    public MultiVarPowerSeries<C> sumZip(MultiVarPowerSeries<C> ps) {
+        return zip(new BinaryFunctor<C, C, C>() {
+
+
+            @Override
+            public C eval(C c1, C c2) {
+                return c1.sum(c2);
+            }
+        }, ps);
+    }
+
+
+    /**
+     * Subtraction of two power series, using zip().
+     * @param ps other power series.
+     * @return this - ps.
+     */
+    public MultiVarPowerSeries<C> subtractZip(MultiVarPowerSeries<C> ps) {
+        return zip(new BinaryFunctor<C, C, C>() {
+
+
+            @Override
+            public C eval(C c1, C c2) {
+                return c1.subtract(c2);
+            }
+        }, ps);
+    }
+
+
+    /**
+     * Multiply by coefficient.
+     * @param a coefficient.
+     * @return this * a.
+     */
+    public MultiVarPowerSeries<C> multiply(final C a) {
+        if (a.isZERO()) {
+            return ring.getZERO();
+        }
+        if (a.isONE()) {
+            return this;
+        }
+        return map(new UnaryFunctor<C, C>() {
+
+
+            @Override
+            public C eval(C c) {
+                return c.multiply(a);
+            }
+        });
+    }
+
+
+    /**
+     * Monic.
+     * @return 1/orderCoeff() * this.
+     */
+    public MultiVarPowerSeries<C> monic() {
+        ExpVector e = orderExpVector();
+        if (e == null) {
+            return this;
+        }
+        C a = coefficient(e);
+        if (a.isONE()) {
+            return this;
+        }
+        if (a.isZERO()) { // sic
+            return this;
+        }
+        final C b = a.inverse();
+        return map(new UnaryFunctor<C, C>() {
+
+
+            @Override
+            public C eval(C c) {
+                return b.multiply(c);
+            }
+        });
+    }
+
+
+    /**
+     * Negate.
+     * @return - this.
+     */
+    public MultiVarPowerSeries<C> negate() {
+        return map(new UnaryFunctor<C, C>() {
+
+
+            @Override
+            public C eval(C c) {
+                return c.negate();
+            }
+        });
+    }
+
+
+    /**
+     * Absolute value.
+     * @return abs(this).
+     */
+    public MultiVarPowerSeries<C> abs() {
+        if (signum() < 0) {
+            return negate();
+        }
+        return this;
+    }
+
+
+    /**
+     * Evaluate at given point.
+     * @return ps(a).
+     */
+    public C evaluate(List<C> a) {
+        C v = ring.coFac.getZERO();
+        for (ExpVector i : new ExpVectorIterable(ring.nvar, true, truncate)) {
+            C c = coefficient(i);
+            if (c.isZERO()) {
+                continue;
+            }
+            c = c.multiply(i.evaluate(ring.coFac, a));
+            v = v.sum(c);
+        }
+        return v;
+    }
+
+
+    /**
+     * Order.
+     * @return index of first non zero coefficient.
+     */
+    public int order() {
+        if (order >= 0) {
+            return order;
+        }
+        // must compute it
+        GenPolynomial<C> p = null;
+        int t = 0;
+        while (lazyCoeffs.homCheck.get(t)) {
+            p = lazyCoeffs.coeffCache.get((long) t);
+            if (p == null || p.isZERO()) { // ??
+                t++;
+                continue;
+            }
+            order = t;
+            evorder = p.trailingExpVector();
+            //System.out.println("order = " + t);
+            return order;
+        }
+        for (ExpVector i : new ExpVectorIterable(ring.nvar, true, truncate)) {
+            if (!coefficient(i).isZERO()) {
+                order = (int) i.totalDeg(); //ord;
+                evorder = i;
+                //System.out.println("order = " + order + ", evorder = " + evorder);
+                return order;
+            }
+        }
+        order = truncate + 1;
+        // evorder is null
+        return order;
+    }
+
+
+    /**
+     * Order ExpVector.
+     * @return ExpVector of first non zero coefficient.
+     */
+    public ExpVector orderExpVector() {
+        //int x = 
+        order(); // ensure evorder is set
+        return evorder;
+    }
+
+
+    /**
+     * Order monomial.
+     * @return first map entry or null.
+     */
+    public Map.Entry<ExpVector, C> orderMonomial() {
+        ExpVector e = orderExpVector();
+        if (e == null) {
+            return null;
+        }
+        //JAVA6only:
+        //return new AbstractMap.SimpleImmutableEntry<ExpVector, C>(e, coefficient(e));
+        return new MapEntry<ExpVector, C>(e, coefficient(e));
+    }
+
+
+    /**
+     * Truncate.
+     * @return truncate index of power series.
+     */
+    public int truncate() {
+        return truncate;
+    }
+
+
+    /**
+     * Set truncate.
+     * @param t new truncate index.
+     * @return old truncate index of power series.
+     */
+    public int setTruncate(int t) {
+        if (t < 0) {
+            throw new IllegalArgumentException("negative truncate not allowed");
+        }
+        int ot = truncate;
+        if (order >= 0) {
+            if (order > truncate) {
+                order = -1; // reset
+                evorder = null;
+            }
+        }
+        truncate = t;
+        return ot;
+    }
+
+
+    /**
+     * Ecart.
+     * @return ecart.
+     */
+    public long ecart() {
+        ExpVector e = orderExpVector();
+        if (e == null) {
+            return 0L;
+        }
+        long d = e.totalDeg();
+        long hd = d;
+        for (long i = d + 1L; i <= truncate; i++) {
+            if (!homogeneousPart(i).isZERO()) {
+                hd = i;
+            }
+        }
+        //System.out.println("d = " + d + ", hd = " + hd + ", coeffCache = " + lazyCoeffs.coeffCache + ", this = " + this);
+        return hd - d;
+    }
+
+
+    /**
+     * Signum.
+     * @return sign of first non zero coefficient.
+     */
+    public int signum() {
+        ExpVector ev = orderExpVector();
+        if (ev != null) {
+            return coefficient(ev).signum();
+        }
+        return 0;
+    }
+
+
+    /**
+     * Compare to. <b>Note: </b> compare only up to max(truncates).
+     * @return sign of first non zero coefficient of this-ps.
+     */
+    @Override
+    public int compareTo(MultiVarPowerSeries<C> ps) {
+        final int m = truncate();
+        final int n = ps.truncate();
+        final int pos = Math.min(ring.truncate, Math.min(m, n));
+        int s = 0;
+        //System.out.println("coeffCache_c1 = " + lazyCoeffs.coeffCache);
+        //System.out.println("coeffCache_c2 = " + ps.lazyCoeffs.coeffCache);
+        // test homogeneous parts first is slower
+        for (ExpVector i : new ExpVectorIterable(ring.nvar, true, pos)) {
+            s = coefficient(i).compareTo(ps.coefficient(i));
+            if (s != 0) {
+                //System.out.println("i = " + i + ", coeff = " + coefficient(i) + ", ps.coeff = " + ps.coefficient(i));
+                return s;
+            }
+        }
+        for (int j = pos + 1; j <= Math.min(ring.truncate, Math.max(m, n)); j++) {
+            for (ExpVector i : new ExpVectorIterable(ring.nvar, j)) {
+                s = coefficient(i).compareTo(ps.coefficient(i));
+                //System.out.println("i = " + i + ", coeff = " + coefficient(i) + ", ps.coeff = " + ps.coefficient(i));
+                if (s != 0) {
+                    //System.out.println("i = " + i + ", coeff = " + coefficient(i) + ", ps.coeff = " + ps.coefficient(i));
+                    return s;
+                }
+            }
+        }
+        return s;
+    }
+
+
+    /**
+     * Is power series zero. <b>Note: </b> compare only up to truncate.
+     * @return If this is 0 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isZERO()
+     */
+    public boolean isZERO() {
+        return (signum() == 0);
+    }
+
+
+    /**
+     * Is power series one. <b>Note: </b> compare only up to truncate.
+     * @return If this is 1 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isONE()
+     */
+    public boolean isONE() {
+        if (!leadingCoefficient().isONE()) {
+            return false;
+        }
+        return (compareTo(ring.ONE) == 0);
+        //return reductum().isZERO();
+    }
+
+
+    /**
+     * Comparison with any other object. <b>Note: </b> compare only up to
+     * truncate.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object B) {
+        if (B == null) {
+            return false;
+        }
+        if (!(B instanceof MultiVarPowerSeries)) {
+            return false;
+        }
+        MultiVarPowerSeries<C> a = (MultiVarPowerSeries<C>) B;
+        return compareTo(a) == 0;
+    }
+
+
+    /**
+     * Hash code for this polynomial. <b>Note: </b> only up to truncate.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h = 0;
+        //h = ( ring.hashCode() << 23 );
+        //h += val.hashCode();
+        for (ExpVector i : new ExpVectorIterable(ring.nvar, true, truncate)) {
+            C c = coefficient(i);
+            if (!c.isZERO()) {
+                h += i.hashCode();
+                h = (h << 23);
+            }
+            h += c.hashCode();
+            h = (h << 23);
+        }
+        return h;
+    }
+
+
+    /**
+     * Is unit.
+     * @return true, if this power series is invertible, else false.
+     */
+    public boolean isUnit() {
+        return leadingCoefficient().isUnit();
+    }
+
+
+    /**
+     * Sum a another power series.
+     * @param ps other power series.
+     * @return this + ps.
+     */
+    public MultiVarPowerSeries<C> sum(final MultiVarPowerSeries<C> ps) {
+        //final MultiVarPowerSeries<C> ps1 = this; // method name was ambiguous in generate
+        int nt = Math.min(ring.truncate, Math.max(truncate(), ps.truncate()));
+
+        return new MultiVarPowerSeries<C>(ring, new MultiVarCoefficients<C>(ring) {
+
+
+            @Override
+            public C generate(ExpVector e) {
+                long tdeg = e.totalDeg();
+                if (lazyCoeffs.homCheck.get((int) tdeg)) {
+                    // generate respective homogeneous polynomial
+                    GenPolynomial<C> p = homogeneousPart(tdeg).sum(ps.homogeneousPart(tdeg));
+                    coeffCache.put(tdeg, p); // overwrite
+                    homCheck.set((int) tdeg);
+                    C c = p.coefficient(e);
+                    //System.out.println("c = " + c + ", e = " + e + ", tdeg = " + tdeg);
+                    return c;
+                }
+                return coefficient(e).sum(ps.coefficient(e));
+            }
+        }, nt);
+    }
+
+
+    /**
+     * Subtract a another power series.
+     * @param ps other power series.
+     * @return this - ps.
+     */
+    public MultiVarPowerSeries<C> subtract(final MultiVarPowerSeries<C> ps) {
+        //final MultiVarPowerSeries<C> ps1 = this; // method name was ambiguous in generate
+        int nt = Math.min(ring.truncate, Math.max(truncate(), ps.truncate()));
+
+        return new MultiVarPowerSeries<C>(ring, new MultiVarCoefficients<C>(ring) {
+
+
+            @Override
+            public C generate(ExpVector e) {
+                long tdeg = e.totalDeg();
+                if (lazyCoeffs.homCheck.get((int) tdeg)) {
+                    // generate respective homogeneous polynomial
+                    GenPolynomial<C> p = homogeneousPart(tdeg).subtract(ps.homogeneousPart(tdeg));
+                    coeffCache.put(tdeg, p); // overwrite
+                    homCheck.set((int) tdeg);
+                    C c = p.coefficient(e);
+                    //System.out.println("p = " + p + ", e = " + e + ", tdeg = " + tdeg);
+                    return c;
+                }
+                return coefficient(e).subtract(ps.coefficient(e));
+            }
+        }, nt);
+    }
+
+
+    /**
+     * Multiply by another power series.
+     * @param ps other power series.
+     * @return this * ps.
+     */
+    public MultiVarPowerSeries<C> multiply(final MultiVarPowerSeries<C> ps) {
+        //final MultiVarPowerSeries<C> ps1 = this; // method name was ambiguous in generate
+        int nt = Math.min(ring.truncate, truncate() + ps.truncate());
+
+        return new MultiVarPowerSeries<C>(ring, new MultiVarCoefficients<C>(ring) {
+
+
+            @Override
+            public C generate(ExpVector e) {
+                long tdeg = e.totalDeg();
+                // generate respective homogeneous polynomial
+                GenPolynomial<C> p = null; //fac.getZERO();
+                for (int k = 0; k <= tdeg; k++) {
+                    GenPolynomial<C> m = homogeneousPart(k).multiply(ps.homogeneousPart(tdeg - k));
+                    if (p == null) {
+                        p = m;
+                    } else {
+                        p = p.sum(m);
+                    }
+                }
+                coeffCache.put(tdeg, p); // overwrite
+                homCheck.set((int) tdeg);
+                C c = p.coefficient(e);
+                return c;
+            }
+        }, nt);
+    }
+
+
+    /**
+     * Inverse power series.
+     * @return ps with this * ps = 1.
+     */
+    public MultiVarPowerSeries<C> inverse() {
+        return new MultiVarPowerSeries<C>(ring, new MultiVarCoefficients<C>(ring) {
+
+
+            @Override
+            public C generate(ExpVector e) {
+                long tdeg = e.totalDeg();
+                C d = leadingCoefficient().inverse(); // may fail
+                if (tdeg == 0) {
+                    return d;
+                }
+                GenPolynomial<C> p = null; //fac.getZERO();
+                for (int k = 0; k < tdeg; k++) {
+                    GenPolynomial<C> m = getHomPart(k).multiply(homogeneousPart(tdeg - k));
+                    if (p == null) {
+                        p = m;
+                    } else {
+                        p = p.sum(m);
+                    }
+                }
+                p = p.multiply(d.negate());
+                //System.out.println("tdeg = " + tdeg + ", p = " + p);
+                coeffCache.put(tdeg, p); // overwrite
+                homCheck.set((int) tdeg);
+                C c = p.coefficient(e);
+                return c;
+            }
+        });
+    }
+
+
+    /**
+     * Divide by another power series.
+     * @param ps nonzero power series with invertible coefficient.
+     * @return this / ps.
+     */
+    public MultiVarPowerSeries<C> divide(MultiVarPowerSeries<C> ps) {
+        if (ps.isUnit()) {
+            return multiply(ps.inverse());
+        }
+        int m = order();
+        int n = ps.order();
+        if (m < n) {
+            return ring.getZERO();
+        }
+        ExpVector em = orderExpVector();
+        ExpVector en = ps.orderExpVector();
+        if (!ps.coefficient(en).isUnit()) {
+            throw new ArithmeticException("division by non unit coefficient " + ps.coefficient(ps.evorder)
+                            + ", evorder = " + ps.evorder);
+        }
+        // now m >= n
+        MultiVarPowerSeries<C> st, sps, q, sq;
+        if (m == 0) {
+            st = this;
+        } else {
+            st = this.shift(em.negate());
+        }
+        if (n == 0) {
+            sps = ps;
+        } else {
+            sps = ps.shift(en.negate());
+        }
+        q = st.multiply(sps.inverse());
+        sq = q.shift(em.subtract(en));
+        return sq;
+    }
+
+
+    /**
+     * Power series remainder.
+     * @param ps nonzero power series with invertible leading coefficient.
+     * @return remainder with this = quotient * ps + remainder.
+     */
+    public MultiVarPowerSeries<C> remainder(MultiVarPowerSeries<C> ps) {
+        int m = order();
+        int n = ps.order();
+        if (m >= n) {
+            return ring.getZERO();
+        }
+        return this;
+    }
+
+
+    /**
+     * Quotient and remainder by division of this by S.
+     * @param S a MultiVarPowerSeries
+     * @return [this/S, this - (this/S)*S].
+     */
+    @SuppressWarnings("unchecked")
+    public MultiVarPowerSeries<C>[] quotientRemainder(MultiVarPowerSeries<C> S) {
+        return new MultiVarPowerSeries[] { divide(S), remainder(S) };
+    }
+
+
+    /**
+     * Differentiate with respect to variable r.
+     * @param r variable for the direction.
+     * @return differentiate(this).
+     */
+    public MultiVarPowerSeries<C> differentiate(final int r) {
+        if (r < 0 || ring.nvar < r) {
+            throw new IllegalArgumentException("variable index out of bound");
+        }
+        return new MultiVarPowerSeries<C>(ring, new MultiVarCoefficients<C>(ring) {
+
+
+            @Override
+            public C generate(ExpVector i) {
+                long d = i.getVal(r);
+                ExpVector e = i.subst(r, d + 1);
+                C v = coefficient(e);
+                v = v.multiply(ring.coFac.fromInteger(d + 1));
+                return v;
+            }
+        });
+    }
+
+
+    /**
+     * Integrate with respect to variable r and with given constant.
+     * @param c integration constant.
+     * @param r variable for the direction.
+     * @return integrate(this).
+     */
+    public MultiVarPowerSeries<C> integrate(final C c, final int r) {
+        if (r < 0 || ring.nvar < r) {
+            throw new IllegalArgumentException("variable index out of bound");
+        }
+        int nt = Math.min(ring.truncate, truncate + 1);
+        return new MultiVarPowerSeries<C>(ring, new MultiVarCoefficients<C>(ring) {
+
+
+            @Override
+            public C generate(ExpVector i) {
+                if (i.isZERO()) {
+                    return c;
+                }
+                long d = i.getVal(r);
+                if (d > 0) {
+                    ExpVector e = i.subst(r, d - 1);
+                    C v = coefficient(e);
+                    v = v.divide(ring.coFac.fromInteger(d));
+                    return v;
+                }
+                return ring.coFac.getZERO();
+            }
+        }, nt);
+    }
+
+
+    /**
+     * Power series greatest common divisor.
+     * @param ps power series.
+     * @return gcd(this,ps).
+     */
+    public MultiVarPowerSeries<C> gcd(MultiVarPowerSeries<C> ps) {
+        if (ps.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return ps;
+        }
+        ExpVector em = orderExpVector();
+        ExpVector en = ps.orderExpVector();
+        return ring.getONE().shift(em.gcd(en));
+    }
+
+
+    /**
+     * Power series extended greatest common divisor. <b>Note:</b> not
+     * implemented.
+     * @param S power series.
+     * @return [ gcd(this,S), a, b ] with a*this + b*S = gcd(this,S).
+     */
+    //SuppressWarnings("unchecked")
+    public MultiVarPowerSeries<C>[] egcd(MultiVarPowerSeries<C> S) {
+        throw new UnsupportedOperationException("egcd for power series not implemented");
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/MultiVarPowerSeriesMap.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/MultiVarPowerSeriesMap.java
@@ -1,0 +1,27 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ps;
+
+
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Multivariate power series map interface. Defines method for mapping of power
+ * series.
+ * @param <C> ring element type
+ * @author Heinz Kredel
+ */
+
+public interface MultiVarPowerSeriesMap<C extends RingElem<C>> {
+
+
+    /**
+     * Map.
+     * @return new power series resulting from mapping elements of ps.
+     */
+    public MultiVarPowerSeries<C> map(MultiVarPowerSeries<C> ps);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/MultiVarPowerSeriesRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/MultiVarPowerSeriesRing.java
@@ -1,0 +1,813 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ps;
+
+
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Random;
+import java.util.function.Function;
+
+import edu.jas.kern.PrettyPrint;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.Monomial;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.structure.UnaryFunctor;
+import edu.jas.util.ListUtil;
+
+
+/**
+ * Multivariate power series ring implementation. Uses lazy evaluated generating
+ * function for coefficients.
+ * @param <C> ring element type
+ * @author Heinz Kredel
+ */
+
+public class MultiVarPowerSeriesRing<C extends RingElem<C>> implements RingFactory<MultiVarPowerSeries<C>> {
+
+
+    /**
+     * A default random sequence generator.
+     */
+    protected final static Random random = new Random();
+
+
+    /**
+     * Default truncate.
+     */
+    public final static int DEFAULT_TRUNCATE = 7;
+
+
+    /**
+     * Truncate.
+     */
+    int truncate;
+
+
+    /**
+     * Zero ExpVector.
+     */
+    public final ExpVector EVZERO;
+
+
+    /**
+     * Coefficient ring factory.
+     */
+    public final RingFactory<C> coFac;
+
+
+    /**
+     * The number of variables.
+     */
+    public final int nvar;
+
+
+    /**
+     * The names of the variables. This value can be modified.
+     */
+    protected String[] vars;
+
+
+    /**
+     * The constant power series 1 for this ring.
+     */
+    public final MultiVarPowerSeries<C> ONE;
+
+
+    /**
+     * The constant power series 0 for this ring.
+     */
+    public final MultiVarPowerSeries<C> ZERO;
+
+
+    /**
+     * No argument constructor.
+     */
+    @SuppressWarnings("unused")
+    private MultiVarPowerSeriesRing() {
+        throw new IllegalArgumentException("do not use no-argument constructor");
+    }
+
+
+    /**
+     * Constructor.
+     * @param fac polynomial ring factory.
+     */
+    public MultiVarPowerSeriesRing(GenPolynomialRing<C> fac) {
+        this(fac.coFac, fac.nvar, fac.getVars());
+    }
+
+
+    /**
+     * Constructor.
+     * @param coFac coefficient ring factory.
+     */
+    public MultiVarPowerSeriesRing(RingFactory<C> coFac, int nv) {
+        this(coFac, nv, DEFAULT_TRUNCATE);
+    }
+
+
+    /**
+     * Constructor.
+     * @param coFac coefficient ring factory.
+     * @param truncate index of truncation.
+     */
+    public MultiVarPowerSeriesRing(RingFactory<C> coFac, int nv, int truncate) {
+        this(coFac, nv, truncate, null);
+    }
+
+
+    /**
+     * Constructor.
+     * @param coFac coefficient ring factory.
+     * @param names of the variables.
+     */
+    public MultiVarPowerSeriesRing(RingFactory<C> coFac, String[] names) {
+        this(coFac, names.length, DEFAULT_TRUNCATE, names);
+    }
+
+
+    /**
+     * Constructor.
+     * @param cofac coefficient ring factory.
+     * @param nv number of variables.
+     * @param names of the variables.
+     */
+    public MultiVarPowerSeriesRing(RingFactory<C> cofac, int nv, String[] names) {
+        this(cofac, nv, DEFAULT_TRUNCATE, names);
+    }
+
+
+    /**
+     * Constructor.
+     * @param cofac coefficient ring factory.
+     * @param truncate index of truncation.
+     * @param names of the variables.
+     */
+    public MultiVarPowerSeriesRing(RingFactory<C> cofac, int nv, int truncate, String[] names) {
+        this.coFac = cofac;
+        this.nvar = nv;
+        this.truncate = truncate;
+        if (names == null) {
+            vars = null;
+        } else {
+            vars = Arrays.copyOf(names, names.length); // > Java-5
+        }
+        if (vars == null) {
+            if (PrettyPrint.isTrue()) {
+                vars = GenPolynomialRing.newVars("x", nvar);
+            }
+        } else {
+            if (vars.length != nvar) {
+                throw new IllegalArgumentException("incompatible variable size " + vars.length + ", " + nvar);
+            }
+            // GenPolynomialRing.addVars(vars);
+        }
+        EVZERO = ExpVector.create(nvar);
+        ONE = new MultiVarPowerSeries<C>(this, new MultiVarCoefficients<C>(this) {
+
+
+            @Override
+            public C generate(ExpVector i) {
+                if (i.isZERO()) {
+                    return coFac.getONE();
+                }
+                return coFac.getZERO();
+            }
+        });
+        ZERO = new MultiVarPowerSeries<C>(this, new MultiVarCoefficients<C>(this) {
+
+
+            @Override
+            public C generate(ExpVector i) {
+                return coFac.getZERO();
+            }
+        });
+    }
+
+
+    /**
+     * Fixed point construction.
+     * @param map a mapping of power series.
+     * @return fix point wrt map.
+     */
+    // Cannot be a static method because a power series ring is required.
+    public MultiVarPowerSeries<C> fixPoint(MultiVarPowerSeriesMap<C> map) {
+        MultiVarPowerSeries<C> ps1 = new MultiVarPowerSeries<C>(this);
+        MultiVarPowerSeries<C> ps2 = map.map(ps1);
+        ps1.lazyCoeffs = ps2.lazyCoeffs;
+        return ps2;
+    }
+
+
+    /**
+     * To String.
+     * @return string representation of this.
+     */
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        String scf = coFac.getClass().getSimpleName();
+        sb.append(scf + "((" + varsToString() + "))");
+        return sb.toString();
+    }
+
+
+    /**
+     * Get a String representation of the variable names.
+     * @return names separated by commas.
+     */
+    public String varsToString() {
+        if (vars == null) {
+            return "#" + nvar;
+        }
+        return ExpVector.varsToString(vars);
+        //return Arrays.toString(vars);
+    }
+
+
+    /**
+     * Get the variable names.
+     * @return names.
+     */
+    public String[] getVars() {
+        return Arrays.copyOf(vars, vars.length); // > Java-5
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.ElemFactory#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        StringBuffer s = new StringBuffer("MPS(");
+        String f = null;
+        try {
+            f = ((RingElem<C>) coFac).toScriptFactory(); // sic
+        } catch (Exception e) {
+            f = coFac.toScript();
+        }
+        s.append(f + ",\"" + varsToString() + "\"," + truncate + ")");
+        return s.toString();
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object B) {
+        MultiVarPowerSeriesRing<C> a = null;
+        try {
+            a = (MultiVarPowerSeriesRing<C>) B;
+        } catch (ClassCastException ignored) {
+        }
+        if (a == null) {
+            return false;
+        }
+        if (!coFac.equals(a.coFac)) {
+            return false;
+        }
+        if (Arrays.deepEquals(vars, a.vars)) {
+            return true;
+        }
+        return false;
+    }
+
+
+    /**
+     * Hash code for this .
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h = coFac.hashCode();
+        h = h << 7;
+        h += (Arrays.hashCode(vars) << 17);
+        h += truncate;
+        return h;
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as MultiVarPowerSeries<C>.
+     */
+    public MultiVarPowerSeries<C> getZERO() {
+        return ZERO;
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as MultiVarPowerSeries<C>.
+     */
+    public MultiVarPowerSeries<C> getONE() {
+        return ONE;
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     * @see edu.jas.structure.ElemFactory#generators()
+     */
+    public List<MultiVarPowerSeries<C>> generators() {
+        List<C> rgens = coFac.generators();
+        List<MultiVarPowerSeries<C>> gens = new ArrayList<MultiVarPowerSeries<C>>(rgens.size());
+        for (final C cg : rgens) {
+            MultiVarPowerSeries<C> g = new MultiVarPowerSeries<C>(this, new MultiVarCoefficients<C>(this) {
+
+
+                @Override
+                public C generate(ExpVector i) {
+                    if (i.isZERO()) {
+                        return cg;
+                    }
+                    return coFac.getZERO();
+                }
+            });
+            gens.add(g);
+        }
+        for (int i = 0; i < nvar; i++) {
+            gens.add(ONE.shift(1, nvar - 1 - i));
+        }
+        return gens;
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite()
+     */
+    public boolean isFinite() {
+        return false;
+    }
+
+
+    /**
+     * Truncate.
+     * @return truncate index of power series.
+     */
+    public int truncate() {
+        return truncate;
+    }
+
+
+    /**
+     * Set truncate.
+     * @param t new truncate index.
+     * @return old truncate index of power series.
+     */
+    public int setTruncate(int t) {
+        if (t < 0) {
+            throw new IllegalArgumentException("negative truncate not allowed");
+        }
+        int ot = truncate;
+        truncate = t;
+        ONE.setTruncate(t);
+        ZERO.setTruncate(t);
+        return ot;
+    }
+
+
+    /**
+     * Get the power series of the exponential function.
+     * @param r variable for the direction.
+     * @return exp(x_r) as MultiVarPowerSeries<C>.
+     */
+    public MultiVarPowerSeries<C> getEXP(final int r) {
+        return fixPoint(new MultiVarPowerSeriesMap<C>() {
+
+
+            public MultiVarPowerSeries<C> map(MultiVarPowerSeries<C> e) {
+                return e.integrate(coFac.getONE(), r);
+            }
+        });
+    }
+
+
+    /**
+     * Get the power series of the sinus function.
+     * @param r variable for the direction.
+     * @return sin(x_r) as MultiVarPowerSeries<C>.
+     */
+    public MultiVarPowerSeries<C> getSIN(final int r) {
+        return fixPoint(new MultiVarPowerSeriesMap<C>() {
+
+
+            public MultiVarPowerSeries<C> map(MultiVarPowerSeries<C> s) {
+                return s.negate().integrate(coFac.getONE(), r).integrate(coFac.getZERO(), r);
+            }
+        });
+    }
+
+
+    /**
+     * Get the power series of the cosinus function.
+     * @param r variable for the direction.
+     * @return cos(x_r) as MultiVarPowerSeries<C>.
+     */
+    public MultiVarPowerSeries<C> getCOS(final int r) {
+        return fixPoint(new MultiVarPowerSeriesMap<C>() {
+
+
+            public MultiVarPowerSeries<C> map(MultiVarPowerSeries<C> c) {
+                return c.negate().integrate(coFac.getZERO(), r).integrate(coFac.getONE(), r);
+            }
+        });
+    }
+
+
+    /**
+     * Get the power series of the tangens function.
+     * @param r variable for the direction.
+     * @return tan(x_r) as MultiVarPowerSeries<C>.
+     */
+    public MultiVarPowerSeries<C> getTAN(final int r) {
+        return fixPoint(new MultiVarPowerSeriesMap<C>() {
+
+
+            public MultiVarPowerSeries<C> map(MultiVarPowerSeries<C> t) {
+                return t.multiply(t).sum(getONE()).integrate(coFac.getZERO(), r);
+            }
+        });
+    }
+
+
+    /**
+     * Solve an partial differential equation. y_r' = f(y_r) with y_r(0) = c.
+     * @param f a MultiVarPowerSeries<C>.
+     * @param c integration constant.
+     * @param r variable for the direction.
+     * @return f.integrate(c).
+     */
+    public MultiVarPowerSeries<C> solvePDE(MultiVarPowerSeries<C> f, C c, int r) {
+        return f.integrate(c, r);
+    }
+
+
+    /**
+     * Query if this ring is commuative.
+     * @return true, if this ring is commutative, else false.
+     */
+    public boolean isCommutative() {
+        return coFac.isCommutative();
+    }
+
+
+    /**
+     * Query if this ring is associative.
+     * @return true if this ring is associative, else false.
+     */
+    public boolean isAssociative() {
+        return coFac.isAssociative();
+    }
+
+
+    /**
+     * Query if this ring is a field.
+     * @return true if this ring is a field, else false.
+     */
+    public boolean isField() {
+        return (nvar == 0) && coFac.isField(); //false;
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic() {
+        return coFac.characteristic();
+    }
+
+
+    /**
+     * Get a (constant) MultiVarPowerSeries&lt;C&gt; from a long value.
+     * @param a long.
+     * @return a MultiVarPowerSeries&lt;C&gt;.
+     */
+    public MultiVarPowerSeries<C> fromInteger(final long a) {
+        return new MultiVarPowerSeries<C>(this, new MultiVarCoefficients<C>(this) {
+
+
+            @Override
+            public C generate(ExpVector i) {
+                if (i.isZERO()) {
+                    return coFac.fromInteger(a);
+                }
+                return coFac.getZERO();
+            }
+        });
+    }
+
+
+    /**
+     * Get a (constant) MultiVarPowerSeries&lt;C&gt; from a
+     * java.math.BigInteger.
+     * @param a BigInteger.
+     * @return a MultiVarPowerSeries&lt;C&gt;.
+     */
+    public MultiVarPowerSeries<C> fromInteger(final java.math.BigInteger a) {
+        return new MultiVarPowerSeries<C>(this, new MultiVarCoefficients<C>(this) {
+
+
+            @Override
+            public C generate(ExpVector i) {
+                if (i.isZERO()) {
+                    return coFac.fromInteger(a);
+                }
+                return coFac.getZERO();
+            }
+        });
+    }
+
+
+    /**
+     * Get the corresponding GenPolynomialRing&lt;C&gt;.
+     * @return GenPolynomialRing&lt;C&gt;.
+     */
+    public GenPolynomialRing<C> polyRing() {
+        return new GenPolynomialRing<C>(coFac, nvar, vars);
+    }
+
+
+    /**
+     * Get a MultiVarPowerSeries&lt;C&gt; from a GenPolynomial&lt;C&gt;.
+     * @param a GenPolynomial&lt;C&gt;.
+     * @return a MultiVarPowerSeries&lt;C&gt;.
+     */
+    public MultiVarPowerSeries<C> fromPolynomial(GenPolynomial<C> a) {
+        if (a == null || a.isZERO()) {
+            return ZERO;
+        }
+        if (a.isONE()) {
+            return ONE;
+        }
+        GenPolynomialRing<C> pfac = polyRing();
+        HashMap<Long, GenPolynomial<C>> cache = new HashMap<Long, GenPolynomial<C>>();
+        int mt = 0;
+        for (Monomial<C> m : a) {
+            ExpVector e = m.exponent();
+            long t = e.totalDeg();
+            mt = Math.max(mt, (int) t);
+            GenPolynomial<C> p = cache.get(t);
+            if (p == null) {
+                p = pfac.getZERO().copy();
+                cache.put(t, p);
+            }
+            p.doPutToMap(e, m.coefficient());
+        }
+        mt++;
+        if (mt > truncate()) {
+            setTruncate(mt);
+        }
+        BitSet check = new BitSet();
+        for (int i = 0; i <= truncate(); i++) {
+            check.set(i);
+            if (cache.get((long) i) == null) {
+                GenPolynomial<C> p = pfac.getZERO().copy();
+                cache.put((long) i, p);
+                //System.out.println("p zero for deg i = " + i);
+            }
+        }
+
+        return new MultiVarPowerSeries<C>(this, new MultiVarCoefficients<C>(pfac, cache, check) {
+
+
+            @Override
+            public C generate(ExpVector e) {
+                // cached coefficients returned by get
+                return coFac.getZERO();
+            }
+        });
+    }
+
+
+    /**
+     * Get a list of MultiVarPowerSeries&lt;C&gt; from a list of
+     * GenPolynomial&lt;C&gt;.
+     * @param A list of GenPolynomial&lt;C&gt;.
+     * @return a list of MultiVarPowerSeries&lt;C&gt;.
+     */
+    public List<MultiVarPowerSeries<C>> fromPolynomial(List<GenPolynomial<C>> A) {
+        return ListUtil.<GenPolynomial<C>, MultiVarPowerSeries<C>> map(A,
+                        new UnaryFunctor<GenPolynomial<C>, MultiVarPowerSeries<C>>() {
+
+
+                            public MultiVarPowerSeries<C> eval(GenPolynomial<C> c) {
+                                return fromPolynomial(c);
+                            }
+                        });
+    }
+
+
+    /**
+     * Get a MultiVarPowerSeries&lt;C&gt; from a univariate power series.
+     * @param ps UnivPowerSeries&lt;C&gt;.
+     * @param r variable for the direction.
+     * @return a MultiVarPowerSeries&lt;C&gt;.
+     */
+    public MultiVarPowerSeries<C> fromPowerSeries(final UnivPowerSeries<C> ps, final int r) {
+        if (ps == null) {
+            return ZERO;
+        }
+        return new MultiVarPowerSeries<C>(this, new MultiVarCoefficients<C>(this) {
+
+
+            @Override
+            public C generate(ExpVector i) {
+                if (i.isZERO()) {
+                    return ps.coefficient(0);
+                }
+                int[] dep = i.dependencyOnVariables();
+                if (dep.length != 1) {
+                    return coFac.getZERO();
+                }
+                if (dep[0] != r) {
+                    return coFac.getZERO();
+                }
+                int j = (int) i.getVal(r);
+                if (j > 0) {
+                    return ps.coefficient(j);
+                }
+                return coFac.getZERO();
+            }
+        });
+    }
+
+
+    /**
+     * Generate a random power series with k = 5, d = 0.7.
+     * @return a random power series.
+     */
+    public MultiVarPowerSeries<C> random() {
+        return random(5, 0.7f, random);
+    }
+
+
+    /**
+     * Generate a random power series with d = 0.7.
+     * @param k bit-size of random coefficients.
+     * @return a random power series.
+     */
+    public MultiVarPowerSeries<C> random(int k) {
+        return random(k, 0.7f, random);
+    }
+
+
+    /**
+     * Generate a random power series with d = 0.7.
+     * @param k bit-size of random coefficients.
+     * @param rnd is a source for random bits.
+     * @return a random power series.
+     */
+    public MultiVarPowerSeries<C> random(int k, Random rnd) {
+        return random(k, 0.7f, rnd);
+    }
+
+
+    /**
+     * Generate a random power series.
+     * @param k bit-size of random coefficients.
+     * @param d density of non-zero coefficients.
+     * @return a random power series.
+     */
+    public MultiVarPowerSeries<C> random(int k, float d) {
+        return random(k, d, random);
+    }
+
+
+    /**
+     * Generate a random power series.
+     * @param k bit-size of random coefficients.
+     * @param d density of non-zero coefficients.
+     * @param rnd is a source for random bits.
+     * @return a random power series.
+     */
+    public MultiVarPowerSeries<C> random(final int k, final float d, final Random rnd) {
+        return new MultiVarPowerSeries<C>(this, new MultiVarCoefficients<C>(this) {
+
+
+            @Override
+            public C generate(ExpVector i) {
+                // cached coefficients returned by get
+                C c;
+                float f = rnd.nextFloat();
+                if (f < d) {
+                    c = coFac.random(k, rnd);
+                } else {
+                    c = coFac.getZERO();
+                }
+                return c;
+            }
+        });
+    }
+
+
+    /**
+     * Generate a power series via lambda expression.
+     * @param gener lambda expression.
+     * @return a generated power series.
+     */
+    public MultiVarPowerSeries<C> generate(final Function<ExpVector, C> gener) {
+        return new MultiVarPowerSeries<C>(this, new MultiVarCoefficients<C>(this) {
+
+
+            @Override
+            public C generate(ExpVector i) {
+                // cached coefficients returned by get
+                C c = gener.apply(i);
+                return c;
+            }
+        });
+    }
+
+
+    /**
+     * Copy power series.
+     * @param c a power series.
+     * @return a copy of c.
+     */
+    public MultiVarPowerSeries<C> copy(MultiVarPowerSeries<C> c) {
+        return new MultiVarPowerSeries<C>(this, c.lazyCoeffs);
+    }
+
+
+    /**
+     * Parse a power series. <b>Note:</b> not implemented.
+     * @param s String.
+     * @return power series from s.
+     */
+    public MultiVarPowerSeries<C> parse(String s) {
+        throw new UnsupportedOperationException("parse for power series not implemented");
+    }
+
+
+    /**
+     * Parse a power series. <b>Note:</b> not implemented.
+     * @param r Reader.
+     * @return next power series from r.
+     */
+    public MultiVarPowerSeries<C> parse(Reader r) {
+        throw new UnsupportedOperationException("parse for power series not implemented");
+    }
+
+
+    /**
+     * Taylor power series.
+     * @param f function.
+     * @param a expansion point.
+     * @return Taylor series of f.
+     */
+    public MultiVarPowerSeries<C> seriesOfTaylor(final TaylorFunction<C> f, final List<C> a) {
+        return new MultiVarPowerSeries<C>(this, new MultiVarCoefficients<C>(this) {
+
+
+            TaylorFunction<C> der = f;
+
+
+            // Map<ExpVextor,TaylorFunction<C>> pderCache = ...
+            final List<C> v = a;
+
+
+            @Override
+            public C generate(ExpVector i) {
+                C c;
+                int s = i.signum();
+                if (s == 0) {
+                    c = der.evaluate(v);
+                    return c;
+                }
+                TaylorFunction<C> pder = der.deriviative(i);
+                if (pder.isZERO()) {
+                    return coFac.getZERO();
+                }
+                c = pder.evaluate(v);
+                if (c.isZERO()) {
+                    return c;
+                }
+                long f = pder.getFacul();
+                c = c.divide(coFac.fromInteger(f));
+                return c;
+            }
+        });
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/OrderedPairlist.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/OrderedPairlist.java
@@ -1,0 +1,325 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ps;
+
+
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.ExpVector;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Pair list management. Implemented using MultiVarPowerSeries, TreeMap and
+ * BitSet.
+ * @author Heinz Kredel
+ */
+
+public class OrderedPairlist<C extends RingElem<C>> {
+
+
+    protected final ArrayList<MultiVarPowerSeries<C>> P;
+
+
+    protected final TreeMap<ExpVector, LinkedList<Pair<C>>> pairlist;
+
+
+    protected final ArrayList<BitSet> red;
+
+
+    protected final MultiVarPowerSeriesRing<C> ring;
+
+
+    protected final ReductionSeq<C> reduction;
+
+
+    protected boolean oneInGB = false;
+
+
+    protected boolean useCriterion4 = true;
+
+
+    protected boolean useCriterion3 = true;
+
+
+    protected int putCount;
+
+
+    protected int remCount;
+
+
+    protected final int moduleVars;
+
+
+    private static final Logger logger = LogManager.getLogger(OrderedPairlist.class);
+
+
+    /**
+     * Constructor for OrderedPairlist.
+     * @param r power series factory.
+     */
+    public OrderedPairlist(MultiVarPowerSeriesRing<C> r) {
+        this(0, r);
+    }
+
+
+    /**
+     * Constructor for OrderedPairlist.
+     * @param m number of module variables.
+     * @param r power series factory.
+     */
+    public OrderedPairlist(int m, MultiVarPowerSeriesRing<C> r) {
+        moduleVars = m;
+        ring = r;
+        P = new ArrayList<MultiVarPowerSeries<C>>();
+        pairlist = new TreeMap<ExpVector, LinkedList<Pair<C>>>(ring.polyRing().tord.getAscendComparator());
+        //pairlist = new TreeMap<ExpVector, LinkedList<Pair<C>>>(ring.polyRing().tord.getDescendComparator());
+        red = new ArrayList<BitSet>();
+        putCount = 0;
+        remCount = 0;
+        reduction = new ReductionSeq<C>();
+    }
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString() {
+        StringBuffer s = new StringBuffer("OrderedPairlist(");
+        //s.append("ps="+P.size());
+        s.append("#put=" + putCount);
+        s.append(", #rem=" + remCount);
+        if (pairlist.size() != 0) {
+            s.append(", size=" + pairlist.size());
+        }
+        s.append(")");
+        return s.toString();
+    }
+
+
+    /**
+     * Put one power Series to the pairlist and reduction matrix.
+     * @param p power series.
+     * @return the index of the added power series.
+     */
+    public synchronized int put(MultiVarPowerSeries<C> p) {
+        putCount++;
+        if (oneInGB) {
+            return P.size() - 1;
+        }
+        ExpVector e = p.orderExpVector();
+        int l = P.size();
+        for (int j = 0; j < l; j++) {
+            MultiVarPowerSeries<C> pj = P.get(j);
+            ExpVector f = pj.orderExpVector();
+            if (moduleVars > 0) {
+                if (!reduction.moduleCriterion(moduleVars, e, f)) {
+                    continue; // skip pair
+                }
+            }
+            ExpVector g = e.lcm(f);
+            Pair<C> pair = new Pair<C>(pj, p, j, l);
+            // redi = (BitSet)red.get(j);
+            ///if ( j < l ) redi.set( l );
+            // System.out.println("bitset."+j+" = " + redi );  
+
+            //multiple pairs under same keys -> list of pairs
+            LinkedList<Pair<C>> xl = pairlist.get(g);
+            if (xl == null) {
+                xl = new LinkedList<Pair<C>>();
+            }
+            //xl.addLast( pair ); // first or last ?
+            xl.addFirst(pair); // first or last ? better for d- e-GBs
+            pairlist.put(g, xl);
+        }
+        // System.out.println("pairlist.keys@put = " + pairlist.keySet() );  
+        P.add(p);
+        BitSet redi = new BitSet();
+        redi.set(0, l); // jdk 1.4
+        red.add(redi);
+        return P.size() - 1;
+    }
+
+
+    /**
+     * Put all power series in F to the pairlist and reduction matrix.
+     * @param F power series list.
+     * @return the index of the last added power series.
+     */
+    public int put(List<MultiVarPowerSeries<C>> F) {
+        int i = 0;
+        for (MultiVarPowerSeries<C> p : F) {
+            i = put(p);
+        }
+        return i;
+    }
+
+
+    /**
+     * Remove the next required pair from the pairlist and reduction matrix.
+     * Apply the criterions 3 and 4 to see if the S-power-series is required.
+     * @return the next pair if one exists, otherwise null.
+     */
+    public synchronized Pair<C> removeNext() {
+        if (oneInGB) {
+            return null;
+        }
+        Iterator<Map.Entry<ExpVector, LinkedList<Pair<C>>>> ip = pairlist.entrySet().iterator();
+
+        Pair<C> pair = null;
+        boolean c = false;
+        int i, j;
+
+        while (!c && ip.hasNext()) {
+            Map.Entry<ExpVector, LinkedList<Pair<C>>> me = ip.next();
+            ExpVector g = me.getKey();
+            LinkedList<Pair<C>> xl = me.getValue();
+            if (logger.isInfoEnabled())
+                logger.info("g  = " + g);
+            pair = null;
+            while (!c && xl.size() > 0) {
+                pair = xl.removeFirst();
+                // xl is also modified in pairlist 
+                i = pair.i;
+                j = pair.j;
+                // System.out.println("pair(" + j + "," +i+") ");
+                c = true;
+                if (useCriterion4) {
+                    c = reduction.criterion4(pair.pi, pair.pj, g);
+                }
+                //System.out.println("c4  = " + c);  
+                if (c && useCriterion3) {
+                    c = criterion3(i, j, g);
+                    //System.out.println("c3  = " + c); 
+                }
+                red.get(j).clear(i); // set(i,false) jdk1.4
+            }
+            if (xl.size() == 0)
+                ip.remove();
+            // = pairlist.remove( g );
+        }
+        if (!c) {
+            pair = null;
+        } else {
+            remCount++; // count only real pairs
+        }
+        return pair;
+    }
+
+
+    /**
+     * Test if there is possibly a pair in the list.
+     * @return true if a next pair could exist, otherwise false.
+     */
+    public synchronized boolean hasNext() {
+        return pairlist.size() > 0;
+    }
+
+
+    /**
+     * Get the list of power series.
+     * @return the power series list.
+     */
+    public List<MultiVarPowerSeries<C>> getList() {
+        return P;
+    }
+
+
+    /**
+     * Get the number of power series put to the pairlist.
+     * @return the number of calls to put.
+     */
+    public synchronized int putCount() {
+        return putCount;
+    }
+
+
+    /**
+     * Get the number of required pairs removed from the pairlist.
+     * @return the number of non null pairs delivered.
+     */
+    public synchronized int remCount() {
+        return remCount;
+    }
+
+
+    /**
+     * Put to ONE-power-series to the pairlist.
+     * @param one power series. (no more required)
+     * @return the index of the last power series.
+     */
+    public synchronized int putOne(MultiVarPowerSeries<C> one) {
+        putCount++;
+        if (one == null) {
+            return P.size() - 1;
+        }
+        if (!one.isONE()) {
+            return P.size() - 1;
+        }
+        return putOne();
+    }
+
+
+    /**
+     * Put the ONE-power-series to the pairlist.
+     * @return the index of the last power-series.
+     */
+    public synchronized int putOne() {
+        oneInGB = true;
+        pairlist.clear();
+        P.clear();
+        P.add(ring.getONE());
+        red.clear();
+        return P.size() - 1;
+    }
+
+
+    /**
+     * GB criterion 3.
+     * @return true if the S-power-series(i,j) is required.
+     */
+    public boolean criterion3(int i, int j, ExpVector eij) {
+        // assert i < j;
+        boolean s = red.get(j).get(i);
+        if (!s) {
+            logger.warn("c3.s false for " + j + " " + i);
+            return s;
+        }
+        // now s = true;
+        for (int k = 0; k < P.size(); k++) {
+            MultiVarPowerSeries<C> A = P.get(k);
+            ExpVector ek = A.orderExpVector();
+            boolean m = eij.multipleOf(ek);
+            if (m) {
+                if (k < i) {
+                    // System.out.println("k < i "+k+" "+i); 
+                    s = red.get(i).get(k) || red.get(j).get(k);
+                } else if (i < k && k < j) {
+                    // System.out.println("i < k < j "+i+" "+k+" "+j); 
+                    s = red.get(k).get(i) || red.get(j).get(k);
+                } else if (j < k) {
+                    //System.out.println("j < k "+j+" "+k); 
+                    s = red.get(k).get(i) || red.get(k).get(j);
+                }
+                //System.out.println("s."+k+" = " + s); 
+                if (!s) {
+                    return s;
+                }
+            }
+        }
+        return true;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/PSUtil.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/PSUtil.java
@@ -1,0 +1,64 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ps;
+
+
+import java.util.List;
+
+import edu.jas.structure.RingElem;
+import edu.jas.structure.UnaryFunctor;
+import edu.jas.util.ListUtil;
+
+
+/**
+ * Power series utilities. For example monic power series.
+ * @author Heinz Kredel
+ */
+
+public class PSUtil {
+
+
+    /**
+     * Power series list monic.
+     * @param <C> coefficient type.
+     * @param L list of power series with field coefficients.
+     * @return list of power series with leading coefficient 1.
+     */
+    public static <C extends RingElem<C>> List<MultiVarPowerSeries<C>> monic(List<MultiVarPowerSeries<C>> L) {
+        return ListUtil.<MultiVarPowerSeries<C>, MultiVarPowerSeries<C>> map(L,
+                        new UnaryFunctor<MultiVarPowerSeries<C>, MultiVarPowerSeries<C>>() {
+
+
+                            public MultiVarPowerSeries<C> eval(MultiVarPowerSeries<C> c) {
+                                if (c == null) {
+                                    return null;
+                                }
+                                return c.monic();
+                            }
+                        });
+    }
+
+
+    /**
+     * Univariate power series list monic.
+     * @param <C> coefficient type.
+     * @param L list of univariate power series with field coefficients.
+     * @return list of univariate power series with leading coefficient 1.
+     */
+    public static <C extends RingElem<C>> List<UnivPowerSeries<C>> monicUniv(List<UnivPowerSeries<C>> L) {
+        return ListUtil.<UnivPowerSeries<C>, UnivPowerSeries<C>> map(L,
+                        new UnaryFunctor<UnivPowerSeries<C>, UnivPowerSeries<C>>() {
+
+
+                            public UnivPowerSeries<C> eval(UnivPowerSeries<C> c) {
+                                if (c == null) {
+                                    return null;
+                                }
+                                return c.monic();
+                            }
+                        });
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/Pair.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/Pair.java
@@ -1,0 +1,186 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ps;
+
+
+import java.io.Serializable;
+
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Serializable subclass to hold pairs of power series.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+public class Pair<C extends RingElem<C>> implements Serializable, Comparable<Pair> {
+
+
+    public final MultiVarPowerSeries<C> pi;
+
+
+    public final MultiVarPowerSeries<C> pj;
+
+
+    public final int i;
+
+
+    public final int j;
+
+
+    protected int n;
+
+
+    protected boolean toZero = false;
+
+
+    protected boolean useCriterion4 = false;
+
+
+    protected boolean useCriterion3 = false;
+
+
+    /**
+     * Pair constructor.
+     * @param a power series i.
+     * @param b power series j.
+     * @param i first index.
+     * @param j second index.
+     */
+    public Pair(MultiVarPowerSeries<C> a, MultiVarPowerSeries<C> b, int i, int j) {
+        pi = a;
+        pj = b;
+        this.i = i;
+        this.j = j;
+        this.n = 0;
+        toZero = false; // ok
+    }
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString() {
+        return "pair[" + n + "](" + i + j + ", r0=" + toZero + ", c4=" + useCriterion4 + ", c3="
+                + useCriterion3 + ")";
+    }
+
+
+    /**
+     * Set removed pair number.
+     * @param n number of this pair generated in OrderedPairlist.
+     */
+    public void pairNumber(int n) {
+        this.n = n;
+    }
+
+
+    /**
+     * Get removed pair number.
+     * @return n number of this pair generated in OrderedPairlist.
+     */
+    public int getPairNumber() {
+        return n;
+    }
+
+
+    /**
+     * Set zero reduction. The S-power-series of this Pair was reduced to zero.
+     */
+    public void setZero() {
+        toZero = true;
+    }
+
+
+    /**
+     * Is reduced to zero.
+     * @return true if the S-power-series of this Pair was reduced to zero, else
+     *         false.
+     */
+    public boolean isZero() {
+        return toZero;
+    }
+
+
+    /**
+     * equals.
+     * @param ob an Object.
+     * @return true if this is equal to o, else false.
+     */
+    @Override
+    public boolean equals(Object ob) {
+        if (!(ob instanceof Pair)) {
+            return false;
+            // throw new ClassCastException("Pair "+n+" o "+o);
+        }
+        return 0 == compareTo((Pair) ob);
+    }
+
+
+    /**
+     * compareTo used in TreeMap // not used at moment. Comparison is based on
+     * the number of the pairs.
+     * @param p a Pair.
+     * @return 1 if (this &lt; o), 0 if (this == o), -1 if (this &gt; o).
+     */
+    public int compareTo(Pair p) {
+        int x = p.getPairNumber();
+        if (n > x) {
+            return 1;
+        }
+        if (n < x) {
+            return -1;
+        }
+        return 0;
+    }
+
+
+    /**
+     * Hash code for this Pair.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return (i << 16) + j;
+    }
+
+
+    /**
+     * Set useCriterion4.
+     * @param c boolean value to set.
+     */
+    public void setUseCriterion4(boolean c) {
+        this.useCriterion4 = c;
+    }
+
+
+    /**
+     * Get useCriterion4.
+     * @return boolean value.
+     */
+    public boolean getUseCriterion4() {
+        return this.useCriterion4;
+    }
+
+
+    /**
+     * Set useCriterion3.
+     * @param c boolean value to set.
+     */
+    public void setUseCriterion3(boolean c) {
+        this.useCriterion3 = c;
+    }
+
+
+    /**
+     * Get useCriterion3.
+     * @return boolean value.
+     */
+    public boolean getUseCriterion3() {
+        return this.useCriterion3;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/PolynomialTaylorFunction.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/PolynomialTaylorFunction.java
@@ -1,0 +1,141 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ps;
+
+
+import java.util.List;
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Polynomial functions capable for Taylor series expansion.
+ * @param <C> ring element type
+ * @author Heinz Kredel
+ */
+
+public class PolynomialTaylorFunction<C extends RingElem<C>> implements TaylorFunction<C> {
+
+
+    final GenPolynomial<C> pol;
+
+
+    final long facul;
+
+
+    public PolynomialTaylorFunction(GenPolynomial<C> p) {
+        this(p, 1L);
+    }
+
+
+    public PolynomialTaylorFunction(GenPolynomial<C> p, long f) {
+        pol = p;
+        facul = f;
+    }
+
+
+    /**
+     * To String.
+     * @return string representation of this.
+     */
+    @Override
+    public String toString() {
+        return pol.toString();
+    }
+
+
+    /**
+     * Get the factorial coefficient.
+     * @return factorial coefficient.
+     */
+    @Override
+    public long getFacul() {
+        return facul;
+    }
+
+
+    /**
+     * Test if this is zero.
+     * @return true if this is 0, else false.
+     */
+    public boolean isZERO() {
+        return pol.isZERO();
+    }
+
+
+    /**
+     * Deriviative.
+     * @return deriviative of this.
+     */
+    @Override
+    public TaylorFunction<C> deriviative() {
+        return new PolynomialTaylorFunction<C>(PolyUtil.<C> baseDeriviative(pol));
+    }
+
+
+    /*
+     * Partial deriviative.
+     * @param r index of the variable.
+     * @return partial deriviative of this with respect to variable r.
+    public TaylorFunction<C> deriviative(int r) {
+        return new PolynomialTaylorFunction<C>(PolyUtil. <C> baseDeriviative(pol,r)); 
+    }
+     */
+
+
+    /**
+     * Multi-partial deriviative.
+     * @param i exponent vector.
+     * @return partial deriviative of this with respect to all variables.
+     */
+    public TaylorFunction<C> deriviative(ExpVector i) {
+        GenPolynomial<C> p = pol;
+        long f = 1L;
+        if (i.signum() == 0 || pol.isZERO()) {
+            return new PolynomialTaylorFunction<C>(p, f);
+        }
+        for (int j = 0; j < i.length(); j++) {
+            long e = i.getVal(j);
+            if (e == 0) {
+                continue;
+            }
+            int jl = i.length() - 1 - j;
+            for (long k = 0; k < e; k++) {
+                p = PolyUtil.<C> baseDeriviative(p, jl);
+                f *= (k + 1);
+                if (p.isZERO()) {
+                    return new PolynomialTaylorFunction<C>(p, f);
+                }
+            }
+        }
+        //System.out.println("i = " + i + ", f = " + f + ", der = " + p);
+        return new PolynomialTaylorFunction<C>(p, f);
+    }
+
+
+    /**
+     * Evaluate.
+     * @param a element.
+     * @return this(a).
+     */
+    @Override
+    public C evaluate(C a) {
+        return PolyUtil.<C> evaluateMain(pol.ring.coFac, pol, a);
+    }
+
+
+    /**
+     * Evaluate at a tuple of elements.
+     * @param a tuple of elements.
+     * @return this(a).
+     */
+    public C evaluate(List<C> a) {
+        return PolyUtil.<C> evaluateAll(pol.ring.coFac, pol, a);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/ReductionSeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/ReductionSeq.java
@@ -1,0 +1,393 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ps;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Multivariate power series reduction sequential use algorithm. Implements Mora
+ * normal-form algorithm.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class ReductionSeq<C extends RingElem<C>> // should be FieldElem<C>>
+/* extends ReductionAbstract<C> */{
+
+
+    private static final Logger logger = LogManager.getLogger(ReductionSeq.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     */
+    public ReductionSeq() {
+    }
+
+
+    /**
+     * Module criterium.
+     * @param modv number of module variables.
+     * @param A power series.
+     * @param B power series.
+     * @return true if the module S-power-series(i,j) is required.
+     */
+    public boolean moduleCriterion(int modv, MultiVarPowerSeries<C> A, MultiVarPowerSeries<C> B) {
+        if (modv == 0) {
+            return true;
+        }
+        ExpVector ei = A.orderExpVector();
+        ExpVector ej = B.orderExpVector();
+        return moduleCriterion(modv, ei, ej);
+    }
+
+
+    /**
+     * Module criterion.
+     * @param modv number of module variables.
+     * @param ei ExpVector.
+     * @param ej ExpVector.
+     * @return true if the module S-power-series(i,j) is required.
+     */
+    public boolean moduleCriterion(int modv, ExpVector ei, ExpVector ej) {
+        if (modv == 0) {
+            return true;
+        }
+        if (ei.invLexCompareTo(ej, 0, modv) != 0) {
+            return false; // skip pair
+        }
+        return true;
+    }
+
+
+    /**
+     * GB criterion 4. Use only for commutative power series rings.
+     * @param A power series.
+     * @param B power series.
+     * @param e = lcm(ht(A),ht(B))
+     * @return true if the S-power-series(i,j) is required, else false.
+     */
+    public boolean criterion4(MultiVarPowerSeries<C> A, MultiVarPowerSeries<C> B, ExpVector e) {
+        if (logger.isInfoEnabled()) {
+            if (!A.ring.equals(B.ring)) {
+                logger.error("rings not equal " + A.ring + ", " + B.ring);
+            }
+            if (!A.ring.isCommutative()) {
+                logger.error("GBCriterion4 not applicabable to non-commutative power series");
+                return true;
+            }
+        }
+        ExpVector ei = A.orderExpVector();
+        ExpVector ej = B.orderExpVector();
+        ExpVector g = ei.sum(ej);
+        // boolean t =  g == e ;
+        ExpVector h = g.subtract(e);
+        int s = h.signum();
+        return !(s == 0);
+    }
+
+
+    /**
+     * S-Power-series, S-polynomial.
+     * @param A power series.
+     * @param B power series.
+     * @return spol(A,B) the S-power-series of A and B.
+     */
+    public MultiVarPowerSeries<C> SPolynomial(MultiVarPowerSeries<C> A, MultiVarPowerSeries<C> B) {
+        if (B == null || B.isZERO()) {
+            if (A == null) {
+                return B;
+            }
+            return A.ring.getZERO();
+        }
+        if (A == null || A.isZERO()) {
+            return B.ring.getZERO();
+        }
+        if (debug) {
+            if (!A.ring.equals(B.ring)) {
+                logger.error("rings not equal " + A.ring + ", " + B.ring);
+            }
+        }
+        Map.Entry<ExpVector, C> ma = A.orderMonomial();
+        Map.Entry<ExpVector, C> mb = B.orderMonomial();
+
+        ExpVector e = ma.getKey();
+        ExpVector f = mb.getKey();
+
+        ExpVector g = e.lcm(f);
+        ExpVector e1 = g.subtract(e);
+        ExpVector f1 = g.subtract(f);
+
+        C a = ma.getValue();
+        C b = mb.getValue();
+
+        MultiVarPowerSeries<C> Ap = A.multiply(b, e1);
+        MultiVarPowerSeries<C> Bp = B.multiply(a, f1);
+        MultiVarPowerSeries<C> C = Ap.subtract(Bp);
+        return C;
+    }
+
+
+    /**
+     * Top normal-form with Mora's algorithm.
+     * @param Ap power series.
+     * @param Pp power series list.
+     * @return top-nf(Ap) with respect to Pp.
+     */
+    public MultiVarPowerSeries<C> normalform(List<MultiVarPowerSeries<C>> Pp, MultiVarPowerSeries<C> Ap) {
+        if (Pp == null || Pp.isEmpty()) {
+            return Ap;
+        }
+        if (Ap == null || Ap.isZERO()) {
+            return Ap;
+        }
+        if (!Ap.ring.coFac.isField()) {
+            throw new IllegalArgumentException("coefficients not from a field");
+        }
+        List<MultiVarPowerSeries<C>> P = new ArrayList<MultiVarPowerSeries<C>>(Pp.size());
+        synchronized (Pp) {
+            P.addAll(Pp);
+        }
+        ArrayList<ExpVector> htl = new ArrayList<ExpVector>(P.size());
+        ArrayList<C> lbc = new ArrayList<C>(P.size());
+        ArrayList<MultiVarPowerSeries<C>> p = new ArrayList<MultiVarPowerSeries<C>>(P.size());
+        ArrayList<Long> ecart = new ArrayList<Long>(P.size());
+        Map.Entry<ExpVector, C> m;
+        //int j = 0;
+        for (int i = 0; i < P.size(); i++) {
+            m = P.get(i).orderMonomial();
+            //System.out.println("m_i = " + m);
+            if (m != null) {
+                p.add(P.get(i));
+                //System.out.println("e = " + m.getKey().toString(Ap.ring.vars));
+                htl.add(m.getKey());
+                lbc.add(m.getValue());
+                ecart.add(P.get(i).ecart());
+                //j++;
+            }
+        }
+        //int ll = j;
+        MultiVarPowerSeries<C> S = Ap;
+        //S.setTruncate(Ap.ring.truncate()); // ??
+        m = S.orderMonomial();
+        while (true) {
+            //System.out.println("m = " + m);
+            //System.out.println("S = " + S);
+            if (m == null) {
+                return S;
+            }
+            if (S.isZERO()) {
+                return S;
+            }
+            ExpVector e = m.getKey();
+            if (debug) {
+                logger.debug("e = " + e.toString(Ap.ring.vars));
+            }
+            // search ps with ht(ps) | ht(S)
+            List<Integer> li = new ArrayList<Integer>();
+            int i;
+            for (i = 0; i < htl.size(); i++) {
+                if (e.multipleOf(htl.get(i))) {
+                    //System.out.println("m = " + m);
+                    li.add(i);
+                }
+            }
+            if (li.isEmpty()) {
+                return S;
+            }
+            //System.out.println("li = " + li);
+            // select ps with smallest ecart
+            long mi = Long.MAX_VALUE;
+            //String es = "";
+            for (int k = 0; k < li.size(); k++) {
+                int ki = li.get(k);
+                long x = ecart.get(ki); //p.get( ki ).ecart();
+                //es = es + x + " ";
+                if (x < mi) { // first < or last <= ?
+                    mi = x;
+                    i = ki;
+                }
+            }
+            //System.out.println("li = " + li + ", ecarts = " + es);
+            //System.out.println("i = " + i + ", p_i = " + p.get(i));
+            //if ( i <= ll ) {
+            //} else {
+            //    System.out.println("i = " + i + ", ll = " + ll);
+            //}
+            long si = S.ecart();
+            if (mi > si) {
+                //System.out.println("ecart_i = " + mi + ", ecart_S = " + si + ", S+ = " + S);
+                p.add(S);
+                htl.add(m.getKey());
+                lbc.add(m.getValue());
+                ecart.add(si);
+            }
+            e = e.subtract(htl.get(i));
+            C a = m.getValue().divide(lbc.get(i));
+            MultiVarPowerSeries<C> Q = p.get(i).multiply(a, e);
+            S = S.subtract(Q);
+            m = S.orderMonomial();
+        }
+    }
+
+
+    /**
+     * Total reduced normal-form with Mora's algorithm.
+     * @param A power series.
+     * @param P power series list.
+     * @return total-nf(A) with respect to P.
+     */
+    public MultiVarPowerSeries<C> totalNormalform(List<MultiVarPowerSeries<C>> P, MultiVarPowerSeries<C> A) {
+        if (P == null || P.isEmpty()) {
+            return A;
+        }
+        if (A == null) {
+            return A;
+        }
+        MultiVarPowerSeries<C> R = normalform(P, A);
+        if (R.isZERO()) {
+            return R;
+        }
+        MultiVarCoefficients<C> Rc = new MultiVarCoefficients<C>(A.ring) {
+
+
+            @Override
+            public C generate(ExpVector i) { // will not be used
+                return pfac.coFac.getZERO();
+            }
+        };
+        GenPolynomialRing<C> pfac = A.lazyCoeffs.pfac;
+        while (!R.isZERO()) {
+            Map.Entry<ExpVector, C> m = R.orderMonomial();
+            if (m == null) {
+                break;
+            }
+            R = R.reductum();
+            ExpVector e = m.getKey();
+            long t = e.totalDeg();
+            GenPolynomial<C> p = Rc.coeffCache.get(t);
+            if (p == null) {
+                p = pfac.getZERO();
+            }
+            p = p.sum(m.getValue(), e);
+            Rc.coeffCache.put(t, p);
+            // zeros need never update
+
+            R = normalform(P, R);
+        }
+        R = R.sum(Rc);
+        //System.out.println("R+Rc = " + R);
+        return R;
+    }
+
+
+    /**
+     * Total reduced normalform with Mora's algorithm.
+     * @param P power series list.
+     * @return total-nf(p) for p with respect to P\{p}.
+     */
+    public List<MultiVarPowerSeries<C>> totalNormalform(List<MultiVarPowerSeries<C>> P) {
+        if (P == null || P.isEmpty()) {
+            return P;
+        }
+        //StandardBaseSeq<C> std = new StandardBaseSeq<C>();
+        List<MultiVarPowerSeries<C>> R = new ArrayList<MultiVarPowerSeries<C>>(P.size());
+        List<MultiVarPowerSeries<C>> S = new ArrayList<MultiVarPowerSeries<C>>(P);
+        for (MultiVarPowerSeries<C> a : P) {
+            //S.remove(a);
+            //if ( !std.isSTD(S) ) {
+            //    System.out.println("a = " + a);
+            //}
+            Map.Entry<ExpVector, C> m = a.orderMonomial();
+            if (m == null) {
+                //S.add(a);
+                continue;
+            }
+            MultiVarPowerSeries<C> r = a.reductum();
+
+            MultiVarPowerSeries<C> b = normalform(S, r);
+            // need also unit of reduction: u r --> b
+            // b = b.multiply(u);
+            b = b.sum(m);
+            if (!b.isZERO()) {
+                R.add(b);
+            }
+        }
+        return R;
+    }
+
+
+    /**
+     * Is top reducible.
+     * @param A power series.
+     * @param P power series list.
+     * @return true if A is top reducible with respect to P.
+     */
+    public boolean isTopReducible(List<MultiVarPowerSeries<C>> P, MultiVarPowerSeries<C> A) {
+        if (P == null || P.isEmpty()) {
+            return false;
+        }
+        if (A == null) {
+            return false;
+        }
+        ExpVector e = A.orderExpVector();
+        if (e == null) {
+            return false;
+        }
+        for (MultiVarPowerSeries<C> p : P) {
+            ExpVector ep = p.orderExpVector();
+            if (ep == null) { // found by findbugs
+                continue;
+            }
+            if (e.multipleOf(ep)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    /**
+     * Ideal containment. Test if each b in B is contained in ideal S.
+     * @param S standard base.
+     * @param B list of power series
+     * @return true, if each b in B is contained in ideal(S), else false
+     */
+    public boolean contains(List<MultiVarPowerSeries<C>> S, List<MultiVarPowerSeries<C>> B) {
+        if (B == null || B.size() == 0) {
+            return true;
+        }
+        if (S == null || S.size() == 0) {
+            return true;
+        }
+        for (MultiVarPowerSeries<C> b : B) {
+            if (b == null) {
+                continue;
+            }
+            MultiVarPowerSeries<C> z = normalform(S, b);
+            if (!z.isZERO()) {
+                System.out.println("contains nf(b) != 0: " + b + ", z = " + z);
+                return false;
+            }
+        }
+        return true;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/StandardBaseSeq.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/StandardBaseSeq.java
@@ -1,0 +1,273 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ps;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.ExpVector;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Standard Base sequential algorithm. Implements Standard bases and GB test.
+ * <b>Note: </b> Currently the term order is fixed to the order defined by the
+ * iterator over exponent vectors <code>ExpVectorIterator</code>.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class StandardBaseSeq<C extends RingElem<C>>
+/* extends StandardBaseAbstract<C> */{
+
+
+    private static final Logger logger = LogManager.getLogger(StandardBaseSeq.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Reduction engine.
+     */
+    public final ReductionSeq<C> red;
+
+
+    /**
+     * Constructor.
+     */
+    public StandardBaseSeq() {
+        //super();
+        this(new ReductionSeq<C>());
+    }
+
+
+    /**
+     * Constructor.
+     * @param red Reduction engine
+     */
+    public StandardBaseSeq(ReductionSeq<C> red) {
+        this.red = red; //super(red);
+    }
+
+
+    /**
+     * Normalize power series list.
+     * @param A list of power series.
+     * @return list of power series with zeros removed and ones/units reduced.
+     */
+    public List<MultiVarPowerSeries<C>> normalizeZerosOnes(List<MultiVarPowerSeries<C>> A) {
+        if (A == null) {
+            return A;
+        }
+        List<MultiVarPowerSeries<C>> N = new ArrayList<MultiVarPowerSeries<C>>(A.size());
+        if (A.isEmpty()) {
+            return N;
+        }
+        for (MultiVarPowerSeries<C> p : A) {
+            if (p == null || p.isZERO()) {
+                continue;
+            }
+            if (p.isUnit()) {
+                N.clear();
+                N.add(p.ring.getONE());
+                return N;
+            }
+            N.add(p.abs());
+        }
+        //N.trimToSize();
+        return N;
+    }
+
+
+    /**
+     * Standard base test.
+     * @param F power series list.
+     * @return true, if F is a Standard base, else false.
+     */
+    public boolean isSTD(List<MultiVarPowerSeries<C>> F) {
+        return isSTD(0, F);
+    }
+
+
+    /**
+     * Standard base test.
+     * @param modv module variable number.
+     * @param F power series list.
+     * @return true, if F is a Standard base, else false.
+     */
+    public boolean isSTD(int modv, List<MultiVarPowerSeries<C>> F) {
+        if (F == null) {
+            return true;
+        }
+        MultiVarPowerSeries<C> pi, pj, s, h;
+        for (int i = 0; i < F.size(); i++) {
+            pi = F.get(i);
+            for (int j = i + 1; j < F.size(); j++) {
+                pj = F.get(j);
+                if (!red.moduleCriterion(modv, pi, pj)) {
+                    continue;
+                }
+                // if ( ! red.criterion4( pi, pj ) ) { 
+                //       continue;
+                // }
+                s = red.SPolynomial(pi, pj);
+                if (s.isZERO()) {
+                    continue;
+                }
+                h = red.normalform(F, s);
+                if (!h.isZERO()) {
+                    System.out.println("pi = " + pi + ", pj = " + pj);
+                    System.out.println("s  = " + s + ", h = " + h);
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Standard base using pairlist class.
+     * @param F power series list.
+     * @return STD(F) a Standard base of F.
+     */
+    public List<MultiVarPowerSeries<C>> STD(List<MultiVarPowerSeries<C>> F) {
+        return STD(0, F);
+    }
+
+
+    /**
+     * Standard base using pairlist class.
+     * @param modv module variable number.
+     * @param F power series list.
+     * @return STD(F) a Standard base of F.
+     */
+    public List<MultiVarPowerSeries<C>> STD(int modv, List<MultiVarPowerSeries<C>> F) {
+        List<MultiVarPowerSeries<C>> G = normalizeZerosOnes(F);
+        G = PSUtil.<C> monic(G);
+        if (G.size() <= 1) {
+            return G;
+        }
+        MultiVarPowerSeriesRing<C> ring = G.get(0).ring;
+        if (!ring.coFac.isField()) {
+            throw new IllegalArgumentException("coefficients not from a field");
+        }
+        OrderedPairlist<C> pairlist = new OrderedPairlist<C>(modv, ring); //strategy.create( modv, ring ); 
+        pairlist.put(G);
+        logger.info("start " + pairlist);
+
+        Pair<C> pair;
+        MultiVarPowerSeries<C> pi, pj, S, H;
+        while (pairlist.hasNext()) {
+            pair = pairlist.removeNext();
+            //logger.debug("pair = " + pair);
+            if (pair == null) {
+                continue;
+            }
+            pi = pair.pi;
+            pj = pair.pj;
+            if ( /*false &&*/debug) {
+                logger.debug("pi    = " + pi);
+                logger.debug("pj    = " + pj);
+            }
+
+            S = red.SPolynomial(pi, pj);
+            //S.setTruncate(p.ring.truncate()); // ??
+            if (S.isZERO()) {
+                pair.setZero();
+                continue;
+            }
+            if (logger.isInfoEnabled()) {
+                ExpVector es = S.orderExpVector();
+                logger.info("ht(S) = " + es.toString(S.ring.vars) + ", " + es); // + ", S = " + S);
+            }
+
+            //long t = System.currentTimeMillis();
+            H = red.normalform(G, S);
+            if (H.isZERO()) {
+                pair.setZero();
+                continue;
+            }
+            //t = System.currentTimeMillis() - t;
+            //System.out.println("time = " + t);
+            if (logger.isInfoEnabled()) {
+                ExpVector eh = H.orderExpVector();
+                logger.info("ht(H) = " + eh.toString(S.ring.vars) + ", " + eh); // + ", coeff(HT(H)) = " + H.coefficient(eh));
+            }
+
+            //H = H.monic();
+            if (H.isUnit()) {
+                G.clear();
+                G.add(H);
+                return G; // since no threads are activated
+            }
+            if (logger.isDebugEnabled()) {
+                logger.info("H = " + H);
+            }
+            //if (!H.isZERO()) {
+            //l++;
+            G.add(H);
+            pairlist.put(H);
+            //}
+        }
+        logger.debug("#sequential list = " + G.size());
+        G = minimalSTD(G);
+        logger.info("" + pairlist);
+        return G;
+    }
+
+
+    /**
+     * Minimal ordered Standard basis.
+     * @param Gp a Standard base.
+     * @return a minimal Standard base of Gp, not auto reduced.
+     */
+    public List<MultiVarPowerSeries<C>> minimalSTD(List<MultiVarPowerSeries<C>> Gp) {
+        if (Gp == null || Gp.size() <= 1) {
+            return Gp;
+        }
+        // remove zero power series
+        List<MultiVarPowerSeries<C>> G = new ArrayList<MultiVarPowerSeries<C>>(Gp.size());
+        for (MultiVarPowerSeries<C> a : Gp) {
+            if (a != null && !a.isZERO()) { // always true in GB()
+                // make positive a = a.abs(); ?
+                a = a.monic();
+                G.add(a);
+            }
+        }
+        if (G.size() <= 1) {
+            return G;
+        }
+        // remove top reducible power series
+        MultiVarPowerSeries<C> a;
+        List<MultiVarPowerSeries<C>> F = new ArrayList<MultiVarPowerSeries<C>>(G.size());
+        while (G.size() > 0) {
+            a = G.remove(0);
+            if (red.isTopReducible(G, a) || red.isTopReducible(F, a)) {
+                // drop power series 
+                if (debug) {
+                    System.out.println("dropped " + a);
+                    List<MultiVarPowerSeries<C>> ff = new ArrayList<MultiVarPowerSeries<C>>(G);
+                    ff.addAll(F);
+                    a = red.normalform(ff, a);
+                    if (!a.isZERO()) {
+                        System.out.println("error, nf(a) " + a);
+                    }
+                }
+            } else {
+                F.add(a);
+            }
+        }
+        G = F;
+        // power series not reduced
+        return G;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/TaylorFunction.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/TaylorFunction.java
@@ -1,0 +1,67 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ps;
+
+
+import java.util.List;
+
+import edu.jas.poly.ExpVector;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Interface for functions capable for Taylor series expansion.
+ * @param <C> ring element type
+ * @author Heinz Kredel
+ */
+
+public interface TaylorFunction<C extends RingElem<C>> {
+
+
+    /**
+     * Get the factorial coefficient.
+     * @return factorial coefficient.
+     */
+    public long getFacul();
+
+
+    /**
+     * Test if this is zero.
+     * @return true if this is 0, else false.
+     */
+    public boolean isZERO();
+
+
+    /**
+     * Deriviative.
+     * @return deriviative of this.
+     */
+    public TaylorFunction<C> deriviative();
+
+
+    /**
+     * Multi-partial deriviative.
+     * @param i exponent vector.
+     * @return partial deriviative of this with respect to all variables.
+     */
+    public TaylorFunction<C> deriviative(ExpVector i);
+
+
+    /**
+     * Evaluate.
+     * @param a element.
+     * @return this(a).
+     */
+    public C evaluate(C a);
+
+
+    /**
+     * Evaluate at a tuple of elements.
+     * @param a tuple of elements.
+     * @return this(a).
+     */
+    public C evaluate(List<C> a);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/TaylorFunctionAdapter.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/TaylorFunctionAdapter.java
@@ -1,0 +1,80 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ps;
+
+
+import java.util.List;
+
+import edu.jas.poly.ExpVector;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Adapter for functions capable for Taylor series expansion.
+ * @param <C> ring element type
+ * @author Heinz Kredel
+ */
+
+public abstract class TaylorFunctionAdapter<C extends RingElem<C>> implements TaylorFunction<C> {
+
+
+    /**
+     * Get the factorial coefficient.
+     * @return factorial coefficient.
+     */
+    public long getFacul() {
+        return 1L;
+    }
+
+
+    /**
+     * Test if this is zero.
+     * @return true if this is 0, else false.
+     */
+    public boolean isZERO() {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+
+
+    /**
+     * Deriviative.
+     * @return deriviative of this.
+     */
+    public TaylorFunction<C> deriviative() {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+
+    /**
+     * Multi-partial deriviative.
+     * @param i exponent vector.
+     * @return partial deriviative of this with respect to all variables.
+     */
+    public TaylorFunction<C> deriviative(ExpVector i) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+
+    /**
+     * Evaluate.
+     * @param a element.
+     * @return this(a).
+     */
+    public C evaluate(C a) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+
+    /**
+     * Evaluate at a tuple of elements.
+     * @param a tuple of elements.
+     * @return this(a).
+     */
+    public C evaluate(List<C> a) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/UnivPowerSeries.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/UnivPowerSeries.java
@@ -1,0 +1,921 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ps;
+
+
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.BinaryFunctor;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.Selector;
+import edu.jas.structure.UnaryFunctor;
+
+
+/**
+ * Univariate power series implementation. Uses inner classes and lazy evaluated
+ * generating function for coefficients. All ring element methods use lazy
+ * evaluation except where noted otherwise. Eager evaluated methods are
+ * <code>toString()</code>, <code>compareTo()</code>, <code>equals()</code>,
+ * <code>evaluate()</code>, or they use the <code>order()</code> method, like
+ * <code>signum()</code>, <code>abs()</code>, <code>divide()</code>,
+ * <code>remainder()</code> and <code>gcd()</code>.
+ * @param <C> ring element type
+ * @author Heinz Kredel
+ */
+
+public class UnivPowerSeries<C extends RingElem<C>> implements RingElem<UnivPowerSeries<C>> {
+
+
+    /**
+     * Power series ring factory.
+     */
+    public final UnivPowerSeriesRing<C> ring;
+
+
+    /**
+     * Data structure / generating function for coeffcients. Cannot be final
+     * because of fixPoint, must be accessible in factory.
+     */
+    /*package*/Coefficients<C> lazyCoeffs;
+
+
+    /**
+     * Truncation of computations.
+     */
+    private int truncate = 11;
+
+
+    /**
+     * Order of power series.
+     */
+    private int order = -1; // == unknown
+
+
+    /**
+     * Private constructor.
+     */
+    @SuppressWarnings("unused")
+    private UnivPowerSeries() {
+        throw new IllegalArgumentException("do not use no-argument constructor");
+    }
+
+
+    /**
+     * Package constructor. Use in fixPoint only, must be accessible in factory.
+     * @param ring power series ring.
+     */
+    /*package*/ UnivPowerSeries(UnivPowerSeriesRing<C> ring) {
+        this.ring = ring;
+        this.lazyCoeffs = null;
+    }
+
+
+    /**
+     * Constructor.
+     * @param ring power series ring.
+     * @param lazyCoeffs generating function for coefficients.
+     */
+    public UnivPowerSeries(UnivPowerSeriesRing<C> ring, Coefficients<C> lazyCoeffs) {
+        if (lazyCoeffs == null || ring == null) {
+            throw new IllegalArgumentException(
+                            "null not allowed: ring = " + ring + ", lazyCoeffs = " + lazyCoeffs);
+        }
+        this.ring = ring;
+        this.lazyCoeffs = lazyCoeffs;
+        this.truncate = ring.truncate;
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public UnivPowerSeriesRing<C> factory() {
+        return ring;
+    }
+
+
+    /**
+     * Clone this power series.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public UnivPowerSeries<C> copy() {
+        return new UnivPowerSeries<C>(ring, lazyCoeffs);
+    }
+
+
+    /**
+     * String representation of power series.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return toString(truncate);
+    }
+
+
+    /**
+     * To String with given truncate.
+     * @return string representation of this to given truncate.
+     */
+    public String toString(int truncate) {
+        StringBuffer sb = new StringBuffer();
+        UnivPowerSeries<C> s = this;
+        String var = ring.var;
+        //System.out.println("cache = " + s.coeffCache);
+        for (int i = 0; i < truncate; i++) {
+            C c = s.coefficient(i);
+            int si = c.signum();
+            if (si != 0) {
+                if (si > 0) {
+                    if (sb.length() > 0) {
+                        sb.append(" + ");
+                    }
+                } else {
+                    c = c.negate();
+                    sb.append(" - ");
+                }
+                if (!c.isONE() || i == 0) {
+                    if (c instanceof GenPolynomial || c instanceof AlgebraicNumber) {
+                        sb.append("{ ");
+                    }
+                    sb.append(c.toString());
+                    if (c instanceof GenPolynomial || c instanceof AlgebraicNumber) {
+                        sb.append(" }");
+                    }
+                    if (i > 0) {
+                        sb.append(" * ");
+                    }
+                }
+                if (i == 0) {
+                    //skip; sb.append(" ");
+                } else if (i == 1) {
+                    sb.append(var);
+                } else {
+                    sb.append(var + "^" + i);
+                }
+                //sb.append(c.toString() + ", ");
+            }
+            //System.out.println("cache = " + s.coeffCache);
+        }
+        if (sb.length() == 0) {
+            sb.append("0");
+        }
+        sb.append(" + BigO(" + var + "^" + truncate + ")");
+        //sb.append("...");
+        return sb.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        StringBuffer sb = new StringBuffer("");
+        UnivPowerSeries<C> s = this;
+        String var = ring.var;
+        //System.out.println("cache = " + s.coeffCache);
+        for (int i = 0; i < truncate; i++) {
+            C c = s.coefficient(i);
+            int si = c.signum();
+            if (si != 0) {
+                if (si > 0) {
+                    if (sb.length() > 0) {
+                        sb.append(" + ");
+                    }
+                } else {
+                    c = c.negate();
+                    sb.append(" - ");
+                }
+                if (!c.isONE() || i == 0) {
+                    if (c instanceof GenPolynomial || c instanceof AlgebraicNumber) {
+                        sb.append("{ ");
+                    }
+                    sb.append(c.toScript());
+                    if (c instanceof GenPolynomial || c instanceof AlgebraicNumber) {
+                        sb.append(" }");
+                    }
+                    if (i > 0) {
+                        sb.append(" * ");
+                    }
+                }
+                if (i == 0) {
+                    //skip; sb.append(" ");
+                } else if (i == 1) {
+                    sb.append(var);
+                } else {
+                    sb.append(var + "**" + i);
+                }
+                //sb.append(c.toString() + ", ");
+            }
+            //System.out.println("cache = " + s.coeffCache);
+        }
+        if (sb.length() == 0) {
+            sb.append("0");
+        }
+        // sb.append("," + truncate + "");
+        return sb.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python case
+        return factory().toScript();
+    }
+
+
+    /**
+     * Get coefficient.
+     * @param index number of requested coefficient.
+     * @return coefficient at index.
+     */
+    public C coefficient(int index) {
+        if (index < 0) {
+            throw new IndexOutOfBoundsException("negative index not allowed");
+        }
+        //System.out.println("cache = " + coeffCache);
+        return lazyCoeffs.get(index);
+    }
+
+
+    /**
+     * Get a GenPolynomial&lt;C&gt; from this.
+     * @return a GenPolynomial&lt;C&gt; from this up to truncate parts.
+     */
+    public GenPolynomial<C> asPolynomial() {
+        GenPolynomial<C> p = ring.polyRing().getZERO();
+        for (int i = 0; i <= truncate; i++) {
+            C c = coefficient(i);
+            ExpVector e = ExpVector.create(1, 0, i);
+            p = p.sum(c, e);
+        }
+        return p;
+    }
+
+
+    /**
+     * Leading base coefficient.
+     * @return first coefficient.
+     */
+    public C leadingCoefficient() {
+        return coefficient(0);
+    }
+
+
+    /**
+     * Reductum.
+     * @return this - leading monomial.
+     */
+    public UnivPowerSeries<C> reductum() {
+        return new UnivPowerSeries<C>(ring, new Coefficients<C>() {
+
+
+            @Override
+            public C generate(int i) {
+                return coefficient(i + 1);
+            }
+        });
+    }
+
+
+    /**
+     * Prepend a new leading coefficient.
+     * @param h new coefficient.
+     * @return new power series.
+     */
+    public UnivPowerSeries<C> prepend(final C h) {
+        return new UnivPowerSeries<C>(ring, new Coefficients<C>() {
+
+
+            @Override
+            public C generate(int i) {
+                if (i == 0) {
+                    return h;
+                }
+                return coefficient(i - 1);
+            }
+        });
+    }
+
+
+    /**
+     * Shift coefficients.
+     * @param k shift index.
+     * @return new power series with coefficient(i) = old.coefficient(i-k).
+     */
+    public UnivPowerSeries<C> shift(final int k) {
+        return new UnivPowerSeries<C>(ring, new Coefficients<C>() {
+
+
+            @Override
+            public C generate(int i) {
+                if (i - k < 0) {
+                    return ring.coFac.getZERO();
+                }
+                return coefficient(i - k);
+            }
+        });
+    }
+
+
+    /**
+     * Select coefficients.
+     * @param sel selector functor.
+     * @return new power series with selected coefficients.
+     */
+    public UnivPowerSeries<C> select(final Selector<? super C> sel) {
+        return new UnivPowerSeries<C>(ring, new Coefficients<C>() {
+
+
+            @Override
+            public C generate(int i) {
+                C c = coefficient(i);
+                if (sel.select(c)) {
+                    return c;
+                }
+                return ring.coFac.getZERO();
+            }
+        });
+    }
+
+
+    /**
+     * Shift select coefficients. Not selected coefficients are removed from the
+     * result series.
+     * @param sel selector functor.
+     * @return new power series with shifted selected coefficients.
+     */
+    public UnivPowerSeries<C> shiftSelect(final Selector<? super C> sel) {
+        return new UnivPowerSeries<C>(ring, new Coefficients<C>() {
+
+
+            int pos = 0;
+
+
+            @Override
+            public C generate(int i) {
+                C c;
+                if (i > 0) {
+                    c = get(i - 1); // ensure coeffs are all generated
+                }
+                do {
+                    c = coefficient(pos++);
+                } while (!sel.select(c));
+                return c;
+            }
+        });
+    }
+
+
+    /**
+     * Map a unary function to this power series.
+     * @param f evaluation functor.
+     * @return new power series with coefficients f(this(i)).
+     */
+    public UnivPowerSeries<C> map(final UnaryFunctor<? super C, C> f) {
+        return new UnivPowerSeries<C>(ring, new Coefficients<C>() {
+
+
+            @Override
+            public C generate(int i) {
+                return f.eval(coefficient(i));
+            }
+        });
+    }
+
+
+    /**
+     * Map a binary function to this and another power series.
+     * @param f evaluation functor with coefficients f(this(i),other(i)).
+     * @param ps other power series.
+     * @return new power series.
+     */
+    public <C2 extends RingElem<C2>> UnivPowerSeries<C> zip(final BinaryFunctor<? super C, ? super C2, C> f,
+                    final UnivPowerSeries<C2> ps) {
+        return new UnivPowerSeries<C>(ring, new Coefficients<C>() {
+
+
+            @Override
+            public C generate(int i) {
+                return f.eval(coefficient(i), ps.coefficient(i));
+            }
+        });
+    }
+
+
+    /**
+     * Sum of two power series.
+     * @param ps other power series.
+     * @return this + ps.
+     */
+    public UnivPowerSeries<C> sum(UnivPowerSeries<C> ps) {
+        return zip(new Sum<C>(), ps);
+    }
+
+
+    /**
+     * Subtraction of two power series.
+     * @param ps other power series.
+     * @return this - ps.
+     */
+    public UnivPowerSeries<C> subtract(UnivPowerSeries<C> ps) {
+        return zip(new Subtract<C>(), ps);
+    }
+
+
+    /**
+     * Multiply by coefficient.
+     * @param c coefficient.
+     * @return this * c.
+     */
+    public UnivPowerSeries<C> multiply(C c) {
+        return map(new Multiply<C>(c));
+    }
+
+
+    /**
+     * Monic.
+     * @return 1/orderCoeff() * this.
+     */
+    public UnivPowerSeries<C> monic() {
+        int i = order();
+        C a = coefficient(i);
+        if (a.isONE()) {
+            return this;
+        }
+        if (a.isZERO()) { // sic
+            return this;
+        }
+        final C b = a.inverse();
+        return map(new UnaryFunctor<C, C>() {
+
+
+            @Override
+            public C eval(C c) {
+                return b.multiply(c);
+            }
+        });
+    }
+
+
+    /**
+     * Negate.
+     * @return - this.
+     */
+    public UnivPowerSeries<C> negate() {
+        return map(new Negate<C>());
+    }
+
+
+    /**
+     * Absolute value.
+     * @return abs(this).
+     */
+    public UnivPowerSeries<C> abs() {
+        if (signum() < 0) {
+            return negate();
+        }
+        return this;
+    }
+
+
+    /**
+     * Evaluate at given point.
+     * @return ps(c).
+     */
+    public C evaluate(C e) {
+        C v = coefficient(0);
+        C p = e;
+        for (int i = 1; i < truncate; i++) {
+            C c = coefficient(i).multiply(p);
+            v = v.sum(c);
+            p = p.multiply(e);
+        }
+        return v;
+    }
+
+
+    /**
+     * Order.
+     * @return index of first non zero coefficient.
+     */
+    public int order() {
+        if (order < 0) { // compute it
+            for (int i = 0; i <= truncate; i++) {
+                if (!coefficient(i).isZERO()) {
+                    order = i;
+                    return order;
+                }
+            }
+            order = truncate + 1;
+        }
+        return order;
+    }
+
+
+    /**
+     * Truncate.
+     * @return truncate index of power series.
+     */
+    public int truncate() {
+        return truncate;
+    }
+
+
+    /**
+     * Set truncate.
+     * @param t new truncate index.
+     * @return old truncate index of power series.
+     */
+    public int setTruncate(int t) {
+        if (t < 0) {
+            throw new IllegalArgumentException("negative truncate not allowed");
+        }
+        int ot = truncate;
+        truncate = t;
+        return ot;
+    }
+
+
+    /**
+     * Signum.
+     * @return sign of first non zero coefficient.
+     */
+    public int signum() {
+        return coefficient(order()).signum();
+    }
+
+
+    /**
+     * Compare to. <b>Note: </b> compare only up to truncate.
+     * @return sign of first non zero coefficient of this-ps.
+     */
+    @Override
+    public int compareTo(UnivPowerSeries<C> ps) {
+        int m = order();
+        int n = ps.order();
+        int pos = (m <= n) ? m : n;
+        int s = 0;
+        do {
+            s = coefficient(pos).compareTo(ps.coefficient(pos));
+            pos++;
+        } while (s == 0 && pos <= truncate);
+        return s;
+    }
+
+
+    /**
+     * Is power series zero. <b>Note: </b> compare only up to truncate.
+     * @return If this is 0 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isZERO()
+     */
+    public boolean isZERO() {
+        return (compareTo(ring.ZERO) == 0);
+    }
+
+
+    /**
+     * Is power series one. <b>Note: </b> compare only up to truncate.
+     * @return If this is 1 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isONE()
+     */
+    public boolean isONE() {
+        return (compareTo(ring.ONE) == 0);
+    }
+
+
+    /**
+     * Comparison with any other object. <b>Note: </b> compare only up to
+     * truncate.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object B) {
+        UnivPowerSeries<C> a = null;
+        try {
+            a = (UnivPowerSeries<C>) B;
+        } catch (ClassCastException ignored) {
+        }
+        if (a == null) {
+            return false;
+        }
+        return compareTo(a) == 0;
+    }
+
+
+    /**
+     * Hash code for this polynomial. <b>Note: </b> only up to truncate.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h = 0;
+        //h = ( ring.hashCode() << 23 );
+        //h += val.hashCode();
+        for (int i = 0; i <= truncate; i++) {
+            h += coefficient(i).hashCode();
+            h = (h << 23);
+        }
+        return h;
+    }
+
+
+    /**
+     * Is unit.
+     * @return true, if this power series is invertible, else false.
+     */
+    public boolean isUnit() {
+        return leadingCoefficient().isUnit();
+    }
+
+
+    /**
+     * Multiply by another power series.
+     * @return this * ps.
+     */
+    public UnivPowerSeries<C> multiply(final UnivPowerSeries<C> ps) {
+        return new UnivPowerSeries<C>(ring, new Coefficients<C>() {
+
+
+            @Override
+            public C generate(int i) {
+                C c = null; //fac.getZERO();
+                for (int k = 0; k <= i; k++) {
+                    C m = coefficient(k).multiply(ps.coefficient(i - k));
+                    if (c == null) {
+                        c = m;
+                    } else {
+                        c = c.sum(m);
+                    }
+                }
+                return c;
+            }
+        });
+    }
+
+
+    /**
+     * Inverse power series.
+     * @return ps with this * ps = 1.
+     */
+    public UnivPowerSeries<C> inverse() {
+        return new UnivPowerSeries<C>(ring, new Coefficients<C>() {
+
+
+            @Override
+            public C generate(int i) {
+                C d = leadingCoefficient().inverse(); // may fail
+                if (i == 0) {
+                    return d;
+                }
+                C c = null; //fac.getZERO();
+                for (int k = 0; k < i; k++) {
+                    C m = get(k).multiply(coefficient(i - k));
+                    if (c == null) {
+                        c = m;
+                    } else {
+                        c = c.sum(m);
+                    }
+                }
+                c = c.multiply(d.negate());
+                return c;
+            }
+        });
+    }
+
+
+    /**
+     * Divide by another power series.
+     * @return this / ps.
+     */
+    public UnivPowerSeries<C> divide(UnivPowerSeries<C> ps) {
+        if (ps.isUnit()) {
+            return multiply(ps.inverse());
+        }
+        int m = order();
+        int n = ps.order();
+        if (m < n) {
+            return ring.getZERO();
+        }
+        if (!ps.coefficient(n).isUnit()) {
+            throw new ArithmeticException(
+                            "division by non unit coefficient " + ps.coefficient(n) + ", n = " + n);
+        }
+        // now m >= n
+        UnivPowerSeries<C> st, sps, q, sq;
+        if (m == 0) {
+            st = this;
+        } else {
+            st = this.shift(-m);
+        }
+        if (n == 0) {
+            sps = ps;
+        } else {
+            sps = ps.shift(-n);
+        }
+        q = st.multiply(sps.inverse());
+        if (m == n) {
+            sq = q;
+        } else {
+            sq = q.shift(m - n);
+        }
+        return sq;
+    }
+
+
+    /**
+     * Power series remainder.
+     * @param ps nonzero power series with invertible leading coefficient.
+     * @return remainder with this = quotient * ps + remainder.
+     */
+    public UnivPowerSeries<C> remainder(UnivPowerSeries<C> ps) {
+        int m = order();
+        int n = ps.order();
+        if (m >= n) {
+            return ring.getZERO();
+        }
+        return this;
+    }
+
+
+    /**
+     * Quotient and remainder by division of this by S.
+     * @param S a UnivPowerSeries
+     * @return [this/S, this - (this/S)*S].
+     */
+    @SuppressWarnings("unchecked")
+    public UnivPowerSeries<C>[] quotientRemainder(UnivPowerSeries<C> S) {
+        return new UnivPowerSeries[] { divide(S), remainder(S) };
+    }
+
+
+    /**
+     * Differentiate.
+     * @return differentiate(this).
+     */
+    public UnivPowerSeries<C> differentiate() {
+        return new UnivPowerSeries<C>(ring, new Coefficients<C>() {
+
+
+            @Override
+            public C generate(int i) {
+                C v = coefficient(i + 1);
+                v = v.multiply(ring.coFac.fromInteger(i + 1));
+                return v;
+            }
+        });
+    }
+
+
+    /**
+     * Integrate with given constant.
+     * @param c integration constant.
+     * @return integrate(this).
+     */
+    public UnivPowerSeries<C> integrate(final C c) {
+        return new UnivPowerSeries<C>(ring, new Coefficients<C>() {
+
+
+            @Override
+            public C generate(int i) {
+                if (i == 0) {
+                    return c;
+                }
+                C v = coefficient(i - 1);
+                v = v.divide(ring.coFac.fromInteger(i));
+                return v;
+            }
+        });
+    }
+
+
+    /**
+     * Power series greatest common divisor.
+     * @param ps power series.
+     * @return gcd(this,ps).
+     */
+    public UnivPowerSeries<C> gcd(UnivPowerSeries<C> ps) {
+        if (ps.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return ps;
+        }
+        int m = order();
+        int n = ps.order();
+        int ll = (m < n) ? m : n;
+        return ring.getONE().shift(ll);
+    }
+
+
+    /**
+     * Power series extended greatest common divisor. <b>Note:</b> not
+     * implemented.
+     * @param S power series.
+     * @return [ gcd(this,S), a, b ] with a*this + b*S = gcd(this,S).
+     */
+    //SuppressWarnings("unchecked")
+    public UnivPowerSeries<C>[] egcd(UnivPowerSeries<C> S) {
+        throw new UnsupportedOperationException("egcd for power series not implemented");
+    }
+
+}
+
+
+/* arithmetic method functors */
+
+
+/**
+ * Internal summation functor.
+ */
+class Sum<C extends RingElem<C>> implements BinaryFunctor<C, C, C> {
+
+
+    public C eval(C c1, C c2) {
+        return c1.sum(c2);
+    }
+}
+
+
+/**
+ * Internal subtraction functor.
+ */
+class Subtract<C extends RingElem<C>> implements BinaryFunctor<C, C, C> {
+
+
+    public C eval(C c1, C c2) {
+        return c1.subtract(c2);
+    }
+}
+
+
+/**
+ * Internal scalar multiplication functor.
+ */
+class Multiply<C extends RingElem<C>> implements UnaryFunctor<C, C> {
+
+
+    C x;
+
+
+    public Multiply(C x) {
+        this.x = x;
+    }
+
+
+    public C eval(C c) {
+        return c.multiply(x);
+    }
+}
+
+
+/**
+ * Internal negation functor.
+ */
+class Negate<C extends RingElem<C>> implements UnaryFunctor<C, C> {
+
+
+    public C eval(C c) {
+        return c.negate();
+    }
+}
+
+
+/* only for sequential access:
+class Abs<C extends RingElem<C>> implements UnaryFunctor<C,C> {
+        int sign = 0;
+        public C eval(C c) {
+            int s = c.signum();
+            if ( s == 0 ) {
+               return c;
+            }
+            if ( sign > 0 ) {
+               return c;
+            } else if ( sign < 0 ) {
+               return c.negate();
+            }
+            // first non zero coefficient:
+            sign = s;
+            if ( s > 0 ) {
+               return c;
+            }
+            return c.negate();
+        }
+}
+*/

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/UnivPowerSeriesMap.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/UnivPowerSeriesMap.java
@@ -1,0 +1,27 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ps;
+
+
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Univariate power series map interface. Defines method for mapping of power
+ * series.
+ * @param <C> ring element type
+ * @author Heinz Kredel
+ */
+
+public interface UnivPowerSeriesMap<C extends RingElem<C>> {
+
+
+    /**
+     * Map.
+     * @return new power series resulting from mapping elements of ps.
+     */
+    public UnivPowerSeries<C> map(UnivPowerSeries<C> ps);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/UnivPowerSeriesRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/UnivPowerSeriesRing.java
@@ -1,0 +1,652 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ps;
+
+
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Random;
+import java.util.function.IntFunction;
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.Monomial;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.vector.GenVector;
+
+
+/**
+ * Univariate power series ring implementation. Uses lazy evaluated generating
+ * function for coefficients.
+ * @param <C> ring element type
+ * @author Heinz Kredel
+ */
+
+public class UnivPowerSeriesRing<C extends RingElem<C>> implements RingFactory<UnivPowerSeries<C>> {
+
+
+    /**
+     * A default random sequence generator.
+     */
+    protected final static Random random = new Random();
+
+
+    /**
+     * Default truncate.
+     */
+    public final static int DEFAULT_TRUNCATE = 11;
+
+
+    /**
+     * Truncate.
+     */
+    int truncate;
+
+
+    /**
+     * Default variable name.
+     */
+    public final static String DEFAULT_NAME = "x";
+
+
+    /**
+     * Variable name.
+     */
+    String var;
+
+
+    /**
+     * Coefficient ring factory.
+     */
+    public final RingFactory<C> coFac;
+
+
+    /**
+     * The constant power series 1 for this ring.
+     */
+    public final UnivPowerSeries<C> ONE;
+
+
+    /**
+     * The constant power series 0 for this ring.
+     */
+    public final UnivPowerSeries<C> ZERO;
+
+
+    /**
+     * No argument constructor.
+     */
+    @SuppressWarnings("unused")
+    private UnivPowerSeriesRing() {
+        throw new IllegalArgumentException("do not use no-argument constructor");
+    }
+
+
+    /**
+     * Constructor.
+     * @param coFac coefficient ring factory.
+     */
+    public UnivPowerSeriesRing(RingFactory<C> coFac) {
+        this(coFac, DEFAULT_TRUNCATE, DEFAULT_NAME);
+    }
+
+
+    /**
+     * Constructor.
+     * @param coFac coefficient ring factory.
+     * @param truncate index of truncation.
+     */
+    public UnivPowerSeriesRing(RingFactory<C> coFac, int truncate) {
+        this(coFac, truncate, DEFAULT_NAME);
+    }
+
+
+    /**
+     * Constructor.
+     * @param coFac coefficient ring factory.
+     * @param name of the variable.
+     */
+    public UnivPowerSeriesRing(RingFactory<C> coFac, String name) {
+        this(coFac, DEFAULT_TRUNCATE, name);
+    }
+
+
+    /**
+     * Constructor.
+     * @param pfac polynomial ring factory.
+     */
+    public UnivPowerSeriesRing(GenPolynomialRing<C> pfac) {
+        this(pfac.coFac, DEFAULT_TRUNCATE, pfac.getVars()[0]);
+    }
+
+
+    /**
+     * Constructor.
+     * @param cofac coefficient ring factory.
+     * @param truncate index of truncation.
+     * @param name of the variable.
+     */
+    public UnivPowerSeriesRing(RingFactory<C> cofac, int truncate, String name) {
+        this.coFac = cofac;
+        this.truncate = truncate;
+        this.var = name;
+        this.ONE = new UnivPowerSeries<C>(this, new Coefficients<C>() {
+
+
+            @Override
+            public C generate(int i) {
+                if (i == 0) {
+                    return coFac.getONE();
+                }
+                return coFac.getZERO();
+            }
+        });
+        this.ZERO = new UnivPowerSeries<C>(this, new Coefficients<C>() {
+
+
+            @Override
+            public C generate(int i) {
+                return coFac.getZERO();
+            }
+        });
+    }
+
+
+    /**
+     * Fixed point construction.
+     * @param map a mapping of power series.
+     * @return fix point wrt map.
+     */
+    // Cannot be a static method because a power series ring is required.
+    public UnivPowerSeries<C> fixPoint(UnivPowerSeriesMap<C> map) {
+        UnivPowerSeries<C> ps1 = new UnivPowerSeries<C>(this);
+        UnivPowerSeries<C> ps2 = map.map(ps1);
+        ps1.lazyCoeffs = ps2.lazyCoeffs;
+        return ps2;
+    }
+
+
+    /**
+     * To String.
+     * @return string representation of this.
+     */
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        String scf = coFac.getClass().getSimpleName();
+        sb.append(scf + "((" + var + "))");
+        return sb.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.ElemFactory#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        StringBuffer s = new StringBuffer("PS(");
+        String f = null;
+        try {
+            f = ((RingElem<C>) coFac).toScriptFactory(); // sic
+        } catch (Exception e) {
+            f = coFac.toScript();
+        }
+        s.append(f + ",\"" + var + "\"," + truncate + ")");
+        return s.toString();
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object B) {
+        UnivPowerSeriesRing<C> a = null;
+        try {
+            a = (UnivPowerSeriesRing<C>) B;
+        } catch (ClassCastException ignored) {
+        }
+        if (a == null) {
+            return false;
+        }
+        if (!coFac.equals(a.coFac)) {
+            return false;
+        }
+        if (!var.equals(a.var)) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Hash code for this .
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h = coFac.hashCode();
+        h += (var.hashCode() << 27);
+        h += truncate;
+        return h;
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as UnivPowerSeries<C>.
+     */
+    public UnivPowerSeries<C> getZERO() {
+        return ZERO;
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as UnivPowerSeries<C>.
+     */
+    public UnivPowerSeries<C> getONE() {
+        return ONE;
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     * @see edu.jas.structure.ElemFactory#generators()
+     */
+    public List<UnivPowerSeries<C>> generators() {
+        List<C> rgens = coFac.generators();
+        List<UnivPowerSeries<C>> gens = new ArrayList<UnivPowerSeries<C>>(rgens.size());
+        for (final C cg : rgens) {
+            UnivPowerSeries<C> g = new UnivPowerSeries<C>(this, new Coefficients<C>() {
+
+
+                @Override
+                public C generate(int i) {
+                    if (i == 0) {
+                        return cg;
+                    }
+                    return coFac.getZERO();
+                }
+            });
+            gens.add(g);
+        }
+        gens.add(ONE.shift(1));
+        return gens;
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite()
+     */
+    public boolean isFinite() {
+        return false;
+    }
+
+
+    /**
+     * Get the power series of the exponential function.
+     * @return exp(x) as UnivPowerSeries<C>.
+     */
+    public UnivPowerSeries<C> getEXP() {
+        return fixPoint(new UnivPowerSeriesMap<C>() {
+
+
+            public UnivPowerSeries<C> map(UnivPowerSeries<C> e) {
+                return e.integrate(coFac.getONE());
+            }
+        });
+    }
+
+
+    /**
+     * Get the power series of the sinus function.
+     * @return sin(x) as UnivPowerSeries<C>.
+     */
+    public UnivPowerSeries<C> getSIN() {
+        return fixPoint(new UnivPowerSeriesMap<C>() {
+
+
+            public UnivPowerSeries<C> map(UnivPowerSeries<C> s) {
+                return s.negate().integrate(coFac.getONE()).integrate(coFac.getZERO());
+            }
+        });
+    }
+
+
+    /**
+     * Get the power series of the cosine function.
+     * @return cos(x) as UnivPowerSeries<C>.
+     */
+    public UnivPowerSeries<C> getCOS() {
+        return fixPoint(new UnivPowerSeriesMap<C>() {
+
+
+            public UnivPowerSeries<C> map(UnivPowerSeries<C> c) {
+                return c.negate().integrate(coFac.getZERO()).integrate(coFac.getONE());
+            }
+        });
+    }
+
+
+    /**
+     * Get the power series of the tangens function.
+     * @return tan(x) as UnivPowerSeries<C>.
+     */
+    public UnivPowerSeries<C> getTAN() {
+        return fixPoint(new UnivPowerSeriesMap<C>() {
+
+
+            public UnivPowerSeries<C> map(UnivPowerSeries<C> t) {
+                return t.multiply(t).sum(getONE()).integrate(coFac.getZERO());
+            }
+        });
+    }
+
+
+    /**
+     * Solve an ordinary differential equation. y' = f(y) with y(0) = c.
+     * @param f a UnivPowerSeries<C>.
+     * @param c integration constant.
+     * @return f.integrate(c).
+     */
+    public UnivPowerSeries<C> solveODE(final UnivPowerSeries<C> f, final C c) {
+        return f.integrate(c);
+    }
+
+
+    /**
+     * Is commutative.
+     * @return true, if this ring is commutative, else false.
+     */
+    public boolean isCommutative() {
+        return coFac.isCommutative();
+    }
+
+
+    /**
+     * Query if this ring is associative.
+     * @return true if this ring is associative, else false.
+     */
+    public boolean isAssociative() {
+        return coFac.isAssociative();
+    }
+
+
+    /**
+     * Query if this ring is a field.
+     * @return false.
+     */
+    public boolean isField() {
+        return false;
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic() {
+        return coFac.characteristic();
+    }
+
+
+    /**
+     * Get a (constant) UnivPowerSeries&lt;C&gt; from a long value.
+     * @param a long.
+     * @return a UnivPowerSeries&lt;C&gt;.
+     */
+    public UnivPowerSeries<C> fromInteger(long a) {
+        return ONE.multiply(coFac.fromInteger(a));
+    }
+
+
+    /**
+     * Get a (constant) UnivPowerSeries&lt;C&gt; from a java.math.BigInteger.
+     * @param a BigInteger.
+     * @return a UnivPowerSeries&lt;C&gt;.
+     */
+    public UnivPowerSeries<C> fromInteger(java.math.BigInteger a) {
+        return ONE.multiply(coFac.fromInteger(a));
+    }
+
+
+    /**
+     * Get the corresponding GenPolynomialRing&lt;C&gt;.
+     * @return GenPolynomialRing&lt;C&gt;.
+     */
+    public GenPolynomialRing<C> polyRing() {
+        return new GenPolynomialRing<C>(coFac, 1, new String[] { var });
+    }
+
+
+    /**
+     * Get a UnivPowerSeries&lt;C&gt; from a GenPolynomial&lt;C&gt;.
+     * @param a GenPolynomial&lt;C&gt;.
+     * @return a UnivPowerSeries&lt;C&gt;.
+     */
+    public UnivPowerSeries<C> fromPolynomial(GenPolynomial<C> a) {
+        if (a == null || a.isZERO()) {
+            return ZERO;
+        }
+        if (a.isONE()) {
+            return ONE;
+        }
+        if (a.ring.nvar != 1) {
+            throw new IllegalArgumentException("only for univariate polynomials");
+        }
+        HashMap<Integer, C> cache = new HashMap<Integer, C>(a.length());
+        for (Monomial<C> m : a) {
+            long e = m.exponent().getVal(0);
+            cache.put((int) e, m.coefficient());
+        }
+        return new UnivPowerSeries<C>(this, new Coefficients<C>(cache) {
+
+
+            @Override
+            public C generate(int i) {
+                // cached coefficients returned by get
+                return coFac.getZERO();
+            }
+        });
+    }
+
+
+    /**
+     * Get a UnivPowerSeries&lt;C&gt; from a GenVector&lt;C&gt;.
+     * @param a GenVector&lt;C&gt;.
+     * @return a UnivPowerSeries&lt;C&gt;.
+     */
+    public UnivPowerSeries<C> fromVector(GenVector<C> a) {
+        if (a == null || a.isZERO()) {
+            return ZERO;
+        }
+        HashMap<Integer, C> cache = new HashMap<Integer, C>(a.val.size());
+        int i = 0;
+        for (C m : a.val) {
+            cache.put(i++, m);
+        }
+        return new UnivPowerSeries<C>(this, new Coefficients<C>(cache) {
+
+
+            @Override
+            public C generate(int i) {
+                // cached coefficients returned by get
+                return coFac.getZERO();
+            }
+        });
+    }
+
+
+    /**
+     * Generate a random power series with k = 5, d = 0.7.
+     * @return a random power series.
+     */
+    public UnivPowerSeries<C> random() {
+        return random(5, 0.7f, random);
+    }
+
+
+    /**
+     * Generate a random power series with d = 0.7.
+     * @param k bitsize of random coefficients.
+     * @return a random power series.
+     */
+    public UnivPowerSeries<C> random(int k) {
+        return random(k, 0.7f, random);
+    }
+
+
+    /**
+     * Generate a random power series with d = 0.7.
+     * @param k bit-size of random coefficients.
+     * @param rnd is a source for random bits.
+     * @return a random power series.
+     */
+    public UnivPowerSeries<C> random(int k, Random rnd) {
+        return random(k, 0.7f, rnd);
+    }
+
+
+    /**
+     * Generate a random power series.
+     * @param k bit-size of random coefficients.
+     * @param d density of non-zero coefficients.
+     * @return a random power series.
+     */
+    public UnivPowerSeries<C> random(int k, float d) {
+        return random(k, d, random);
+    }
+
+
+    /**
+     * Generate a random power series.
+     * @param k bit-size of random coefficients.
+     * @param d density of non-zero coefficients.
+     * @param rnd is a source for random bits.
+     * @return a random power series.
+     */
+    public UnivPowerSeries<C> random(final int k, final float d, final Random rnd) {
+        return new UnivPowerSeries<C>(this, new Coefficients<C>() {
+
+
+            @Override
+            public C generate(int i) {
+                // cached coefficients returned by get
+                C c;
+                float f = rnd.nextFloat();
+                if (f < d) {
+                    c = coFac.random(k, rnd);
+                } else {
+                    c = coFac.getZERO();
+                }
+                return c;
+            }
+        });
+    }
+
+
+    /**
+     * Generate a power series via lambda expression.
+     * @param gener lambda expression.
+     * @return a generated power series.
+     */
+    public UnivPowerSeries<C> generate(final IntFunction<C> gener) {
+        return new UnivPowerSeries<C>(this, new Coefficients<C>() {
+
+
+            @Override
+            public C generate(int i) {
+                // cached coefficients returned by get
+                C c = gener.apply(i);
+                return c;
+            }
+        });
+    }
+
+
+    /**
+     * Copy power series.
+     * @param c a power series.
+     * @return a copy of c.
+     */
+    public UnivPowerSeries<C> copy(UnivPowerSeries<C> c) {
+        return new UnivPowerSeries<C>(this, c.lazyCoeffs);
+    }
+
+
+    /**
+     * Parse a power series. <b>Note:</b> not implemented.
+     * @param s String.
+     * @return power series from s.
+     */
+    public UnivPowerSeries<C> parse(String s) {
+        throw new UnsupportedOperationException("parse for power series not implemented");
+    }
+
+
+    /**
+     * Parse a power series. <b>Note:</b> not implemented.
+     * @param r Reader.
+     * @return next power series from r.
+     */
+    public UnivPowerSeries<C> parse(Reader r) {
+        throw new UnsupportedOperationException("parse for power series not implemented");
+    }
+
+
+    /**
+     * Taylor power series.
+     * @param f function.
+     * @param a expansion point.
+     * @return Taylor series of f.
+     */
+    public UnivPowerSeries<C> seriesOfTaylor(final TaylorFunction<C> f, final C a) {
+        return new UnivPowerSeries<C>(this, new Coefficients<C>() {
+
+
+            TaylorFunction<C> der = f;
+
+
+            long k = 0;
+
+
+            long n = 1;
+
+
+            @Override
+            public C generate(int i) {
+                C c;
+                if (i == 0) {
+                    c = der.evaluate(a);
+                    der = der.deriviative();
+                    return c;
+                }
+                if (i > 0) {
+                    c = get(i - 1); // ensure deriv is updated
+                }
+                k++;
+                n *= k;
+                c = der.evaluate(a);
+                //System.out.println("n = " + n + ", i = " +i);
+                c = c.divide(coFac.fromInteger(n));
+                der = der.deriviative();
+                return c;
+            }
+        });
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/package.html
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ps/package.html
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "../DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>Generic coefficients power series package</title>
+  </head>
+
+  <body>
+    <h1>Generic coefficients power series package.</h1>
+
+<p>
+  This package 
+  contains classes for univariate and multivariate power series arithmetic in
+  classes <code>UnivPowerSeries</code>, <code>UnivPowerSeriesRing</code>,
+  <code>MultiVarPowerSeries</code> and <code>MultiVarPowerSeriesRing</code>
+  over coefficient rings which implement the <code>RingElem</code> interface.
+  It contains also classes for reduction (with Mora's tangent cone algorithm) 
+  and standard base computations.
+  Currently the term order is fixed to the order defined by the iterator over 
+  exponent vectors <code>ExpVectorIterator</code>.
+</p>
+
+
+    <hr />
+    <address><a href="mailto:kredel at rz.uni-mannheim.de">Heinz Kredel</a></address>
+<p>
+<!-- Created: Sun Sep 28 13:10:45 CEST 2008 -->
+<!-- hhmts start -->
+Last modified: Sat Sep 18 14:15:26 CEST 2010
+<!-- hhmts end -->
+</p>
+<p>$Id$ 
+</p>
+  </body>
+</html>

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/AlgebraicRoots.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/AlgebraicRoots.java
@@ -1,0 +1,216 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.root;
+
+
+import java.io.Serializable;
+import java.util.List;
+
+import edu.jas.arith.Rational;
+import edu.jas.poly.AlgebraicNumberRing;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.Complex;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Container for the real and complex algebraic roots of a univariate
+ * polynomial.
+ * @param <C> coefficient type.
+ * @author Heinz Kredel
+ */
+public class AlgebraicRoots<C extends GcdRingElem<C> & Rational> implements Serializable {
+
+
+    /**
+     * Univariate polynomial.
+     */
+    public final GenPolynomial<C> p;
+
+
+    /**
+     * Real algebraic roots.
+     */
+    public final List<RealAlgebraicNumber<C>> real;
+
+
+    /**
+     * Univariate polynomial with complex coefficients equivalent to p.
+     */
+    public final GenPolynomial<Complex<C>> cp;
+
+
+    /**
+     * Complex algebraic roots.
+     */
+    public final List<ComplexAlgebraicNumber<C>> complex;
+
+
+    /**
+     * Constructor not for use.
+     */
+    protected AlgebraicRoots() {
+        throw new IllegalArgumentException("do not use this constructor");
+    }
+
+
+    /**
+     * Constructor.
+     * @param p univariate polynomial
+     * @param cp univariate polynomial with compelx coefficients
+     * @param r list of real algebraic roots
+     * @param c list of complex algebraic roots
+     */
+    public AlgebraicRoots(GenPolynomial<C> p, GenPolynomial<Complex<C>> cp, List<RealAlgebraicNumber<C>> r,
+                    List<ComplexAlgebraicNumber<C>> c) {
+        this.p = p;
+        this.cp = cp;
+        this.real = r;
+        this.complex = c;
+    }
+
+
+    /**
+     * String representation of AlgebraicRoots.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "[" + p + ", real=" + real + ", complex=" + complex + "]";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this roots.
+     */
+    public String toScript() {
+        // Python case
+        StringBuffer sb = new StringBuffer("[");
+        sb.append(p.toScript());
+        //sb.append(", ");
+        //sb.append(cp.toScript());
+        if (!real.isEmpty()) {
+            sb.append(", real=[");
+            boolean first = true;
+            for (RealAlgebraicNumber<C> r : real) {
+                if (first) {
+                    first = false;
+                } else {
+                    sb.append(", ");
+                }
+                sb.append(r.ring.root.toScript());
+            }
+            sb.append("]");
+        }
+        if (!complex.isEmpty()) {
+            sb.append(", complex=[");
+            boolean first = true;
+            for (ComplexAlgebraicNumber<C> c : complex) {
+                if (first) {
+                    first = false;
+                } else {
+                    sb.append(", ");
+                }
+                sb.append(c.ring.root.toScript());
+            }
+            sb.append("]");
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+
+    /**
+     * Get a decimal number scripting compatible string representation.
+     * @return decimal number script compatible representation for this roots.
+     */
+    public String toDecimalScript() {
+        // Python case
+        StringBuffer sb = new StringBuffer("[");
+        sb.append(p.toScript());
+        //sb.append(", ");
+        //sb.append(cp.toScript());
+        if (!real.isEmpty()) {
+            sb.append(", real=[");
+            boolean first = true;
+            for (RealAlgebraicNumber<C> r : real) {
+                if (first) {
+                    first = false;
+                } else {
+                    sb.append(", ");
+                }
+                r.ring.refineRoot();
+                sb.append(r.ring.root.toDecimal().toScript());
+            }
+            sb.append("]");
+        }
+        if (!complex.isEmpty()) {
+            sb.append(", complex=[");
+            boolean first = true;
+            for (ComplexAlgebraicNumber<C> c : complex) {
+                if (first) {
+                    first = false;
+                } else {
+                    sb.append(", ");
+                }
+                c.ring.refineRoot();
+                sb.append(c.ring.root.getDecimalCenter().toScript());
+            }
+            sb.append("]");
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+
+    /**
+     * Copy this.
+     * @return a copy of this.
+     */
+    public AlgebraicRoots<C> copy() {
+        return new AlgebraicRoots<C>(p, cp, real, complex);
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (!(b instanceof AlgebraicRoots)) {
+            return false;
+        }
+        AlgebraicRoots<C> a = null;
+        try {
+            a = (AlgebraicRoots<C>) b;
+        } catch (ClassCastException e) {
+            return false;
+        }
+        return p.equals(a.p) && real.equals(a.real) && complex.equals(a.complex);
+    }
+
+
+    /**
+     * Hash code for this AlgebraicRoots.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return (161 * p.hashCode() + 37) * real.hashCode() + complex.hashCode();
+    }
+
+
+    /**
+     * Algebraic number ring.
+     * @return algebraic ring of roots.
+     */
+    public AlgebraicNumberRing<C> getAlgebraicRing() {
+        AlgebraicNumberRing<C> anr = new AlgebraicNumberRing<C>(p);
+        return anr;
+    }
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/Boundary.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/Boundary.java
@@ -1,0 +1,200 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.root;
+
+
+import java.io.Serializable;
+
+import edu.jas.arith.Rational;
+import edu.jas.poly.Complex;
+import edu.jas.poly.ComplexRing;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.ufd.GCDFactory;
+import edu.jas.ufd.GreatestCommonDivisor;
+
+
+/**
+ * Boundary determined by a rectangle and a polynomial.
+ * 
+ * For a given complex polynomial A a closed path throught the corners of the
+ * given rectangle is constructed. The path is represented by four polynomials,
+ * one for each side of the rectangle. For a real t in [0,1] the i-th polynomial
+ * describes the path of A from corner[i] to corner[i+1]. In particular
+ * polys[i](0) = A(corner[i]) and polys[i](1) = A(corner[i+1]), with corner[4] =
+ * corner[0]. If A would be zero on a point of the path, an
+ * InvalidBoundaryException is thrown.
+ * @param <C> coefficient type.
+ * @author Heinz Kredel
+ */
+public class Boundary<C extends RingElem<C> & Rational> implements Serializable {
+
+
+    /**
+     * Rectangle.
+     */
+    public final Rectangle<C> rect;
+
+
+    /**
+     * Polynomial.
+     */
+    public final GenPolynomial<Complex<C>> A;
+
+
+    /**
+     * Boundary polynomials.
+     */
+    public final GenPolynomial<Complex<C>>[] polys;
+
+
+    /**
+     * Factory for real polynomials.
+     */
+    GenPolynomialRing<C> rfac;
+
+
+    /**
+     * Constructor.
+     * @param r rectangle of of corners.
+     * @param p non constant polynomial.
+     */
+    @SuppressWarnings("unchecked")
+    public Boundary(Rectangle<C> r, GenPolynomial<Complex<C>> p) throws InvalidBoundaryException {
+        if (p.isConstant() || p.isZERO()) {
+            throw new InvalidBoundaryException("p is constant or 0 " + p);
+        }
+        rect = r;
+        A = p;
+        GreatestCommonDivisor<Complex<C>> ufd = GCDFactory.<Complex<C>> getImplementation(A.ring.coFac);
+        polys = (GenPolynomial<Complex<C>>[]) new GenPolynomial[5];
+
+        Complex<C>[] corner = rect.corners;
+        for (int i = 0; i < 4; i++) {
+            Complex<C> t = corner[i + 1].subtract(corner[i]);
+            GenPolynomial<Complex<C>> tp = A.ring.univariate(0, 1L).multiply(t);
+            //System.out.println("t = " + t);
+            GenPolynomial<Complex<C>> pc = PolyUtil.<Complex<C>> seriesOfTaylor(A, corner[i]);
+            pc = PolyUtil.<Complex<C>> substituteUnivariate(pc, tp);
+            GenPolynomial<Complex<C>> gcd = ufd.gcd(A, pc);
+            if (!gcd.isONE()) {
+                //System.out.println("A = " + A);
+                //System.out.println("PC["+i+"] = " + pc);
+                //System.out.println("gcd = " + gcd);
+                throw new InvalidBoundaryException("A has a zero on rectangle " + rect + ", A = " + A);
+            }
+            polys[i] = pc;
+        }
+        polys[4] = polys[0];
+
+        // setup factory for real and imaginary parts
+        ComplexRing<C> cr = (ComplexRing<C>) A.ring.coFac;
+        RingFactory<C> cf = cr.ring;
+        rfac = new GenPolynomialRing<C>(cf, A.ring);
+    }
+
+
+    /**
+     * Constructor.
+     * @param r rectangle of of corners.
+     * @param p polynomial.
+     * @param b boundary polynomials.
+     */
+    protected Boundary(Rectangle<C> r, GenPolynomial<Complex<C>> p, GenPolynomial<Complex<C>>[] b) {
+        rect = r;
+        A = p;
+        polys = b;
+        // setup factory for real and imaginary parts
+        ComplexRing<C> cr = (ComplexRing<C>) A.ring.coFac;
+        RingFactory<C> cf = cr.ring;
+        rfac = new GenPolynomialRing<C>(cf, A.ring);
+    }
+
+
+    /**
+     * String representation of Boundary.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return rect.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Boundary.
+     */
+    public String toScript() {
+        // Python case
+        return rect.toScript();
+    }
+
+
+    /**
+     * Get real part for polynomial i.
+     * @param i index of polynomial.
+     * @return real part for polynomial i.
+     */
+    public GenPolynomial<C> getRealPart(int i) {
+        GenPolynomial<C> f = PolyUtil.<C> realPartFromComplex(rfac, polys[i]);
+        return f;
+    }
+
+
+    /**
+     * Get imaginary part for polynomial i.
+     * @param i index of polynomial.
+     * @return imaginary part for polynomial i.
+     */
+    public GenPolynomial<C> getImagPart(int i) {
+        GenPolynomial<C> g = PolyUtil.<C> imaginaryPartFromComplex(rfac, polys[i]);
+        return g;
+    }
+
+
+    /**
+     * Copy this.
+     * @return a copy of this.
+     */
+    public Boundary<C> copy() {
+        return new Boundary<C>(rect, A, polys);
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        Boundary<C> a = null;
+        try {
+            a = (Boundary<C>) b;
+        } catch (ClassCastException e) {
+        }
+        if (a == null) {
+            return false;
+        }
+        return rect.equals(a.rect) && A.equals(a.A);
+    }
+
+
+    /**
+     * Hash code for this Rectangle.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int hc = 0;
+        hc += 37 * rect.hashCode();
+        return 37 * hc + A.hashCode();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/ComplexAlgebraicNumber.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/ComplexAlgebraicNumber.java
@@ -1,0 +1,470 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.root;
+
+
+import edu.jas.arith.BigDecimal;
+import edu.jas.arith.BigRational;
+import edu.jas.arith.Rational;
+import edu.jas.kern.PrettyPrint;
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.Complex;
+import edu.jas.poly.ComplexRing;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.NotInvertibleException;
+
+
+/**
+ * Complex algebraic number class based on AlgebraicNumber. Objects of this
+ * class are immutable.
+ * @author Heinz Kredel
+ */
+
+public class ComplexAlgebraicNumber<C extends GcdRingElem<C> & Rational>
+                /*extends AlgebraicNumber<C>*/
+                implements GcdRingElem<ComplexAlgebraicNumber<C>> {
+
+
+    /**
+     * Representing AlgebraicNumber.
+     */
+    public final AlgebraicNumber<Complex<C>> number;
+
+
+    /**
+     * Ring part of the data structure.
+     */
+    public final ComplexAlgebraicRing<C> ring;
+
+
+    /**
+     * The constructor creates a ComplexAlgebraicNumber object from
+     * ComplexAlgebraicRing modul and a GenPolynomial value.
+     * @param r ring ComplexAlgebraicRing<C>.
+     * @param a value GenPolynomial<C>.
+     */
+    public ComplexAlgebraicNumber(ComplexAlgebraicRing<C> r, GenPolynomial<Complex<C>> a) {
+        number = new AlgebraicNumber<Complex<C>>(r.algebraic, a);
+        ring = r;
+    }
+
+
+    /**
+     * The constructor creates a ComplexAlgebraicNumber object from
+     * ComplexAlgebraicRing modul and a AlgebraicNumber value.
+     * @param r ring ComplexAlgebraicRing<C>.
+     * @param a value AlgebraicNumber<C>.
+     */
+    public ComplexAlgebraicNumber(ComplexAlgebraicRing<C> r, AlgebraicNumber<Complex<C>> a) {
+        number = a;
+        ring = r;
+    }
+
+
+    /**
+     * The constructor creates a ComplexAlgebraicNumber object from a
+     * GenPolynomial object module.
+     * @param r ring ComplexAlgebraicRing<C>.
+     */
+    public ComplexAlgebraicNumber(ComplexAlgebraicRing<C> r) {
+        this(r, r.algebraic.getZERO());
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public ComplexAlgebraicRing<C> factory() {
+        return ring;
+    }
+
+
+    /**
+     * Copy this.
+     * @see edu.jas.structure.Element#copy()
+     */
+    @Override
+    public ComplexAlgebraicNumber<C> copy() {
+        return new ComplexAlgebraicNumber<C>(ring, number);
+    }
+
+
+    /**
+     * Is ComplexAlgebraicNumber zero.
+     * @return If this is 0 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isZERO()
+     */
+    public boolean isZERO() {
+        return number.isZERO();
+    }
+
+
+    /**
+     * Is ComplexAlgebraicNumber one.
+     * @return If this is 1 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isONE()
+     */
+    public boolean isONE() {
+        return number.isONE();
+    }
+
+
+    /**
+     * Is ComplexAlgebraicNumber unit.
+     * @return If this is a unit then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isUnit()
+     */
+    public boolean isUnit() {
+        return number.isUnit();
+    }
+
+
+    /**
+     * Is ComplexAlgebraicNumber a root of unity.
+     * @return true if |this**i| == 1, for some 0 &lt; i &le; deg(modul), else
+     *         false.
+     */
+    public boolean isRootOfUnity() {
+        return number.isRootOfUnity();
+    }
+
+
+    /**
+     * Get the String representation as RingElem.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        if (PrettyPrint.isTrue()) {
+            return "{ " + number.toString() + " }";
+        }
+        return "Complex" + number.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        return number.toScript();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python case
+        return factory().toScript();
+    }
+
+
+    /**
+     * ComplexAlgebraicNumber comparison.
+     * @param b ComplexAlgebraicNumber.
+     * @return sign(this-b).
+     */
+    @Override
+    public int compareTo(ComplexAlgebraicNumber<C> b) {
+        int s = 0;
+        if (number.ring != b.number.ring) { // avoid compareTo if possible
+            s = number.ring.modul.compareTo(b.number.ring.modul);
+            System.out.println("s_mod = " + s);
+        }
+        if (s != 0) {
+            return s;
+        }
+        s = number.compareTo(b.number); // TODO
+        //System.out.println("s_real = " + s);
+        return s;
+    }
+
+
+    /**
+     * ComplexAlgebraicNumber comparison.
+     * @param b AlgebraicNumber.
+     * @return polynomial sign(this-b).
+     */
+    public int compareTo(AlgebraicNumber<Complex<C>> b) {
+        int s = number.compareTo(b);
+        //System.out.println("s_algeb = " + s);
+        return s;
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (b == null) {
+            return false;
+        }
+        if (!(b instanceof ComplexAlgebraicNumber)) {
+            return false;
+        }
+        ComplexAlgebraicNumber<C> a = (ComplexAlgebraicNumber<C>) b;
+        if (!ring.equals(a.ring)) {
+            return false;
+        }
+        return number.equals(a.number);
+    }
+
+
+    /**
+     * Hash code for this ComplexAlgebraicNumber.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return 37 * number.val.hashCode() + ring.hashCode();
+    }
+
+
+    /**
+     * ComplexAlgebraicNumber absolute value.
+     * @return the absolute value of this.
+     * @see edu.jas.structure.RingElem#abs()
+     */
+    public ComplexAlgebraicNumber<C> abs() {
+        if (this.signum() < 0) {
+            return new ComplexAlgebraicNumber<C>(ring, number.negate());
+        }
+        return this;
+    }
+
+
+    /**
+     * ComplexAlgebraicNumber summation.
+     * @param S ComplexAlgebraicNumber.
+     * @return this+S.
+     */
+    public ComplexAlgebraicNumber<C> sum(ComplexAlgebraicNumber<C> S) {
+        return new ComplexAlgebraicNumber<C>(ring, number.sum(S.number));
+    }
+
+
+    /**
+     * ComplexAlgebraicNumber summation.
+     * @param c complex polynomial.
+     * @return this+c.
+     */
+    public ComplexAlgebraicNumber<C> sum(GenPolynomial<Complex<C>> c) {
+        return new ComplexAlgebraicNumber<C>(ring, number.sum(c));
+    }
+
+
+    /**
+     * ComplexAlgebraicNumber summation.
+     * @param c algebraic number.
+     * @return this+c.
+     */
+    public ComplexAlgebraicNumber<C> sum(AlgebraicNumber<Complex<C>> c) {
+        return new ComplexAlgebraicNumber<C>(ring, number.sum(c));
+    }
+
+
+    /**
+     * ComplexAlgebraicNumber summation.
+     * @param c coefficient.
+     * @return this+c.
+     */
+    public ComplexAlgebraicNumber<C> sum(Complex<C> c) {
+        return new ComplexAlgebraicNumber<C>(ring, number.sum(c));
+    }
+
+
+    /**
+     * ComplexAlgebraicNumber negate.
+     * @return -this.
+     * @see edu.jas.structure.RingElem#negate()
+     */
+    public ComplexAlgebraicNumber<C> negate() {
+        return new ComplexAlgebraicNumber<C>(ring, number.negate());
+    }
+
+
+    /**
+     * ComplexAlgebraicNumber subtraction.
+     * @param S ComplexAlgebraicNumber.
+     * @return this-S.
+     */
+    public ComplexAlgebraicNumber<C> subtract(ComplexAlgebraicNumber<C> S) {
+        return new ComplexAlgebraicNumber<C>(ring, number.subtract(S.number));
+    }
+
+
+    /**
+     * ComplexAlgebraicNumber division.
+     * @param S ComplexAlgebraicNumber.
+     * @return this/S.
+     */
+    public ComplexAlgebraicNumber<C> divide(ComplexAlgebraicNumber<C> S) {
+        return multiply(S.inverse());
+    }
+
+
+    /**
+     * ComplexAlgebraicNumber inverse.
+     * @see edu.jas.structure.RingElem#inverse()
+     * @throws NotInvertibleException if the element is not invertible.
+     * @return S with S = 1/this if defined.
+     */
+    public ComplexAlgebraicNumber<C> inverse() {
+        return new ComplexAlgebraicNumber<C>(ring, number.inverse());
+    }
+
+
+    /**
+     * ComplexAlgebraicNumber remainder.
+     * @param S ComplexAlgebraicNumber.
+     * @return this - (this/S)*S.
+     */
+    public ComplexAlgebraicNumber<C> remainder(ComplexAlgebraicNumber<C> S) {
+        return new ComplexAlgebraicNumber<C>(ring, number.remainder(S.number));
+    }
+
+
+    /**
+     * Quotient and remainder by division of this by S.
+     * @param S a ComplexAlgebraicNumber
+     * @return [this/S, this - (this/S)*S].
+     */
+    @SuppressWarnings("unchecked")
+    public ComplexAlgebraicNumber<C>[] quotientRemainder(ComplexAlgebraicNumber<C> S) {
+        return new ComplexAlgebraicNumber[] { divide(S), remainder(S) };
+    }
+
+
+    /**
+     * ComplexAlgebraicNumber multiplication.
+     * @param S ComplexAlgebraicNumber.
+     * @return this*S.
+     */
+    public ComplexAlgebraicNumber<C> multiply(ComplexAlgebraicNumber<C> S) {
+        return new ComplexAlgebraicNumber<C>(ring, number.multiply(S.number));
+    }
+
+
+    /**
+     * ComplexAlgebraicNumber multiplication.
+     * @param c coefficient.
+     * @return this*c.
+     */
+    public ComplexAlgebraicNumber<C> multiply(Complex<C> c) {
+        return new ComplexAlgebraicNumber<C>(ring, number.multiply(c));
+    }
+
+
+    /**
+     * ComplexAlgebraicNumber multiplication.
+     * @param c polynomial.
+     * @return this*c.
+     */
+    public ComplexAlgebraicNumber<C> multiply(GenPolynomial<Complex<C>> c) {
+        return new ComplexAlgebraicNumber<C>(ring, number.multiply(c));
+    }
+
+
+    /**
+     * ComplexAlgebraicNumber monic.
+     * @return this with monic value part.
+     */
+    public ComplexAlgebraicNumber<C> monic() {
+        return new ComplexAlgebraicNumber<C>(ring, number.monic());
+    }
+
+
+    /**
+     * ComplexAlgebraicNumber greatest common divisor.
+     * @param S ComplexAlgebraicNumber.
+     * @return gcd(this,S).
+     */
+    public ComplexAlgebraicNumber<C> gcd(ComplexAlgebraicNumber<C> S) {
+        return new ComplexAlgebraicNumber<C>(ring, number.gcd(S.number));
+    }
+
+
+    /**
+     * ComplexAlgebraicNumber extended greatest common divisor.
+     * @param S ComplexAlgebraicNumber.
+     * @return [ gcd(this,S), a, b ] with a*this + b*S = gcd(this,S).
+     */
+    @SuppressWarnings("unchecked")
+    public ComplexAlgebraicNumber<C>[] egcd(ComplexAlgebraicNumber<C> S) {
+        AlgebraicNumber<Complex<C>>[] aret = number.egcd(S.number);
+        ComplexAlgebraicNumber<C>[] ret = new ComplexAlgebraicNumber[3];
+        ret[0] = new ComplexAlgebraicNumber<C>(ring, aret[0]);
+        ret[1] = new ComplexAlgebraicNumber<C>(ring, aret[1]);
+        ret[2] = new ComplexAlgebraicNumber<C>(ring, aret[2]);
+        return ret;
+    }
+
+
+    /**
+     * ComplexAlgebraicNumber signum.
+     * @see edu.jas.structure.RingElem#signum()
+     * @return signum(this).
+     */
+    public int signum() {
+        ring.ensureEngine();
+        try {
+            Rectangle<C> v = ring.engine.invariantRectangle(ring.root, ring.algebraic.modul, number.val);
+            ring.setRoot(v);
+            Complex<C> c = v.getCenter();
+            return c.signum();
+        } catch (InvalidBoundaryException e) { // should not happen
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    /**
+     * ComplexAlgebraicNumber magnitude.
+     * @return |this| as complex rational number.
+     */
+    public Complex<BigRational> magnitude() {
+        ring.ensureEngine();
+        try {
+            Rectangle<C> v = ring.engine.invariantMagnitudeRectangle(ring.root, ring.algebraic.modul,
+                            number.val, ring.getEps());
+            ring.setRoot(v);
+            //System.out.println("new v = " + v);
+            Complex<C> ev = ring.engine.complexRectangleMagnitude(v, ring.algebraic.modul, number.val); //, ring.eps);
+            BigRational er = ev.getRe().getRational();
+            BigRational ei = ev.getIm().getRational();
+            ComplexRing<BigRational> cr = new ComplexRing<BigRational>(er.factory());
+            return new Complex<BigRational>(cr, er, ei);
+        } catch (InvalidBoundaryException e) { // should not happen
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    /**
+     * ComplexAlgebraicNumber magnitude.
+     * @return |this| as complex big decimal.
+     */
+    public Complex<BigDecimal> decimalMagnitude() {
+        Complex<BigRational> cr = magnitude();
+        ComplexRing<BigDecimal> dr = new ComplexRing<BigDecimal>(BigDecimal.ZERO);
+        return new Complex<BigDecimal>(dr, new BigDecimal(cr.getRe()), new BigDecimal(cr.getIm()));
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/ComplexAlgebraicRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/ComplexAlgebraicRing.java
@@ -1,0 +1,421 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.root;
+
+
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.arith.BigRational;
+import edu.jas.arith.BigDecimal;
+import edu.jas.arith.Rational;
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.AlgebraicNumberRing;
+import edu.jas.poly.Complex;
+import edu.jas.poly.ComplexRing;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Complex algebraic number factory class based on AlgebraicNumberRing with
+ * RingFactory interface. Objects of this class are immutable with the exception
+ * of the isolating intervals.
+ * @author Heinz Kredel
+ */
+
+public class ComplexAlgebraicRing<C extends GcdRingElem<C> & Rational>
+                /*extends AlgebraicNumberRing<C>*/
+                implements RingFactory<ComplexAlgebraicNumber<C>> {
+
+
+    private static final Logger logger = LogManager.getLogger(ComplexAlgebraicRing.class);
+
+
+    /**
+     * Representing AlgebraicNumberRing.
+     */
+    public final AlgebraicNumberRing<Complex<C>> algebraic;
+
+
+    /**
+     * Isolating rectangle for a complex root. <b>Note: </b> interval may shrink
+     * eventually.
+     */
+    /*package*/Rectangle<C> root;
+
+
+    /**
+     * Epsilon of the isolating rectangle for a complex root.
+     */
+    protected BigRational eps;
+
+
+    /**
+     * Precision of the isolating rectangle for a complex root.
+     */
+    public static final int PRECISION = BigDecimal.DEFAULT_PRECISION;
+
+
+    /**
+     * Complex root computation engine.
+     */
+    protected ComplexRootsSturm<C> engine = null;
+
+
+    /**
+     * The constructor creates a ComplexAlgebraicNumber factory object from a
+     * GenPolynomial objects module.
+     * @param m module GenPolynomial&lt;C&gt;.
+     * @param root isolating rectangle for a complex root.
+     */
+    public ComplexAlgebraicRing(GenPolynomial<Complex<C>> m, Rectangle<C> root) {
+        algebraic = new AlgebraicNumberRing<Complex<C>>(m);
+        this.root = root;
+        if (m.ring.characteristic().signum() > 0) {
+            throw new IllegalArgumentException("characteristic not zero");
+        }
+        BigRational e = new BigRational(10L); //m.ring.coFac.fromInteger(10L).getRe();
+        e = e.power( - PRECISION/2 ); //Power.positivePower(e, PRECISION);
+        eps = e; //BigRational.ONE; // initially
+        ensureEngine();
+    }
+
+
+    /**
+     * The constructor creates a ComplexAlgebraicNumber factory object from a
+     * GenPolynomial objects module.
+     * @param m module GenPolynomial&lt;C&gt;.
+     * @param root isolating rectangle for a complex root.
+     * @param isField indicator if m is prime.
+     */
+    public ComplexAlgebraicRing(GenPolynomial<Complex<C>> m, Rectangle<C> root, boolean isField) {
+        this(m, root);
+        setField(isField);
+    }
+
+
+    /**
+     * Set a refined rectangle for the complex root. <b>Note: </b> rectangle may
+     * shrink eventually.
+     * @param v rectangle.
+     */
+    public synchronized void setRoot(Rectangle<C> v) {
+        // assert v is contained in root
+        assert root.contains(v) : "root contains v";
+        this.root = v;
+    }
+
+
+    /**
+     * Get rectangle for the complex root.
+     * @return v rectangle.
+     */
+    public synchronized Rectangle<C> getRoot() {
+        return this.root;
+    }
+
+
+    /**
+     * Get epsilon.
+     * @return epsilon.
+     */
+    public synchronized BigRational getEps() {
+        return this.eps;
+    }
+
+
+    /**
+     * Set a new epsilon.
+     * @param e epsilon.
+     */
+    public synchronized void setEps(C e) {
+        setEps(e.getRational());
+    }
+
+
+    /**
+     * Set a new epsilon.
+     * @param e epsilon.
+     */
+    public synchronized void setEps(BigRational e) {
+        this.eps = e; //algebraic.ring.coFac.parse(e.toString()).getRe();
+    }
+
+
+    /**
+     * Refine root.
+     */
+    public synchronized void refineRoot() {
+            refineRoot(eps);
+    }
+
+
+    /**
+     * Ensure engine is initialized.
+     */
+    public synchronized void ensureEngine() {
+        if (engine == null) {
+            engine = new ComplexRootsSturm<C>(algebraic.ring.coFac);
+        }
+    }
+
+
+    /**
+     * Refine root.
+     * @param e epsilon.
+     */
+    public synchronized void refineRoot(BigRational e) {
+        ensureEngine();
+        try {
+            root = engine.complexRootRefinement(root, algebraic.modul, e);
+        } catch (InvalidBoundaryException e1) {
+            logger.warn("new eps not set: " + e);
+            //e1.printStackTrace();
+            return; // ignore new eps
+        }
+        this.eps = e; 
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite()
+     */
+    public boolean isFinite() {
+        return algebraic.isFinite();
+    }
+
+
+    /**
+     * Copy ComplexAlgebraicNumber element c.
+     * @param c
+     * @return a copy of c.
+     */
+    public ComplexAlgebraicNumber<C> copy(ComplexAlgebraicNumber<C> c) {
+        return new ComplexAlgebraicNumber<C>(this, c.number);
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as ComplexAlgebraicNumber.
+     */
+    public ComplexAlgebraicNumber<C> getZERO() {
+        return new ComplexAlgebraicNumber<C>(this, algebraic.getZERO());
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as ComplexAlgebraicNumber.
+     */
+    public ComplexAlgebraicNumber<C> getONE() {
+        return new ComplexAlgebraicNumber<C>(this, algebraic.getONE());
+    }
+
+
+    /**
+     * Get the i element.
+     * @return i as ComplexAlgebraicNumber.
+     */
+    public ComplexAlgebraicNumber<C> getIMAG() {
+        ComplexRing<C> cr = (ComplexRing<C>) algebraic.ring.coFac;
+        Complex<C> I = cr.getIMAG();
+        return new ComplexAlgebraicNumber<C>(this, algebraic.getZERO().sum(I));
+    }
+
+
+    /**
+     * Get the generating element.
+     * @return alpha as ComplexAlgebraicNumber.
+     */
+    public ComplexAlgebraicNumber<C> getGenerator() {
+        return new ComplexAlgebraicNumber<C>(this, algebraic.getGenerator());
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     * @see edu.jas.structure.ElemFactory#generators()
+     */
+    public List<ComplexAlgebraicNumber<C>> generators() {
+        List<AlgebraicNumber<Complex<C>>> agens = algebraic.generators();
+        List<ComplexAlgebraicNumber<C>> gens = new ArrayList<ComplexAlgebraicNumber<C>>(agens.size());
+        for (AlgebraicNumber<Complex<C>> a : agens) {
+            gens.add(getZERO().sum(a.getVal()));
+        }
+        return gens;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true if this ring is commutative, else false.
+     */
+    public boolean isCommutative() {
+        return algebraic.isCommutative();
+    }
+
+
+    /**
+     * Query if this ring is associative.
+     * @return true if this ring is associative, else false.
+     */
+    public boolean isAssociative() {
+        return algebraic.isAssociative();
+    }
+
+
+    /**
+     * Query if this ring is a field.
+     * @return true if algebraic is prime, else false.
+     */
+    public boolean isField() {
+        return algebraic.isField();
+    }
+
+
+    /**
+     * Assert that this ring is a field.
+     * @param isField true if this ring is a field, else false.
+     */
+    public void setField(boolean isField) {
+        algebraic.setField(isField);
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic() {
+        return algebraic.characteristic();
+    }
+
+
+    /**
+     * Get a ComplexAlgebraicNumber element from a BigInteger value.
+     * @param a BigInteger.
+     * @return a ComplexAlgebraicNumber.
+     */
+    public ComplexAlgebraicNumber<C> fromInteger(java.math.BigInteger a) {
+        return new ComplexAlgebraicNumber<C>(this, algebraic.fromInteger(a));
+    }
+
+
+    /**
+     * Get a ComplexAlgebraicNumber element from a long value.
+     * @param a long.
+     * @return a ComplexAlgebraicNumber.
+     */
+    public ComplexAlgebraicNumber<C> fromInteger(long a) {
+        return new ComplexAlgebraicNumber<C>(this, algebraic.fromInteger(a));
+    }
+
+
+    /**
+     * Get the String representation as RingFactory.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "ComplexAlgebraicRing[ " + algebraic.modul.toString() + " in " + root + " | isField="
+                        + algebraic.isField() + " :: " + algebraic.ring.toString() + " ]";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.ElemFactory#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        return "ComplexN( " + algebraic.modul.toScript() + ", " + root.toScript()
+        //+ ", " + algebraic.isField() 
+        //+ ", " + algebraic.ring.toScript() 
+                        + " )";
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (b == null) {
+            return false;
+        }
+        if (!(b instanceof ComplexAlgebraicRing)) {
+            return false;
+        }
+        ComplexAlgebraicRing<C> a = (ComplexAlgebraicRing<C>) b;
+        return algebraic.equals(a.algebraic) && root.equals(a.root);
+    }
+
+
+    /**
+     * Hash code for this ComplexAlgebraicNumber.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return 37 * algebraic.hashCode() + root.hashCode();
+    }
+
+
+    /**
+     * ComplexAlgebraicNumber random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @return a random integer mod modul.
+     */
+    public ComplexAlgebraicNumber<C> random(int n) {
+        return new ComplexAlgebraicNumber<C>(this, algebraic.random(n));
+    }
+
+
+    /**
+     * ComplexAlgebraicNumber random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @param rnd is a source for random bits.
+     * @return a random integer mod modul.
+     */
+    public ComplexAlgebraicNumber<C> random(int n, Random rnd) {
+        return new ComplexAlgebraicNumber<C>(this, algebraic.random(n, rnd));
+    }
+
+
+    /**
+     * Parse ComplexAlgebraicNumber from String.
+     * @param s String.
+     * @return ComplexAlgebraicNumber from s.
+     */
+    public ComplexAlgebraicNumber<C> parse(String s) {
+        return new ComplexAlgebraicNumber<C>(this, algebraic.parse(s));
+    }
+
+
+    /**
+     * Parse ComplexAlgebraicNumber from Reader.
+     * @param r Reader.
+     * @return next ComplexAlgebraicNumber from r.
+     */
+    public ComplexAlgebraicNumber<C> parse(Reader r) {
+        return new ComplexAlgebraicNumber<C>(this, algebraic.parse(r));
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/ComplexRoots.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/ComplexRoots.java
@@ -1,0 +1,73 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.root;
+
+
+import java.io.Serializable;
+import java.util.List;
+
+import edu.jas.arith.BigRational;
+import edu.jas.arith.Rational;
+import edu.jas.poly.Complex;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Complex roots interface.
+ * @param <C> coefficient type.
+ * @author Heinz Kredel
+ */
+public interface ComplexRoots<C extends RingElem<C> & Rational> extends Serializable {
+
+
+    /**
+     * Root bound. With f(-M + i M) * f(-M - i M) * f(M - i M) * f(M + i M) !=
+     * 0.
+     * @param f univariate polynomial.
+     * @return M such that root(f) is contained in the rectangle spanned by M.
+     */
+    public Complex<C> rootBound(GenPolynomial<Complex<C>> f);
+
+
+    /**
+     * Complex root count of complex polynomial on rectangle.
+     * @param rect rectangle.
+     * @param a univariate complex polynomial.
+     * @return root count of a in rectangle.
+     */
+    public long complexRootCount(Rectangle<C> rect, GenPolynomial<Complex<C>> a)
+                    throws InvalidBoundaryException;
+
+
+    /**
+     * List of complex roots of complex polynomial a on rectangle.
+     * @param rect rectangle.
+     * @param a univariate squarefree complex polynomial.
+     * @return list of complex roots.
+     */
+    public List<Rectangle<C>> complexRoots(Rectangle<C> rect, GenPolynomial<Complex<C>> a)
+                    throws InvalidBoundaryException;
+
+
+    /**
+     * List of complex roots of complex polynomial.
+     * @param a univariate complex polynomial.
+     * @return list of complex roots.
+     */
+    public List<Rectangle<C>> complexRoots(GenPolynomial<Complex<C>> a);
+
+
+    /**
+     * Complex root refinement of complex polynomial a on rectangle.
+     * @param rect rectangle containing exactly one complex root.
+     * @param a univariate squarefree complex polynomial.
+     * @param len rational length for refinement.
+     * @return refined complex root.
+     */
+    public Rectangle<C> complexRootRefinement(Rectangle<C> rect, GenPolynomial<Complex<C>> a, BigRational len)
+                    throws InvalidBoundaryException;
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/ComplexRootsAbstract.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/ComplexRootsAbstract.java
@@ -1,0 +1,742 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.root;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.SortedMap;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.arith.BigDecimal;
+import edu.jas.arith.BigRational;
+import edu.jas.arith.Rational;
+import edu.jas.poly.Complex;
+import edu.jas.poly.ComplexRing;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.structure.UnaryFunctor;
+import edu.jas.ufd.Squarefree;
+import edu.jas.ufd.SquarefreeFactory;
+
+
+/**
+ * Complex roots abstract class.
+ * @param <C> coefficient type.
+ * @author Heinz Kredel
+ */
+public abstract class ComplexRootsAbstract<C extends RingElem<C> & Rational> implements ComplexRoots<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(ComplexRootsAbstract.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Engine for square free decomposition.
+     */
+    public final Squarefree<Complex<C>> engine;
+
+
+    /**
+     * Constructor.
+     * @param cf coefficient factory.
+     */
+    public ComplexRootsAbstract(RingFactory<Complex<C>> cf) {
+        if (!(cf instanceof ComplexRing)) {
+            throw new IllegalArgumentException("cf not supported coefficients " + cf);
+        }
+        engine = SquarefreeFactory.<Complex<C>> getImplementation(cf);
+    }
+
+
+    /**
+     * Root bound. With f(-M + i M) * f(-M - i M) * f(M - i M) * f(M + i M) !=
+     * 0.
+     * @param f univariate polynomial.
+     * @return M such that root(f) is contained in the rectangle spanned by M.
+     */
+    public Complex<C> rootBound(GenPolynomial<Complex<C>> f) {
+        if (f == null) {
+            return null;
+        }
+        RingFactory<Complex<C>> cfac = f.ring.coFac;
+        Complex<C> M = cfac.getONE();
+        if (f.isZERO() || f.isConstant()) {
+            return M;
+        }
+        Complex<C> a = f.leadingBaseCoefficient().norm();
+        for (Complex<C> c : f.getMap().values()) {
+            Complex<C> d = c.norm().divide(a);
+            if (M.compareTo(d) < 0) {
+                M = d;
+            }
+        }
+        M = M.sum(cfac.getONE());
+        //System.out.println("M = " + M);
+        return M;
+    }
+
+
+    /**
+     * Magnitude bound.
+     * @param rect rectangle.
+     * @param f univariate polynomial.
+     * @return B such that |f(c)| &lt; B for c in rect.
+     */
+    public C magnitudeBound(Rectangle<C> rect, GenPolynomial<Complex<C>> f) {
+        if (f == null) {
+            return null;
+        }
+        if (f.isZERO()) {
+            return f.ring.coFac.getONE().getRe();
+        }
+        //System.out.println("f = " + f);
+        if (f.isConstant()) {
+            Complex<C> c = f.leadingBaseCoefficient();
+            return c.norm().getRe();
+        }
+        GenPolynomial<Complex<C>> fa = f.map(new UnaryFunctor<Complex<C>, Complex<C>>() {
+
+
+            public Complex<C> eval(Complex<C> a) {
+                return a.norm();
+            }
+        });
+        //System.out.println("fa = " + fa);
+        Complex<C> Mc = rect.getNW().norm();
+        C M = Mc.getRe();
+        //System.out.println("M = " + M);
+        Complex<C> M1c = rect.getSW().norm();
+        C M1 = M1c.getRe();
+        if (M.compareTo(M1) < 0) {
+            M = M1;
+            Mc = M1c;
+        }
+        M1c = rect.getSE().norm();
+        M1 = M1c.getRe();
+        if (M.compareTo(M1) < 0) {
+            M = M1;
+            Mc = M1c;
+        }
+        M1c = rect.getNE().norm();
+        M1 = M1c.getRe();
+        if (M.compareTo(M1) < 0) {
+            //M = M1;
+            Mc = M1c;
+        }
+        //System.out.println("M = " + M);
+        Complex<C> B = PolyUtil.<Complex<C>> evaluateMain(f.ring.coFac, fa, Mc);
+        //System.out.println("B = " + B);
+        return B.getRe();
+    }
+
+
+    /**
+     * Complex root count of complex polynomial on rectangle.
+     * @param rect rectangle.
+     * @param a univariate complex polynomial.
+     * @return root count of a in rectangle.
+     */
+    public abstract long complexRootCount(Rectangle<C> rect, GenPolynomial<Complex<C>> a)
+                    throws InvalidBoundaryException;
+
+
+    /**
+     * List of complex roots of complex polynomial a on rectangle.
+     * @param rect rectangle.
+     * @param a univariate squarefree complex polynomial.
+     * @return list of complex roots.
+     */
+    public abstract List<Rectangle<C>> complexRoots(Rectangle<C> rect, GenPolynomial<Complex<C>> a)
+                    throws InvalidBoundaryException;
+
+
+    /**
+     * List of complex roots of complex polynomial.
+     * @param a univariate complex polynomial.
+     * @return list of complex roots.
+     */
+    @SuppressWarnings({"cast","unchecked"})
+    public List<Rectangle<C>> complexRoots(GenPolynomial<Complex<C>> a) {
+        List<Rectangle<C>> roots = new ArrayList<Rectangle<C>>();
+        if (a.isConstant() || a.isZERO()) {
+            return roots;
+        }
+        ComplexRing<C> cr = (ComplexRing<C>) a.ring.coFac;
+        GenPolynomial<Complex<C>> sp = engine.squarefreePart(a);
+        SortedMap<GenPolynomial<Complex<C>>, Long> sa = new TreeMap<GenPolynomial<Complex<C>>, Long>();
+        sa.put(sp, 1L);
+        //SortedMap<GenPolynomial<Complex<C>>, Long> sa = engine.squarefreeFactors(a); // BUG to addAll 
+        //System.out.println("squarefree factors = " + sa);
+        for (Map.Entry<GenPolynomial<Complex<C>>, Long> me : sa.entrySet()) { // todo fix addAll
+            GenPolynomial<Complex<C>> p = me.getKey();
+            Complex<C> Mb = rootBound(p);
+            C M = Mb.getRe();
+            C M1 = M.sum(M.factory().fromInteger(1)); // asymmetric to origin
+            //System.out.println("M = " + M);
+            if (debug) {
+                logger.info("rootBound = " + M);
+            }
+            Complex<C>[] corner = (Complex<C>[]) new Complex[4];
+            corner[0] = new Complex<C>(cr, M1.negate(), M); // nw
+            corner[1] = new Complex<C>(cr, M1.negate(), M1.negate()); // sw
+            corner[2] = new Complex<C>(cr, M, M1.negate()); // se
+            corner[3] = new Complex<C>(cr, M, M); // ne
+            Rectangle<C> rect = new Rectangle<C>(corner);
+            try {
+                List<Rectangle<C>> rs = complexRoots(rect, p);
+                long e = me.getValue(); // sa.get(p);
+                for (int i = 0; i < e; i++) { // add with multiplicity
+                    roots.addAll(rs);
+                }
+            } catch (InvalidBoundaryException e) {
+                //logger.error("invalid boundary for p = " + p);
+                throw new RuntimeException("this should never happen " + e);
+            }
+        }
+        return roots;
+    }
+
+
+    /**
+     * Complex root refinement of complex polynomial a on rectangle.
+     * @param rect rectangle containing exactly one complex root.
+     * @param a univariate squarefree complex polynomial.
+     * @param len rational length for refinement.
+     * @return refined complex root.
+     */
+    @SuppressWarnings({"cast","unchecked"})
+    public Rectangle<C> complexRootRefinement(Rectangle<C> rect, GenPolynomial<Complex<C>> a, BigRational len)
+                    throws InvalidBoundaryException {
+        ComplexRing<C> cr = (ComplexRing<C>) a.ring.coFac;
+        Rectangle<C> root = rect;
+        long w;
+        if (debug) {
+            w = complexRootCount(root, a);
+            if (w != 1) {
+                System.out.println("#root = " + w);
+                System.out.println("root = " + root);
+                throw new ArithmeticException("no initial isolating rectangle " + rect);
+            }
+        }
+        Complex<C> eps = cr.fromInteger(1);
+        eps = eps.divide(cr.fromInteger(1000)); // 1/1000
+        BigRational length = len.multiply(len);
+        Complex<C> delta = null;
+        boolean work = true;
+        while (work) {
+            try {
+                while (root.rationalLength().compareTo(length) > 0) {
+                    //System.out.println("root = " + root + ", len = " + new BigDecimal(root.rationalLength())); 
+                    if (delta == null) {
+                        delta = root.corners[3].subtract(root.corners[1]);
+                        delta = delta.divide(cr.fromInteger(2));
+                        //System.out.println("delta = " + toDecimal(delta)); 
+                    }
+                    Complex<C> center = root.corners[1].sum(delta);
+                    //System.out.println("refine center = " + toDecimal(center)); 
+                    if (debug) {
+                        logger.info("new center = " + center);
+                    }
+
+                    Complex<C>[] cp = (Complex<C>[]) copyOfComplex(root.corners, 4);
+                    // cp[0] fix
+                    cp[1] = new Complex<C>(cr, cp[1].getRe(), center.getIm());
+                    cp[2] = center;
+                    cp[3] = new Complex<C>(cr, center.getRe(), cp[3].getIm());
+                    Rectangle<C> nw = new Rectangle<C>(cp);
+                    w = complexRootCount(nw, a);
+                    if (w == 1) {
+                        root = nw;
+                        delta = null;
+                        continue;
+                    }
+
+                    cp = (Complex<C>[]) copyOfComplex(root.corners, 4);
+                    cp[0] = new Complex<C>(cr, cp[0].getRe(), center.getIm());
+                    // cp[1] fix
+                    cp[2] = new Complex<C>(cr, center.getRe(), cp[2].getIm());
+                    cp[3] = center;
+                    Rectangle<C> sw = new Rectangle<C>(cp);
+                    w = complexRootCount(sw, a);
+                    //System.out.println("#swr = " + w); 
+                    if (w == 1) {
+                        root = sw;
+                        delta = null;
+                        continue;
+                    }
+
+                    cp = (Complex<C>[]) copyOfComplex(root.corners, 4);
+                    cp[0] = center;
+                    cp[1] = new Complex<C>(cr, center.getRe(), cp[1].getIm());
+                    // cp[2] fix
+                    cp[3] = new Complex<C>(cr, cp[3].getRe(), center.getIm());
+                    Rectangle<C> se = new Rectangle<C>(cp);
+                    w = complexRootCount(se, a);
+                    //System.out.println("#ser = " + w); 
+                    if (w == 1) {
+                        root = se;
+                        delta = null;
+                        continue;
+                    }
+
+                    cp = (Complex<C>[]) copyOfComplex(root.corners, 4);
+                    cp[0] = new Complex<C>(cr, center.getRe(), cp[0].getIm());
+                    cp[1] = center;
+                    cp[2] = new Complex<C>(cr, cp[2].getRe(), center.getIm());
+                    // cp[3] fix
+                    Rectangle<C> ne = new Rectangle<C>(cp);
+                    w = complexRootCount(ne, a);
+                    //System.out.println("#ner = " + w); 
+                    if (w == 1) {
+                        root = ne;
+                        delta = null;
+                        continue;
+                    }
+                    if (true) {
+                        w = complexRootCount(root, a);
+                        System.out.println("#root = " + w);
+                        System.out.println("root = " + root);
+                    }
+                    throw new ArithmeticException("no isolating rectangle " + rect);
+                }
+                work = false;
+            } catch (InvalidBoundaryException e) {
+                // repeat with new center
+                delta = delta.sum(delta.multiply(eps)); // distort
+                //System.out.println("new refine delta = " + toDecimal(delta));
+                eps = eps.sum(eps.multiply(cr.getIMAG()));
+            }
+        }
+        return root;
+    }
+
+
+    /**
+     * List of complex roots of complex polynomial.
+     * @param a univariate complex polynomial.
+     * @param len rational length for refinement.
+     * @return list of complex roots to desired precision.
+     */
+    @SuppressWarnings({"cast","unchecked"})
+    public List<Rectangle<C>> complexRoots(GenPolynomial<Complex<C>> a, BigRational len) {
+        ComplexRing<C> cr = (ComplexRing<C>) a.ring.coFac;
+        SortedMap<GenPolynomial<Complex<C>>, Long> sa = engine.squarefreeFactors(a);
+        List<Rectangle<C>> roots = new ArrayList<Rectangle<C>>();
+        for (Map.Entry<GenPolynomial<Complex<C>>, Long> me : sa.entrySet()) {
+            GenPolynomial<Complex<C>> p = me.getKey();
+            Complex<C> Mb = rootBound(p);
+            C M = Mb.getRe();
+            C M1 = M.sum(M.factory().fromInteger(1)); // asymmetric to origin
+            if (debug) {
+                logger.info("rootBound = " + M);
+            }
+            Complex<C>[] corner = (Complex<C>[]) new Complex[4];
+            corner[0] = new Complex<C>(cr, M1.negate(), M); // nw
+            corner[1] = new Complex<C>(cr, M1.negate(), M1.negate()); // sw
+            corner[2] = new Complex<C>(cr, M, M1.negate()); // se
+            corner[3] = new Complex<C>(cr, M, M); // ne
+            Rectangle<C> rect = new Rectangle<C>(corner);
+            try {
+                List<Rectangle<C>> rs = complexRoots(rect, p);
+                List<Rectangle<C>> rf = new ArrayList<Rectangle<C>>(rs.size());
+                for (Rectangle<C> r : rs) {
+                    Rectangle<C> rr = complexRootRefinement(r, p, len);
+                    rf.add(rr);
+                }
+                long e = me.getValue(); // sa.get(p);
+                for (int i = 0; i < e; i++) { // add with multiplicity
+                    roots.addAll(rf);
+                }
+            } catch (InvalidBoundaryException e) {
+                throw new RuntimeException("this should never happen " + e);
+            }
+        }
+        return roots;
+    }
+
+
+    /**
+     * Invariant rectangle for algebraic number.
+     * @param rect root isolating rectangle for f which contains exactly one
+     *            root.
+     * @param f univariate polynomial, non-zero.
+     * @param g univariate polynomial, gcd(f,g) == 1.
+     * @return v with v a new rectangle contained in iv such that g(w) != 0 for
+     *         w in v.
+     */
+    public abstract Rectangle<C> invariantRectangle(Rectangle<C> rect, GenPolynomial<Complex<C>> f,
+                    GenPolynomial<Complex<C>> g) throws InvalidBoundaryException;
+
+
+    /**
+     * Get decimal approximation.
+     * @param a complex number.
+     * @return decimal(a).
+     */
+    public String toDecimal(Complex<C> a) {
+        C r = a.getRe();
+        String s = r.toString();
+        BigRational rs = new BigRational(s);
+        BigDecimal rd = new BigDecimal(rs);
+        C i = a.getIm();
+        s = i.toString();
+        BigRational is = new BigRational(s);
+        BigDecimal id = new BigDecimal(is);
+        //System.out.println("rd = " + rd);
+        //System.out.println("id = " + id);
+        return rd.toString() + " i " + id.toString();
+    }
+
+
+    /**
+     * Approximate complex root.
+     * @param rt root isolating rectangle.
+     * @param f univariate polynomial, non-zero.
+     * @param eps requested interval length.
+     * @return a decimal approximation d such that |d-v| &lt; eps, for f(v) = 0,
+     *         v in rt.
+     */
+    public Complex<BigDecimal> approximateRoot(Rectangle<C> rt, GenPolynomial<Complex<C>> f, BigRational eps)
+                    throws NoConvergenceException {
+        if (rt == null) {
+            throw new IllegalArgumentException("null interval not allowed");
+        }
+        Complex<BigDecimal> d = rt.getDecimalCenter();
+        //System.out.println("d  = " + d);
+        if (f == null || f.isZERO() || f.isConstant() || eps == null) {
+            return d;
+        }
+        if (rt.rationalLength().compareTo(eps) < 0) {
+            return d;
+        }
+        ComplexRing<BigDecimal> cr = d.ring;
+        Complex<C> sw = rt.getSW();
+        BigDecimal swr = new BigDecimal(sw.getRe().getRational());
+        BigDecimal swi = new BigDecimal(sw.getIm().getRational());
+        Complex<BigDecimal> ll = new Complex<BigDecimal>(cr, swr, swi);
+        Complex<C> ne = rt.getNE();
+        BigDecimal ner = new BigDecimal(ne.getRe().getRational());
+        BigDecimal nei = new BigDecimal(ne.getIm().getRational());
+        Complex<BigDecimal> ur = new Complex<BigDecimal>(cr, ner, nei);
+
+        BigDecimal e = new BigDecimal(eps.getRational());
+        Complex<BigDecimal> q = new Complex<BigDecimal>(cr, new BigDecimal("0.25"));
+        e = e.multiply(d.norm().getRe()); // relative error
+        //System.out.println("e  = " + e);
+
+        // polynomials with decimal coefficients
+        GenPolynomialRing<Complex<BigDecimal>> dfac = new GenPolynomialRing<Complex<BigDecimal>>(cr, f.ring);
+        GenPolynomial<Complex<BigDecimal>> df = PolyUtil.<C> complexDecimalFromRational(dfac, f);
+        GenPolynomial<Complex<C>> fp = PolyUtil.<Complex<C>> baseDeriviative(f);
+        GenPolynomial<Complex<BigDecimal>> dfp = PolyUtil.<C> complexDecimalFromRational(dfac, fp);
+
+        // Newton Raphson iteration: x_{n+1} = x_n - f(x_n)/f'(x_n)
+        int i = 0;
+        final int MITER = 50;
+        int dir = -1;
+        while (i++ < MITER) {
+            Complex<BigDecimal> fx = PolyUtil.<Complex<BigDecimal>> evaluateMain(cr, df, d); // f(d)
+            //BigDecimal fs = fx.norm().getRe();
+            //System.out.println("fs = " + fs);
+            if (fx.isZERO()) {
+                return d;
+            }
+            Complex<BigDecimal> fpx = PolyUtil.<Complex<BigDecimal>> evaluateMain(cr, dfp, d); // f'(d)
+            if (fpx.isZERO()) {
+                throw new NoConvergenceException("zero deriviative should not happen");
+            }
+            Complex<BigDecimal> x = fx.divide(fpx);
+            Complex<BigDecimal> dx = d.subtract(x);
+            //System.out.println("dx = " + dx);
+            if (d.subtract(dx).norm().getRe().compareTo(e) <= 0) {
+                return dx;
+            }
+            //             if ( false ) { // not useful:
+            //                 Complex<BigDecimal> fxx  = PolyUtil.<Complex<BigDecimal>> evaluateMain(cr, df, dx); // f(dx)
+            //                 //System.out.println("fxx = " + fxx);
+            //                 BigDecimal fsx = fxx.norm().getRe();
+            //                 System.out.println("fsx = " + fsx);
+            //                 while ( fsx.compareTo( fs ) >= 0 ) {
+            //                     System.out.println("trying to increase f(d) ");
+            //                     if ( i++ > MITER ) { // dx > right: dx - right > 0
+            //                         throw new NoConvergenceException("no convergence after " + i + " steps");
+            //                     }
+            //                     x = x.multiply(q); // x * 1/4
+            //                     dx = d.subtract(x);
+            //                     //System.out.println(" x = " + x);
+            //                     System.out.println("dx = " + dx);
+            //                     fxx  = PolyUtil.<Complex<BigDecimal>> evaluateMain(cr, df, dx); // f(dx)
+            //                     //System.out.println("fxx = " + fxx);
+            //                     fsx = fxx.norm().getRe();
+            //                     System.out.println("fsx = " + fsx);
+            //                 }
+            //             }
+            // check interval bounds
+            while (dx.getRe().compareTo(ll.getRe()) < 0 || dx.getIm().compareTo(ll.getIm()) < 0
+                            || dx.getRe().compareTo(ur.getRe()) > 0 || dx.getIm().compareTo(ur.getIm()) > 0) {
+                // dx < ll: dx - ll < 0
+                // dx > ur: dx - ur > 0
+                if (i++ > MITER) { // dx > right: dx - right > 0
+                    throw new NoConvergenceException("no convergence after " + i + " steps");
+                }
+                if (i > MITER / 2 && dir == 0) {
+                    Complex<C> cc = rt.getCenter();
+                    Rectangle<C> nrt = rt.exchangeSE(cc);
+                    Complex<BigDecimal> sd = nrt.getDecimalCenter();
+                    d = sd;
+                    x = cr.getZERO();
+                    logger.info("trying new SE starting point " + d);
+                    i = 0;
+                    dir = 1;
+                }
+                if (i > MITER / 2 && dir == 1) {
+                    Complex<C> cc = rt.getCenter();
+                    Rectangle<C> nrt = rt.exchangeNW(cc);
+                    Complex<BigDecimal> sd = nrt.getDecimalCenter();
+                    d = sd;
+                    x = cr.getZERO();
+                    logger.info("trying new NW starting point " + d);
+                    i = 0;
+                    dir = 2;
+                }
+                if (i > MITER / 2 && dir == 2) {
+                    Complex<C> cc = rt.getCenter();
+                    Rectangle<C> nrt = rt.exchangeSW(cc);
+                    Complex<BigDecimal> sd = nrt.getDecimalCenter();
+                    d = sd;
+                    x = cr.getZERO();
+                    logger.info("trying new SW starting point " + d);
+                    i = 0;
+                    dir = 3;
+                }
+                if (i > MITER / 2 && dir == 3) {
+                    Complex<C> cc = rt.getCenter();
+                    Rectangle<C> nrt = rt.exchangeNE(cc);
+                    Complex<BigDecimal> sd = nrt.getDecimalCenter();
+                    d = sd;
+                    x = cr.getZERO();
+                    logger.info("trying new NE starting point " + d);
+                    i = 0;
+                    dir = 4;
+                }
+                if (i > MITER / 2 && (dir == -1 || dir == 4 || dir == 5)) {
+                    Complex<C> sr = rt.randomPoint();
+                    BigDecimal srr = new BigDecimal(sr.getRe().getRational());
+                    BigDecimal sri = new BigDecimal(sr.getIm().getRational());
+                    Complex<BigDecimal> sd = new Complex<BigDecimal>(cr, srr, sri);
+                    d = sd;
+                    x = cr.getZERO();
+                    logger.info("trying new random starting point " + d);
+                    if (dir == -1) {
+                        i = 0;
+                        dir = 0;
+                    } else if (dir == 4) {
+                        i = 0;
+                        dir = 5;
+                    } else {
+                        //i = 0; 
+                        dir = 6; // end
+                    }
+                }
+                x = x.multiply(q); // x * 1/4
+                dx = d.subtract(x);
+                //System.out.println(" x = " + x);
+                //System.out.println("dx = " + dx);
+            }
+            d = dx;
+        }
+        throw new NoConvergenceException("no convergence after " + i + " steps");
+    }
+
+
+    /**
+     * List of decimal approximations of complex roots of complex polynomial.
+     * @param a univariate complex polynomial.
+     * @param eps length for refinement.
+     * @return list of complex decimal root approximations to desired precision.
+     */
+    @SuppressWarnings({"cast","unchecked"})
+    public List<Complex<BigDecimal>> approximateRoots(GenPolynomial<Complex<C>> a, BigRational eps) {
+        ComplexRing<C> cr = (ComplexRing<C>) a.ring.coFac;
+        SortedMap<GenPolynomial<Complex<C>>, Long> sa = engine.squarefreeFactors(a);
+        List<Complex<BigDecimal>> roots = new ArrayList<Complex<BigDecimal>>();
+        for (Map.Entry<GenPolynomial<Complex<C>>, Long> me : sa.entrySet()) {
+            GenPolynomial<Complex<C>> p = me.getKey();
+            List<Complex<BigDecimal>> rf = null;
+            if (p.degree(0) <= 1) {
+                Complex<C> tc = p.trailingBaseCoefficient();
+                tc = tc.negate();
+                BigDecimal rr = new BigDecimal(tc.getRe().getRational());
+                BigDecimal ri = new BigDecimal(tc.getIm().getRational());
+                ComplexRing<BigDecimal> crf = new ComplexRing<BigDecimal>(rr);
+                Complex<BigDecimal> r = new Complex<BigDecimal>(crf, rr, ri);
+                rf = new ArrayList<Complex<BigDecimal>>(1);
+                rf.add(r);
+            } else {
+                Complex<C> Mb = rootBound(p);
+                C M = Mb.getRe();
+                C M1 = M.sum(M.factory().fromInteger(1)); // asymmetric to origin
+                if (debug) {
+                    logger.info("rootBound = " + M);
+                }
+                Complex<C>[] corner = (Complex<C>[]) new Complex[4];
+                corner[0] = new Complex<C>(cr, M1.negate(), M); // nw
+                corner[1] = new Complex<C>(cr, M1.negate(), M1.negate()); // sw
+                corner[2] = new Complex<C>(cr, M, M1.negate()); // se
+                corner[3] = new Complex<C>(cr, M, M); // ne
+                Rectangle<C> rect = new Rectangle<C>(corner);
+                List<Rectangle<C>> rs = null;
+                try {
+                    rs = complexRoots(rect, p);
+                } catch (InvalidBoundaryException e) {
+                    throw new RuntimeException("this should never happen " + e);
+                }
+                rf = new ArrayList<Complex<BigDecimal>>(rs.size());
+                for (Rectangle<C> r : rs) {
+                    Complex<BigDecimal> rr = null;
+                    while (rr == null) {
+                        try {
+                            rr = approximateRoot(r, p, eps);
+                            rf.add(rr);
+                        } catch (NoConvergenceException e) {
+                            // fall back to exact algorithm
+                            BigRational len = r.rationalLength();
+                            len = len.multiply(new BigRational(1, 1000));
+                            try {
+                                r = complexRootRefinement(r, p, len);
+                                logger.info("fall back rootRefinement = " + r);
+                                //System.out.println("len = " + len);
+                            } catch (InvalidBoundaryException ee) {
+                                throw new RuntimeException("this should never happen " + ee);
+                            }
+                        }
+                    }
+                }
+            }
+            long e = me.getValue(); // sa.get(p);
+            for (int i = 0; i < e; i++) { // add with multiplicity
+                roots.addAll(rf);
+            }
+        }
+        return roots;
+    }
+
+
+    /**
+     * Copy the specified array.
+     * @param original array.
+     * @param newLength new array length.
+     * @return copy of this.
+     */
+    public Complex[] copyOfComplex(Complex[] original, int newLength) {
+        Complex[] copy = new Complex[newLength];
+        System.arraycopy(original, 0, copy, 0, Math.min(original.length, newLength));
+        return copy;
+    }
+
+
+    /**
+     * Invariant rectangle for algebraic number magnitude.
+     * @param rect root isolating rectangle for f which contains exactly one
+     *            root.
+     * @param f univariate polynomial, non-zero.
+     * @param g univariate polynomial, gcd(f,g) == 1.
+     * @param eps length limit for rectangle length.
+     * @return v with v a new rectangle contained in rect such that |g(a) -
+     *         g(b)| &lt; eps for a, b in v in rect.
+     */
+    public Rectangle<C> invariantMagnitudeRectangle(Rectangle<C> rect, GenPolynomial<Complex<C>> f,
+                    GenPolynomial<Complex<C>> g, BigRational eps) throws InvalidBoundaryException {
+        Rectangle<C> v = rect;
+        if (g == null || g.isZERO()) {
+            return v;
+        }
+        if (g.isConstant()) {
+            return v;
+        }
+        if (f == null || f.isZERO() || f.isConstant()) { // ?
+            return v;
+        }
+        GenPolynomial<Complex<C>> gp = PolyUtil.<Complex<C>> baseDeriviative(g);
+        //System.out.println("g  = " + g);
+        //System.out.println("gp = " + gp);
+        BigRational B = magnitudeBound(rect, gp).getRational();
+        //System.out.println("B = " + B + " : " + B.getClass());
+
+        BigRational len = v.rationalLength();
+        BigRational half = new BigRational(1, 2);
+
+        BigRational vlen = v.rationalLength();
+        vlen = vlen.multiply(vlen);
+        //eps = eps.multiply(eps);
+        //System.out.println("v = " + v);
+        //System.out.println("vlen = " + vlen);
+        while (B.multiply(vlen).compareTo(eps) >= 0) { // TODO: test squared
+            len = len.multiply(half);
+            v = complexRootRefinement(v, f, len);
+            //System.out.println("v = " + v);
+            vlen = v.rationalLength();
+            vlen = vlen.multiply(vlen);
+            //System.out.println("vlen = " + vlen);
+        }
+        //System.out.println("vlen = " + vlen);
+        return v;
+    }
+
+
+    /**
+     * Complex algebraic number magnitude.
+     * @param rect root isolating rectangle for f which contains exactly one
+     *            root, with rect such that |g(a) - g(b)| &lt; eps for a, b in
+     *            rect.
+     * @param f univariate polynomial, non-zero.
+     * @param g univariate polynomial, gcd(f,g) == 1.
+     * @return g(rect) .
+     */
+    public Complex<C> complexRectangleMagnitude(Rectangle<C> rect, GenPolynomial<Complex<C>> f,
+                    GenPolynomial<Complex<C>> g) {
+        if (g.isZERO() || g.isConstant()) {
+            return g.leadingBaseCoefficient();
+        }
+        RingFactory<Complex<C>> cfac = f.ring.coFac;
+        //System.out.println("cfac = " + cfac + " : " + cfac.getClass());
+        Complex<C> c = rect.getCenter();
+        Complex<C> ev = PolyUtil.<Complex<C>> evaluateMain(cfac, g, c);
+        return ev;
+    }
+
+
+    /**
+     * Complex algebraic number magnitude.
+     * @param rect root isolating rectangle for f which contains exactly one
+     *            root, with rect such that |g(a) - g(b)| &lt; eps for a, b in
+     *            rect.
+     * @param f univariate polynomial, non-zero.
+     * @param g univariate polynomial, gcd(f,g) == 1.
+     * @param eps length limit for rectangle length.
+     * @return g(rect) .
+     */
+    public Complex<C> complexMagnitude(Rectangle<C> rect, GenPolynomial<Complex<C>> f,
+                    GenPolynomial<Complex<C>> g, BigRational eps) throws InvalidBoundaryException {
+        if (g.isZERO() || g.isConstant()) {
+            return g.leadingBaseCoefficient();
+        }
+        Rectangle<C> v = invariantMagnitudeRectangle(rect, f, g, eps);
+        //System.out.println("ref = " + ref);
+        return complexRectangleMagnitude(v, f, g);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/ComplexRootsSturm.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/ComplexRootsSturm.java
@@ -1,0 +1,474 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.root;
+
+
+import java.util.ArrayList;
+// import java.util.Arrays;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.arith.BigRational;
+import edu.jas.arith.Rational;
+import edu.jas.poly.Complex;
+import edu.jas.poly.ComplexRing;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Complex roots implemented by Sturm sequences. Algorithms use exact method
+ * derived from Wilf's numeric Routh-Hurwitz method.
+ * @param <C> coefficient type.
+ * @author Heinz Kredel
+ */
+public class ComplexRootsSturm<C extends RingElem<C> & Rational> extends ComplexRootsAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(ComplexRootsSturm.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     * @param cf coefficient factory.
+     */
+    public ComplexRootsSturm(RingFactory<Complex<C>> cf) {
+        super(cf);
+        //ufd = GCDFactory.<Complex<C>> getImplementation(cf);
+    }
+
+
+    /**
+     * Cauchy index of rational function f/g on interval.
+     * @param a interval bound for I = [a,b].
+     * @param b interval bound for I = [a,b].
+     * @param f univariate polynomial.
+     * @param g univariate polynomial.
+     * @return winding number of f/g in I.
+     */
+    public long indexOfCauchy(C a, C b, GenPolynomial<C> f, GenPolynomial<C> g) {
+        List<GenPolynomial<C>> S = sturmSequence(g, f);
+        //System.out.println("S = " + S);
+        if (debug) {
+            logger.info("sturmSeq = " + S);
+        }
+        RingFactory<C> cfac = f.ring.coFac;
+        List<C> l = PolyUtil.<C> evaluateMain(cfac, S, a);
+        List<C> r = PolyUtil.<C> evaluateMain(cfac, S, b);
+        long v = RootUtil.<C> signVar(l) - RootUtil.<C> signVar(r);
+        //System.out.println("v = " + v);
+        //         if (v < 0L) {
+        //             v = -v;
+        //         }
+        return v;
+    }
+
+
+    /**
+     * Routh index of complex function f + i g on interval.
+     * @param a interval bound for I = [a,b].
+     * @param b interval bound for I = [a,b].
+     * @param f univariate polynomial.
+     * @param g univariate polynomial != 0.
+     * @return index number of f + i g.
+     */
+    public long[] indexOfRouth(C a, C b, GenPolynomial<C> f, GenPolynomial<C> g) {
+        List<GenPolynomial<C>> S = sturmSequence(f, g);
+        //System.out.println("S = " + S);
+        RingFactory<C> cfac = f.ring.coFac;
+        List<C> l = PolyUtil.<C> evaluateMain(cfac, S, a);
+        List<C> r = PolyUtil.<C> evaluateMain(cfac, S, b);
+        long v = RootUtil.<C> signVar(l) - RootUtil.<C> signVar(r);
+        //System.out.println("v = " + v);
+
+        long d = f.degree(0);
+        if (d < g.degree(0)) {
+            d = g.degree(0);
+        }
+        //System.out.println("d = " + d);
+        long ui = (d - v) / 2;
+        long li = (d + v) / 2;
+        //System.out.println("upper = " + ui);
+        //System.out.println("lower = " + li);
+        return new long[] { ui, li };
+    }
+
+
+    /**
+     * Sturm sequence.
+     * @param f univariate polynomial.
+     * @param g univariate polynomial.
+     * @return a Sturm sequence for f and g.
+     */
+    public List<GenPolynomial<C>> sturmSequence(GenPolynomial<C> f, GenPolynomial<C> g) {
+        List<GenPolynomial<C>> S = new ArrayList<GenPolynomial<C>>();
+        if (f == null || f.isZERO()) {
+            return S;
+        }
+        if (f.isConstant()) {
+            S.add(f.monic());
+            return S;
+        }
+        GenPolynomial<C> F = f;
+        S.add(F);
+        GenPolynomial<C> G = g; //PolyUtil.<C> baseDeriviative(f);
+        while (!G.isZERO()) {
+            GenPolynomial<C> r = F.remainder(G);
+            F = G;
+            G = r.negate();
+            S.add(F/*.monic()*/);
+        }
+        //System.out.println("F = " + F);
+        if (F.isConstant()) {
+            return S;
+        }
+        // make squarefree
+        List<GenPolynomial<C>> Sp = new ArrayList<GenPolynomial<C>>(S.size());
+        for (GenPolynomial<C> p : S) {
+            p = p.divide(F);
+            Sp.add(p);
+        }
+        return Sp;
+    }
+
+
+    /**
+     * Complex root count of complex polynomial on rectangle.
+     * @param rect rectangle.
+     * @param a univariate complex polynomial.
+     * @return root count of a in rectangle.
+     */
+    @Override
+    public long complexRootCount(Rectangle<C> rect, GenPolynomial<Complex<C>> a)
+                    throws InvalidBoundaryException {
+        C rl = rect.lengthReal();
+        C il = rect.lengthImag();
+        //System.out.println("complexRootCount: rl = " + rl + ", il = " + il);
+        // only linear polynomials have zero length intervals
+        if (rl.isZERO() && il.isZERO()) {
+            Complex<C> e = PolyUtil.<Complex<C>> evaluateMain(a.ring.coFac, a, rect.getSW());
+            if (e.isZERO()) {
+                return 1;
+            }
+            return 0;
+        }
+        if (rl.isZERO() || il.isZERO()) {
+            //RingFactory<C> cf = (RingFactory<C>) rl.factory();
+            //GenPolynomialRing<C> rfac = new GenPolynomialRing<C>(cf,a.ring);
+            //cf = (RingFactory<C>) il.factory();
+            //GenPolynomialRing<C> ifac = new GenPolynomialRing<C>(cf,a.ring);
+            //GenPolynomial<C> rp = PolyUtil.<C> realPartFromComplex(rfac, a);
+            //GenPolynomial<C> ip = PolyUtil.<C> imaginaryPartFromComplex(ifac, a);
+            //RealRoots<C> rr = new RealRootsSturm<C>();
+            if (rl.isZERO()) {
+                //logger.info("lengthReal == 0: " + rect);
+                //Complex<C> r = rect.getSW();
+                //r = new Complex<C>(r.ring,r.getRe()/*,0*/);
+                //Complex<C> e = PolyUtil.<Complex<C>> evaluateMain(a.ring.coFac, a, r);
+                //logger.info("a(re(rect)): " + e);
+                //if ( !e.getRe().isZERO() ) {
+                //    return 0;
+                //}
+                //C ev = PolyUtil.<C> evaluateMain(rp.ring.coFac, rp, rl);
+                //logger.info("re(a)(re(rect)): " + ev);
+                //Interval<C> iv = new Interval<C>(rect.getSW().getIm(),rect.getNE().getIm());
+                //logger.info("iv: " + iv);
+                //long ic = rr.realRootCount(iv,ip);
+                //logger.info("ic: " + ic);
+
+                Complex<C> sw = rect.getSW();
+                Complex<C> ne = rect.getNE();
+                C delta = sw.ring.ring.getONE(); //parse("1"); // works since linear polynomial
+                Complex<C> cd = new Complex<C>(sw.ring, delta/*, 0*/);
+                sw = sw.subtract(cd);
+                ne = ne.sum(cd);
+                rect = rect.exchangeSW(sw);
+                rect = rect.exchangeNE(ne);
+                logger.info("new rectangle: " + rect.toScript());
+            }
+            if (il.isZERO()) {
+                //logger.info("lengthImag == 0: " + rect);
+                //Interval<C> rv = new Interval<C>(rect.getSW().getRe(),rect.getNE().getRe());
+                //logger.info("rv: " + rv);
+                //long rc = rr.realRootCount(rv,rp);
+                //logger.info("rc: " + rc);
+
+                Complex<C> sw = rect.getSW();
+                Complex<C> ne = rect.getNE();
+                C delta = sw.ring.ring.getONE(); //parse("1"); // works since linear polynomial
+                Complex<C> cd = new Complex<C>(sw.ring, sw.ring.ring.getZERO(), delta);
+                sw = sw.subtract(cd);
+                ne = ne.sum(cd);
+                rect = rect.exchangeSW(sw);
+                rect = rect.exchangeNE(ne);
+                logger.info("new rectangle: " + rect.toScript());
+            }
+        }
+        long wn = windingNumber(rect, a);
+        //System.out.println("complexRootCount: wn = " + wn);
+        return wn;
+    }
+
+
+    /**
+     * Winding number of complex function A on rectangle.
+     * @param rect rectangle.
+     * @param A univariate complex polynomial.
+     * @return winding number of A arround rect.
+     */
+    public long windingNumber(Rectangle<C> rect, GenPolynomial<Complex<C>> A)
+                    throws InvalidBoundaryException {
+        Boundary<C> bound = new Boundary<C>(rect, A); // throws InvalidBoundaryException
+        ComplexRing<C> cr = (ComplexRing<C>) A.ring.coFac;
+        RingFactory<C> cf = cr.ring;
+        C zero = cf.getZERO();
+        C one = cf.getONE();
+        long ix = 0L;
+        for (int i = 0; i < 4; i++) {
+            long ci = indexOfCauchy(zero, one, bound.getRealPart(i), bound.getImagPart(i));
+            //System.out.println("ci[" + i + "," + (i + 1) + "] = " + ci);
+            ix += ci;
+        }
+        if (ix % 2L != 0) {
+            throw new InvalidBoundaryException("odd winding number " + ix);
+        }
+        return ix / 2L;
+    }
+
+
+    /**
+     * List of complex roots of complex polynomial a on rectangle.
+     * @param rect rectangle.
+     * @param a univariate squarefree complex polynomial.
+     * @return list of complex roots.
+     */
+    @SuppressWarnings({"cast","unchecked"})
+    @Override
+    public List<Rectangle<C>> complexRoots(Rectangle<C> rect, GenPolynomial<Complex<C>> a)
+                    throws InvalidBoundaryException {
+        ComplexRing<C> cr = (ComplexRing<C>) a.ring.coFac;
+        List<Rectangle<C>> roots = new ArrayList<Rectangle<C>>();
+        if (a.isConstant() || a.isZERO()) {
+            return roots;
+        }
+        //System.out.println("rect = " + rect); 
+        long n = windingNumber(rect, a);
+        if (n < 0) { // can this happen?
+            throw new RuntimeException("negative winding number " + n);
+            //System.out.println("negative winding number " + n);
+            //return roots;
+        }
+        if (n == 0) {
+            return roots;
+        }
+        if (n == 1) {
+            //not ok: rect = excludeZero(rect, a);
+            roots.add(rect);
+            return roots;
+        }
+        Complex<C> eps = cr.fromInteger(1);
+        eps = eps.divide(cr.fromInteger(1000)); // 1/1000
+        //System.out.println("eps = " + eps);
+        //System.out.println("rect = " + rect); 
+        // construct new center
+        Complex<C> delta = rect.corners[3].subtract(rect.corners[1]);
+        delta = delta.divide(cr.fromInteger(2));
+        //System.out.println("delta = " + delta); 
+        boolean work = true;
+        while (work) {
+            Complex<C> center = rect.corners[1].sum(delta);
+            //System.out.println("center = " + toDecimal(center)); 
+            if (debug) {
+                logger.info("new center = " + center);
+            }
+            try {
+                Complex<C>[] cp = (Complex<C>[]) copyOfComplex(rect.corners, 4);
+                // (Complex<C>[]) new Complex[4];  cp[0] = rect.corners[0];
+                // cp[0] fix
+                cp[1] = new Complex<C>(cr, cp[1].getRe(), center.getIm());
+                cp[2] = center;
+                cp[3] = new Complex<C>(cr, center.getRe(), cp[3].getIm());
+                Rectangle<C> nw = new Rectangle<C>(cp);
+                //System.out.println("nw = " + nw); 
+                List<Rectangle<C>> nwr = complexRoots(nw, a);
+                //System.out.println("#nwr = " + nwr.size()); 
+                roots.addAll(nwr);
+                if (roots.size() == a.degree(0)) {
+                    work = false;
+                    break;
+                }
+
+                cp = (Complex<C>[]) copyOfComplex(rect.corners, 4);
+                cp[0] = new Complex<C>(cr, cp[0].getRe(), center.getIm());
+                // cp[1] fix
+                cp[2] = new Complex<C>(cr, center.getRe(), cp[2].getIm());
+                cp[3] = center;
+                Rectangle<C> sw = new Rectangle<C>(cp);
+                //System.out.println("sw = " + sw); 
+                List<Rectangle<C>> swr = complexRoots(sw, a);
+                //System.out.println("#swr = " + swr.size()); 
+                roots.addAll(swr);
+                if (roots.size() == a.degree(0)) {
+                    work = false;
+                    break;
+                }
+
+                cp = (Complex<C>[]) copyOfComplex(rect.corners, 4);
+                cp[0] = center;
+                cp[1] = new Complex<C>(cr, center.getRe(), cp[1].getIm());
+                // cp[2] fix
+                cp[3] = new Complex<C>(cr, cp[3].getRe(), center.getIm());
+                Rectangle<C> se = new Rectangle<C>(cp);
+                //System.out.println("se = " + se); 
+                List<Rectangle<C>> ser = complexRoots(se, a);
+                //System.out.println("#ser = " + ser.size()); 
+                roots.addAll(ser);
+                if (roots.size() == a.degree(0)) {
+                    work = false;
+                    break;
+                }
+
+                cp = (Complex<C>[]) copyOfComplex(rect.corners, 4);
+                cp[0] = new Complex<C>(cr, center.getRe(), cp[0].getIm());
+                cp[1] = center;
+                cp[2] = new Complex<C>(cr, cp[2].getRe(), center.getIm());
+                // cp[3] fix
+                Rectangle<C> ne = new Rectangle<C>(cp);
+                //System.out.println("ne = " + ne); 
+                List<Rectangle<C>> ner = complexRoots(ne, a);
+                //System.out.println("#ner = " + ner.size()); 
+                roots.addAll(ner);
+                work = false;
+            } catch (InvalidBoundaryException e) {
+                // repeat with new center
+                delta = delta.sum(delta.multiply(eps)); // distort
+                //System.out.println("new delta = " + toDecimal(delta)); 
+                eps = eps.sum(eps.multiply(cr.getIMAG()));
+            }
+        }
+        return roots;
+    }
+
+
+    /**
+     * Invariant rectangle for algebraic number.
+     * @param rect root isolating rectangle for f which contains exactly one
+     *            root.
+     * @param f univariate polynomial, non-zero.
+     * @param g univariate polynomial, gcd(f,g) == 1.
+     * @return v a new rectangle contained in rect such that g(w) != 0 for w in
+     *         v.
+     */
+    @Override
+    public Rectangle<C> invariantRectangle(Rectangle<C> rect, GenPolynomial<Complex<C>> f,
+                    GenPolynomial<Complex<C>> g) throws InvalidBoundaryException {
+        Rectangle<C> v = rect;
+        if (g == null || g.isZERO()) {
+            return v;
+        }
+        if (g.isConstant()) {
+            return v;
+        }
+        if (f == null || f.isZERO() || f.isConstant()) { // ?
+            return v;
+        }
+        BigRational len = v.rationalLength();
+        BigRational half = new BigRational(1, 2);
+        while (true) {
+            long n = windingNumber(v, g);
+            //System.out.println("n = " + n);
+            if (n < 0) { // can this happen?
+                throw new RuntimeException("negative winding number " + n);
+            }
+            if (n == 0) {
+                return v;
+            }
+            len = len.multiply(half);
+            Rectangle<C> v1 = v;
+            v = complexRootRefinement(v, f, len);
+            if (v.equals(v1)) {
+                //System.out.println("len = " + len);
+                if (!f.gcd(g).isONE()) {
+                    System.out.println("f.gcd(g) = " + f.gcd(g));
+                    throw new RuntimeException("no convergence " + v);
+                }
+                //break; // no convergence
+            }
+        }
+        //return v;
+    }
+
+
+    /**
+     * Exclude zero. If an axis intersects with the rectangle, it is shrinked 
+     * to exclude the axis.
+     * Not used.
+     * @param rect root isolating rectangle for f which contains exactly one
+     *            root.
+     * @return a new rectangle r such that re(r) &lt; 0 or (re)r &gt; 0 and
+     *         im(r) &lt; 0 or (im)r &gt; 0.
+     */
+    public Rectangle<C> excludeZero(Rectangle<C> rect, GenPolynomial<Complex<C>> f)
+                    throws InvalidBoundaryException {
+        if (f == null || f.isZERO()) {
+            return rect;
+        }
+        System.out.println("\nexcludeZero: rect = " + rect + ", f = " + f);
+        Complex<C> zero = f.ring.coFac.getZERO();
+        ComplexRing<C> cr = zero.ring;
+        Complex<C> sw = rect.getSW();
+        Complex<C> ne = rect.getNE();
+        Interval<C> ir = new Interval<C>(sw.getRe(), ne.getRe());
+        Interval<C> ii = new Interval<C>(sw.getIm(), ne.getIm());
+        System.out.println("intervals, ir = " + ir + ", ii = " + ii);
+        if (!(ir.contains(zero.getRe()) || ii.contains(zero.getIm()))) {
+            // !rect.contains(zero) not correct
+            return rect;
+        }
+        //System.out.println("contains: ir = " + ir.contains(zero.getRe()) + ", ii = " + ii.contains(zero.getIm()) );
+        Rectangle<C> rn = rect;
+        // shrink real part
+        if (ir.contains(zero.getRe())) {
+            Complex<C> sw0 = new Complex<C>(cr, zero.getRe(), sw.getIm());
+            Complex<C> ne0 = new Complex<C>(cr, zero.getRe(), ne.getIm());
+            Rectangle<C> rl = new Rectangle<C>(sw, ne0);
+            Rectangle<C> rr = new Rectangle<C>(sw0, ne);
+            System.out.println("rectangle, rl = " + rl + ", rr = " + rr);
+            if (complexRootCount(rr, f) == 1) {
+                rn = rr;
+            } else { // complexRootCount(rl,f) == 1
+                rn = rl;
+            }
+            System.out.println("rectangle, real = " + rn);
+        }
+        // shrink imaginary part
+        sw = rn.getSW();
+        ne = rn.getNE();
+        ii = new Interval<C>(sw.getIm(), ne.getIm());
+        System.out.println("interval, ii = " + ii);
+        if (ii.contains(zero.getIm())) {
+            Complex<C> sw1 = new Complex<C>(cr, sw.getRe(), zero.getIm());
+            Complex<C> ne1 = new Complex<C>(cr, ne.getRe(), zero.getIm());
+            Rectangle<C> iu = new Rectangle<C>(sw1, ne);
+            Rectangle<C> il = new Rectangle<C>(sw, ne1);
+            System.out.println("rectangle, il = " + il + ", iu = " + iu);
+            if (complexRootCount(il, f) == 1) {
+                rn = il;;
+            } else { // complexRootCount(iu,f) == 1
+                rn = iu;
+            }
+            System.out.println("rectangle, imag = " + rn);
+        }
+        return rn;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/DecimalRoots.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/DecimalRoots.java
@@ -1,0 +1,154 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.root;
+
+
+import java.io.Serializable;
+import java.util.List;
+
+import edu.jas.arith.Rational;
+import edu.jas.arith.BigDecimal;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.Complex;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Container for the real and complex algebraic roots of a univariate
+ * polynomial.
+ * @param <C> coefficient type.
+ * @author Heinz Kredel
+ */
+public class DecimalRoots<C extends GcdRingElem<C> & Rational> implements Serializable {
+
+
+    /**
+     * univariate polynomial.
+     */
+    public final GenPolynomial<C> p;
+
+
+    /**
+     * real decimal roots.
+     */
+    public final List<BigDecimal> real;
+
+
+    /**
+     * univariate polynomial with complex coefficients.
+     */
+    public final GenPolynomial<Complex<C>> cp;
+
+
+    /**
+     * complex decimal roots.
+     */
+    public final List<Complex<BigDecimal>> complex;
+
+
+    /**
+     * Constructor.
+     * @param p univariate polynomial
+     * @param cp univariate complex polynomial
+     * @param r list of real decimal roots
+     * @param c list of complex decimal roots
+     */
+    public DecimalRoots(GenPolynomial<C> p,  GenPolynomial<Complex<C>> cp, List<BigDecimal> r,
+                        List<Complex<BigDecimal>> c) {
+        this.p = p;
+        this.cp = cp;
+        this.real = r;
+        this.complex = c;
+    }
+
+
+    /**
+     * String representation of AlgebraicRoots.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "[" + p + ", real=" + real + ", complex=" + complex + "]";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Interval.
+     */
+    public String toScript() {
+        // Python case
+        StringBuffer sb = new StringBuffer("[");
+        sb.append(p.toScript());
+        if (!real.isEmpty()) {
+            sb.append(", real=[");
+            boolean first = true;
+            for (BigDecimal r : real) {
+                if (first) {
+                    first = false;
+                } else {
+                    sb.append(", ");
+                }
+                sb.append(r.toScript());
+            }
+            sb.append("]");
+        }
+        if (!complex.isEmpty()) {
+            sb.append(", complex=[");
+            boolean first = true;
+            for (Complex<BigDecimal> c : complex) {
+                if (first) {
+                    first = false;
+                } else {
+                    sb.append(", ");
+                }
+                sb.append(c.toScript());
+            }
+            sb.append("]");
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+
+    /**
+     * Copy this.
+     * @return a copy of this.
+     */
+    public DecimalRoots<C> copy() {
+        return new DecimalRoots<C>(p, cp, real, complex);
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (!(b instanceof DecimalRoots)) {
+            return false;
+        }
+        DecimalRoots<C> a = null;
+        try {
+            a = (DecimalRoots<C>) b;
+        } catch (ClassCastException e) {
+            return false;
+        }
+        return p.equals(a.p) && real.equals(a.real) && complex.equals(a.complex);
+    }
+
+
+    /**
+     * Hash code for this AlgebraicRoots.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return (161 * p.hashCode() + 37) * real.hashCode() + complex.hashCode();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/Interval.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/Interval.java
@@ -1,0 +1,259 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.root;
+
+
+import java.io.Serializable;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import edu.jas.arith.BigDecimal;
+import edu.jas.arith.BigRational;
+import edu.jas.arith.Rational;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Interval. For example isolating interval for real roots.
+ * @param <C> coefficient type.
+ * @author Heinz Kredel
+ */
+public class Interval<C extends RingElem<C> & Rational> implements Serializable { //findbugs
+
+
+    /**
+     * left interval border.
+     */
+    public final C left;
+
+
+    /**
+     * right interval border.
+     */
+    public final C right;
+
+
+    /**
+     * Constructor.
+     * @param left interval border.
+     * @param right interval border.
+     */
+    public Interval(C left, C right) {
+        this.left = left;
+        this.right = right;
+    }
+
+
+    /**
+     * Constructor.
+     * @param mid left and right interval border.
+     */
+    public Interval(C mid) {
+        this(mid, mid);
+    }
+
+
+    /**
+     * String representation of Interval.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "[" + left + ", " + right + "]";
+        //return "[" + left.getRational().getDecimal() + ", " + right.getRational().getDecimal() + "]";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Interval.
+     */
+    public String toScript() {
+        // Python case
+        return "[ " + left.toScript() + ", " + right.toScript() + " ]";
+    }
+
+
+    /**
+     * Copy this.
+     * @return a copy of this.
+     */
+    public Interval<C> copy() {
+        return new Interval<C>(left, right);
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (!(b instanceof Interval)) {
+            return false;
+        }
+        Interval<C> a = null;
+        try {
+            a = (Interval<C>) b;
+        } catch (ClassCastException e) {
+            return false;
+        }
+        return left.equals(a.left) && right.equals(a.right);
+    }
+
+
+    /**
+     * Hash code for this Interval.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return 37 * left.hashCode() + right.hashCode();
+    }
+
+
+    /**
+     * Test if an element is contained in this interval.
+     * @param c element to test.
+     * @return true, if left &le; b &le; right;
+     */
+    public boolean contains(C c) {
+        return left.compareTo(c) <= 0 && c.compareTo(right) <= 0;
+    }
+
+
+    /**
+     * Test if an interval is contained in this interval.
+     * @param vc interval to test.
+     * @return true, if left &le; vc.left and vc.right &le; right;
+     */
+    public boolean contains(Interval<C> vc) {
+        return contains(vc.left) && contains(vc.right);
+    }
+
+
+    /**
+     * Length.
+     * @return |left-right|;
+     */
+    public C length() {
+        C m = right.subtract(left);
+        return m.abs();
+    }
+
+
+    /**
+     * BigRational Length.
+     * @return |left-right|;
+     */
+    public BigRational rationalLength() {
+        return length().getRational();
+    }
+
+
+    /**
+     * BigDecimal representation of Interval.
+     */
+    public BigDecimal toDecimal() {
+        BigDecimal l = new BigDecimal(left.getRational());
+        BigDecimal r = new BigDecimal(right.getRational());
+        BigDecimal two = new BigDecimal(2);
+        BigDecimal v = l.sum(r).divide(two);
+        return v;
+    }
+
+
+    /**
+     * Rational middle point.
+     * @return (left+right)/2;
+     */
+    public BigRational rationalMiddle() {
+        BigRational m = left.getRational().sum(right.getRational());
+        BigRational t = new BigRational(1L, 2L);
+        m = m.multiply(t);
+        return m;
+    }
+
+
+    /**
+     * Middle point.
+     * @return (left+right)/2;
+     */
+    public C middle() {
+        C m = left.sum(right);
+        C h = left.factory().parse("1/2");
+        m = m.multiply(h);
+        return m;
+    }
+
+
+    /**
+     * Random point of interval.
+     * @return a random point contained in this interval.
+     */
+    public C randomPoint() {
+        C dr = right.subtract(left);
+        RingFactory<C> fac = (RingFactory<C>) dr.factory();
+        C r = fac.random(13);
+        r = r.abs();
+        if (!r.isZERO()) {
+            if (r.compareTo(fac.getONE()) > 0) {
+                r = r.inverse();
+            }
+        }
+        // 0 <= r <= 1
+        dr = dr.multiply(r);
+        C rv = left.sum(dr);
+        //System.out.println("rv   = " + new BigDecimal(rv.getRational()) );
+        return rv;
+    }
+
+
+    /**
+     * Sum of intervals.
+     * @param o other interval.
+     * @return this+other
+     */
+    public Interval<C> sum(Interval<C> o) {
+        C l = left.sum(o.left);
+        C r = right.sum(o.right);
+        Interval<C> v = new Interval<C>(l, r);
+        return v;
+    }
+
+
+    /**
+     * Subtract intervals.
+     * @param o other interval.
+     * @return this-other
+     */
+    public Interval<C> subtract(Interval<C> o) {
+        C l = left.subtract(o.right);
+        C r = right.subtract(o.left);
+        Interval<C> v = new Interval<C>(l, r);
+        return v;
+    }
+
+
+    /**
+     * Multiply intervals.
+     * @param o other interval.
+     * @return this*other
+     */
+    public Interval<C> multiply(Interval<C> o) {
+        C v1 = left.multiply(o.left);
+        C v2 = left.multiply(o.right);
+        C v3 = right.multiply(o.left);
+        C v4 = right.multiply(o.right);
+        SortedSet<C> so = new TreeSet<C>();
+        so.add(v1); so.add(v2); so.add(v3); so.add(v4);
+        //System.out.println("sorted set = " + so);
+        Interval<C> v = new Interval<C>(so.first(), so.last());
+        return v;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/InvalidBoundaryException.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/InvalidBoundaryException.java
@@ -1,0 +1,36 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.root;
+
+
+/**
+ * Invalid boundary exception class. Exception to be thrown when a valid
+ * boundary cannot be constructed.
+ * @author Heinz Kredel
+ */
+
+public class InvalidBoundaryException extends Exception {
+
+
+    public InvalidBoundaryException() {
+        super("InvalidBoundaryException");
+    }
+
+
+    public InvalidBoundaryException(String c) {
+        super(c);
+    }
+
+
+    public InvalidBoundaryException(String c, Throwable t) {
+        super(c, t);
+    }
+
+
+    public InvalidBoundaryException(Throwable t) {
+        super("InvalidBoundaryException", t);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/NoConvergenceException.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/NoConvergenceException.java
@@ -1,0 +1,36 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.root;
+
+
+/**
+ * No convergence exception class. Exception to be thrown when an iteration does
+ * not converge.
+ * @author Heinz Kredel
+ */
+
+public class NoConvergenceException extends Exception {
+
+
+    public NoConvergenceException() {
+        super("NoConvergenceException");
+    }
+
+
+    public NoConvergenceException(String c) {
+        super(c);
+    }
+
+
+    public NoConvergenceException(String c, Throwable t) {
+        super(c, t);
+    }
+
+
+    public NoConvergenceException(Throwable t) {
+        super("NoConvergenceException", t);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/PolyUtilRoot.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/PolyUtilRoot.java
@@ -1,0 +1,452 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.root;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.arith.Rational;
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.AlgebraicNumberRing;
+import edu.jas.poly.Complex;
+import edu.jas.poly.ComplexRing;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.structure.UnaryFunctor;
+
+
+/**
+ * Polynomial utilities related to real and complex roots.
+ * @author Heinz Kredel
+ */
+
+public class PolyUtilRoot {
+
+
+    private static final Logger logger = LogManager.getLogger(PolyUtilRoot.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Convert to RealAlgebraicNumber coefficients. Represent as polynomial with
+     * RealAlgebraicNumber<C> coefficients, C is e.g. ModInteger or BigRational.
+     * @param pfac result polynomial factory.
+     * @param A polynomial with C coefficients to be converted.
+     * @return polynomial with RealAlgebraicNumber&lt;C&gt; coefficients.
+     */
+    public static <C extends GcdRingElem<C> & Rational> GenPolynomial<RealAlgebraicNumber<C>> convertToAlgebraicCoefficients(
+                    GenPolynomialRing<RealAlgebraicNumber<C>> pfac, GenPolynomial<C> A) {
+        RealAlgebraicRing<C> afac = (RealAlgebraicRing<C>) pfac.coFac;
+        if (debug) {
+            logger.info("afac = " + afac);
+        }
+        return PolyUtil.<C, RealAlgebraicNumber<C>> map(pfac, A, new CoeffToReAlg<C>(afac));
+    }
+
+
+    /**
+     * Convert to recursive RealAlgebraicNumber coefficients. Represent as
+     * polynomial with recursive RealAlgebraicNumber<C> coefficients, C is e.g.
+     * ModInteger or BigRational.
+     * @param depth recursion depth of RealAlgebraicNumber coefficients.
+     * @param pfac result polynomial factory.
+     * @param A polynomial with C coefficients to be converted.
+     * @return polynomial with RealAlgebraicNumber&lt;C&gt; coefficients.
+     */
+    public static <C extends GcdRingElem<C> & Rational> GenPolynomial<RealAlgebraicNumber<C>> convertToRecAlgebraicCoefficients(
+                    int depth, GenPolynomialRing<RealAlgebraicNumber<C>> pfac, GenPolynomial<C> A) {
+        RealAlgebraicRing<C> afac = (RealAlgebraicRing<C>) pfac.coFac;
+        return PolyUtil.<C, RealAlgebraicNumber<C>> map(pfac, A, new CoeffToRecReAlg<C>(depth, afac));
+    }
+
+
+    /**
+     * Convert to RealAlgebraicNumber coefficients. Represent as polynomial with
+     * RealAlgebraicNumber<C> coefficients, C is e.g. ModInteger or BigRational.
+     * @param pfac result polynomial factory.
+     * @param A recursive polynomial with GenPolynomial&lt;BigInteger&gt;
+     *            coefficients to be converted.
+     * @return polynomial with RealAlgebraicNumber&lt;C&gt; coefficients.
+     */
+    public static <C extends GcdRingElem<C> & Rational> GenPolynomial<RealAlgebraicNumber<C>> convertRecursiveToAlgebraicCoefficients(
+                    GenPolynomialRing<RealAlgebraicNumber<C>> pfac, GenPolynomial<GenPolynomial<C>> A) {
+        RealAlgebraicRing<C> afac = (RealAlgebraicRing<C>) pfac.coFac;
+        return PolyUtil.<GenPolynomial<C>, RealAlgebraicNumber<C>> map(pfac, A, new PolyToReAlg<C>(afac));
+    }
+
+
+    /**
+     * Convert to AlgebraicNumber coefficients. Represent as polynomial with
+     * AlgebraicNumber<C> coefficients.
+     * @param afac result polynomial factory.
+     * @param A polynomial with RealAlgebraicNumber&lt;C&gt; coefficients to be
+     *            converted.
+     * @return polynomial with AlgebraicNumber&lt;C&gt; coefficients.
+     */
+    public static <C extends GcdRingElem<C> & Rational> GenPolynomial<AlgebraicNumber<C>> algebraicFromRealCoefficients(
+                    GenPolynomialRing<AlgebraicNumber<C>> afac, GenPolynomial<RealAlgebraicNumber<C>> A) {
+        AlgebraicNumberRing<C> cfac = (AlgebraicNumberRing<C>) afac.coFac;
+        return PolyUtil.<RealAlgebraicNumber<C>, AlgebraicNumber<C>> map(afac, A,
+                        new AlgFromRealCoeff<C>(cfac));
+    }
+
+
+    /**
+     * Convert to RealAlgebraicNumber coefficients. Represent as polynomial with
+     * RealAlgebraicNumber<C> coefficients.
+     * @param rfac result polynomial factory.
+     * @param A polynomial with AlgebraicNumber&lt;C&gt; coefficients to be
+     *            converted.
+     * @return polynomial with RealAlgebraicNumber&lt;C&gt; coefficients.
+     */
+    public static <C extends GcdRingElem<C> & Rational> GenPolynomial<RealAlgebraicNumber<C>> realFromAlgebraicCoefficients(
+                    GenPolynomialRing<RealAlgebraicNumber<C>> rfac, GenPolynomial<AlgebraicNumber<C>> A) {
+        RealAlgebraicRing<C> cfac = (RealAlgebraicRing<C>) rfac.coFac;
+        return PolyUtil.<AlgebraicNumber<C>, RealAlgebraicNumber<C>> map(rfac, A,
+                        new RealFromAlgCoeff<C>(cfac));
+    }
+
+
+    /**
+     * Convert to RealAlgebraicNumber coefficients. Represent as polynomial with
+     * RealAlgebraicNumber<C> coefficients, C is e.g. BigRational.
+     * @param pfac result polynomial factory.
+     * @param A polynomial with C coefficients to be converted.
+     * @return polynomial with RealAlgebraicNumber&lt;C&gt; coefficients.
+     */
+    public static <C extends GcdRingElem<C> & Rational> GenPolynomial<RealAlgebraicNumber<C>> convertToRealCoefficients(
+                    GenPolynomialRing<RealAlgebraicNumber<C>> pfac, GenPolynomial<C> A) {
+        RealAlgebraicRing<C> afac = (RealAlgebraicRing<C>) pfac.coFac;
+        return PolyUtil.<C, RealAlgebraicNumber<C>> map(pfac, A, new CoeffToReal<C>(afac));
+    }
+
+
+    /**
+     * Convert to ComplexAlgebraicNumber coefficients. Represent as polynomial
+     * with ComplexAlgebraicNumber<C> coefficients, C is e.g. BigRational.
+     * @param pfac result polynomial factory.
+     * @param A polynomial with C coefficients to be converted.
+     * @return polynomial with ComplexAlgebraicNumber&lt;C&gt; coefficients.
+     */
+    public static <C extends GcdRingElem<C> & Rational> GenPolynomial<ComplexAlgebraicNumber<C>> convertToComplexCoefficients(
+                    GenPolynomialRing<ComplexAlgebraicNumber<C>> pfac, GenPolynomial<C> A) {
+        ComplexAlgebraicRing<C> afac = (ComplexAlgebraicRing<C>) pfac.coFac;
+        return PolyUtil.<C, ComplexAlgebraicNumber<C>> map(pfac, A, new CoeffToComplex<C>(afac));
+    }
+
+
+    /**
+     * Convert to ComplexAlgebraicNumber coefficients. Represent as polynomial
+     * with ComplexAlgebraicNumber<C> coefficients, C is e.g. BigRational.
+     * @param pfac result polynomial factory.
+     * @param A polynomial with C coefficients to be converted.
+     * @return polynomial with ComplexAlgebraicNumber&lt;C&gt; coefficients.
+     */
+    public static <C extends GcdRingElem<C> & Rational> GenPolynomial<ComplexAlgebraicNumber<C>> convertToComplexCoefficientsFromComplex(
+                    GenPolynomialRing<ComplexAlgebraicNumber<C>> pfac, GenPolynomial<Complex<C>> A) {
+        ComplexAlgebraicRing<C> afac = (ComplexAlgebraicRing<C>) pfac.coFac;
+        return PolyUtil.<Complex<C>, ComplexAlgebraicNumber<C>> map(pfac, A,
+                        new CoeffToComplexFromComplex<C>(afac));
+    }
+
+
+    /**
+     * Convert to Complex coefficients. Represent as polynomial
+     * with Complex&lt;C&gt; coefficients.
+     * @param f univariate polynomial.
+     * @return f with complex coefficients
+     */
+    public static <C extends GcdRingElem<C> & Rational> 
+           GenPolynomial<Complex<C>> complexFromAny(GenPolynomial<C> f) {
+        if (f.ring.coFac instanceof ComplexRing) {
+            throw new IllegalArgumentException("f already has ComplexRing coefficients " + f.ring);
+        }
+        if (f.ring.coFac instanceof ComplexAlgebraicRing) {
+            throw new UnsupportedOperationException(
+                            "unsupported ComplexAlgebraicRing coefficients " + f.ring);
+        }
+        ComplexRing<C> cr = new ComplexRing<C>(f.ring.coFac);
+        GenPolynomialRing<Complex<C>> fac = new GenPolynomialRing<Complex<C>>(cr, f.ring);
+        GenPolynomial<Complex<C>> fc = PolyUtil.<C> complexFromAny(fac, f);
+        return fc;
+    }
+}
+
+
+/**
+ * Polynomial to algebraic functor.
+ */
+class PolyToReAlg<C extends GcdRingElem<C> & Rational>
+                implements UnaryFunctor<GenPolynomial<C>, RealAlgebraicNumber<C>> {
+
+
+    final protected RealAlgebraicRing<C> afac;
+
+
+    public PolyToReAlg(RealAlgebraicRing<C> fac) {
+        if (fac == null) {
+            throw new IllegalArgumentException("fac must not be null");
+        }
+        afac = fac;
+    }
+
+
+    public RealAlgebraicNumber<C> eval(GenPolynomial<C> c) {
+        if (c == null) {
+            return afac.getZERO();
+        }
+        return new RealAlgebraicNumber<C>(afac, c);
+    }
+}
+
+
+/**
+ * Coefficient to algebraic functor.
+ */
+class CoeffToReAlg<C extends GcdRingElem<C> & Rational> implements UnaryFunctor<C, RealAlgebraicNumber<C>> {
+
+
+    final protected RealAlgebraicRing<C> afac;
+
+
+    final protected GenPolynomial<C> zero;
+
+
+    public CoeffToReAlg(RealAlgebraicRing<C> fac) {
+        if (fac == null) {
+            throw new IllegalArgumentException("fac must not be null");
+        }
+        afac = fac;
+        GenPolynomialRing<C> pfac = afac.algebraic.ring;
+        zero = pfac.getZERO();
+    }
+
+
+    public RealAlgebraicNumber<C> eval(C c) {
+        if (c == null) {
+            return afac.getZERO();
+        }
+        return new RealAlgebraicNumber<C>(afac, zero.sum(c));
+    }
+}
+
+
+/**
+ * Coefficient to recursive algebraic functor.
+ */
+class CoeffToRecReAlg<C extends GcdRingElem<C> & Rational>
+                implements UnaryFunctor<C, RealAlgebraicNumber<C>> {
+
+
+    final protected List<RealAlgebraicRing<C>> lfac;
+
+
+    final int depth;
+
+
+    @SuppressWarnings({ "unchecked", "cast" })
+    public CoeffToRecReAlg(int depth, RealAlgebraicRing<C> fac) {
+        if (fac == null) {
+            throw new IllegalArgumentException("fac must not be null");
+        }
+        RealAlgebraicRing<C> afac = fac;
+        this.depth = depth;
+        lfac = new ArrayList<RealAlgebraicRing<C>>(this.depth);
+        lfac.add(fac);
+        for (int i = 1; i < this.depth; i++) {
+            RingFactory<C> rf = afac.algebraic.ring.coFac;
+            if (!(rf instanceof RealAlgebraicRing)) {
+                throw new IllegalArgumentException("fac depth to low");
+            }
+            afac = (RealAlgebraicRing<C>) (Object) rf;
+            lfac.add(afac);
+        }
+    }
+
+
+    @SuppressWarnings("unchecked")
+    public RealAlgebraicNumber<C> eval(C c) {
+        if (c == null) {
+            return lfac.get(0).getZERO();
+        }
+        C ac = c;
+        RealAlgebraicRing<C> af = lfac.get(lfac.size() - 1);
+        GenPolynomial<C> zero = af.algebraic.ring.getZERO();
+        RealAlgebraicNumber<C> an = new RealAlgebraicNumber<C>(af, zero.sum(ac));
+        for (int i = lfac.size() - 2; i >= 0; i--) {
+            af = lfac.get(i);
+            zero = af.algebraic.ring.getZERO();
+            ac = (C) (Object) an;
+            an = new RealAlgebraicNumber<C>(af, zero.sum(ac));
+        }
+        return an;
+    }
+}
+
+
+/**
+ * Coefficient to algebraic from real algebraic functor.
+ */
+class AlgFromRealCoeff<C extends GcdRingElem<C> & Rational>
+                implements UnaryFunctor<RealAlgebraicNumber<C>, AlgebraicNumber<C>> {
+
+
+    final protected AlgebraicNumberRing<C> afac;
+
+
+    public AlgFromRealCoeff(AlgebraicNumberRing<C> fac) {
+        if (fac == null) {
+            throw new IllegalArgumentException("fac must not be null");
+        }
+        afac = fac;
+    }
+
+
+    public AlgebraicNumber<C> eval(RealAlgebraicNumber<C> c) {
+        if (c == null) {
+            return afac.getZERO();
+        }
+        return c.number;
+    }
+}
+
+
+/**
+ * Coefficient to real algebriac from algebraic functor.
+ */
+class RealFromAlgCoeff<C extends GcdRingElem<C> & Rational>
+                implements UnaryFunctor<AlgebraicNumber<C>, RealAlgebraicNumber<C>> {
+
+
+    final protected RealAlgebraicRing<C> rfac;
+
+
+    public RealFromAlgCoeff(RealAlgebraicRing<C> fac) {
+        if (fac == null) {
+            throw new IllegalArgumentException("fac must not be null");
+        }
+        rfac = fac;
+    }
+
+
+    public RealAlgebraicNumber<C> eval(AlgebraicNumber<C> c) {
+        if (c == null) {
+            return rfac.getZERO();
+        }
+        return new RealAlgebraicNumber<C>(rfac, c);
+    }
+}
+
+
+/**
+ * Coefficient to real algebraic functor.
+ */
+class CoeffToReal<C extends GcdRingElem<C> & Rational> implements UnaryFunctor<C, RealAlgebraicNumber<C>> {
+
+
+    final protected RealAlgebraicRing<C> rfac;
+
+
+    final protected AlgebraicNumber<C> zero;
+
+
+    public CoeffToReal(RealAlgebraicRing<C> fac) {
+        if (fac == null) {
+            throw new IllegalArgumentException("fac must not be null");
+        }
+        rfac = fac;
+        AlgebraicNumberRing<C> afac = rfac.algebraic;
+        zero = afac.getZERO();
+    }
+
+
+    public RealAlgebraicNumber<C> eval(C c) {
+        if (c == null) {
+            return rfac.getZERO();
+        }
+        return new RealAlgebraicNumber<C>(rfac, zero.sum(c));
+    }
+}
+
+
+/**
+ * Coefficient to complex algebraic functor.
+ */
+class CoeffToComplex<C extends GcdRingElem<C> & Rational>
+                implements UnaryFunctor<C, ComplexAlgebraicNumber<C>> {
+
+
+    final protected ComplexAlgebraicRing<C> cfac;
+
+
+    final protected AlgebraicNumber<Complex<C>> zero;
+
+
+    final protected ComplexRing<C> cr;
+
+
+    public CoeffToComplex(ComplexAlgebraicRing<C> fac) {
+        if (fac == null) {
+            throw new IllegalArgumentException("fac must not be null");
+        }
+        cfac = fac;
+        AlgebraicNumberRing<Complex<C>> afac = cfac.algebraic;
+        zero = afac.getZERO();
+        cr = (ComplexRing<C>) afac.ring.coFac;
+    }
+
+
+    public ComplexAlgebraicNumber<C> eval(C c) {
+        if (c == null) {
+            return cfac.getZERO();
+        }
+        return new ComplexAlgebraicNumber<C>(cfac, zero.sum(new Complex<C>(cr, c)));
+    }
+}
+
+
+/**
+ * Coefficient to complex algebraic from complex functor.
+ */
+class CoeffToComplexFromComplex<C extends GcdRingElem<C> & Rational>
+                implements UnaryFunctor<Complex<C>, ComplexAlgebraicNumber<C>> {
+
+
+    final protected ComplexAlgebraicRing<C> cfac;
+
+
+    final protected AlgebraicNumber<Complex<C>> zero;
+
+
+    //final protected ComplexRing<C> cr;
+
+
+    public CoeffToComplexFromComplex(ComplexAlgebraicRing<C> fac) {
+        if (fac == null) {
+            throw new IllegalArgumentException("fac must not be null");
+        }
+        cfac = fac;
+        AlgebraicNumberRing<Complex<C>> afac = cfac.algebraic;
+        zero = afac.getZERO();
+        //cr = (ComplexRing<C>) afac.ring.coFac;
+    }
+
+
+    public ComplexAlgebraicNumber<C> eval(Complex<C> c) {
+        if (c == null) {
+            return cfac.getZERO();
+        }
+        return new ComplexAlgebraicNumber<C>(cfac, zero.sum(c));
+    }
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/RealAlgebraicNumber.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/RealAlgebraicNumber.java
@@ -1,0 +1,476 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.root;
+
+
+import java.math.BigInteger;
+
+import edu.jas.arith.BigDecimal;
+import edu.jas.arith.BigRational;
+import edu.jas.arith.Rational;
+import edu.jas.kern.PrettyPrint;
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.NotInvertibleException;
+
+
+/**
+ * Real algebraic number class based on AlgebraicNumber. Objects of this class
+ * are immutable.
+ * @author Heinz Kredel
+ */
+
+public class RealAlgebraicNumber<C extends GcdRingElem<C> & Rational>
+                /*extends AlgebraicNumber<C>*/
+                implements GcdRingElem<RealAlgebraicNumber<C>>, Rational {
+
+
+    /**
+     * Representing AlgebraicNumber.
+     */
+    public final AlgebraicNumber<C> number;
+
+
+    /**
+     * Ring part of the data structure.
+     */
+    public final RealAlgebraicRing<C> ring;
+
+
+    /**
+     * The constructor creates a RealAlgebraicNumber object from
+     * RealAlgebraicRing modul and a GenPolynomial value.
+     * @param r ring RealAlgebraicRing<C>.
+     * @param a value GenPolynomial<C>.
+     */
+    public RealAlgebraicNumber(RealAlgebraicRing<C> r, GenPolynomial<C> a) {
+        number = new AlgebraicNumber<C>(r.algebraic, a);
+        ring = r;
+    }
+
+
+    /**
+     * The constructor creates a RealAlgebraicNumber object from
+     * RealAlgebraicRing modul and a AlgebraicNumber value.
+     * @param r ring RealAlgebraicRing<C>.
+     * @param a value AlgebraicNumber<C>.
+     */
+    public RealAlgebraicNumber(RealAlgebraicRing<C> r, AlgebraicNumber<C> a) {
+        number = a;
+        ring = r;
+    }
+
+
+    /**
+     * The constructor creates a RealAlgebraicNumber object from a GenPolynomial
+     * object module.
+     * @param r ring RealAlgebraicRing<C>.
+     */
+    public RealAlgebraicNumber(RealAlgebraicRing<C> r) {
+        this(r, r.algebraic.getZERO());
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public RealAlgebraicRing<C> factory() {
+        return ring;
+    }
+
+
+    /**
+     * Copy this.
+     * @see edu.jas.structure.Element#copy()
+     */
+    @Override
+    public RealAlgebraicNumber<C> copy() {
+        return new RealAlgebraicNumber<C>(ring, number);
+    }
+
+
+    /**
+     * Return a BigRational approximation of this Element.
+     * @return a BigRational approximation of this.
+     * @see edu.jas.arith.Rational#getRational()
+     */
+    public BigRational getRational() {
+        return magnitude();
+    }
+
+
+    /**
+     * Is RealAlgebraicNumber zero.
+     * @return If this is 0 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isZERO()
+     */
+    public boolean isZERO() {
+        return number.isZERO();
+        //return magnitude().isZERO();
+    }
+
+
+    /**
+     * Is RealAlgebraicNumber one.
+     * @return If this is 1 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isONE()
+     */
+    public boolean isONE() {
+        return number.isONE();
+    }
+
+
+    /**
+     * Is RealAlgebraicNumber unit.
+     * @return If this is a unit then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isUnit()
+     */
+    public boolean isUnit() {
+        return number.isUnit();
+    }
+
+
+    /**
+     * Is RealAlgebraicNumber a root of unity.
+     * @return true if |this**i| == 1, for some 0 &lt; i &le; deg(modul), else
+     *         false.
+     */
+    public boolean isRootOfUnity() {
+        return number.isRootOfUnity();
+    }
+
+
+    /**
+     * Get the String representation as RingElem.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        if (PrettyPrint.isTrue()) {
+            return "{ " + number.toString() + " }";
+        }
+        return "Real" + number.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        return number.toScript();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python case
+        return factory().toScript();
+    }
+
+
+    /**
+     * RealAlgebraicNumber comparison.
+     * @param b RealAlgebraicNumber.
+     * @return real sign(this-b).
+     */
+    @Override
+    public int compareTo(RealAlgebraicNumber<C> b) {
+        int s = 0;
+        if (number.ring != b.number.ring) { // avoid compareTo if possible
+            s = number.ring.modul.compareTo(b.number.ring.modul);
+            System.out.println("s_mod = " + s);
+        }
+        if (s != 0) {
+            return s;
+        }
+        s = this.subtract(b).signum(); // avoid subtract if possible
+        //System.out.println("s_real = " + s);
+        return s;
+    }
+
+
+    /**
+     * RealAlgebraicNumber comparison.
+     * @param b AlgebraicNumber.
+     * @return polynomial sign(this-b).
+     */
+    public int compareTo(AlgebraicNumber<C> b) {
+        int s = number.compareTo(b);
+        System.out.println("s_algeb = " + s);
+        return s;
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (b == null) {
+            return false;
+        }
+        if (!(b instanceof RealAlgebraicNumber)) {
+            return false;
+        }
+        RealAlgebraicNumber<C> a = (RealAlgebraicNumber<C>) b;
+        if (!ring.equals(a.ring)) {
+            return false;
+        }
+        return number.equals(a.number);
+    }
+
+
+    /**
+     * Hash code for this RealAlgebraicNumber.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return 37 * number.val.hashCode() + ring.hashCode();
+    }
+
+
+    /**
+     * RealAlgebraicNumber absolute value.
+     * @return the absolute value of this.
+     * @see edu.jas.structure.RingElem#abs()
+     */
+    public RealAlgebraicNumber<C> abs() {
+        if (this.signum() < 0) {
+            return new RealAlgebraicNumber<C>(ring, number.negate());
+        }
+        return this;
+    }
+
+
+    /**
+     * RealAlgebraicNumber summation.
+     * @param S RealAlgebraicNumber.
+     * @return this+S.
+     */
+    public RealAlgebraicNumber<C> sum(RealAlgebraicNumber<C> S) {
+        return new RealAlgebraicNumber<C>(ring, number.sum(S.number));
+    }
+
+
+    /**
+     * RealAlgebraicNumber summation.
+     * @param c coefficient.
+     * @return this+c.
+     */
+    public RealAlgebraicNumber<C> sum(GenPolynomial<C> c) {
+        return new RealAlgebraicNumber<C>(ring, number.sum(c));
+    }
+
+
+    /**
+     * RealAlgebraicNumber summation.
+     * @param c polynomial.
+     * @return this+c.
+     */
+    public RealAlgebraicNumber<C> sum(C c) {
+        return new RealAlgebraicNumber<C>(ring, number.sum(c));
+    }
+
+
+    /**
+     * RealAlgebraicNumber negate.
+     * @return -this.
+     * @see edu.jas.structure.RingElem#negate()
+     */
+    public RealAlgebraicNumber<C> negate() {
+        return new RealAlgebraicNumber<C>(ring, number.negate());
+    }
+
+
+    /**
+     * RealAlgebraicNumber signum. <b>Note: </b> Modifies ring.root eventually.
+     * @see edu.jas.structure.RingElem#signum()
+     * @return real signum(this).
+     */
+    public int signum() {
+        Interval<C> v = ring.engine.invariantSignInterval(ring.root, ring.algebraic.modul, number.val);
+        ring.setRoot(v);
+        return ring.engine.realIntervalSign(v, ring.algebraic.modul, number.val);
+    }
+
+
+    /**
+     * RealAlgebraicNumber half interval.
+     */
+    public void halfInterval() {
+        Interval<C> v = ring.engine.halfInterval(ring.root, ring.algebraic.modul);
+        //System.out.println("old v = " + ring.root + ", new v = " + v);
+        ring.setRoot(v);
+    }
+
+
+    /**
+     * RealAlgebraicNumber floor.
+     * @return floor of this.
+     */
+    public BigInteger floor() {
+        BigRational f = magnitude();
+        BigInteger fi = f.floor(); // todo: ensure int not in interval
+        return fi;
+    }
+
+
+    /**
+     * RealAlgebraicNumber magnitude.
+     * @return |this|.
+     */
+    public BigRational magnitude() {
+        Interval<C> v = ring.engine.invariantMagnitudeInterval(ring.root, ring.algebraic.modul, number.val,
+                        ring.getEps());
+        //System.out.println("old v = " + ring.root + ", new v = " + v);
+        ring.setRoot(v);
+        C ev = ring.engine.realIntervalMagnitude(v, ring.algebraic.modul, number.val); //, ring.eps);
+        //Interval<C> ev = ring.engine.realIntervalMagnitudeInterval(v, ring.algebraic.modul, number.val);
+        BigRational er = ev.getRational(); //middle().
+        return er;
+    }
+
+
+    /**
+     * RealAlgebraicNumber magnitude.
+     * @return |this| as big decimal.
+     */
+    public BigDecimal decimalMagnitude() {
+        return new BigDecimal(magnitude());
+    }
+
+
+    /**
+     * RealAlgebraicNumber subtraction.
+     * @param S RealAlgebraicNumber.
+     * @return this-S.
+     */
+    public RealAlgebraicNumber<C> subtract(RealAlgebraicNumber<C> S) {
+        return new RealAlgebraicNumber<C>(ring, number.subtract(S.number));
+    }
+
+
+    /**
+     * RealAlgebraicNumber division.
+     * @param S RealAlgebraicNumber.
+     * @return this/S.
+     */
+    public RealAlgebraicNumber<C> divide(RealAlgebraicNumber<C> S) {
+        return multiply(S.inverse());
+    }
+
+
+    /**
+     * RealAlgebraicNumber inverse.
+     * @see edu.jas.structure.RingElem#inverse()
+     * @throws NotInvertibleException if the element is not invertible.
+     * @return S with S = 1/this if defined.
+     */
+    public RealAlgebraicNumber<C> inverse() {
+        return new RealAlgebraicNumber<C>(ring, number.inverse());
+    }
+
+
+    /**
+     * RealAlgebraicNumber remainder.
+     * @param S RealAlgebraicNumber.
+     * @return this - (this/S)*S.
+     */
+    public RealAlgebraicNumber<C> remainder(RealAlgebraicNumber<C> S) {
+        return new RealAlgebraicNumber<C>(ring, number.remainder(S.number));
+    }
+
+
+    /**
+     * Quotient and remainder by division of this by S.
+     * @param S a RealAlgebraicNumber
+     * @return [this/S, this - (this/S)*S].
+     */
+    @SuppressWarnings("unchecked")
+    public RealAlgebraicNumber<C>[] quotientRemainder(RealAlgebraicNumber<C> S) {
+        return new RealAlgebraicNumber[] { divide(S), remainder(S) };
+    }
+
+
+    /**
+     * RealAlgebraicNumber multiplication.
+     * @param S RealAlgebraicNumber.
+     * @return this*S.
+     */
+    public RealAlgebraicNumber<C> multiply(RealAlgebraicNumber<C> S) {
+        return new RealAlgebraicNumber<C>(ring, number.multiply(S.number));
+    }
+
+
+    /**
+     * RealAlgebraicNumber multiplication.
+     * @param c coefficient.
+     * @return this*c.
+     */
+    public RealAlgebraicNumber<C> multiply(C c) {
+        return new RealAlgebraicNumber<C>(ring, number.multiply(c));
+    }
+
+
+    /**
+     * RealAlgebraicNumber multiplication.
+     * @param c polynomial.
+     * @return this*c.
+     */
+    public RealAlgebraicNumber<C> multiply(GenPolynomial<C> c) {
+        return new RealAlgebraicNumber<C>(ring, number.multiply(c));
+    }
+
+
+    /**
+     * RealAlgebraicNumber monic.
+     * @return this with monic value part.
+     */
+    public RealAlgebraicNumber<C> monic() {
+        return new RealAlgebraicNumber<C>(ring, number.monic());
+    }
+
+
+    /**
+     * RealAlgebraicNumber greatest common divisor.
+     * @param S RealAlgebraicNumber.
+     * @return gcd(this,S).
+     */
+    public RealAlgebraicNumber<C> gcd(RealAlgebraicNumber<C> S) {
+        return new RealAlgebraicNumber<C>(ring, number.gcd(S.number));
+    }
+
+
+    /**
+     * RealAlgebraicNumber extended greatest common divisor.
+     * @param S RealAlgebraicNumber.
+     * @return [ gcd(this,S), a, b ] with a*this + b*S = gcd(this,S).
+     */
+    @SuppressWarnings("unchecked")
+    public RealAlgebraicNumber<C>[] egcd(RealAlgebraicNumber<C> S) {
+        AlgebraicNumber<C>[] aret = number.egcd(S.number);
+        RealAlgebraicNumber<C>[] ret = new RealAlgebraicNumber[3];
+        ret[0] = new RealAlgebraicNumber<C>(ring, aret[0]);
+        ret[1] = new RealAlgebraicNumber<C>(ring, aret[1]);
+        ret[2] = new RealAlgebraicNumber<C>(ring, aret[2]);
+        return ret;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/RealAlgebraicRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/RealAlgebraicRing.java
@@ -1,0 +1,417 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.root;
+
+
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import edu.jas.arith.BigDecimal;
+import edu.jas.arith.BigRational;
+import edu.jas.arith.Rational;
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.AlgebraicNumberRing;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Real algebraic number factory class based on AlgebraicNumberRing with
+ * RingFactory interface. Objects of this class are immutable with the exception
+ * of the isolating intervals.
+ * @author Heinz Kredel
+ */
+
+public class RealAlgebraicRing<C extends GcdRingElem<C> & Rational>
+                /*extends AlgebraicNumberRing<C>*/
+                implements RingFactory<RealAlgebraicNumber<C>> {
+
+
+    /**
+     * Representing AlgebraicNumberRing.
+     */
+    public final AlgebraicNumberRing<C> algebraic;
+
+
+    /**
+     * Isolating interval for a real root. <b>Note: </b> interval may shrink
+     * eventually.
+     */
+    /*package*/Interval<C> root;
+
+
+    /**
+     * Precision of the isolating rectangle for a complex root.
+     */
+    public static final int PRECISION = BigDecimal.DEFAULT_PRECISION;
+
+
+    /**
+     * Precision of the isolating interval for a real root.
+     */
+    protected BigRational eps;
+
+
+    /**
+     * Real root computation engine.
+     */
+    public final RealRootsSturm<C> engine;
+
+
+    /**
+     * The constructor creates a RealAlgebraicNumber factory object from a
+     * GenPolynomial objects module.
+     * @param m module GenPolynomial<C>.
+     * @param root isolating interval for a real root.
+     */
+    public RealAlgebraicRing(GenPolynomial<C> m, Interval<C> root) {
+        algebraic = new AlgebraicNumberRing<C>(m);
+        this.root = root;
+        engine = new RealRootsSturm<C>();
+        if (m.ring.characteristic().signum() > 0) {
+            throw new RuntimeException("characteristic not zero");
+        }
+        BigRational e = new BigRational(10L); //m.ring.coFac.fromInteger(10L);
+        e = e.power(-PRECISION / 2); // better not too much for speed
+        eps = e; //BigRational.ONE; // initially
+    }
+
+
+    /**
+     * The constructor creates a RealAlgebraicNumber factory object from a
+     * GenPolynomial objects module.
+     * @param m module GenPolynomial.
+     * @param root isolating interval for a real root.
+     * @param isField indicator if m is prime.
+     */
+    public RealAlgebraicRing(GenPolynomial<C> m, Interval<C> root, boolean isField) {
+        this(m, root);
+        setField(isField);
+    }
+
+
+    /**
+     * Get the interval for the real root. <b>Note:</b> interval may shrink
+     * later.
+     * @return real root isolating interval
+     */
+    public synchronized Interval<C> getRoot() {
+        return root;
+    }
+
+
+    /**
+     * Set a refined interval for the real root. <b>Note: </b> interval may
+     * shrink eventually.
+     * @param v interval.
+     */
+    public synchronized void setRoot(Interval<C> v) {
+        assert root.contains(v) : "root contains v";
+        this.root = v;
+    }
+
+
+    /**
+     * Get the epsilon.
+     * @return eps.
+     */
+    public synchronized BigRational getEps() {
+        return this.eps;
+    }
+
+
+    /**
+     * Set a new epsilon.
+     * @param e epsilon.
+     */
+    public synchronized void setEps(C e) {
+        setEps(e.getRational());
+    }
+
+
+    /**
+     * Set a new epsilon.
+     * @param e epsilon.
+     */
+    public synchronized void setEps(BigRational e) {
+        this.eps = e; //algebraic.ring.coFac.parse(e.toString());
+    }
+
+
+    /**
+     * Refine root.
+     */
+    public synchronized void refineRoot() {
+        refineRoot(eps);
+    }
+
+
+    /**
+     * Refine root.
+     * @param e epsilon.
+     */
+    public synchronized void refineRoot(BigRational e) {
+        root = engine.refineInterval(root, algebraic.modul, e);
+        eps = e;
+    }
+
+
+    /**
+     * RealAlgebraicRing half interval.
+     */
+    public void halfInterval() {
+        Interval<C> v = engine.halfInterval(root, algebraic.modul);
+        //System.out.println("old v = " + ring.root + ", new v = " + v);
+        setRoot(v);
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite()
+     */
+    public boolean isFinite() {
+        return algebraic.isFinite();
+    }
+
+
+    /**
+     * Copy RealAlgebraicNumber element c.
+     * @param c
+     * @return a copy of c.
+     */
+    public RealAlgebraicNumber<C> copy(RealAlgebraicNumber<C> c) {
+        return new RealAlgebraicNumber<C>(this, c.number);
+    }
+
+
+    /**
+     * Copy this RealAlgebraicRing.
+     * @return a copy of this.
+     */
+    public RealAlgebraicRing<C> copy() {
+        if (algebraic.isField()) {
+            return new RealAlgebraicRing<C>(algebraic.modul, root, algebraic.isField());
+        }
+        return new RealAlgebraicRing<C>(algebraic.modul, root);
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as RealAlgebraicNumber.
+     */
+    public RealAlgebraicNumber<C> getZERO() {
+        return new RealAlgebraicNumber<C>(this, algebraic.getZERO());
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as RealAlgebraicNumber.
+     */
+    public RealAlgebraicNumber<C> getONE() {
+        return new RealAlgebraicNumber<C>(this, algebraic.getONE());
+    }
+
+
+    /**
+     * Get the generating element.
+     * @return alpha as RealAlgebraicNumber.
+     */
+    public RealAlgebraicNumber<C> getGenerator() {
+        return new RealAlgebraicNumber<C>(this, algebraic.getGenerator());
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     * @see edu.jas.structure.ElemFactory#generators()
+     */
+    public List<RealAlgebraicNumber<C>> generators() {
+        List<AlgebraicNumber<C>> agens = algebraic.generators();
+        List<RealAlgebraicNumber<C>> gens = new ArrayList<RealAlgebraicNumber<C>>(agens.size());
+        for (AlgebraicNumber<C> a : agens) {
+            gens.add(getZERO().sum(a.getVal()));
+        }
+        return gens;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true if this ring is commutative, else false.
+     */
+    public boolean isCommutative() {
+        return algebraic.isCommutative();
+    }
+
+
+    /**
+     * Query if this ring is associative.
+     * @return true if this ring is associative, else false.
+     */
+    public boolean isAssociative() {
+        return algebraic.isAssociative();
+    }
+
+
+    /**
+     * Query if this ring is a field.
+     * @return true if algebraic is prime, else false.
+     */
+    public boolean isField() {
+        return algebraic.isField();
+    }
+
+
+    /**
+     * Assert that this ring is a field.
+     * @param isField true if this ring is a field, else false.
+     */
+    public void setField(boolean isField) {
+        algebraic.setField(isField);
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic() {
+        return algebraic.characteristic();
+    }
+
+
+    /**
+     * Get a RealAlgebraicNumber element from a BigInteger value.
+     * @param a BigInteger.
+     * @return a RealAlgebraicNumber.
+     */
+    public RealAlgebraicNumber<C> fromInteger(java.math.BigInteger a) {
+        return new RealAlgebraicNumber<C>(this, algebraic.fromInteger(a));
+    }
+
+
+    /**
+     * Get a RealAlgebraicNumber element from a BigRational value.
+     * @param a BigRational.
+     * @return a RealAlgebraicNumber.
+     */
+    public RealAlgebraicNumber<C> fromRational(BigRational a) {
+        return new RealAlgebraicNumber<C>(this, algebraic.parse(a.toString()));
+    }
+
+
+    /**
+     * Get a RealAlgebraicNumber element from a long value.
+     * @param a long.
+     * @return a RealAlgebraicNumber.
+     */
+    public RealAlgebraicNumber<C> fromInteger(long a) {
+        return new RealAlgebraicNumber<C>(this, algebraic.fromInteger(a));
+    }
+
+
+    /**
+     * Get the String representation as RingFactory.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "RealAlgebraicRing[ " + algebraic.modul.toString() + " in " + root + " | isField="
+                        + algebraic.isField() + " :: " + algebraic.ring.toString() + " ]";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.ElemFactory#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        return "RealN( " + algebraic.modul.toScript() + ", " + root.toScript()
+        //+ ", " + algebraic.isField() 
+        //+ ", " + algebraic.ring.toScript() 
+                        + " )";
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (b == null) {
+            return false;
+        }
+        if (!(b instanceof RealAlgebraicRing)) {
+            return false;
+        }
+        RealAlgebraicRing<C> a = (RealAlgebraicRing<C>) b;
+        return algebraic.equals(a.algebraic) && root.equals(a.root);
+    }
+
+
+    /**
+     * Hash code for this RealAlgebraicNumber.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return 37 * algebraic.hashCode() + root.hashCode();
+    }
+
+
+    /**
+     * RealAlgebraicNumber random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @return a random integer mod modul.
+     */
+    public RealAlgebraicNumber<C> random(int n) {
+        return new RealAlgebraicNumber<C>(this, algebraic.random(n));
+    }
+
+
+    /**
+     * RealAlgebraicNumber random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @param rnd is a source for random bits.
+     * @return a random integer mod modul.
+     */
+    public RealAlgebraicNumber<C> random(int n, Random rnd) {
+        return new RealAlgebraicNumber<C>(this, algebraic.random(n, rnd));
+    }
+
+
+    /**
+     * Parse RealAlgebraicNumber from String.
+     * @param s String.
+     * @return RealAlgebraicNumber from s.
+     */
+    public RealAlgebraicNumber<C> parse(String s) {
+        return new RealAlgebraicNumber<C>(this, algebraic.parse(s));
+    }
+
+
+    /**
+     * Parse RealAlgebraicNumber from Reader.
+     * @param r Reader.
+     * @return next RealAlgebraicNumber from r.
+     */
+    public RealAlgebraicNumber<C> parse(Reader r) {
+        return new RealAlgebraicNumber<C>(this, algebraic.parse(r));
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/RealArithUtil.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/RealArithUtil.java
@@ -1,0 +1,82 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.root;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.arith.ArithUtil;
+import edu.jas.arith.BigInteger;
+import edu.jas.arith.BigRational;
+
+
+/**
+ * Real arithmetic utilities.
+ * @author Heinz Kredel
+ */
+
+public class RealArithUtil {
+
+
+    private static final Logger logger = LogManager.getLogger(RealArithUtil.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Continued fraction.
+     * @param A real algebraic number.
+     * @param M approximation, length of continued fraction.
+     * @return continued fraction for A.
+     */
+    public static List<BigInteger> continuedFraction(RealAlgebraicNumber<BigRational> A, final int M) {
+        List<BigInteger> cf = new ArrayList<BigInteger>();
+        if (A == null) {
+            return cf;
+        }
+        RealAlgebraicRing<BigRational> fac = A.ring;
+        if (A.isZERO()) {
+            cf.add(BigInteger.ZERO);
+            return cf;
+        }
+        if (A.isONE()) {
+            cf.add(BigInteger.ONE);
+            return cf;
+        }
+        RealAlgebraicNumber<BigRational> x = A;
+        BigInteger q = new BigInteger(x.floor());
+        cf.add(q);
+        RealAlgebraicNumber<BigRational> xd = x.subtract(fac.fromInteger(q.val));
+        int m = 0;
+        while (!xd.isZERO() && m++ < M) {
+            //System.out.println("xd = " + xd + " :: " + xd.ring); // + ", q = " + q + ", x = " + x);
+            //System.out.println("xd = " + xd.decimalMagnitude());
+            x = xd.inverse();
+            q = new BigInteger(x.floor());
+            cf.add(q);
+            xd = x.subtract(fac.fromInteger(q.val));
+        }
+        if (debug) {
+            logger.info("cf = " + cf);
+        }
+        return cf;
+    }
+
+
+    /**
+     * Continued fraction approximation.
+     * @param A continued fraction.
+     * @return ratonal number approximation for A.
+     */
+    public static BigRational continuedFractionApprox(List<BigInteger> A) {
+        return ArithUtil.continuedFractionApprox(A);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/RealRootTuple.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/RealRootTuple.java
@@ -1,0 +1,226 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.root;
+
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.jas.arith.BigDecimal;
+import edu.jas.arith.BigRational;
+import edu.jas.arith.Rational;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * RealAlgebraicNumber root tuple.
+ * @param <C> coefficient type.
+ * @author Heinz Kredel
+ */
+public class RealRootTuple<C extends GcdRingElem<C> & Rational> implements Serializable {
+
+
+    /**
+     * Tuple of RealAlgebraicNumbers.
+     */
+    public final List<RealAlgebraicNumber<C>> tuple;
+
+
+    /**
+     * Constructor.
+     * @param t list of roots.
+     */
+    public RealRootTuple(List<RealAlgebraicNumber<C>> t) {
+        if (t == null) {
+            throw new IllegalArgumentException("null tuple not allowed");
+        }
+        tuple = t;
+    }
+
+
+    /**
+     * String representation of tuple.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return tuple.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Rectangle.
+     */
+    public String toScript() {
+        // Python case
+        StringBuffer sb = new StringBuffer("[");
+        boolean first = true;
+        for (RealAlgebraicNumber<C> r : tuple) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append(",");
+            }
+            sb.append(r.toScript());
+        }
+        return sb.toString();
+    }
+
+
+    /**
+     * Contains a point.
+     * @param c real root tuple representing a point.
+     * @return true if c is contained in this root tuple, else false.
+     */
+    public boolean contains(RealRootTuple<C> c) {
+        return contains(c.tuple);
+    }
+
+
+    /**
+     * Contains a point.
+     * @param c list of real algebraic numbers representing a point.
+     * @return true if c is contained in this root tuple, else false.
+     */
+    public boolean contains(List<RealAlgebraicNumber<C>> c) {
+        int i = 0;
+        for (RealAlgebraicNumber<C> r : tuple) {
+            RealAlgebraicNumber<C> cn = c.get(i++);
+            boolean t = r.ring.root.contains(cn.ring.root);
+            if (!t) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Random point of real root tuple.
+     * @return a random point contained in this real root tuple.
+     */
+    public List<C> randomPoint() {
+        List<C> tp = new ArrayList<C>(tuple.size());
+        for (RealAlgebraicNumber<C> r : tuple) {
+            C rp = r.ring.root.randomPoint();
+            tp.add(rp);
+        }
+        return tp;
+    }
+
+
+    /**
+     * Refine root isolating intervals.
+     * @param eps desired interval length.
+     */
+    public void refineRoot(BigRational eps) {
+        for (RealAlgebraicNumber<C> r : tuple) {
+            r.ring.refineRoot(eps);
+        }
+        return;
+    }
+
+
+    /**
+     * Copy this.
+     * @return a copy of this.
+     */
+    public RealRootTuple<C> copy() {
+        return new RealRootTuple<C>(new ArrayList<RealAlgebraicNumber<C>>(tuple));
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        RealRootTuple<C> a = null;
+        try {
+            a = (RealRootTuple<C>) b;
+        } catch (ClassCastException e) {
+        }
+        if (a == null) {
+            return false;
+        }
+        return tuple.equals(a.tuple);
+    }
+
+
+    /**
+     * Hash code for this Rectangle.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return tuple.hashCode();
+    }
+
+
+    /**
+     * Rational approximation of each coordinate.
+     * @return list of coordinate points.
+     */
+    public List<BigRational> getRational() {
+        List<BigRational> center = new ArrayList<BigRational>(tuple.size());
+        for (RealAlgebraicNumber<C> rr : tuple) {
+            BigRational r = rr.getRational();
+            center.add(r);
+        }
+        return center;
+    }
+
+
+    /**
+     * Decimal approximation of each coordinate.
+     * @return list of coordinate points.
+     */
+    public List<BigDecimal> decimalMagnitude() {
+        List<BigDecimal> center = new ArrayList<BigDecimal>(tuple.size());
+        for (RealAlgebraicNumber<C> rr : tuple) {
+            BigDecimal r = rr.decimalMagnitude();
+            center.add(r);
+        }
+        return center;
+    }
+
+
+    /**
+     * Rational Length.
+     * @return max |v_i|;
+     */
+    public BigRational rationalLength() {
+        BigRational len = new BigRational();
+        for (RealAlgebraicNumber<C> rr : tuple) {
+            BigRational r = rr.ring.root.rationalLength();
+            int s = len.compareTo(r);
+            if (s < 0) {
+                len = r;
+            }
+        }
+        return len;
+    }
+
+
+    /**
+     * Signum.
+     * @return ?;
+     */
+    public int signum() {
+        int s = 0;
+        for (RealAlgebraicNumber<C> rr : tuple) {
+            int rs = rr.signum();
+            if (rs != 0) {
+                s = rs;
+            }
+        }
+        return s;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/RealRoots.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/RealRoots.java
@@ -1,0 +1,118 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.root;
+
+
+import java.io.Serializable;
+import java.util.List;
+
+import edu.jas.arith.BigRational;
+import edu.jas.arith.Rational;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Real roots interface.
+ * @param <C> coefficient type.
+ * @author Heinz Kredel
+ */
+public interface RealRoots<C extends RingElem<C> & Rational> extends Serializable {
+
+
+    /**
+     * Real root bound. With f(M) * f(-M) != 0.
+     * @param f univariate polynomial.
+     * @return M such that -M &lt; root(f) &gt; M.
+     */
+    public C realRootBound(GenPolynomial<C> f);
+
+
+    /**
+     * Isolating intervals for the real roots.
+     * @param f univariate polynomial.
+     * @return a list of isolating intervalls for the real roots of f.
+     */
+    public List<Interval<C>> realRoots(GenPolynomial<C> f);
+
+
+    /**
+     * Isolating intervals for the real roots.
+     * @param f univariate polynomial.
+     * @param eps requested intervals length.
+     * @return a list of isolating intervals v such that |v| &lt; eps.
+     */
+    public List<Interval<C>> realRoots(GenPolynomial<C> f, C eps);
+
+
+    /**
+     * Isolating intervals for the real roots.
+     * @param f univariate polynomial.
+     * @param eps requested intervals length.
+     * @return a list of isolating intervals v such that |v| &lt; eps.
+     */
+    public List<Interval<C>> realRoots(GenPolynomial<C> f, BigRational eps);
+
+
+    /**
+     * Sign changes on interval bounds.
+     * @param iv root isolating interval with f(left) * f(right) != 0.
+     * @param f univariate polynomial.
+     * @return true if f(left) * f(right) &lt; 0, else false
+     */
+    public boolean signChange(Interval<C> iv, GenPolynomial<C> f);
+
+
+    /**
+     * Number of real roots in interval.
+     * @param iv interval with f(left) * f(right) != 0.
+     * @param f univariate polynomial.
+     * @return number of real roots of f in I.
+     */
+    public long realRootCount(Interval<C> iv, GenPolynomial<C> f);
+
+
+    /**
+     * Refine interval.
+     * @param iv root isolating interval with f(left) * f(right) &lt; 0.
+     * @param f univariate polynomial, non-zero.
+     * @param eps requested interval length.
+     * @return a new interval v such that |v| &lt; eps.
+     */
+    public Interval<C> refineInterval(Interval<C> iv, GenPolynomial<C> f, BigRational eps);
+
+
+    /**
+     * Refine intervals.
+     * @param V list of isolating intervals with f(left) * f(right) &lt; 0.
+     * @param f univariate polynomial, non-zero.
+     * @param eps requested intervals length.
+     * @return a list of new intervals v such that |v| &lt; eps.
+     */
+    public List<Interval<C>> refineIntervals(List<Interval<C>> V, GenPolynomial<C> f, BigRational eps);
+
+
+    /**
+     * Real algebraic number sign.
+     * @param iv root isolating interval for f, with f(left) * f(right) &lt; 0.
+     * @param f univariate polynomial, non-zero.
+     * @param g univariate polynomial, gcd(f,g) == 1.
+     * @return sign(g(v)), with v a new interval contained in iv such that g(v)
+     *         != 0.
+     */
+    public int realSign(Interval<C> iv, GenPolynomial<C> f, GenPolynomial<C> g);
+
+
+    /**
+     * Real algebraic number magnitude.
+     * @param iv root isolating interval for f, with f(left) * f(right) &lt; 0.
+     * @param f univariate polynomial, non-zero.
+     * @param g univariate polynomial, gcd(f,g) == 1.
+     * @param eps length limit for interval length.
+     * @return g(iv).
+     */
+    public C realMagnitude(Interval<C> iv, GenPolynomial<C> f, GenPolynomial<C> g, BigRational eps);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/RealRootsAbstract.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/RealRootsAbstract.java
@@ -1,0 +1,784 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.root;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.arith.BigDecimal;
+import edu.jas.arith.BigInteger;
+import edu.jas.arith.BigRational;
+import edu.jas.arith.Rational;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.structure.UnaryFunctor;
+
+
+/**
+ * Real roots abstract class.
+ * @param <C> coefficient type.
+ * @author Heinz Kredel
+ */
+public abstract class RealRootsAbstract<C extends RingElem<C> & Rational> implements RealRoots<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(RealRootsAbstract.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Real root bound. With f(-M) * f(M) != 0.
+     * @param f univariate polynomial.
+     * @return M such that -M &lt; root(f) &lt; M.
+     */
+    public C realRootBound(GenPolynomial<C> f) {
+        if (f == null) {
+            return null;
+        }
+        RingFactory<C> cfac = f.ring.coFac;
+        C M = cfac.getONE();
+        if (f.isZERO()) {
+            return M;
+        }
+        if (f.isConstant()) {
+            M = f.leadingBaseCoefficient().abs().sum(cfac.getONE());
+            return M;
+        }
+        C a = f.leadingBaseCoefficient().abs();
+        for (C c : f.getMap().values()) {
+            C d = c.abs().divide(a);
+            if (M.compareTo(d) < 0) {
+                M = d;
+            }
+        }
+        BigRational r = M.getRational();
+        logger.info("rational root bound: " + r);
+        BigInteger i = new BigInteger(r.numerator().divide(r.denominator()));
+        i = i.sum(BigInteger.ONE); // ceiling
+        M = cfac.fromInteger(i.getVal());
+        M = M.sum(f.ring.coFac.getONE());
+        logger.info("integer root bound: " + M);
+        //System.out.println("M = " + M);
+        return M;
+    }
+
+
+    /**
+     * Magnitude bound.
+     * @param iv interval.
+     * @param f univariate polynomial.
+     * @return B such that |f(c)| &lt; B for c in iv.
+     */
+    @SuppressWarnings("unchecked")
+    public C magnitudeBound(Interval<C> iv, GenPolynomial<C> f) {
+        if (f == null) {
+            return null;
+        }
+        if (f.isZERO()) {
+            return f.ring.coFac.getONE();
+        }
+        if (f.isConstant()) {
+            return f.leadingBaseCoefficient().abs();
+        }
+        GenPolynomial<C> fa = f.map(new UnaryFunctor<C, C>() {
+
+
+            public C eval(C a) {
+                return a.abs();
+            }
+        });
+        //System.out.println("fa = " + fa);
+        C M = iv.left.abs();
+        if (M.compareTo(iv.right.abs()) < 0) {
+            M = iv.right.abs();
+        }
+        //System.out.println("M = " + M);
+        RingFactory<C> cfac = f.ring.coFac;
+        C B = PolyUtil.<C> evaluateMain(cfac, fa, M);
+        // works also without this case, only for optimization 
+        // to use rational number interval end points
+        // can fail if real root is in interval [r,r+1] 
+        // for too low precision or too big r, since r is approximation
+        //if ((Object) B instanceof RealAlgebraicNumber) {
+        //    RealAlgebraicNumber Br = (RealAlgebraicNumber) B;
+        //    BigRational r = Br.magnitude();
+        //    B = cfac.fromInteger(r.numerator()).divide(cfac.fromInteger(r.denominator()));
+        //}
+        BigRational r = B.getRational();
+        B = cfac.fromInteger(r.numerator()).divide(cfac.fromInteger(r.denominator()));
+        //System.out.println("B = " + B);
+        return B;
+    }
+
+
+    /**
+     * Real minimal root bound.
+     * @param f univariate polynomial.
+     * @return M such that abs(xi) &gt; M for f(xi) == 0.
+     */
+    public C realMinimalRootBound(GenPolynomial<C> f) {
+        if (f == null) {
+            return null;
+        }
+        RingFactory<C> cfac = f.ring.coFac;
+        // maxNorm root bound
+        BigRational mr = f.maxNorm().getRational().sum(BigRational.ONE);
+        BigRational di = mr.sum(BigRational.ONE).inverse();
+        C B = cfac.fromInteger(di.numerator()).divide(cfac.fromInteger(di.denominator()));
+        //System.out.println("B = " + B + ", sign(B) = " + B.signum());
+        return B;
+    }
+
+
+    /**
+     * Real minimal root separation.
+     * @param f univariate polynomial.
+     * @return M such that abs(xi-xj) &gt; M for roots xi, xj of f.
+     */
+    public C realMinimalRootSeparation(GenPolynomial<C> f) {
+        if (f == null) {
+            return null;
+        }
+        RingFactory<C> cfac = f.ring.coFac;
+        // sumNorm root bound
+        BigRational pr = f.sumNorm().getRational();
+        pr = pr.sum(BigRational.ONE);
+        BigRational sep = BigRational.ZERO;
+        long n = f.degree();
+        if (n > 0) {
+            sep = pr.power(2 * n).multiply(pr.fromInteger(n).power(n + 1)).inverse();
+        }
+        //System.out.println("sep = " + sep + ", sign(sep) = " + sep.signum());
+        C M = cfac.fromInteger(sep.numerator()).divide(cfac.fromInteger(sep.denominator()));
+        return M;
+    }
+
+
+    /**
+     * Bi-section point.
+     * @param iv interval with f(left) * f(right) != 0.
+     * @param f univariate polynomial, non-zero.
+     * @return a point c in the interval iv such that f(c) != 0.
+     */
+    public C bisectionPoint(Interval<C> iv, GenPolynomial<C> f) {
+        if (f == null) {
+            return null;
+        }
+        RingFactory<C> cfac = f.ring.coFac;
+        C two = cfac.fromInteger(2);
+        C c = iv.left.sum(iv.right);
+        c = c.divide(two);
+        if (f.isZERO() || f.isConstant()) {
+            return c;
+        }
+        C m = PolyUtil.<C> evaluateMain(cfac, f, c);
+        while (m.isZERO()) {
+            C d = iv.left.sum(c);
+            d = d.divide(two);
+            if (d.equals(c)) {
+                d = iv.right.sum(c);
+                d = d.divide(two);
+                if (d.equals(c)) {
+                    throw new RuntimeException("should not happen " + iv);
+                }
+            }
+            c = d;
+            m = PolyUtil.<C> evaluateMain(cfac, f, c);
+            //System.out.println("c = " + c);
+        }
+        //System.out.println("c = " + c);
+        return c;
+    }
+
+
+    /**
+     * Isolating intervals for the real roots.
+     * @param f univariate polynomial.
+     * @return a list of isolating intervalls for the real roots of f.
+     */
+    public abstract List<Interval<C>> realRoots(GenPolynomial<C> f);
+
+
+    /**
+     * Isolating intervals for the real roots.
+     * @param f univariate polynomial.
+     * @param eps requested intervals length.
+     * @return a list of isolating intervals v such that |v| &lt; eps.
+     */
+    public List<Interval<C>> realRoots(GenPolynomial<C> f, C eps) {
+        return realRoots(f, eps.getRational());
+    }
+
+
+    /**
+     * Isolating intervals for the real roots.
+     * @param f univariate polynomial.
+     * @param eps requested intervals length.
+     * @return a list of isolating intervals v such that |v| &lt; eps.
+     */
+    public List<Interval<C>> realRoots(GenPolynomial<C> f, BigRational eps) {
+        List<Interval<C>> iv = realRoots(f);
+        return refineIntervals(iv, f, eps);
+    }
+
+
+    /**
+     * Sign changes on interval bounds.
+     * @param iv root isolating interval with f(left) * f(right) != 0.
+     * @param f univariate polynomial.
+     * @return true if f(left) * f(right) &lt; 0, else false
+     */
+    public boolean signChange(Interval<C> iv, GenPolynomial<C> f) {
+        if (f == null) {
+            return false;
+        }
+        RingFactory<C> cfac = f.ring.coFac;
+        C l = PolyUtil.<C> evaluateMain(cfac, f, iv.left);
+        C r = PolyUtil.<C> evaluateMain(cfac, f, iv.right);
+        return l.signum() * r.signum() < 0;
+    }
+
+
+    /**
+     * Number of real roots in interval.
+     * @param iv interval with f(left) * f(right) != 0.
+     * @param f univariate polynomial.
+     * @return number of real roots of f in I.
+     */
+    public abstract long realRootCount(Interval<C> iv, GenPolynomial<C> f);
+
+
+    /**
+     * Half interval.
+     * @param iv root isolating interval with f(left) * f(right) &lt; 0.
+     * @param f univariate polynomial, non-zero.
+     * @return a new interval v such that |v| &lt; |iv|/2.
+     */
+    public Interval<C> halfInterval(Interval<C> iv, GenPolynomial<C> f) {
+        if (f == null || f.isZERO()) {
+            return iv;
+        }
+        BigRational len = iv.rationalLength();
+        BigRational two = len.factory().fromInteger(2);
+        BigRational eps = len.divide(two);
+        return refineInterval(iv, f, eps);
+    }
+
+
+    /**
+     * Refine interval.
+     * @param iv root isolating interval with f(left) * f(right) &lt; 0.
+     * @param f univariate polynomial, non-zero.
+     * @param eps requested interval length.
+     * @return a new interval v such that |v| &lt; eps.
+     */
+    public Interval<C> refineInterval(Interval<C> iv, GenPolynomial<C> f, BigRational eps) {
+        if (f == null || f.isZERO() || f.isConstant() || eps == null) {
+            return iv;
+        }
+        if (iv.rationalLength().compareTo(eps) < 0) {
+            return iv;
+        }
+        RingFactory<C> cfac = f.ring.coFac;
+        C two = cfac.fromInteger(2);
+        Interval<C> v = iv;
+        while (v.rationalLength().compareTo(eps) >= 0) {
+            C c = v.left.sum(v.right);
+            c = c.divide(two);
+            //System.out.println("c = " + c);
+            //c = RootUtil.<C>bisectionPoint(v,f);
+            if (PolyUtil.<C> evaluateMain(cfac, f, c).isZERO()) {
+                v = new Interval<C>(c, c);
+                break;
+            }
+            Interval<C> iv1 = new Interval<C>(v.left, c);
+            if (signChange(iv1, f)) {
+                v = iv1;
+            } else {
+                v = new Interval<C>(c, v.right);
+            }
+        }
+        return v;
+    }
+
+
+    /**
+     * Refine intervals.
+     * @param V list of isolating intervals with f(left) * f(right) &lt; 0.
+     * @param f univariate polynomial, non-zero.
+     * @param eps requested intervals length.
+     * @return a list of new intervals v such that |v| &lt; eps.
+     */
+    public List<Interval<C>> refineIntervals(List<Interval<C>> V, GenPolynomial<C> f, BigRational eps) {
+        if (f == null || f.isZERO() || f.isConstant() || eps == null) {
+            return V;
+        }
+        List<Interval<C>> IV = new ArrayList<Interval<C>>();
+        for (Interval<C> v : V) {
+            Interval<C> iv = refineInterval(v, f, eps);
+            IV.add(iv);
+        }
+        return IV;
+    }
+
+
+    /**
+     * Invariant interval for algebraic number sign.
+     * @param iv root isolating interval for f, with f(left) * f(right) &lt; 0.
+     * @param f univariate polynomial, non-zero.
+     * @param g univariate polynomial, gcd(f,g) == 1.
+     * @return v with v a new interval contained in iv such that g(v) != 0.
+     */
+    public abstract Interval<C> invariantSignInterval(Interval<C> iv, GenPolynomial<C> f, GenPolynomial<C> g);
+
+
+    /**
+     * Real algebraic number sign.
+     * @param iv root isolating interval for f, with f(left) * f(right) &lt; 0,
+     *            with iv such that g(iv) != 0.
+     * @param f univariate polynomial, non-zero.
+     * @param g univariate polynomial, gcd(f,g) == 1.
+     * @return sign(g(iv)) .
+     */
+    public int realIntervalSign(Interval<C> iv, GenPolynomial<C> f, GenPolynomial<C> g) {
+        if (g == null || g.isZERO()) {
+            return 0;
+        }
+        if (f == null || f.isZERO() || f.isConstant()) {
+            return g.signum();
+        }
+        if (g.isConstant()) {
+            return g.signum();
+        }
+        RingFactory<C> cfac = f.ring.coFac;
+        C c = iv.left.sum(iv.right);
+        c = c.divide(cfac.fromInteger(2));
+        C ev = PolyUtil.<C> evaluateMain(cfac, g, c);
+        //System.out.println("ev = " + ev);
+        return ev.signum();
+    }
+
+
+    /**
+     * Real algebraic number sign.
+     * @param iv root isolating interval for f, with f(left) * f(right) &lt; 0.
+     * @param f univariate polynomial, non-zero.
+     * @param g univariate polynomial, gcd(f,g) == 1.
+     * @return sign(g(v)), with v a new interval contained in iv such that g(v)
+     *         != 0.
+     */
+    public int realSign(Interval<C> iv, GenPolynomial<C> f, GenPolynomial<C> g) {
+        if (g == null || g.isZERO()) {
+            return 0;
+        }
+        if (f == null || f.isZERO() || f.isConstant()) {
+            return g.signum();
+        }
+        if (g.isConstant()) {
+            return g.signum();
+        }
+        Interval<C> v = invariantSignInterval(iv, f, g);
+        return realIntervalSign(v, f, g);
+    }
+
+
+    /**
+     * Invariant interval for algebraic number magnitude.
+     * @param iv root isolating interval for f, with f(left) * f(right) &lt; 0.
+     * @param f univariate polynomial, non-zero.
+     * @param g univariate polynomial, gcd(f,g) == 1.
+     * @param eps length limit for interval length.
+     * @return v with v a new interval contained in iv such that |g(a) - g(b)|
+     *         &lt; eps for a, b in v in iv.
+     */
+    public Interval<C> invariantMagnitudeInterval(Interval<C> iv, GenPolynomial<C> f, GenPolynomial<C> g,
+                    BigRational eps) {
+        Interval<C> v = iv;
+        if (g == null || g.isZERO()) {
+            return v;
+        }
+        if (g.isConstant()) {
+            return v;
+        }
+        if (f == null || f.isZERO() || f.isConstant()) { // ?
+            return v;
+        }
+        GenPolynomial<C> gp = PolyUtil.<C> baseDeriviative(g);
+        //System.out.println("g  = " + g);
+        //System.out.println("gp = " + gp);
+        C B = magnitudeBound(iv, gp);
+        //System.out.println("B = " + B);
+        RingFactory<C> cfac = f.ring.coFac;
+        C two = cfac.fromInteger(2);
+        while (B.multiply(v.length()).getRational().compareTo(eps) >= 0) {
+            C c = v.left.sum(v.right);
+            c = c.divide(two);
+            Interval<C> im = new Interval<C>(c, v.right);
+            if (signChange(im, f)) {
+                v = im;
+            } else {
+                v = new Interval<C>(v.left, c);
+            }
+            //System.out.println("v = " + v.toDecimal());
+        }
+        return v;
+    }
+
+
+    /**
+     * Real algebraic number magnitude.
+     * @param iv root isolating interval for f, with f(left) * f(right) &lt; 0,
+     *            with iv such that |g(a) - g(b)| &lt; eps for a, b in iv.
+     * @param f univariate polynomial, non-zero.
+     * @param g univariate polynomial, gcd(f,g) == 1.
+     * @return g(iv) .
+     */
+    public C realIntervalMagnitude(Interval<C> iv, GenPolynomial<C> f, GenPolynomial<C> g) {
+        if (g.isZERO() || g.isConstant()) {
+            return g.leadingBaseCoefficient();
+        }
+        RingFactory<C> cfac = f.ring.coFac;
+        C evl = PolyUtil.<C> evaluateMain(cfac, g, iv.left);
+        C evr = PolyUtil.<C> evaluateMain(cfac, g, iv.right);
+        C ev = evl;
+        if (evl.compareTo(evr) <= 0) {
+            ev = evr;
+        }
+        //System.out.println("ev = " + ev + ", evl = " + evl + ", evr = " + evr + ", iv = " + iv);
+        return ev;
+    }
+
+
+    /**
+     * Real algebraic number magnitude.
+     * @param iv root isolating interval for f, with f(left) * f(right) &lt; 0.
+     * @param f univariate polynomial, non-zero.
+     * @param g univariate polynomial, gcd(f,g) == 1.
+     * @param eps length limit for interval length.
+     * @return g(iv) .
+     */
+    public C realMagnitude(Interval<C> iv, GenPolynomial<C> f, GenPolynomial<C> g, BigRational eps) {
+        if (g.isZERO() || g.isConstant()) {
+            return g.leadingBaseCoefficient();
+        }
+        Interval<C> v = invariantMagnitudeInterval(iv, f, g, eps);
+        return realIntervalMagnitude(v, f, g);
+    }
+
+
+    /**
+     * Real algebraic number magnitude.
+     * @param iv root isolating interval for f, with f(left) * f(right) &lt; 0,
+     *            with iv such that |g(a) - g(b)| &lt; eps for a, b in iv.
+     * @param f univariate polynomial, non-zero.
+     * @param g univariate polynomial, gcd(f,g) == 1.
+     * @return Interval( g(iv.left), g(iv.right) ) .
+     */
+    public Interval<C> realIntervalMagnitudeInterval(Interval<C> iv, GenPolynomial<C> f, GenPolynomial<C> g) {
+        if (g.isZERO() || g.isConstant()) {
+            return iv;
+        }
+        RingFactory<C> cfac = f.ring.coFac;
+        C evl = PolyUtil.<C> evaluateMain(cfac, g, iv.left);
+        C evr = PolyUtil.<C> evaluateMain(cfac, g, iv.right);
+        Interval<C> ev = new Interval<C>(evr, evl);
+        if (evl.compareTo(evr) <= 0) {
+            ev = new Interval<C>(evl, evr);
+        }
+        System.out.println("ev = " + ev + ", iv = " + iv);
+        return ev;
+    }
+
+
+    /**
+     * Approximate real root.
+     * @param iv real root isolating interval with f(left) * f(right) &lt; 0.
+     * @param f univariate polynomial, non-zero.
+     * @param eps requested interval length.
+     * @return a decimal approximation d such that |d-v| &lt; eps, for f(v) = 0,
+     *         v real.
+     */
+    public BigDecimal approximateRoot(Interval<C> iv, GenPolynomial<C> f, BigRational eps)
+                    throws NoConvergenceException {
+        if (iv == null) {
+            throw new IllegalArgumentException("null interval not allowed");
+        }
+        BigDecimal d = iv.toDecimal();
+        if (f == null || f.isZERO() || f.isConstant() || eps == null) {
+            return d;
+        }
+        if (iv.rationalLength().compareTo(eps) < 0) {
+            return d;
+        }
+        BigDecimal left = new BigDecimal(iv.left.getRational());
+        BigDecimal right = new BigDecimal(iv.right.getRational());
+        BigRational reps = eps.getRational();
+        BigDecimal e = new BigDecimal(reps);
+        BigDecimal q = new BigDecimal("0.25");
+        //System.out.println("left  = " + left);
+        //System.out.println("right = " + right);
+        e = e.multiply(d); // relative error
+        //System.out.println("e     = " + e);
+        BigDecimal dc = BigDecimal.ONE;
+        // polynomials with decimal coefficients
+        GenPolynomialRing<BigDecimal> dfac = new GenPolynomialRing<BigDecimal>(dc, f.ring);
+        GenPolynomial<BigDecimal> df = PolyUtil.<C> decimalFromRational(dfac, f);
+        GenPolynomial<C> fp = PolyUtil.<C> baseDeriviative(f);
+        GenPolynomial<BigDecimal> dfp = PolyUtil.<C> decimalFromRational(dfac, fp);
+        // Newton Raphson iteration: x_{n+1} = x_n - f(x_n)/f'(x_n)
+        int i = 0;
+        final int MITER = 50;
+        int dir = 0;
+        while (i++ < MITER) {
+            BigDecimal fx = PolyUtil.<BigDecimal> evaluateMain(dc, df, d); // f(d)
+            if (fx.isZERO()) {
+                return d;
+            }
+            BigDecimal fpx = PolyUtil.<BigDecimal> evaluateMain(dc, dfp, d); // f'(d)
+            if (fpx.isZERO()) {
+                throw new NoConvergenceException("zero deriviative should not happen");
+            }
+            BigDecimal x = fx.divide(fpx);
+            BigDecimal dx = d.subtract(x);
+            //System.out.println("dx = " + dx + ", d = " + d);
+            if (d.subtract(dx).abs().compareTo(e) <= 0) {
+                return dx;
+            }
+            while (dx.compareTo(left) < 0 || dx.compareTo(right) > 0) {
+                // dx < left: dx - left < 0
+                // dx > right: dx - right > 0
+                //System.out.println("trying to leave interval");
+                if (i++ > MITER) { // dx > right: dx - right > 0
+                    throw new NoConvergenceException("no convergence after " + i + " steps");
+                }
+                if (i > MITER / 2 && dir == 0) {
+                    BigDecimal sd = new BigDecimal(iv.randomPoint().getRational());
+                    d = sd;
+                    x = sd.getZERO();
+                    logger.info("trying new random starting point " + d);
+                    i = 0;
+                    dir = 1;
+                }
+                if (i > MITER / 2 && dir == 1) {
+                    BigDecimal sd = new BigDecimal(iv.randomPoint().getRational());
+                    d = sd;
+                    x = sd.getZERO();
+                    logger.info("trying new random starting point " + d);
+                    //i = 0;
+                    dir = 2; // end
+                }
+                x = x.multiply(q); // x * 1/4
+                dx = d.subtract(x);
+                //System.out.println(" x = " + x);
+                //System.out.println("dx = " + dx);
+            }
+            d = dx;
+        }
+        throw new NoConvergenceException("no convergence after " + i + " steps");
+    }
+
+
+    /**
+     * Approximate real roots.
+     * @param f univariate polynomial, non-zero.
+     * @param eps requested interval length.
+     * @return a list of decimal approximations d such that |d-v| &lt; eps for
+     *         all real v with f(v) = 0.
+     */
+    public List<BigDecimal> approximateRoots(GenPolynomial<C> f, BigRational eps) {
+        List<Interval<C>> iv = realRoots(f);
+        List<BigDecimal> roots = new ArrayList<BigDecimal>(iv.size());
+        for (Interval<C> i : iv) {
+            BigDecimal r = null; //approximateRoot(i, f, eps); roots.add(r);
+            while (r == null) {
+                try {
+                    r = approximateRoot(i, f, eps);
+                    roots.add(r);
+                } catch (NoConvergenceException e) {
+                    // fall back to exact algorithm
+                    //System.out.println("" + e);
+                    BigRational len = i.rationalLength();
+                    len = len.divide(len.factory().fromInteger(1000));
+                    i = refineInterval(i, f, len);
+                    logger.info("fall back rootRefinement = " + i);
+                }
+            }
+        }
+        return roots;
+    }
+
+
+    /**
+     * Test if x is an approximate real root.
+     * @param x approximate real root.
+     * @param f univariate polynomial, non-zero.
+     * @param eps requested interval length.
+     * @return true if x is a decimal approximation of a real v with f(v) = 0
+     *         with |d-v| &lt; eps, else false.
+     */
+    public boolean isApproximateRoot(BigDecimal x, GenPolynomial<C> f, C eps) {
+        if (x == null) {
+            throw new IllegalArgumentException("null root not allowed");
+        }
+        if (f == null || f.isZERO() || f.isConstant() || eps == null) {
+            return true;
+        }
+        BigDecimal e = new BigDecimal(eps.getRational());
+        e = e.multiply(new BigDecimal("1000")); // relax
+        BigDecimal dc = BigDecimal.ONE;
+        // polynomials with decimal coefficients
+        GenPolynomialRing<BigDecimal> dfac = new GenPolynomialRing<BigDecimal>(dc, f.ring);
+        GenPolynomial<BigDecimal> df = PolyUtil.<C> decimalFromRational(dfac, f);
+        GenPolynomial<C> fp = PolyUtil.<C> baseDeriviative(f);
+        GenPolynomial<BigDecimal> dfp = PolyUtil.<C> decimalFromRational(dfac, fp);
+        //
+        return isApproximateRoot(x, df, dfp, e);
+    }
+
+
+    /**
+     * Test if x is an approximate real root.
+     * @param x approximate real root.
+     * @param f univariate polynomial, non-zero.
+     * @param fp univariate polynomial, non-zero, deriviative of f.
+     * @param eps requested interval length.
+     * @return true if x is a decimal approximation of a real v with f(v) = 0
+     *         with |d-v| &lt; eps, else false.
+     */
+    public boolean isApproximateRoot(BigDecimal x, GenPolynomial<BigDecimal> f, GenPolynomial<BigDecimal> fp,
+                    BigDecimal eps) {
+        if (x == null) {
+            throw new IllegalArgumentException("null root not allowed");
+        }
+        if (f == null || f.isZERO() || f.isConstant() || eps == null) {
+            return true;
+        }
+        BigDecimal dc = BigDecimal.ONE; // only for clarity
+        // f(x)
+        BigDecimal fx = PolyUtil.<BigDecimal> evaluateMain(dc, f, x);
+        //System.out.println("fx    = " + fx);
+        if (fx.isZERO()) {
+            return true;
+        }
+        // f'(x)
+        BigDecimal fpx = PolyUtil.<BigDecimal> evaluateMain(dc, fp, x); // f'(d)
+        //System.out.println("fpx   = " + fpx);
+        if (fpx.isZERO()) {
+            return false;
+        }
+        BigDecimal d = fx.divide(fpx);
+        if (d.isZERO()) {
+            return true;
+        }
+        if (d.abs().compareTo(eps) <= 0) {
+            return true;
+        }
+        System.out.println("x     = " + x);
+        System.out.println("d     = " + d);
+        return false;
+    }
+
+
+    /**
+     * Test if each x in R is an approximate real root.
+     * @param R ist of approximate real roots.
+     * @param f univariate polynomial, non-zero.
+     * @param eps requested interval length.
+     * @return true if each x in R is a decimal approximation of a real v with
+     *         f(v) = 0 with |d-v| &lt; eps, else false.
+     */
+    public boolean isApproximateRoot(List<BigDecimal> R, GenPolynomial<C> f, BigRational eps) {
+        if (R == null) {
+            throw new IllegalArgumentException("null root not allowed");
+        }
+        if (f == null || f.isZERO() || f.isConstant() || eps == null) {
+            return true;
+        }
+        BigDecimal e = new BigDecimal(eps.getRational());
+        e = e.multiply(new BigDecimal("1000")); // relax
+        BigDecimal dc = BigDecimal.ONE;
+        // polynomials with decimal coefficients
+        GenPolynomialRing<BigDecimal> dfac = new GenPolynomialRing<BigDecimal>(dc, f.ring);
+        GenPolynomial<BigDecimal> df = PolyUtil.<C> decimalFromRational(dfac, f);
+        GenPolynomial<C> fp = PolyUtil.<C> baseDeriviative(f);
+        GenPolynomial<BigDecimal> dfp = PolyUtil.<C> decimalFromRational(dfac, fp);
+        for (BigDecimal x : R) {
+            if (!isApproximateRoot(x, df, dfp, e)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Fourier sequence.
+     * @param f univariate polynomial.
+     * @return (f, f', ..., f(n)) a Fourier sequence for f.
+     */
+    public List<GenPolynomial<C>> fourierSequence(GenPolynomial<C> f) {
+        List<GenPolynomial<C>> S = new ArrayList<GenPolynomial<C>>();
+        if (f == null || f.isZERO()) {
+            return S;
+        }
+        long d = f.degree();
+        GenPolynomial<C> F = f;
+        S.add(F);
+        while (d-- > 0) {
+            GenPolynomial<C> G = PolyUtil.<C> baseDeriviative(F);
+            F = G;
+            S.add(F);
+        }
+        //System.out.println("F = " + F);
+        return S;
+    }
+
+
+    /**
+     * Thom sign sequence.
+     * @param f univariate polynomial.
+     * @param v interval for a real root, f(v.left) * f(v.right) &lt; 0.
+     * @return (s1, s2, ..., sn) = (sign(f'(v)), .... sign(f(n)(v))) a Thom sign
+     *         sequence for the real root in v of f.
+     */
+    public List<Integer> signSequence(GenPolynomial<C> f, Interval<C> v) {
+        List<Integer> S = new ArrayList<Integer>();
+        GenPolynomial<C> fp = PolyUtil.<C> baseDeriviative(f);
+        List<GenPolynomial<C>> fs = fourierSequence(fp);
+        for (GenPolynomial<C> p : fs) {
+            int s = realSign(v, f, p);
+            S.add(s);
+        }
+        return S;
+    }
+
+
+    /**
+     * Root number.
+     * @param f univariate polynomial.
+     * @param v interval for a real root, f(v.left) * f(v.right) &lt; 0.
+     * @return r the number of this root in the sequence a1 &lt; a2 &lt; ...,
+     *         &lt; am of all real roots of f
+     */
+    public Long realRootNumber(GenPolynomial<C> f, Interval<C> v) {
+        C M = realRootBound(f);
+        Interval<C> iv = new Interval<C>(M.negate(), v.right);
+        long r = realRootCount(iv, f);
+        if (r <= 0) {
+            logger.warn("no real root in interval " + v);
+        }
+        return r;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/RealRootsSturm.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/RealRootsSturm.java
@@ -1,0 +1,435 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.root;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.arith.BigRational;
+import edu.jas.arith.Rational;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Real root isolation using Sturm sequences.
+ * @param <C> coefficient type.
+ * @author Heinz Kredel
+ */
+public class RealRootsSturm<C extends RingElem<C> & Rational> extends RealRootsAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(RealRootsSturm.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Sturm sequence.
+     * @param f univariate polynomial.
+     * @return a Sturm sequence for f.
+     */
+    public List<GenPolynomial<C>> sturmSequence(GenPolynomial<C> f) {
+        List<GenPolynomial<C>> S = new ArrayList<GenPolynomial<C>>();
+        if (f == null || f.isZERO()) {
+            return S;
+        }
+        if (f.isConstant()) {
+            S.add(f.monic());
+            return S;
+        }
+        GenPolynomial<C> F = f;
+        S.add(F);
+        GenPolynomial<C> G = PolyUtil.<C> baseDeriviative(f);
+        while (!G.isZERO()) {
+            GenPolynomial<C> r = F.remainder(G);
+            F = G;
+            G = r.negate();
+            S.add(F/*.monic()*/);
+        }
+        //System.out.println("F = " + F);
+        if (F.isConstant()) {
+            return S;
+        }
+        // make squarefree
+        List<GenPolynomial<C>> Sp = new ArrayList<GenPolynomial<C>>(S.size());
+        for (GenPolynomial<C> p : S) {
+            p = p.divide(F);
+            Sp.add(p);
+        }
+        return Sp;
+    }
+
+
+    /**
+     * Isolating intervals for the real roots.
+     * @param f univariate polynomial.
+     * @return a list of isolating intervals for the real roots of f.
+     */
+    @SuppressWarnings("cast")
+    @Override
+    public List<Interval<C>> realRoots(GenPolynomial<C> f) {
+        List<Interval<C>> R = new ArrayList<Interval<C>>();
+        if (f == null) {
+            return R;
+        }
+        GenPolynomialRing<C> pfac = f.ring;
+        if (f.isZERO()) {
+            C z = pfac.coFac.getZERO();
+            R.add(new Interval<C>(z));
+            return R;
+        }
+        // check trailing degree
+        ExpVector et = f.trailingExpVector();
+        if (!et.isZERO()) {
+            GenPolynomial<C> tr = pfac.valueOf(et);
+            if (logger.isInfoEnabled()) {
+                logger.info("trailing term = " + tr);
+            }
+            f = PolyUtil.<C> basePseudoDivide(f, tr);
+            R.add(new Interval<C>(pfac.coFac.getZERO()));
+        }
+        if (f.isConstant()) {
+            return R;
+        }
+        if (f.degree(0) == 1L) {
+            C z = f.monic().trailingBaseCoefficient().negate();
+            R.add(new Interval<C>(z));
+            return R;
+        }
+        //if (f.degree(0) == 2L) ... 
+        GenPolynomial<C> F = f;
+        C M = realRootBound(F); // M != 0, since >= 2
+        Interval<C> iv = new Interval<C>(M.negate(), M);
+        //System.out.println("iv = " + iv);
+        List<GenPolynomial<C>> S = sturmSequence(F);
+        //System.out.println("S = " + S);
+        //System.out.println("f_S = " + S.get(0));
+        List<Interval<C>> Rp = realRoots(iv, S);
+        if (logger.isInfoEnabled() && !(((Object) f.ring.coFac) instanceof BigRational)) {
+            //logger.info("realRoots bound: " + iv);
+            logger.info("realRoots: " + Rp);
+        }
+        R.addAll(Rp);
+        return R;
+    }
+
+
+    /**
+     * Isolating intervals for the real roots.
+     * @param iv interval with f(left) * f(right) != 0.
+     * @param S sturm sequence for f and I.
+     * @return a list of isolating intervals for the real roots of f in I.
+     */
+    public List<Interval<C>> realRoots(Interval<C> iv, List<GenPolynomial<C>> S) {
+        List<Interval<C>> R = new ArrayList<Interval<C>>();
+        GenPolynomial<C> f = S.get(0); // squarefree part
+        if (f.isZERO()) {
+            C z = f.leadingBaseCoefficient();
+            if (!iv.contains(z)) {
+                throw new IllegalArgumentException(
+                                                   "root not in interval: f = " + f + ", iv = " + iv + ", z = " + z);
+            }
+            Interval<C> iv1 = new Interval<C>(z);
+            R.add(iv1);
+            return R;
+        }
+        if (f.isConstant()) {
+            return R;
+            //throw new IllegalArgumentException("f has no root: f = " + f + ", iv = " + iv);
+        }
+        if (f.degree(0) == 1L) {
+            C z = f.monic().trailingBaseCoefficient().negate();
+            if (!iv.contains(z)) {
+                return R;
+                //throw new IllegalArgumentException("root not in interval: f = " + f + ", iv = " + iv + ", z = " + z);
+            }
+            Interval<C> iv1 = new Interval<C>(z);
+            R.add(iv1);
+            return R;
+        }
+        //System.out.println("iv = " + iv);
+        // check sign variations at interval bounds
+        long v = realRootCount(iv, S);
+        //System.out.println("v = " + v);
+        if (v == 0) {
+            return R;
+        }
+        if (v == 1) {
+            iv = excludeZero(iv, S);
+            R.add(iv);
+            return R;
+        }
+        // now v &gt; 1
+        // bi-sect interval, such that f(c) != 0
+        C c = bisectionPoint(iv, f);
+        //System.out.println("c = " + c);
+        // recursion on both sub-intervals
+        Interval<C> iv1 = new Interval<C>(iv.left, c);
+        Interval<C> iv2 = new Interval<C>(c, iv.right);
+        List<Interval<C>> R1 = realRoots(iv1, S);
+        //System.out.println("R1 = " + R1);
+        if (debug) {
+            logger.info("R1 = " + R1);
+        }
+        List<Interval<C>> R2 = realRoots(iv2, S);
+        //System.out.println("R2 = " + R2);
+        if (debug) {
+            logger.info("R2 = " + R2);
+        }
+
+        // refine isolating intervals if adjacent 
+        if (R1.isEmpty()) {
+            R.addAll(R2);
+            return R;
+        }
+        if (R2.isEmpty()) {
+            R.addAll(R1);
+            return R;
+        }
+        iv1 = R1.get(R1.size() - 1); // last
+        iv2 = R2.get(0); // first
+        if (iv1.right.compareTo(iv2.left) < 0) {
+            R.addAll(R1);
+            R.addAll(R2);
+            return R;
+        }
+        // now iv1.right == iv2.left
+        //System.out.println("iv1 = " + iv1);
+        //System.out.println("iv2 = " + iv2);
+        R1.remove(iv1);
+        R2.remove(iv2);
+        while (iv1.right.equals(iv2.left)) {
+            C d1 = bisectionPoint(iv1, f);
+            C d2 = bisectionPoint(iv2, f);
+            Interval<C> iv11 = new Interval<C>(iv1.left, d1);
+            Interval<C> iv12 = new Interval<C>(d1, iv1.right);
+            Interval<C> iv21 = new Interval<C>(iv2.left, d2);
+            Interval<C> iv22 = new Interval<C>(d2, iv2.right);
+
+            boolean b11 = signChange(iv11, f);
+            boolean b12 = signChange(iv12, f); // TODO check unnecessary
+            //boolean b21 = signChange(iv21, f); // TODO check unused or unnecessary
+            boolean b22 = signChange(iv22, f);
+            if (b11) {
+                iv1 = iv11;
+                if (b22) {
+                    iv2 = iv22;
+                } else {
+                    iv2 = iv21;
+                }
+                break; // done, refine
+            }
+            if (b22) {
+                iv2 = iv22;
+                if (b12) {
+                    iv1 = iv12;
+                } else {
+                    iv1 = iv11;
+                }
+                break; // done, refine
+            }
+            iv1 = iv12;
+            iv2 = iv21;
+            //System.out.println("iv1 = " + iv1);
+            //System.out.println("iv2 = " + iv2);
+        }
+        R.addAll(R1);
+        R.add(iv1);
+        R.add(iv2);
+        R.addAll(R2);
+        return R;
+    }
+
+
+    /**
+     * Number of real roots in interval.
+     * @param iv interval with f(left) * f(right) != 0.
+     * @param S sturm sequence for f and I.
+     * @return number of real roots of f in I.
+     */
+    public long realRootCount(Interval<C> iv, List<GenPolynomial<C>> S) {
+        // check sign variations at interval bounds
+        GenPolynomial<C> f = S.get(0); // squarefree part
+        //System.out.println("iv = " + iv);
+        RingFactory<C> cfac = f.ring.coFac;
+        List<C> l = PolyUtil.<C> evaluateMain(cfac, S, iv.left);
+        List<C> r = PolyUtil.<C> evaluateMain(cfac, S, iv.right);
+        long v = RootUtil.<C> signVar(l) - RootUtil.<C> signVar(r);
+        //System.out.println("v = " + v);
+        if (v < 0L) {
+            v = -v;
+        }
+        return v;
+    }
+
+
+    /**
+     * Number of real roots in interval.
+     * @param iv interval with f(left) * f(right) != 0.
+     * @param f univariate polynomial.
+     * @return number of real roots of f in I.
+     */
+    @Override
+    public long realRootCount(Interval<C> iv, GenPolynomial<C> f) {
+        if (f == null || f.isConstant()) { // ? 
+            return 0L;
+        }
+        if (f.isZERO()) {
+            C z = f.leadingBaseCoefficient();
+            if (!iv.contains(z)) {
+                return 0L;
+            }
+            return 1L;
+        }
+        List<GenPolynomial<C>> S = sturmSequence(f);
+        return realRootCount(iv, S);
+    }
+
+
+    /**
+     * Invariant interval for algebraic number sign.
+     * @param iv root isolating interval for f, with f(left) * f(right) &lt; 0.
+     * @param f univariate polynomial, non-zero.
+     * @param g univariate polynomial, gcd(f,g) == 1.
+     * @return v with v a new interval contained in iv such that g(w) != 0 for w
+     *         in v.
+     */
+    @Override
+    public Interval<C> invariantSignInterval(Interval<C> iv, GenPolynomial<C> f, GenPolynomial<C> g) {
+        Interval<C> v = iv;
+        if (g == null || g.isZERO()) {
+            //throw new IllegalArgumentException("g == 0");
+            return v;
+        }
+        if (g.isConstant()) {
+            return v;
+        }
+        if (f == null || f.isZERO()) { // ? || f.isConstant()
+            throw new IllegalArgumentException("f == 0");
+            //return v;
+        }
+        List<GenPolynomial<C>> Sg = sturmSequence(g.monic());
+        Interval<C> ivp = invariantSignInterval(iv, f, Sg);
+        return ivp;
+    }
+
+
+    /**
+     * Invariant interval for algebraic number sign.
+     * @param iv root isolating interval for f, with f(left) * f(right) &lt; 0.
+     * @param f univariate polynomial, non-zero.
+     * @param Sg Sturm sequence for (f,g), a univariate polynomial with gcd(f,g) ==
+     *            1.
+     * @return v with v a new interval contained in iv such that g(w) != 0 for w
+     *         in v.
+     */
+    public Interval<C> invariantSignInterval(Interval<C> iv, GenPolynomial<C> f, List<GenPolynomial<C>> Sg) {
+        Interval<C> v = iv;
+        GenPolynomial<C> g = Sg.get(0);
+        if (g == null || g.isZERO()) {
+            return v;
+        }
+        if (g.isConstant()) {
+            return v;
+        }
+        if (f == null || f.isZERO()) { // ? || f.isConstant()
+            return v;
+        }
+        RingFactory<C> cfac = f.ring.coFac;
+        C two = cfac.fromInteger(2);
+
+        while (true) {
+            long n = realRootCount(v, Sg);
+            logger.debug("n = " + n);
+            if (n == 0) {
+                return v;
+            }
+            C c = v.left.sum(v.right);
+            c = c.divide(two);
+            Interval<C> im = new Interval<C>(c, v.right);
+            if (signChange(im, f)) {
+                v = im;
+            } else {
+                v = new Interval<C>(v.left, c);
+            }
+        }
+        // return v;
+    }
+
+
+    /**
+     * Exclude zero, old version.
+     * @param iv root isolating interval with f(left) * f(right) &lt; 0.
+     * @param S sturm sequence for f and I.
+     * @return a new interval v such that v &lt; 0 or v &gt; 0.
+     */
+    public Interval<C> excludeZeroOld(Interval<C> iv, List<GenPolynomial<C>> S) {
+        if (S == null || S.isEmpty()) {
+            return iv;
+        }
+        C zero = S.get(0).ring.coFac.getZERO();
+        if (!iv.contains(zero)) {
+            return iv;
+        }
+        Interval<C> vn = new Interval<C>(iv.left, zero);
+        if (realRootCount(vn,S) == 1) {
+            return vn;
+        }
+        vn = new Interval<C>(zero, iv.right);
+        return vn;
+    }
+
+
+    /**
+     * Exclude zero v2.
+     * @param iv root isolating interval with f(left) * f(right) &lt; 0.
+     * @param S sturm sequence for f and I.
+     * @return a new interval v such that v &lt; 0 or v &gt; 0 or v == 0.
+     */
+    public Interval<C> excludeZero(Interval<C> iv, List<GenPolynomial<C>> S) {
+        if (S == null || S.isEmpty()) {
+            return iv;
+        }
+        GenPolynomial<C> f = S.get(0);
+        C zero = f.ring.coFac.getZERO();
+        if (!iv.contains(zero)) { // left <= 0 <= right
+            return iv;
+        }
+        if (iv.left.isZERO() && iv.right.isZERO()) { // (0, 0)
+            return iv;
+        }
+        C m = realMinimalRootBound(f);
+        Interval<C> vi = iv;
+        Interval<C> vn;
+        if (vi.left.isZERO()) {
+            vi = new Interval<C>(m, vi.right);
+        } else if (vi.right.isZERO()) {
+            vi = new Interval<C>(vi.left, m.negate());
+        }
+        vn = new Interval<C>(vi.left, m.negate()); // l != 0
+        if (realRootCount(vn, S) == 1) {
+            return vn;
+        }
+        vn = new Interval<C>(m, vi.right); // r != 0
+        if (realRootCount(vn, S) == 1) {
+            return vn;
+        }
+        vn = new Interval<C>(zero);
+        logger.warn("interval is zero: iv = " + iv + ", trail = " + f.trailingExpVector().degree()
+                     + ", vi = " + vi + ", vn = " + vn);
+        return vn;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/Rectangle.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/Rectangle.java
@@ -1,0 +1,413 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.root;
+
+
+import java.io.Serializable;
+
+import edu.jas.arith.BigDecimal;
+import edu.jas.arith.BigRational;
+import edu.jas.arith.Rational;
+import edu.jas.poly.Complex;
+import edu.jas.poly.ComplexRing;
+import edu.jas.structure.ElemFactory;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Rectangle. For example isolating rectangle for complex roots.
+ * @param <C> coefficient type.
+ * @author Heinz Kredel
+ */
+public class Rectangle<C extends RingElem<C> & Rational> implements Serializable {
+
+
+    /**
+     * rectangle corners.
+     */
+    public final Complex<C>[] corners;
+
+
+    /**
+     * Constructor.
+     * @param c array of corners.
+     */
+    @SuppressWarnings("unchecked")
+    /*package*/ Rectangle(Complex<C>[] c) {
+        if (c.length < 5) {
+            corners = (Complex<C>[]) new Complex[5];
+            for (int i = 0; i < 4; i++) {
+                corners[i] = c[i];
+            }
+        } else {
+            corners = c;
+        }
+        if (corners[4] == null) {
+            corners[4] = corners[0];
+        }
+    }
+
+
+    /**
+     * Constructor.
+     * @param mid corner.
+     */
+    @SuppressWarnings("unchecked")
+    public Rectangle(Complex<C> mid) {
+        this(mid, mid);
+    }
+
+
+    /**
+     * Constructor.
+     * @param sw corner.
+     * @param ne corner.
+     */
+    @SuppressWarnings("unchecked")
+    public Rectangle(Complex<C> sw, Complex<C> ne) {
+        this(new Complex<C>(sw.ring, sw.getRe(), ne.getIm()), sw,
+                        new Complex<C>(sw.ring, ne.getRe(), sw.getIm()), ne);
+    }
+
+
+    /**
+     * Constructor.
+     * 
+     * <pre>
+     *  nw|0 ne|3
+     *  sw|1 se|2
+     * </pre>
+     * 
+     * @param nw corner.
+     * @param sw corner.
+     * @param se corner.
+     * @param ne corner.
+     */
+    @SuppressWarnings("unchecked")
+    public Rectangle(Complex<C> nw, Complex<C> sw, Complex<C> se, Complex<C> ne) {
+        this((Complex<C>[]) new Complex[] { nw, sw, se, ne });
+    }
+
+
+    /**
+     * String representation of Rectangle.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        //return "[" + corners[0] + ", " + corners[1] + ", " + corners[2] + ", " + corners[3] + "]";
+        return "[" + corners[1] + ", " + corners[3] + "]";
+        //return centerApprox() + " = [" + corners[0] + ", " + corners[1] + ", " + corners[2] + ", " + corners[3] + "]";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Rectangle.
+     */
+    public String toScript() {
+        // Python case
+        //return "(" + corners[0] + ", " + corners[1] + ", " + corners[2] + ", " + corners[3] + ")";
+        return "(" + corners[1].toScript() + ", " + corners[3].toScript() + ")";
+    }
+
+
+    /**
+     * Get north west corner.
+     * @return north west corner of this rectangle.
+     */
+    public Complex<C> getNW() {
+        return corners[0];
+    }
+
+
+    /**
+     * Get south west corner.
+     * @return south west corner of this rectangle.
+     */
+    public Complex<C> getSW() {
+        return corners[1];
+    }
+
+
+    /**
+     * Get south east corner.
+     * @return south east corner of this rectangle.
+     */
+    public Complex<C> getSE() {
+        return corners[2];
+    }
+
+
+    /**
+     * Get north east corner.
+     * @return north east corner of this rectangle.
+     */
+    public Complex<C> getNE() {
+        return corners[3];
+    }
+
+
+    /**
+     * Exchange NW corner.
+     * @param c new NW corner.
+     * @return rectangle with north west corner c of this rectangle.
+     */
+    public Rectangle<C> exchangeNW(Complex<C> c) {
+        Complex<C> d = getSE();
+        Complex<C> sw = new Complex<C>(c.factory(), c.getRe(), d.getIm());
+        Complex<C> ne = new Complex<C>(c.factory(), d.getRe(), c.getIm());
+        return new Rectangle<C>(c, sw, d, ne);
+    }
+
+
+    /**
+     * Exchange SW corner.
+     * @param c new SW corner.
+     * @return rectangle with south west corner c of this rectangle.
+     */
+    public Rectangle<C> exchangeSW(Complex<C> c) {
+        Complex<C> d = getNE();
+        Complex<C> nw = new Complex<C>(c.factory(), c.getRe(), d.getIm());
+        Complex<C> se = new Complex<C>(c.factory(), d.getRe(), c.getIm());
+        return new Rectangle<C>(nw, c, se, d);
+    }
+
+
+    /**
+     * Exchange SE corner.
+     * @param c new SE corner.
+     * @return rectangle with south east corner c of this rectangle.
+     */
+    public Rectangle<C> exchangeSE(Complex<C> c) {
+        Complex<C> d = getNW();
+        Complex<C> sw = new Complex<C>(c.factory(), d.getRe(), c.getIm());
+        Complex<C> ne = new Complex<C>(c.factory(), c.getRe(), d.getIm());
+        return new Rectangle<C>(d, sw, c, ne);
+    }
+
+
+    /**
+     * Exchange NE corner.
+     * @param c new NE corner.
+     * @return rectangle with north east corner c of this rectangle.
+     */
+    public Rectangle<C> exchangeNE(Complex<C> c) {
+        Complex<C> d = getSW();
+        Complex<C> nw = new Complex<C>(c.factory(), d.getRe(), c.getIm());
+        Complex<C> se = new Complex<C>(c.factory(), c.getRe(), d.getIm());
+        return new Rectangle<C>(nw, d, se, c);
+    }
+
+
+    /**
+     * Contains a point.
+     * @param c point.
+     * @return true if c is contained in this rectangle, else false.
+     */
+    public boolean contains(Complex<C> c) {
+        Complex<C> ll = getSW();
+        Complex<C> ur = getNE(); // ?? Fix ?? getSW();
+        C cre = c.getRe();
+        C cim = c.getIm();
+        return cre.compareTo(ll.getRe()) >= 0 && cim.compareTo(ll.getIm()) >= 0
+                        && cre.compareTo(ur.getRe()) <= 0 && cim.compareTo(ur.getIm()) <= 0;
+    }
+
+
+    /**
+     * Contains a rectangle.
+     * @param r rectangle.
+     * @return true if r is contained in this rectangle, else false.
+     */
+    public boolean contains(Rectangle<C> r) {
+        return contains(r.getSW()) && contains(r.getNE()); // && contains(r.getSE()) && contains(r.getNW())
+    }
+
+
+    /**
+     * Random point of recatangle.
+     * @return a random point contained in this rectangle.
+     */
+    public Complex<C> randomPoint() {
+        Complex<C> sw = getSW();
+        Complex<C> se = getSE();
+        Complex<C> nw = getNW();
+        Complex<C> r = sw.factory().random(13);
+        C dr = se.getRe().subtract(sw.getRe()); // >= 0
+        C di = nw.getIm().subtract(sw.getIm()); // >= 0
+        C rr = r.getRe().abs();
+        C ri = r.getIm().abs();
+        C one = ((RingFactory<C>) dr.factory()).getONE();
+        if (!rr.isZERO()) {
+            if (rr.compareTo(one) > 0) {
+                rr = rr.inverse();
+            }
+        }
+        if (!ri.isZERO()) {
+            if (ri.compareTo(one) > 0) {
+                ri = ri.inverse();
+            }
+        }
+        // 0 <= rr, ri <= 1
+        rr = rr.multiply(dr);
+        ri = ri.multiply(di);
+        Complex<C> rp = new Complex<C>(sw.factory(), rr, ri);
+        //System.out.println("rp = " + rp);
+        rp = sw.sum(rp);
+        return rp;
+    }
+
+
+    /**
+     * Copy this.
+     * @return a copy of this.
+     */
+    public Rectangle<C> copy() {
+        return new Rectangle<C>(corners);
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (!(b instanceof Rectangle)) {
+            return false;
+        }
+        Rectangle<C> a = null;
+        try {
+            a = (Rectangle<C>) b;
+        } catch (ClassCastException e) {
+            return false;
+        }
+        for (int i = 0; i < 4; i++) {
+            if (!corners[i].equals(a.corners[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Hash code for this Rectangle.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int hc = 0;
+        for (int i = 0; i < 3; i++) {
+            hc += 37 * corners[i].hashCode();
+        }
+        return 37 * hc + corners[3].hashCode();
+    }
+
+
+    /**
+     * Complex center.
+     * @return r + i m of the center.
+     */
+    public Complex<C> getCenter() {
+        C r = corners[2].getRe().subtract(corners[1].getRe());
+        C m = corners[0].getIm().subtract(corners[1].getIm());
+        ElemFactory<C> rf = r.factory();
+        C two = rf.fromInteger(2);
+        r = r.divide(two);
+        m = m.divide(two);
+        r = corners[1].getRe().sum(r);
+        m = corners[1].getIm().sum(m);
+        return new Complex<C>(corners[0].factory(), r, m);
+    }
+
+
+    /**
+     * Complex of BigRational approximation of center.
+     * @return r + i m as rational approximation of the center.
+     */
+    public Complex<BigRational> getRationalCenter() {
+        Complex<C> cm = getCenter();
+        BigRational rs = cm.getRe().getRational();
+        BigRational ms = cm.getIm().getRational();
+        ComplexRing<BigRational> cf = new ComplexRing<BigRational>(rs.factory());
+        Complex<BigRational> c = new Complex<BigRational>(cf, rs, ms);
+        return c;
+    }
+
+
+    /**
+     * Complex of BigDecimal approximation of center.
+     * @return r + i m as decimal approximation of the center.
+     */
+    public Complex<BigDecimal> getDecimalCenter() {
+        Complex<BigRational> rc = getRationalCenter();
+        BigDecimal rd = new BigDecimal(rc.getRe());
+        BigDecimal md = new BigDecimal(rc.getIm());
+        ComplexRing<BigDecimal> cf = new ComplexRing<BigDecimal>(rd.factory());
+        Complex<BigDecimal> c = new Complex<BigDecimal>(cf, rd, md);
+        return c;
+    }
+
+
+    /**
+     * Approximation of center.
+     * @return r + i m as string of decimal approximation of the center.
+     */
+    public String centerApprox() {
+        Complex<BigDecimal> c = getDecimalCenter();
+        StringBuffer s = new StringBuffer();
+        s.append("[ ");
+        s.append(c.getRe().toString());
+        s.append(" i ");
+        s.append(c.getIm().toString());
+        s.append(" ]");
+        return s.toString();
+    }
+
+
+    /**
+     * Length.
+     * @return |ne-sw|**2;
+     */
+    public C length() {
+        Complex<C> m = corners[3].subtract(corners[1]);
+        return m.norm().getRe();
+    }
+
+
+    /**
+     * Rational Length.
+     * @return rational(|ne-sw|**2);
+     */
+    public BigRational rationalLength() {
+        //BigRational r = new BigRational(length().toString());
+        return length().getRational();
+    }
+
+
+    /**
+     * Length real side.
+     * @return |re(ne)-re(sw)|;
+     */
+    public C lengthReal() {
+        C m = corners[3].getRe().subtract(corners[1].getRe());
+        return m.abs();
+    }
+
+
+    /**
+     * Length imaginary side.
+     * @return |im(ne)-im(sw)|;
+     */
+    public C lengthImag() {
+        C m = corners[3].getIm().subtract(corners[1].getIm());
+        return m.abs();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/RootFactory.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/RootFactory.java
@@ -1,0 +1,635 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.root;
+
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import edu.jas.arith.BigDecimal;
+import edu.jas.arith.BigRational;
+import edu.jas.arith.Rational;
+import edu.jas.poly.Complex;
+import edu.jas.poly.ComplexRing;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.ufd.FactorAbstract;
+import edu.jas.ufd.FactorFactory;
+import edu.jas.ufd.SquarefreeAbstract;
+import edu.jas.ufd.SquarefreeFactory;
+
+
+/**
+ * Roots factory. Generate real and complex algebraic numbers from root
+ * intervals or rectangles.
+ * @author Heinz Kredel
+ */
+public class RootFactory {
+
+
+    /**
+     * Is real algebraic number a root of a polynomial.
+     * @param f univariate polynomial.
+     * @param r real algebraic number.
+     * @return true, if f(r) == 0, else false;
+     */
+    public static <C extends GcdRingElem<C> & Rational> boolean isRoot(GenPolynomial<C> f,
+                    RealAlgebraicNumber<C> r) {
+        RealAlgebraicRing<C> rr = r.factory();
+        GenPolynomialRing<RealAlgebraicNumber<C>> rfac = new GenPolynomialRing<RealAlgebraicNumber<C>>(rr,
+                        f.factory());
+        GenPolynomial<RealAlgebraicNumber<C>> p;
+        p = PolyUtilRoot.<C> convertToRealCoefficients(rfac, f);
+        RealAlgebraicNumber<C> a = PolyUtil.<RealAlgebraicNumber<C>> evaluateMain(rr, p, r);
+        return a.isZERO();
+    }
+
+
+    /**
+     * Real algebraic numbers.
+     * @param f univariate polynomial.
+     * @return a list of different real algebraic numbers.
+     */
+    public static <C extends GcdRingElem<C> & Rational> List<RealAlgebraicNumber<C>> realAlgebraicNumbers(
+                    GenPolynomial<C> f) {
+        RealRoots<C> rr = new RealRootsSturm<C>();
+        SquarefreeAbstract<C> engine = SquarefreeFactory.<C> getImplementation(f.ring.coFac);
+        Map<GenPolynomial<C>, Long> SF = engine.squarefreeFactors(f);
+        //Set<GenPolynomial<C>> S = SF.keySet();
+        List<RealAlgebraicNumber<C>> list = new ArrayList<RealAlgebraicNumber<C>>();
+        for (Map.Entry<GenPolynomial<C>, Long> me : SF.entrySet()) {
+            GenPolynomial<C> sp = me.getKey();
+            List<Interval<C>> iv = rr.realRoots(sp);
+            for (Interval<C> I : iv) {
+                RealAlgebraicRing<C> rar = new RealAlgebraicRing<C>(sp, I);
+                RealAlgebraicNumber<C> rn = rar.getGenerator();
+                long mult = me.getValue();
+                for (int i = 0; i < mult; i++) {
+                    list.add(rn);
+                }
+            }
+        }
+        return list;
+    }
+
+
+    /**
+     * Real algebraic numbers.
+     * @param f univariate polynomial.
+     * @param eps rational precision.
+     * @return a list of different real algebraic numbers.
+     */
+    public static <C extends GcdRingElem<C> & Rational> List<RealAlgebraicNumber<C>> realAlgebraicNumbers(
+                    GenPolynomial<C> f, BigRational eps) {
+        RealRoots<C> rr = new RealRootsSturm<C>();
+        SquarefreeAbstract<C> engine = SquarefreeFactory.<C> getImplementation(f.ring.coFac);
+        Map<GenPolynomial<C>, Long> SF = engine.squarefreeFactors(f);
+        //Set<GenPolynomial<C>> S = SF.keySet();
+        List<RealAlgebraicNumber<C>> list = new ArrayList<RealAlgebraicNumber<C>>();
+        for (Map.Entry<GenPolynomial<C>, Long> me : SF.entrySet()) {
+            GenPolynomial<C> sp = me.getKey();
+            List<Interval<C>> iv = rr.realRoots(sp, eps);
+            for (Interval<C> I : iv) {
+                RealAlgebraicRing<C> rar = new RealAlgebraicRing<C>(sp, I);
+                rar.setEps(eps);
+                RealAlgebraicNumber<C> rn = rar.getGenerator();
+                long mult = me.getValue();
+                for (int i = 0; i < mult; i++) {
+                    list.add(rn);
+                }
+            }
+        }
+        return list;
+    }
+
+
+    /**
+     * Real algebraic numbers from a field.
+     * @param f univariate polynomial.
+     * @return a list of different real algebraic numbers from a field.
+     */
+    public static <C extends GcdRingElem<C> & Rational> List<RealAlgebraicNumber<C>> realAlgebraicNumbersField(
+                    GenPolynomial<C> f) {
+        RealRoots<C> rr = new RealRootsSturm<C>();
+        FactorAbstract<C> engine = FactorFactory.<C> getImplementation(f.ring.coFac);
+        Map<GenPolynomial<C>, Long> SF = engine.baseFactors(f);
+        //Set<GenPolynomial<C>> S = SF.keySet();
+        List<RealAlgebraicNumber<C>> list = new ArrayList<RealAlgebraicNumber<C>>();
+        for (Map.Entry<GenPolynomial<C>, Long> me : SF.entrySet()) {
+            GenPolynomial<C> sp = me.getKey();
+            List<Interval<C>> iv = rr.realRoots(sp);
+            for (Interval<C> I : iv) {
+                RealAlgebraicRing<C> rar = new RealAlgebraicRing<C>(sp, I, true);//field
+                RealAlgebraicNumber<C> rn = rar.getGenerator();
+                long mult = me.getValue();
+                for (int i = 0; i < mult; i++) {
+                    list.add(rn);
+                }
+            }
+        }
+        return list;
+    }
+
+
+    /**
+     * Real algebraic numbers from a field.
+     * @param f univariate polynomial.
+     * @param eps rational precision.
+     * @return a list of different real algebraic numbers from a field.
+     */
+    public static <C extends GcdRingElem<C> & Rational> List<RealAlgebraicNumber<C>> realAlgebraicNumbersField(
+                    GenPolynomial<C> f, BigRational eps) {
+        RealRoots<C> rr = new RealRootsSturm<C>();
+        FactorAbstract<C> engine = FactorFactory.<C> getImplementation(f.ring.coFac);
+        Map<GenPolynomial<C>, Long> SF = engine.baseFactors(f);
+        //Set<GenPolynomial<C>> S = SF.keySet();
+        List<RealAlgebraicNumber<C>> list = new ArrayList<RealAlgebraicNumber<C>>();
+        for (Map.Entry<GenPolynomial<C>, Long> me : SF.entrySet()) {
+            GenPolynomial<C> sp = me.getKey();
+            List<Interval<C>> iv = rr.realRoots(sp, eps);
+            for (Interval<C> I : iv) {
+                RealAlgebraicRing<C> rar = new RealAlgebraicRing<C>(sp, I, true);//field
+                rar.setEps(eps);
+                RealAlgebraicNumber<C> rn = rar.getGenerator();
+                long mult = me.getValue();
+                for (int i = 0; i < mult; i++) {
+                    list.add(rn);
+                }
+            }
+        }
+        return list;
+    }
+
+
+    /**
+     * Real algebraic numbers from a irreducible polynomial.
+     * @param f univariate irreducible polynomial.
+     * @return a list of different real algebraic numbers from a field.
+     */
+    public static <C extends GcdRingElem<C> & Rational> List<RealAlgebraicNumber<C>> realAlgebraicNumbersIrred(
+                    GenPolynomial<C> f) {
+        RealRoots<C> rr = new RealRootsSturm<C>();
+        List<RealAlgebraicNumber<C>> list = new ArrayList<RealAlgebraicNumber<C>>();
+        List<Interval<C>> iv = rr.realRoots(f);
+        for (Interval<C> I : iv) {
+            RealAlgebraicRing<C> rar = new RealAlgebraicRing<C>(f, I, true);//field
+            RealAlgebraicNumber<C> rn = rar.getGenerator();
+            list.add(rn);
+        }
+        return list;
+    }
+
+
+    /**
+     * Real algebraic numbers from a irreducible polynomial.
+     * @param f univariate irreducible polynomial.
+     * @param eps rational precision.
+     * @return a list of different real algebraic numbers from a field.
+     */
+    public static <C extends GcdRingElem<C> & Rational> List<RealAlgebraicNumber<C>> realAlgebraicNumbersIrred(
+                    GenPolynomial<C> f, BigRational eps) {
+        RealRoots<C> rr = new RealRootsSturm<C>();
+        List<RealAlgebraicNumber<C>> list = new ArrayList<RealAlgebraicNumber<C>>();
+        List<Interval<C>> iv = rr.realRoots(f, eps);
+        for (Interval<C> I : iv) {
+            RealAlgebraicRing<C> rar = new RealAlgebraicRing<C>(f, I, true);//field
+            rar.setEps(eps);
+            RealAlgebraicNumber<C> rn = rar.getGenerator();
+            list.add(rn);
+        }
+        return list;
+    }
+
+
+    /**
+     * Is complex algebraic number a root of a polynomial.
+     * @param f univariate polynomial.
+     * @param r complex algebraic number.
+     * @return true, if f(r) == 0, else false;
+     */
+    public static <C extends GcdRingElem<C> & Rational> boolean isRoot(GenPolynomial<C> f,
+                    ComplexAlgebraicNumber<C> r) {
+        ComplexAlgebraicRing<C> cr = r.factory();
+        GenPolynomialRing<ComplexAlgebraicNumber<C>> cfac = new GenPolynomialRing<ComplexAlgebraicNumber<C>>(
+                        cr, f.factory());
+        GenPolynomial<ComplexAlgebraicNumber<C>> p;
+        p = PolyUtilRoot.<C> convertToComplexCoefficients(cfac, f);
+        ComplexAlgebraicNumber<C> a = PolyUtil.<ComplexAlgebraicNumber<C>> evaluateMain(cr, p, r);
+        return a.isZERO();
+    }
+
+
+    /**
+     * Is complex algebraic number a root of a complex polynomial.
+     * @param f univariate complex polynomial.
+     * @param r complex algebraic number.
+     * @return true, if f(r) == 0, else false;
+     */
+    public static <C extends GcdRingElem<C> & Rational> boolean isRootComplex(GenPolynomial<Complex<C>> f,
+                    ComplexAlgebraicNumber<C> r) {
+        ComplexAlgebraicRing<C> cr = r.factory();
+        GenPolynomialRing<ComplexAlgebraicNumber<C>> cfac = new GenPolynomialRing<ComplexAlgebraicNumber<C>>(
+                        cr, f.factory());
+        GenPolynomial<ComplexAlgebraicNumber<C>> p;
+        p = PolyUtilRoot.<C> convertToComplexCoefficientsFromComplex(cfac, f);
+        ComplexAlgebraicNumber<C> a = PolyUtil.<ComplexAlgebraicNumber<C>> evaluateMain(cr, p, r);
+        return a.isZERO();
+    }
+
+
+    /**
+     * Is complex algebraic number a real root of a polynomial.
+     * @param f univariate polynomial.
+     * @param c complex algebraic number.
+     * @param r real algebraic number.
+     * @return true, if f(c) == 0 and c == r, else false;
+     */
+    public static <C extends GcdRingElem<C> & Rational> boolean isRealRoot(GenPolynomial<C> f,
+                    ComplexAlgebraicNumber<C> c, RealAlgebraicNumber<C> r) {
+        boolean t = isRoot(f, c) && isRoot(f, r);
+        if (!t) {
+            return t;
+        }
+        Rectangle<C> rc = c.ring.root;
+        Interval<C> ivci = new Interval<C>(rc.getSW().getIm(), rc.getNE().getIm());
+        t = ivci.contains(f.ring.coFac.getZERO());
+        if (!t) {
+            return t;
+        }
+        //System.out.println("imag = 0");
+        Interval<C> ivc = new Interval<C>(rc.getSW().getRe(), rc.getNE().getRe());
+        Interval<C> ivr = r.ring.root;
+        // disjoint intervals
+        if (ivc.right.compareTo(ivr.left) < 0 || ivr.right.compareTo(ivc.left) < 0) {
+            //System.out.println("disjoint: ivc = " + ivc + ", ivr = " + ivr);
+            return false;
+        }
+        //System.out.println("not disjoint");
+        // full containement
+        t = ivc.contains(ivr) || ivr.contains(ivc);
+        if (t) {
+            return t;
+        }
+        //System.out.println("with overlap");
+        // overlap, refine to smaller interval
+        C left = ivc.left;
+        if (left.compareTo(ivr.left) > 0) {
+            left = ivr.left;
+        }
+        C right = ivc.right;
+        if (right.compareTo(ivr.right) < 0) {
+            right = ivr.right;
+        }
+        Interval<C> ref = new Interval<C>(left, right);
+        //System.out.println("refined interval " + ref);
+        RealRoots<C> reng = r.ring.engine; //new RealRootsSturm<C>(); 
+        long z = reng.realRootCount(ref, f);
+        if (z != 1) {
+            return false;
+        }
+        ComplexRing<C> cr = rc.getSW().ring;
+        Complex<C> sw = new Complex<C>(cr, left, rc.getSW().getIm());
+        Complex<C> ne = new Complex<C>(cr, right, rc.getNE().getIm());
+        //Complex<C> sw = new Complex<C>(cr, left, cr.ring.getZERO());
+        //Complex<C> ne = new Complex<C>(cr, right, cr.ring.getZERO());
+        Rectangle<C> rec = new Rectangle<C>(sw, ne);
+        //System.out.println("refined rectangle " + rec);
+        ComplexRoots<C> ceng = c.ring.engine; //new ComplexRootsSturm<C>(); 
+        GenPolynomial<Complex<C>> p = PolyUtilRoot.<C> complexFromAny(f);
+        try {
+            z = ceng.complexRootCount(rec, p);
+        } catch (InvalidBoundaryException e) {
+            System.out.println("should not happen, rec = " + rec + ", p = " + p);
+            e.printStackTrace();
+            z = 0;
+        }
+        //System.out.println("complexRootCount: " + z);
+        if (z != 1) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Is complex decimal number a real root of a polynomial.
+     * @param f univariate polynomial.
+     * @param c complex decimal number.
+     * @param r real decimal number.
+     * @param eps desired precision.
+     * @return true, if f(c) == 0 and c == r, else false;
+     */
+    public static <C extends GcdRingElem<C> & Rational> boolean isRealRoot(GenPolynomial<C> f,
+                    Complex<BigDecimal> c, BigDecimal r, BigRational eps) {
+        BigDecimal e = new BigDecimal(eps);
+        if (c.getIm().abs().compareTo(e) > 0) {
+            return false;
+        }
+        if (c.getRe().subtract(r).abs().compareTo(e) > 0) {
+            return false;
+        }
+        GenPolynomialRing<Complex<C>> cfac = new GenPolynomialRing<Complex<C>>(
+                        new ComplexRing<C>(f.ring.coFac), f.ring);
+        GenPolynomial<Complex<C>> cf = PolyUtil.<C> complexFromAny(cfac, f);
+        ComplexRing<BigDecimal> cd = new ComplexRing<BigDecimal>(e);
+        GenPolynomialRing<Complex<BigDecimal>> rfac = new GenPolynomialRing<Complex<BigDecimal>>(cd, cf.ring);
+        GenPolynomial<Complex<BigDecimal>> cdf = PolyUtil.<C> complexDecimalFromRational(rfac, cf);
+        Complex<BigDecimal> z = PolyUtil.evaluateMain(cd, cdf, c);
+        if (z.isZERO()) {
+            return true;
+        }
+        System.out.println("z != 0: " + z);
+        return false;
+    }
+
+
+    /**
+     * Complex algebraic numbers.
+     * @param f univariate polynomial.
+     * @return a list of different complex algebraic numbers.
+     */
+    public static <C extends GcdRingElem<C> & Rational> List<ComplexAlgebraicNumber<C>> complexAlgebraicNumbersComplex(
+                    GenPolynomial<Complex<C>> f) {
+        ComplexRoots<C> cr = new ComplexRootsSturm<C>(f.ring.coFac);
+        SquarefreeAbstract<Complex<C>> engine = SquarefreeFactory
+                        .<Complex<C>> getImplementation(f.ring.coFac);
+        Map<GenPolynomial<Complex<C>>, Long> SF = engine.squarefreeFactors(f);
+        //Set<GenPolynomial<Complex<C>>> S = SF.keySet();
+        List<ComplexAlgebraicNumber<C>> list = new ArrayList<ComplexAlgebraicNumber<C>>();
+        for (Map.Entry<GenPolynomial<Complex<C>>, Long> me : SF.entrySet()) {
+            GenPolynomial<Complex<C>> sp = me.getKey();
+            List<Rectangle<C>> iv = cr.complexRoots(sp);
+            for (Rectangle<C> I : iv) {
+                ComplexAlgebraicRing<C> car = new ComplexAlgebraicRing<C>(sp, I);
+                ComplexAlgebraicNumber<C> cn = car.getGenerator();
+                long mult = me.getValue();
+                for (int i = 0; i < mult; i++) {
+                    list.add(cn);
+                }
+            }
+        }
+        return list;
+    }
+
+
+    /**
+     * Complex algebraic numbers.
+     * @param f univariate polynomial.
+     * @param eps rational precision.
+     * @return a list of different complex algebraic numbers.
+     */
+    public static <C extends GcdRingElem<C> & Rational> List<ComplexAlgebraicNumber<C>> complexAlgebraicNumbersComplex(
+                    GenPolynomial<Complex<C>> f, BigRational eps) {
+        ComplexRoots<C> cr = new ComplexRootsSturm<C>(f.ring.coFac);
+        SquarefreeAbstract<Complex<C>> engine = SquarefreeFactory
+                        .<Complex<C>> getImplementation(f.ring.coFac);
+        Map<GenPolynomial<Complex<C>>, Long> SF = engine.squarefreeFactors(f);
+        //Set<GenPolynomial<Complex<C>>> S = SF.keySet();
+        List<ComplexAlgebraicNumber<C>> list = new ArrayList<ComplexAlgebraicNumber<C>>();
+        for (Map.Entry<GenPolynomial<Complex<C>>, Long> me : SF.entrySet()) {
+            GenPolynomial<Complex<C>> sp = me.getKey();
+            List<Rectangle<C>> iv = cr.complexRoots(sp);
+            for (Rectangle<C> I : iv) {
+                Rectangle<C> Iv = I;
+                try {
+                    Iv = cr.complexRootRefinement(I, sp, eps);
+                } catch (InvalidBoundaryException e) {
+                    e.printStackTrace();
+                }
+                ComplexAlgebraicRing<C> car = new ComplexAlgebraicRing<C>(sp, Iv);
+                car.setEps(eps);
+                ComplexAlgebraicNumber<C> cn = car.getGenerator();
+                long mult = me.getValue();
+                for (int i = 0; i < mult; i++) {
+                    list.add(cn);
+                }
+            }
+        }
+        return list;
+    }
+
+
+    /**
+     * Complex algebraic numbers.
+     * @param f univariate (rational) polynomial.
+     * @return a list of different complex algebraic numbers.
+     */
+    public static <C extends GcdRingElem<C> & Rational> List<ComplexAlgebraicNumber<C>> complexAlgebraicNumbers(
+                    GenPolynomial<C> f) {
+        GenPolynomial<Complex<C>> fc = PolyUtilRoot.<C> complexFromAny(f);
+        return complexAlgebraicNumbersComplex(fc);
+    }
+
+
+    /**
+     * Complex algebraic numbers.
+     * @param f univariate (rational) polynomial.
+     * @param eps rational precision.
+     * @return a list of different complex algebraic numbers.
+     */
+    public static <C extends GcdRingElem<C> & Rational> List<ComplexAlgebraicNumber<C>> complexAlgebraicNumbers(
+                    GenPolynomial<C> f, BigRational eps) {
+        GenPolynomial<Complex<C>> fc = PolyUtilRoot.<C> complexFromAny(f);
+        return complexAlgebraicNumbersComplex(fc, eps);
+    }
+
+
+    /**
+     * Filter real roots from complex roots.
+     * @param f univariate polynomial.
+     * @param c list of complex algebraic numbers.
+     * @param r list of real algebraic numbers.
+     * @return c minus the real roots from r
+     */
+    public static <C extends GcdRingElem<C> & Rational> List<ComplexAlgebraicNumber<C>> filterOutRealRoots(
+                    GenPolynomial<C> f, List<ComplexAlgebraicNumber<C>> c, List<RealAlgebraicNumber<C>> r) {
+        if (c.isEmpty()) {
+            return c;
+        }
+        if (r.isEmpty()) {
+            return c;
+        }
+        List<ComplexAlgebraicNumber<C>> cmr = new ArrayList<ComplexAlgebraicNumber<C>>();
+        if (c.size() == r.size() /*&& r.size() == f.degree()*/ ) {
+            return cmr;
+        }
+        List<RealAlgebraicNumber<C>> rl = new LinkedList<RealAlgebraicNumber<C>>(r);
+        for (ComplexAlgebraicNumber<C> cn : c) {
+            RealAlgebraicNumber<C> rm = null; // ~boolean
+            for (RealAlgebraicNumber<C> rn : rl) {
+                if (isRealRoot(f, cn, rn)) {
+                    //System.out.println("filterOutRealRoots, cn = " + cn + ", rn = " + rn);
+                    rm = rn;
+                    break; // remove from r
+                }
+            }
+            if (rm == null) {
+                cmr.add(cn);
+            } else {
+                rl.remove(rm);
+            }
+        }
+        return cmr;
+    }
+
+
+    /**
+     * Filter real roots from complex roots.
+     * @param f univariate polynomial.
+     * @param c list of complex decimal numbers.
+     * @param r list of real decimal numbers.
+     * @param eps desired precision.
+     * @return c minus the real roots from r
+     */
+    public static <C extends GcdRingElem<C> & Rational> List<Complex<BigDecimal>> filterOutRealRoots(
+                    GenPolynomial<C> f, List<Complex<BigDecimal>> c, List<BigDecimal> r, BigRational eps) {
+        if (c.isEmpty()) {
+            return c;
+        }
+        if (r.isEmpty()) {
+            return c;
+        }
+        List<Complex<BigDecimal>> cmr = new ArrayList<Complex<BigDecimal>>();
+        if (c.size() == r.size() /*&& r.size() == f.degree()*/ ) {
+            return cmr;
+        }
+        List<BigDecimal> rl = new LinkedList<BigDecimal>(r);
+        for (Complex<BigDecimal> cn : c) {
+            BigDecimal rm = null; // ~boolean
+            for (BigDecimal rn : rl) {
+                if (isRealRoot(f, cn, rn, eps)) {
+                    //System.out.println("filterOutRealRoots, cn = " + cn + ", rn = " + rn);
+                    rm = rn;
+                    break; // remove from r
+                }
+            }
+            if (rm == null) {
+                cmr.add(cn);
+            } else {
+                rl.remove(rm);
+            }
+        }
+        return cmr;
+    }
+
+
+    /**
+     * Roots as real and complex algebraic numbers.
+     * @param f univariate polynomial.
+     * @return container of real and complex algebraic numbers.
+     */
+    public static <C extends GcdRingElem<C> & Rational> AlgebraicRoots<C> algebraicRoots(GenPolynomial<C> f) {
+        List<RealAlgebraicNumber<C>> rl = realAlgebraicNumbers(f);
+        List<ComplexAlgebraicNumber<C>> cl = complexAlgebraicNumbers(f);
+        GenPolynomial<Complex<C>> cf = null;
+        if (!cl.isEmpty()) {
+            cf = cl.get(0).ring.algebraic.modul;
+        }
+        cl = filterOutRealRoots(f, cl, rl);
+        AlgebraicRoots<C> ar = new AlgebraicRoots<C>(f, cf, rl, cl);
+        return ar;
+    }
+
+
+    /**
+     * Roots of unity of real and complex algebraic numbers.
+     * @param ar container of real and complex algebraic numbers.
+     * @return container of real and complex algebraic numbers which are roots
+     *         of unity.
+     */
+    public static <C extends GcdRingElem<C> & Rational> AlgebraicRoots<C> rootsOfUnity(AlgebraicRoots<C> ar) {
+        List<RealAlgebraicNumber<C>> rl = new ArrayList<RealAlgebraicNumber<C>>();
+        for (RealAlgebraicNumber<C> r : ar.real) {
+            if (r.isRootOfUnity()) {
+                rl.add(r);
+            }
+        }
+        List<ComplexAlgebraicNumber<C>> cl = new ArrayList<ComplexAlgebraicNumber<C>>();
+        for (ComplexAlgebraicNumber<C> c : ar.complex) {
+            if (c.isRootOfUnity()) {
+                cl.add(c);
+            }
+        }
+        AlgebraicRoots<C> ur = new AlgebraicRoots<C>(ar.p, ar.cp, rl, cl);
+        return ur;
+    }
+
+
+    /**
+     * Root refinement of real and complex algebraic numbers.
+     * @param a container of real and complex algebraic numbers.
+     * @param eps desired precision for root intervals and rectangles.
+     */
+    public static <C extends GcdRingElem<C> & Rational> void rootRefine(AlgebraicRoots<C> a,
+                    BigRational eps) {
+        for (RealAlgebraicNumber<C> r : a.real) {
+            r.ring.refineRoot(eps);
+        }
+        for (ComplexAlgebraicNumber<C> c : a.complex) {
+            c.ring.refineRoot(eps);
+        }
+        return; // a or void?
+    }
+
+
+    /**
+     * Roots as real and complex decimal numbers.
+     * @param f univariate polynomial.
+     * @param eps desired precision.
+     * @return container of real and complex decimal numbers.
+     */
+    public static <C extends GcdRingElem<C> & Rational> DecimalRoots<C> decimalRoots(GenPolynomial<C> f,
+                    BigRational eps) {
+        RealRootsAbstract<C> rengine = new RealRootsSturm<C>();
+        List<BigDecimal> rl = rengine.approximateRoots(f, eps);
+
+        GenPolynomial<Complex<C>> fc = PolyUtilRoot.<C> complexFromAny(f);
+        ComplexRootsAbstract<C> cengine = new ComplexRootsSturm<C>(fc.ring.coFac);
+        List<Complex<BigDecimal>> cl = cengine.approximateRoots(fc, eps);
+
+        cl = filterOutRealRoots(f, cl, rl, eps);
+        DecimalRoots<C> ar = new DecimalRoots<C>(f, fc, rl, cl);
+        return ar;
+    }
+
+
+    /**
+     * Roots as real and complex decimal numbers.
+     * @param ar container for real and complex algebraic roots.
+     * @param eps desired precision.
+     * @return container of real and complex decimal numbers.
+     */
+    public static <C extends GcdRingElem<C> & Rational> DecimalRoots<C> decimalRoots(AlgebraicRoots<C> ar,
+                    BigRational eps) {
+        //no: rootRefine(ar, eps);
+        RealRootsAbstract<C> rengine = new RealRootsSturm<C>();
+        List<BigDecimal> rl = new ArrayList<BigDecimal>(ar.real.size());
+        for (RealAlgebraicNumber<C> r : ar.real) {
+            try {
+                BigDecimal d = rengine.approximateRoot(r.ring.root, ar.p, eps);
+                rl.add(d);
+            } catch (NoConvergenceException e) {
+                System.out.println("should not happen: " + e);
+            }
+        }
+        ComplexRootsAbstract<C> cengine = new ComplexRootsSturm<C>(ar.cp.ring.coFac);
+        List<Complex<BigDecimal>> cl = new ArrayList<Complex<BigDecimal>>(ar.complex.size());
+        for (ComplexAlgebraicNumber<C> c : ar.complex) {
+            try {
+                Complex<BigDecimal> d = cengine.approximateRoot(c.ring.root, ar.cp, eps);
+                cl.add(d);
+            } catch (NoConvergenceException e) {
+                System.out.println("should not happen: " + e);
+            }
+        }
+        DecimalRoots<C> dr = new DecimalRoots<C>(ar.p, ar.cp, rl, cl);
+        return dr;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/RootUtil.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/RootUtil.java
@@ -1,0 +1,160 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.root;
+
+
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.arith.Rational;
+import edu.jas.poly.Complex;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Real root utilities. For example real root count.
+ * @author Heinz Kredel
+ */
+public class RootUtil {
+
+
+    private static final Logger logger = LogManager.getLogger(RootUtil.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Count changes in sign.
+     * @param <C> coefficient type.
+     * @param L list of coefficients.
+     * @return number of sign changes in L.
+     */
+    public static <C extends RingElem<C>> long signVar(List<C> L) {
+        long v = 0;
+        if (L == null || L.isEmpty()) {
+            return v;
+        }
+        C A = L.get(0);
+        for (int i = 1; i < L.size(); i++) {
+            C B = L.get(i);
+            while (B == null || B.signum() == 0) {
+                i++;
+                if (i >= L.size()) {
+                    return v;
+                }
+                B = L.get(i);
+            }
+            if (A.signum() * B.signum() < 0) {
+                v++;
+            }
+            A = B;
+        }
+        return v;
+    }
+
+
+    /**
+     * Parse interval for a real root from String.
+     * @param s String, syntax: [left, right] or [mid].
+     * @return Interval from s.
+     */
+    public static <C extends RingElem<C> & Rational> Interval<C> parseInterval(RingFactory<C> fac, String s) {
+        int r = s.length();
+        int el = s.indexOf("[");
+        if (el >= 0) {
+            int ri = s.indexOf("]");
+            if (ri > 0) {
+                r = ri;
+            }
+        } else {
+            el = -1;
+        }
+        //System.out.println("s  = " + s);
+        String iv = s.substring(el + 1, r).trim();
+        //System.out.println("iv = " + iv);
+        int k = iv.indexOf(",");
+        if (k < 0) {
+            k = s.indexOf(" ");
+        }
+        if (k < 0) {
+            C mid = fac.parse(iv);
+            return new Interval<C>(mid);
+        }
+        //System.out.println("k  = " + k + ", len = " + iv.length());
+        String ls = iv.substring(0, k).trim();
+        String rs = iv.substring(k + 1, iv.length()).trim();
+        //System.out.println("ls = " + ls + ", rs = " + rs);
+        C left = fac.parse(ls);
+        C right = fac.parse(rs);
+        if (debug) {
+            logger.debug("Interval: left = " + left + ", right = " + right);
+        }
+        return new Interval<C>(left, right);
+    }
+
+
+    /**
+     * Parse rectangle for a complex root from String.
+     * @param s String, syntax: [south-west, north-east] or [mid].
+     * @return Interval from s.
+     */
+    @SuppressWarnings("unchecked")
+    public static <C extends RingElem<C> & Rational> Rectangle<C> parseRectangle(RingFactory<Complex<C>> fac,
+                    String s) {
+        int r = s.length();
+        int el = s.indexOf("[");
+        if (el >= 0) {
+            int ri = s.indexOf("]");
+            if (ri > 0) {
+                r = ri;
+            }
+        } else {
+            el = -1;
+        }
+        //System.out.println("s  = " + s);
+        String iv = s.substring(el + 1, r).trim();
+        //System.out.println("iv = " + iv);
+        int k = iv.indexOf(",");
+        if (k < 0) {
+            k = s.indexOf(" ");
+        }
+        if (k < 0) {
+            Complex<C> mid = fac.parse(iv);
+            return new Rectangle<C>(mid);
+        }
+        //System.out.println("k  = " + k + ", len = " + iv.length());
+        String ls = iv.substring(0, k).trim();
+        String rs = iv.substring(k + 1, iv.length()).trim();
+        //System.out.println("ls = " + ls + ", rs = " + rs);
+        Object osw = fac.parse(ls);
+        Object one = fac.parse(rs);
+        //System.out.println("osw = " + osw + ", one = " + one);
+        Complex<C> sw;
+        Complex<C> ne;
+        if (osw instanceof Complex) {
+            sw = (Complex<C>)osw;
+            ne = (Complex<C>)one;
+        } else if (osw instanceof ComplexAlgebraicNumber) {
+            ComplexAlgebraicNumber csw = (ComplexAlgebraicNumber) osw;
+            ComplexAlgebraicNumber cne = (ComplexAlgebraicNumber) one;
+            //System.out.println("csw::ring = " + csw.ring.algebraic.toScript());
+            sw = (Complex<C>) csw.magnitude();
+            ne = (Complex<C>) cne.magnitude();
+        } else {
+            sw = fac.getONE().negate();
+            ne = fac.getONE();
+        }
+        //System.out.println("sw = " + sw + ", ne = " + ne);
+        if (debug) {
+            logger.debug("Rectangle: sw = " + sw + ", ne = " + ne);
+        }
+        return new Rectangle<C>(sw, ne);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/package.html
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/root/package.html
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "../DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>Real and Complex Root Computation package</title>
+  </head>
+
+  <body>
+    <h1>Real and Complex Root Computation package.</h1>
+
+<p>
+  This package contains classes for the computation of 
+  isolating and refining intervals of real roots and complex roots of univariate polynomials.
+</p>
+<p>
+  Method <code>algebraicRoots()</code> from class <code>RootFactory</code>
+  computes both the real and complex algebraic roots of a univariate polynomial.
+  Method <code>decimalRoots()</code> computes isolating intervals (or rectangles) for the roots 
+  and then uses a numerical algorithm to get a decimal approximation of the roots.
+</p>
+<p>
+  For the computation of real roots the main interface is <code>RealRoots</code> 
+  and main implementing class is <code>RealRootsSturm</code>.
+  The implementation follows in part 
+  section 8.8 "Computation of real zeroes of Polynomial Systems" 
+  in <em>Gr&ouml;bner Bases</em>, A computational Approach to Commutative Algebra, by Becker et al.
+  <br />
+  The class <code>RealAlgebraicNumber</code> is based on <code>AlgebraicNumber</code> 
+  with factory class <code>RealAlgebraicRing</code> based on <code>AlgebraicNumberRing</code>.
+  They implement real algebraic numbers, which are algebraic numbers plus an  
+  isolating interval for a real root of the generator.
+  <code>RealRootsSturm</code> can be applied to polynomials with real algebraic
+  numbers as coefficients.
+</p>
+<p>
+  For the computation of complex roots the main interface is <code>ComplexRoots</code> 
+  and the main implementing class is <code>ComplexRootsSturm</code>.
+  The implementation provides an exact infallible method which follows the numeric method of Wilf 
+  (see Wilf: A global bisection algorithm for computing the zeros of polynomials in the complex plane).
+  It uses Sturm sequences following the Routh-Hurwitz Method 
+  to count the number of complex roots within a rectangle in the complex plane.  
+  For a (eventually) more efficient method see: 
+  Collins and Krandick: An efficient algorithm for infallible polynomial complex root isolation,
+  in ISSAC'92.
+</p>
+
+
+    <hr />
+    <address><a href="mailto:kredel at rz.uni-mannheim.de">Heinz Kredel</a></address>
+<p>
+<!-- Created: Sat Mar 21 20:20:15 CET 2009 -->
+<!-- hhmts start -->
+Last modified: Wed Aug 17 23:32:35 CEST 2016
+<!-- hhmts end -->
+</p>
+<p>$Id$ 
+</p>
+  </body>
+</html>

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/AbelianGroupElem.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/AbelianGroupElem.java
@@ -1,0 +1,63 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.structure;
+
+
+/**
+ * Abelian group element interface. Defines the additive methods.
+ * @param <C> element type
+ * @author Heinz Kredel
+ */
+
+public interface AbelianGroupElem<C extends AbelianGroupElem<C>> extends Element<C> {
+
+
+    /**
+     * Test if this is zero.
+     * @return true if this is 0, else false.
+     */
+    public boolean isZERO();
+
+
+    /**
+     * Signum.
+     * @return the sign of this.
+     */
+    public int signum();
+
+
+    /**
+     * Sum of this and S.
+     * @param S
+     * @return this + S.
+     */
+    public C sum(C S);
+
+
+    //public <T extends C> T sum(T S);
+
+
+    /**
+     * Subtract S from this.
+     * @param S
+     * @return this - S.
+     */
+    public C subtract(C S);
+
+
+    /**
+     * Negate this.
+     * @return - this.
+     */
+    public C negate();
+
+
+    /**
+     * Absolute value of this.
+     * @return |this|.
+     */
+    public C abs();
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/AbelianGroupFactory.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/AbelianGroupFactory.java
@@ -1,0 +1,23 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.structure;
+
+
+/**
+ * Abelian group factory interface. Defines get zero.
+ * @author Heinz Kredel
+ */
+
+public interface AbelianGroupFactory<C extends AbelianGroupElem<C>> extends ElemFactory<C> {
+
+
+    /**
+     * Get the constant zero for the AbelianGroupElem.
+     * @return 0.
+     */
+    public C getZERO();
+
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/AlgebraElem.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/AlgebraElem.java
@@ -1,0 +1,43 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.structure;
+
+
+/**
+ * Algabra element interface.
+ * @param <A> algebra type
+ * @param <C> scalar type
+ * @author Heinz Kredel
+ */
+public interface AlgebraElem<A extends AlgebraElem<A, C>, C extends RingElem<C>> extends RingElem<A> {
+
+
+    /**
+     * Scalar multiplication. Multiply this by a scalar.
+     * @param s scalar
+     * @return this * s.
+     */
+    public A scalarMultiply(C s);
+
+
+    /**
+     * Linear combination.
+     * @param a scalar
+     * @param b algebra element
+     * @param s scalar
+     * @return a * b + this * s.
+     */
+    public A linearCombination(C a, A b, C s);
+
+
+    /**
+     * Linear combination.
+     * @param b algebra element
+     * @param s scalar
+     * @return b + this * s.
+     */
+    public A linearCombination(A b, C s);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/AlgebraFactory.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/AlgebraFactory.java
@@ -1,0 +1,37 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.structure;
+
+
+import java.util.List;
+
+
+/**
+ * Algebra factory interface. Defines conversion from list of lists and sparse
+ * random.
+ * @param <A> algebra type
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+public interface AlgebraFactory<A extends AlgebraElem<A, C>, C extends RingElem<C>> extends RingFactory<A> {
+
+
+    /**
+     * Convert list of list to matrix.
+     * @param m list of list of ring elements.
+     * @return a matrix with the elements from m.
+     */
+    public A fromList(List<List<C>> m);
+
+
+    /**
+     * Random Matrix.
+     * @param k size of coefficients.
+     * @param q fraction of non zero elements.
+     * @return a random matrix.
+     */
+    public A random(int k, float q);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/BinaryFunctor.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/BinaryFunctor.java
@@ -1,0 +1,25 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.structure;
+
+
+/**
+ * Binary functor interface.
+ * @param <C1> element type
+ * @param <C2> element type
+ * @param <D> element type
+ * @author Heinz Kredel
+ */
+
+public interface BinaryFunctor<C1 extends Element<C1>, C2 extends Element<C2>, D extends Element<D>> {
+
+
+    /**
+     * Evaluate.
+     * @return evaluated element.
+     */
+    public D eval(C1 c1, C2 c2);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/ElemFactory.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/ElemFactory.java
@@ -1,0 +1,111 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.structure;
+
+
+import java.io.Reader;
+import java.io.Serializable;
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Random;
+
+
+/**
+ * Element factory interface. Defines embedding of integers, parsing and random
+ * element construction.
+ * @author Heinz Kredel
+ */
+
+public interface ElemFactory<C extends Element<C>> extends Serializable {
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     */
+    public List<C> generators();
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     */
+    public boolean isFinite();
+
+
+    /**
+     * Get the Element for a.
+     * @param a long
+     * @return element corresponding to a.
+     */
+    public C fromInteger(long a);
+
+
+    /**
+     * Get the Element for a.
+     * @param a java.math.BigInteger.
+     * @return element corresponding to a.
+     */
+    public C fromInteger(BigInteger a);
+
+
+    /**
+     * Generate a random Element with size less equal to n.
+     * @param n
+     * @return a random element.
+     */
+    public C random(int n);
+
+
+    /**
+     * Generate a random Element with size less equal to n.
+     * @param n
+     * @param random is a source for random bits.
+     * @return a random element.
+     */
+    public C random(int n, Random random);
+
+
+    /**
+     * Create a copy of Element c.
+     * @param c
+     * @return a copy of c.
+     */
+    public C copy(C c);
+
+
+    /**
+     * Value from String.
+     * @param s String.
+     * @return a Element corresponding to s.
+     */
+    default public C valueOf(String s) {
+        return parse(s);
+    }
+
+
+    /**
+     * Parse from String.
+     * @param s String.
+     * @return a Element corresponding to s.
+     */
+    public C parse(String s);
+
+
+    /**
+     * Parse from Reader.
+     * @param r Reader.
+     * @return the next Element found on r.
+     */
+    public C parse(Reader r);
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this ElemFactory.
+     */
+    public String toScript();
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/Element.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/Element.java
@@ -1,0 +1,77 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.structure;
+
+
+import java.io.Serializable;
+
+
+/**
+ * Element interface. Basic functionality of elements, e.g. compareTo, equals,
+ * clone.
+ * <p>
+ * <b>Note:</b> extension of <code>Cloneable</code> removed in 2012-08-18,
+ * <code>clone()</code> is renamed to <code>copy()</code>. See also the
+ * discussion in <a href="http://www.artima.com/intv/bloch13.html">Bloch on
+ * Cloning</a>.
+ * @param <C> element type.
+ * @author Heinz Kredel
+ */
+
+public interface Element<C extends Element<C>> extends Comparable<C>, Serializable {
+
+
+    /**
+     * Clone this Element.
+     * @return Creates and returns a copy of this Element.
+     */
+    public C copy();
+
+
+    /**
+     * Test if this is equal to b.
+     * @param b
+     * @return true if this is equal to b, else false.
+     */
+    public boolean equals(Object b);
+
+
+    /**
+     * Hashcode of this Element.
+     * @return the hashCode.
+     */
+    public int hashCode();
+
+
+    /**
+     * Compare this to b. I.e. this &lt; b iff this.compareTo(b) &lt; 0.
+     * <b>Note:</b> may not be meaningful if structure has no order.
+     * @param b
+     * @return 0 if this is equal to b, -1 if this is less then b, else +1.
+     */
+    public int compareTo(C b);
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     */
+    public ElemFactory<C> factory();
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     */
+    public String toScript();
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     */
+    public String toScriptFactory();
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/FieldElem.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/FieldElem.java
@@ -1,0 +1,17 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.structure;
+
+
+/**
+ * Field element interface. Empty interface since inverse is already in
+ * RingElem.
+ * @param <C> field element type
+ * @author Heinz Kredel
+ */
+
+public interface FieldElem<C extends FieldElem<C>> extends RingElem<C> {
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/FieldFactory.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/FieldFactory.java
@@ -1,0 +1,15 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.structure;
+
+
+/**
+ * Field factory interface. Defines test for field and access of characteristic.
+ * @author Heinz Kredel
+ */
+
+public interface FieldFactory<C extends RingElem<C>> extends RingFactory<C> {
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/GcdRingElem.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/GcdRingElem.java
@@ -1,0 +1,17 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.structure;
+
+
+/**
+ * Gcd ring element interface. Empty interface since gcd and egcd is now in
+ * RingElem. Adds greatest common divisor and extended greatest common divisor.
+ * @param <C> gcd element type
+ * @author Heinz Kredel
+ */
+
+public interface GcdRingElem<C extends GcdRingElem<C>> extends RingElem<C> {
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/ModulElem.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/ModulElem.java
@@ -1,0 +1,63 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.structure;
+
+
+import java.util.List;
+
+
+/**
+ * Module element interface. Defines scalar operations.
+ * @param <M> module type
+ * @param <C> scalar type
+ * @author Heinz Kredel
+ */
+public interface ModulElem<M extends ModulElem<M, C>, C extends RingElem<C>> extends AbelianGroupElem<M> {
+
+
+    /**
+     * Scalar multiplication. Multiply this by a scalar.
+     * @param s scalar
+     * @return this * s.
+     */
+    public M scalarMultiply(C s);
+
+
+    /**
+     * Linear combination.
+     * @param a scalar
+     * @param b module element
+     * @param s scalar
+     * @return a * b + this * s.
+     */
+    public M linearCombination(C a, M b, C s);
+
+
+    /**
+     * Linear combination.
+     * @param b module element
+     * @param s scalar
+     * @return b + this * s.
+     */
+    public M linearCombination(M b, C s);
+
+
+    /**
+     * Scalar product. Multiply two vectors to become a scalar.
+     * @param b module element
+     * @return this * b, a scalar.
+     */
+    public C scalarProduct(M b);
+
+
+    /**
+     * Scalar product. Multiply this vectors by list of vectors to become a
+     * vector.
+     * @param b list of module elements
+     * @return this * b, a list of scalars, a module element.
+     */
+    public M scalarProduct(List<M> b);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/ModulFactory.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/ModulFactory.java
@@ -1,0 +1,37 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.structure;
+
+
+import java.util.List;
+
+
+/**
+ * Module factory interface. Defines conversion from list and sparse random.
+ * @param <M> module type
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+public interface ModulFactory<M extends ModulElem<M, C>, C extends RingElem<C>> extends
+                AbelianGroupFactory<M> {
+
+
+    /**
+     * Convert list to module.
+     * @param v list of ring elements.
+     * @return a module element with the elements from v.
+     */
+    public M fromList(List<C> v);
+
+
+    /**
+     * Random vector.
+     * @param k size of coefficients.
+     * @param q fraction of non zero elements.
+     * @return a random vector.
+     */
+    public M random(int k, float q);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/MonoidElem.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/MonoidElem.java
@@ -1,0 +1,157 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.structure;
+
+
+/**
+ * Monoid element interface. Defines the multiplicative methods.
+ * @param <C> element type
+ * @author Heinz Kredel
+ */
+
+public interface MonoidElem<C extends MonoidElem<C>> extends Element<C> {
+
+
+    /**
+     * Test if this is one.
+     * @return true if this is 1, else false.
+     */
+    public boolean isONE();
+
+
+    /**
+     * Test if this is a unit. I.e. there exists x with this.multiply(x).isONE()
+     * == true.
+     * @return true if this is a unit, else false.
+     */
+    public boolean isUnit();
+
+
+    /**
+     * Multiply this with S.
+     * @param S
+     * @return this * S.
+     */
+    public C multiply(C S);
+
+
+    /**
+     * Divide this by S.
+     * @param S
+     * @return this / S.
+     */
+    public C divide(C S);
+
+
+    /**
+     * Remainder after division of this by S.
+     * @param S
+     * @return this - (this / S) * S.
+     */
+    public C remainder(C S);
+
+
+    /**
+     * Quotient and remainder by division of this by S.
+     * @param S
+     * @return [this/S, this - (this/S)*S].
+     */
+    @SuppressWarnings("unchecked")
+    default public C[] quotientRemainder(C S) {
+        return (C[]) new MonoidElem[] { divide(S), remainder(S) }; 
+    }
+
+
+    /**
+     * Right division.
+     * Returns commutative divide if not overwritten.
+     * @param a element.
+     * @return right, with a * right = this
+     */
+    default public C rightDivide(C a) {
+        return divide(a);
+    }
+
+
+    /**
+     * Left division.
+     * Returns commutative divide if not overwritten.
+     * @param a element.
+     * @return left, with left * a = this
+     */
+    default public C leftDivide(C a) {
+        return divide(a);
+    }
+
+
+    /**
+     * Right remainder.
+     * Returns commutative remainder if not overwritten.
+     * @param a element.
+     * @return r = this - a * (1/right), where a * right = this.
+     */
+    default public C rightRemainder(C a) {
+        return remainder(a);
+    }
+
+
+    /**
+     * Left remainder.
+     * Returns commutative remainder if not overwritten.
+     * @param a element.
+     * @return r = this - (1/left) * a, where left * a = this.
+     */
+    default public C leftRemainder(C a) {
+        return remainder(a);
+    }
+
+
+    /**
+     * Two-sided division.
+     * Returns commutative divide if not overwritten.
+     * @param a element.
+     * @return [left,right], with left * a * right = this
+     */
+    @SuppressWarnings("unchecked")
+    default public C[] twosidedDivide(C a) {
+        C[] ret = (C[]) new MonoidElem[2];
+        ret[0] = divide(a);
+        ret[1] = ((MonoidFactory<C>)factory()).getONE();
+        return ret;
+    }
+
+
+    /**
+     * Two-sided remainder.
+     * Returns commutative remainder if not overwritten.
+     * @param a element.
+     * @return r = this - (a/left) * a * (a/right), where left * a * right = this.
+     */
+    default public C twosidedRemainder(C a){
+        return remainder(a);
+    }
+
+
+    /**
+     * Inverse of this. Some implementing classes will throw
+     * NotInvertibleException if the element is not invertible.
+     * @return x with this * x = 1, if it exists.
+     */
+    public C inverse(); /*throws NotInvertibleException*/
+
+
+    /**
+     * Power of this to the n-th.
+     * @param n integer exponent.
+     * @return a**n, with a**0 = 1 and a**{-n} = {1/a}**n.
+     * Java 8 only
+     */ 
+    @SuppressWarnings("unchecked")
+    default public C power(long n) {
+        //System.out.println("this = " + this + ", n = " + n);
+        return Power.<C>power((MonoidFactory<C>)factory(), (C)this, n);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/MonoidFactory.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/MonoidFactory.java
@@ -1,0 +1,38 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.structure;
+
+
+/**
+ * Monoid factory interface. Defines get one and tests for associativity and
+ * commutativity.
+ * @author Heinz Kredel
+ */
+
+public interface MonoidFactory<C extends MonoidElem<C>> extends ElemFactory<C> {
+
+
+    /**
+     * Get the constant one for the MonoidElem.
+     * @return 1.
+     */
+    public C getONE();
+
+
+    /**
+     * Query if this monoid is commutative.
+     * @return true if this monoid is commutative, else false.
+     */
+    public boolean isCommutative();
+
+
+    /**
+     * Query if this monoid is associative.
+     * @return true if this monoid is associative, else false.
+     */
+    public boolean isAssociative();
+
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/NoncomRingElem.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/NoncomRingElem.java
@@ -1,0 +1,48 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.structure;
+
+
+/**
+ * Non-commutative ring element interface. Defines right divide and right remainder.
+ * @param <C> ring element type
+ * @author Heinz Kredel
+ */
+
+public interface NoncomRingElem<C extends NoncomRingElem<C>> extends RingElem<C> {
+
+
+    /**
+     * Right division.
+     * @param a element.
+     * @return right, with a * right = this
+     */
+    public C rightDivide(C a);
+
+
+    /**
+     * Right remainder.
+     * @param a element.
+     * @return r = this - a * (a/right), where a * right = this.
+     */
+    public C rightRemainder(C a);
+
+
+    /**
+     * Two-sided division.
+     * @param a element.
+     * @return [left,right], with left * a * right = this
+     */
+    public C[] twosidedDivide(C a);
+
+
+    /**
+     * Two-sided remainder.
+     * @param a element.
+     * @return r = this - (a/left) * a * (a/right), where left * a * right = this.
+     */
+    public C twosidedRemainder(C a);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/NotDivisibleException.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/NotDivisibleException.java
@@ -1,0 +1,36 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.structure;
+
+
+/**
+ * NotDivisibleException class. Runtime Exception to be thrown for not
+ * divisible monoid elements.
+ * @author Heinz Kredel
+ */
+
+public class NotDivisibleException extends RuntimeException {
+
+
+    public NotDivisibleException() {
+        super("NotDivisibleException");
+    }
+
+
+    public NotDivisibleException(String c) {
+        super(c);
+    }
+
+
+    public NotDivisibleException(String c, Throwable t) {
+        super(c, t);
+    }
+
+
+    public NotDivisibleException(Throwable t) {
+        super("NotDivisibleException", t);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/NotInvertibleException.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/NotInvertibleException.java
@@ -1,0 +1,36 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.structure;
+
+
+/**
+ * NotInvertibleException class. Runtime Exception to be thrown for not
+ * invertible monoid elements.
+ * @author Heinz Kredel
+ */
+
+public class NotInvertibleException extends RuntimeException {
+
+
+    public NotInvertibleException() {
+        super("NotInvertibleException");
+    }
+
+
+    public NotInvertibleException(String c) {
+        super(c);
+    }
+
+
+    public NotInvertibleException(String c, Throwable t) {
+        super(c, t);
+    }
+
+
+    public NotInvertibleException(Throwable t) {
+        super("NotInvertibleException", t);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/Power.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/Power.java
@@ -1,0 +1,506 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.structure;
+
+
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * Power class to compute powers of RingElem.
+ * @author Heinz Kredel
+ */
+public class Power<C extends RingElem<C>> {
+
+
+    private static final Logger logger = LogManager.getLogger(Power.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    private final RingFactory<C> fac;
+
+
+    /**
+     * The constructor creates a Power object.
+     */
+    public Power() {
+        this(null);
+    }
+
+
+    /**
+     * The constructor creates a Power object.
+     * @param fac ring factory
+     */
+    public Power(RingFactory<C> fac) {
+        this.fac = fac;
+    }
+
+
+    /**
+     * power of a to the n-th, n positive.
+     * @param a element.
+     * @param n integer exponent &ge; 0.
+     * @return a^n.
+     */
+    public static <C extends RingElem<C>> C positivePower(C a, long n) {
+        if (n <= 0) {
+            throw new IllegalArgumentException("only positive n allowed");
+        }
+        if (a.isZERO() || a.isONE()) {
+            return a;
+        }
+        C b = a;
+        long i = n - 1;
+        C p = b;
+        do {
+            if (i % 2 == 1) {
+                p = p.multiply(b);
+            }
+            i = i / 2;
+            if (i > 0) {
+                b = b.multiply(b);
+            }
+        } while (i > 0);
+        return p;
+    }
+
+
+    /**
+     * power of a to the n-th, n positive.
+     * @param a element.
+     * @param n java.math.BigInteger exponent &ge; 0.
+     * @return a^n.
+     */
+    public static <C extends RingElem<C>> C positivePower(C a, java.math.BigInteger n) {
+        if (n.signum() <= 0) {
+            throw new IllegalArgumentException("only positive n allowed");
+        }
+        if (a.isZERO() || a.isONE()) {
+            return a;
+        }
+        C b = a;
+        if (n.compareTo(java.math.BigInteger.ONE) == 0) {
+            return b;
+        }
+        if (n.bitLength() <= 63) {
+            long l = n.longValue();
+            return positivePower(a, l);
+        }
+        C p = a;
+        java.math.BigInteger i = n.subtract(java.math.BigInteger.ONE);
+        do {
+            if (i.testBit(0)) {
+                p = p.multiply(b);
+            }
+            i = i.shiftRight(1);
+            if (i.signum() > 0) {
+                b = b.multiply(b);
+            }
+        } while (i.signum() > 0);
+        return p;
+    }
+
+
+    /**
+     * power of a to the n-th, n positive, modulo m.
+     * @param a element.
+     * @param n integer exponent &ge; 0.
+     * @param m modulus.
+     * @return a^n mod m.
+     */
+    public static <C extends RingElem<C>> C modPositivePower(C a, long n, C m) {
+        if (n <= 0) {
+            throw new IllegalArgumentException("only positive n allowed");
+        }
+        if (a.isZERO() || a.isONE()) {
+            return a;
+        }
+
+        C b = a.remainder(m);
+        long i = n - 1;
+        C p = b;
+        do {
+            if (i % 2 == 1) {
+                p = p.multiply(b).remainder(m);
+            }
+            i = i / 2;
+            if (i > 0) {
+                b = b.multiply(b).remainder(m);
+            }
+        } while (i > 0);
+        return p;
+    }
+
+
+    /**
+     * power of a to the n-th, n positive, modulo m.
+     * @param a element.
+     * @param n big integer exponent &ge; 0.
+     * @param m modulus.
+     * @return a^n mod m.
+     */
+    public static <C extends RingElem<C>> C modPositivePower(C a, java.math.BigInteger n, C m) {
+        if (n.signum() <= 0) {
+            throw new IllegalArgumentException("only positive n allowed");
+        }
+        if (a.isZERO() || a.isONE()) {
+            return a;
+        }
+
+        C b = a.remainder(m);
+        java.math.BigInteger i = n.subtract(java.math.BigInteger.ONE);
+        C p = b;
+        do {
+            if (i.testBit(0)) { // i % 2 == 1
+                p = p.multiply(b).remainder(m);
+            }
+            i = i.shiftRight(1); // / 2;
+            if (i.signum() > 0) {
+                b = b.multiply(b).remainder(m);
+            }
+        } while (i.signum() > 0);
+        return p;
+    }
+
+
+    /**
+     * power of a to the n-th.
+     * @param a element.
+     * @param n integer exponent.
+     * @param fac ring factory.
+     * @return a^n, with 0^0 = 0 and a^{-n} = {1/a}^n.
+     */
+    @SuppressWarnings("unchecked")
+    public static <C extends RingElem<C>> C power(RingFactory<C> fac, C a, long n) {
+        if (a == null || a.isZERO()) {
+            return a;
+        }
+        //return a;
+        return (C) Power.<MonoidElem> power((MonoidFactory) fac, a, n);
+    }
+
+
+    /**
+     * power of a to the n-th.
+     * @param a element.
+     * @param n integer exponent.
+     * @param fac monoid factory.
+     * @return a^n, with a^{-n} = {1/a}^n.
+     */
+    public static <C extends MonoidElem<C>> C power(MonoidFactory<C> fac, C a, long n) {
+        if (n == 0) {
+            if (fac == null) {
+                throw new IllegalArgumentException("fac may not be null for a^0");
+            }
+            return fac.getONE();
+        }
+        if (a.isONE()) {
+            return a;
+        }
+        C b = a;
+        if (n < 0) {
+            b = a.inverse();
+            n = -n;
+        }
+        if (n == 1) {
+            return b;
+        }
+        if (fac == null) {
+            throw new IllegalArgumentException("fac may not be null for n > 1");
+        }
+        C p = fac.getONE();
+        long i = n;
+        do {
+            if (i % 2 == 1) {
+                p = p.multiply(b);
+            }
+            i = i / 2;
+            if (i > 0) {
+                b = b.multiply(b);
+            }
+        } while (i > 0);
+        if (n > 11 && debug) {
+            logger.info("n  = " + n + ", p  = " + p);
+        }
+        return p;
+    }
+
+
+    /**
+     * power of a to the n-th modulo m.
+     * @param a element.
+     * @param n integer exponent.
+     * @param m modulus.
+     * @param fac monoid factory.
+     * @return a^n mod m, with a^{-n} = {1/a}^n.
+     */
+    public static <C extends MonoidElem<C>> C modPower(MonoidFactory<C> fac, C a, long n, C m) {
+        if (n == 0) {
+            if (fac == null) {
+                throw new IllegalArgumentException("fac may not be null for a^0");
+            }
+            return fac.getONE();
+        }
+        if (a.isONE()) {
+            return a;
+        }
+        C b = a.remainder(m);
+        if (n < 0) {
+            b = a.inverse().remainder(m);
+            n = -n;
+        }
+        if (n == 1) {
+            return b;
+        }
+        if (fac == null) {
+            throw new IllegalArgumentException("fac may not be null for n > 1");
+        }
+        C p = fac.getONE();
+        long i = n;
+        do {
+            if (i % 2 == 1) {
+                p = p.multiply(b).remainder(m);
+            }
+            i = i / 2;
+            if (i > 0) {
+                b = b.multiply(b).remainder(m);
+            }
+        } while (i > 0);
+        if (n > 11 && debug) {
+            logger.info("n  = " + n + ", p  = " + p);
+        }
+        return p;
+    }
+
+
+    /**
+     * power of a to the n-th modulo m.
+     * @param a element.
+     * @param n integer exponent.
+     * @param m modulus.
+     * @param fac monoid factory.
+     * @return a^n mod m, with a^{-n} = {1/a}^n.
+     */
+    public static <C extends MonoidElem<C>> C modPower(MonoidFactory<C> fac, C a, java.math.BigInteger n,
+                    C m) {
+        if (n.signum() == 0) {
+            if (fac == null) {
+                throw new IllegalArgumentException("fac may not be null for a^0");
+            }
+            return fac.getONE();
+        }
+        if (a.isONE()) {
+            return a;
+        }
+        C b = a.remainder(m);
+        if (n.signum() < 0) {
+            b = a.inverse().remainder(m);
+            n = n.negate();
+        }
+        if (n.compareTo(java.math.BigInteger.ONE) == 0) {
+            return b;
+        }
+        if (n.bitLength() <= 63) {
+            long l = n.longValue();
+            return modPower(fac, a, l, m);
+        }
+        if (fac == null) {
+            throw new IllegalArgumentException("fac may not be null for n > 1");
+        }
+        C p = fac.getONE();
+        java.math.BigInteger i = n;
+        do {
+            if (i.testBit(0)) {
+                p = p.multiply(b).remainder(m);
+            }
+            i = i.shiftRight(1);
+            if (i.signum() > 0) {
+                b = b.multiply(b).remainder(m);
+            }
+        } while (i.signum() > 0);
+        if (debug) {
+            logger.info("n  = " + n + ", p  = " + p);
+        }
+        return p;
+    }
+
+
+    /**
+     * power of a to the n-th.
+     * @param a element.
+     * @param n integer exponent.
+     * @return a^n, with 0^0 = 0.
+     */
+    public C power(C a, long n) {
+        return power(fac, a, n);
+    }
+
+
+    /**
+     * power of a to the n-th.
+     * @param a long.
+     * @param n integer exponent.
+     * @return a^n, with a^0 = 1.
+     */
+    public static long power(long a, long n) {
+        if (n == 0) {
+            return 1L;
+        }
+        if (a == 1L) {
+            return a;
+        }
+        long b = a;
+        if (n == 1L) {
+            return b;
+        }
+        long p = 1L;
+        long i = n;
+        do {
+            if (i % 2 == 1) {
+                p = p * b;
+            }
+            i = i / 2;
+            if (i > 0) {
+                b = b * b;
+            }
+        } while (i > 0);
+        if (n > 11 && debug) {
+            logger.info("n  = " + n + ", p  = " + p);
+        }
+        return p;
+    }
+
+
+    /**
+     * power of a to the n-th mod m.
+     * @param a element.
+     * @param n integer exponent.
+     * @param m modulus.
+     * @return a^n mod m, with 0^0 = 0.
+     */
+    public C modPower(C a, long n, C m) {
+        return modPower(fac, a, n, m);
+    }
+
+
+    /**
+     * power of a to the n-th mod m.
+     * @param a element.
+     * @param n integer exponent.
+     * @param m modulus.
+     * @return a^n mod m, with 0^0 = 0.
+     */
+    public C modPower(C a, java.math.BigInteger n, C m) {
+        return modPower(fac, a, n, m);
+    }
+
+
+    /**
+     * Logarithm.
+     * @param p logarithm base.
+     * @param a element.
+     * @return k &ge; 1 minimal with p^k &ge; a.
+     */
+    public static <C extends RingElem<C>> long logarithm(C p, C a) {
+        //if ( p.compareTo(a) < 0 ) {
+        //    return 0L;
+        //}
+        long k = 1L;
+        C m = p;
+        while (m.compareTo(a) < 0) {
+            m = m.multiply(p);
+            k++;
+        }
+        return k;
+    }
+
+
+    /**
+     * Logarithm.
+     * @param p logarithm base.
+     * @param a element.
+     * @return k &ge; 1 minimal with p^k &ge; a.
+     */
+    public static <C extends RingElem<C>> long logarithm(long p, long a) {
+        long k = 1;
+        long m = p;
+        while (m < a) {
+            m = m * p;
+            k++;
+        }
+        return k;
+    }
+
+
+    /**
+     * Multiply elements in list.
+     * @param A list of elements (a_0,...,a_k).
+     * @param fac ring factory.
+     * @return prod(i=0,...k) a_i.
+     */
+    public static <C extends RingElem<C>> C multiply(RingFactory<C> fac, List<C> A) {
+        return multiply((MonoidFactory<C>) fac, A);
+    }
+
+
+    /**
+     * Multiply elements in list.
+     * @param A list of elements (a_0,...,a_k).
+     * @param fac monoid factory.
+     * @return prod(i=0,...k) a_i.
+     */
+    public static <C extends MonoidElem<C>> C multiply(MonoidFactory<C> fac, List<C> A) {
+        if (fac == null) {
+            throw new IllegalArgumentException("fac may not be null for empty list");
+        }
+        C res = fac.getONE();
+        if (A == null || A.isEmpty()) {
+            return res;
+        }
+        for (C a : A) {
+            res = res.multiply(a);
+        }
+        return res;
+    }
+
+
+    /**
+     * Sum elements in list.
+     * @param A list of elements (a_0,...,a_k).
+     * @param fac ring factory.
+     * @return sum(i=0,...k) a_i.
+     */
+    public static <C extends RingElem<C>> C sum(RingFactory<C> fac, List<C> A) {
+        return sum((AbelianGroupFactory<C>) fac, A);
+    }
+
+
+    /**
+     * Sum elements in list.
+     * @param A list of elements (a_0,...,a_k).
+     * @param fac monoid factory.
+     * @return sum(i=0,...k) a_i.
+     */
+    public static <C extends AbelianGroupElem<C>> C sum(AbelianGroupFactory<C> fac, List<C> A) {
+        if (fac == null) {
+            throw new IllegalArgumentException("fac may not be null for empty list");
+        }
+        C res = fac.getZERO();
+        if (A == null || A.isEmpty()) {
+            return res;
+        }
+        for (C a : A) {
+            res = res.sum(a);
+        }
+        return res;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/QuotPair.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/QuotPair.java
@@ -1,0 +1,33 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.structure;
+
+
+/**
+ * Quotient pair interface. Defines selectors for numerator and denominator.
+ * @param C base element type
+ * @author Heinz Kredel
+ */
+public interface QuotPair<C extends RingElem<C>> {
+
+
+    /**
+     * Numerator.
+     */
+    public C numerator();
+
+
+    /**
+     * Denominator.
+     */
+    public C denominator();
+
+
+    /**
+     * Test if element type is constant.
+     */
+    public boolean isConstant();
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/QuotPairFactory.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/QuotPairFactory.java
@@ -1,0 +1,35 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.structure;
+
+
+/**
+ * Quotient pair factory interface. Defines constructors from numerators and
+ * denominators.
+ * @param C base element type
+ * @param D result element type
+ * @author Heinz Kredel
+ */
+public interface QuotPairFactory<C extends RingElem<C>, D extends RingElem<D>> {
+
+
+    /**
+     * Create from numerator.
+     */
+    public D create(C n);
+
+
+    /**
+     * Create from numerator, denominator pair.
+     */
+    public D create(C n, C d);
+
+
+    /**
+     * Factory for base elements.
+     */
+    public RingFactory<C> pairFactory();
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/RegularRingElem.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/RegularRingElem.java
@@ -1,0 +1,86 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.structure;
+
+
+/**
+ * Regular ring element interface. Defines idempotent operations and idempotent
+ * tests.
+ * @param <C> regular ring element type
+ * @author Heinz Kredel
+ */
+
+public interface RegularRingElem<C extends RegularRingElem<C>> extends GcdRingElem<C> {
+
+
+    /* Get component. 
+     * Not possible to define in interface.
+     * @param i index of component.
+     * @return val(i).
+    public C get(int i);
+     */
+
+
+    /**
+     * Is regular ring element full.
+     * @return If every component is non zero, then true is returned, else
+     *         false.
+     */
+    public boolean isFull();
+
+
+    /**
+     * Is idempotent.
+     * @return If this is a idempotent element then true is returned, else
+     *         false.
+     */
+    public boolean isIdempotent();
+
+
+    /**
+     * Idempotent.
+     * @return S with this*S = this.
+     */
+    public C idempotent();
+
+
+    /**
+     * Regular ring element idempotent complement.
+     * @return 1-this.idempotent().
+     */
+    public C idemComplement();
+
+
+    /**
+     * Regular ring element idempotent and.
+     * @param S Product.
+     * @return this.idempotent() and S.idempotent().
+     */
+    public C idempotentAnd(C S);
+
+
+    /**
+     * Regular ring element idempotent or.
+     * @param S Product.
+     * @return this.idempotent() or S.idempotent().
+     */
+    public C idempotentOr(C S);
+
+
+    /**
+     * Regular ring element fill with idempotent.
+     * @param S Product.
+     * @return fill this with S.idempotent().
+     */
+    public C fillIdempotent(C S);
+
+
+    /**
+     * Regular ring element fill with one.
+     * @return fill this with one.
+     */
+    public C fillOne();
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/RingElem.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/RingElem.java
@@ -1,0 +1,55 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.structure;
+
+
+/**
+ * Ring element interface. Combines additive and multiplicative methods. Adds
+ * also gcd because of polynomials.
+ * @param <C> ring element type
+ * @author Heinz Kredel
+ */
+
+public interface RingElem<C extends RingElem<C>> extends AbelianGroupElem<C>, MonoidElem<C> {
+
+
+    /**
+     * Greatest common divisor.
+     * @param b other element.
+     * @return gcd(this,b).
+     */
+    public C gcd(C b);
+
+
+    /**
+     * Extended greatest common divisor.
+     * @param b other element.
+     * @return [ gcd(this,b), c1, c2 ] with c1*this + c2*b = gcd(this,b).
+     */
+    public C[] egcd(C b);
+
+
+    /**
+     * Left greatest common divisor.
+     * Returns commutative greatest common divisor if not overwritten.
+     * @param b other element.
+     * @return leftGcd(this,b).
+     */
+    default public C leftGcd(C b) {
+        return gcd(b);
+    }
+
+
+    /**
+     * Right greatest common divisor.
+     * Returns commutative greatest common divisor if not overwritten.
+     * @param b other element.
+     * @return rightGcd(this,b).
+     */
+    default public C rightGcd(C b) {
+        return gcd(b);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/RingFactory.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/RingFactory.java
@@ -1,0 +1,30 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.structure;
+
+
+/**
+ * Ring factory interface. Defines test for field and query of characteristic.
+ * @author Heinz Kredel
+ */
+
+public interface RingFactory<C extends RingElem<C>> extends AbelianGroupFactory<C>, MonoidFactory<C> {
+
+
+    /**
+     * Query if this ring is a field. May return false if it is too hard to
+     * determine if this ring is a field.
+     * @return true if it is known that this ring is a field, else false.
+     */
+    public boolean isField();
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic();
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/Selector.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/Selector.java
@@ -1,0 +1,23 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.structure;
+
+
+/**
+ * Selector interface.
+ * @param <C> ring element type
+ * @author Heinz Kredel
+ */
+
+public interface Selector<C extends RingElem<C>> {
+
+
+    /**
+     * Select.
+     * @return true, if the element is selected, otherwise false.
+     */
+    public boolean select(C c);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/StarRingElem.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/StarRingElem.java
@@ -1,0 +1,30 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.structure;
+
+
+/**
+ * Star ring element interface. Defines norm and conjugation.
+ * @param <C> ring element type
+ * @author Heinz Kredel
+ */
+
+public interface StarRingElem<C extends StarRingElem<C>> extends RingElem<C> {
+
+
+    /**
+     * Conjugate of this.
+     * @return conj(this).
+     */
+    public C conjugate();
+
+
+    /**
+     * Norm of this.
+     * @return norm(this).
+     */
+    public C norm();
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/UnaryFunctor.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/UnaryFunctor.java
@@ -1,0 +1,24 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.structure;
+
+
+/**
+ * Unary functor interface.
+ * @param <C> element type
+ * @param <D> element type
+ * @author Heinz Kredel
+ */
+
+public interface UnaryFunctor<C extends Element<C>, D extends Element<D>> {
+
+
+    /**
+     * Evaluate.
+     * @return evaluated element.
+     */
+    public D eval(C c);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/Value.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/Value.java
@@ -1,0 +1,27 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.structure;
+
+
+/**
+ * Value interface. Defines selector for value.
+ * @param C base element type
+ * @author Heinz Kredel
+ */
+public interface Value<C extends RingElem<C>> {
+
+
+    /**
+     * Value getter.
+     */
+    public C value();
+
+
+    /**
+     * Test if element type is constant.
+     */
+    public boolean isConstant();
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/ValueFactory.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/ValueFactory.java
@@ -1,0 +1,28 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.structure;
+
+
+/**
+ * Value factory interface. Defines constructor from value.
+ * @param C base element type
+ * @param D result element type
+ * @author Heinz Kredel
+ */
+public interface ValueFactory<C extends RingElem<C>, D extends RingElem<D>> {
+
+
+    /**
+     * Create from value.
+     */
+    public D create(C n);
+
+
+    /**
+     * Factory for value elements.
+     */
+    public RingFactory<C> valueFactory();
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/package.html
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/structure/package.html
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "../DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>Basic structural interfaces</title>
+  </head>
+
+  <body>
+    <h1>Basic structural interfaces.</h1>
+
+<p>
+  This package 
+  contains interfaces for the most general algebraic structures used in JAS,
+  e.g. <code>RingElem</code> and <code>RingFactory</code>.
+  The <code>Power</code> class implements exponentation of monoid and ring elements.
+</p>
+
+<p align="center">
+<img src="../../../../../images/jas-poly-over.png" width="80%" 
+     alt="RingElem and Ring overview" />
+<br />
+<b>RingElem, Ring and polynomial overview</b>
+</p>
+
+    <hr />
+    <address><a href="mailto:kredel at rz.uni-mannheim.de">Heinz Kredel</a></address>
+<p>
+<!-- Created: Wed Mar  1 12:29:04 CET 2006 -->
+<!-- hhmts start -->
+Last modified: Sun Sep 21 18:29:11 CEST 2014
+<!-- hhmts end -->
+</p>
+<p>$Id$ 
+</p>
+  </body>
+</html>

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/CycloUtil.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/CycloUtil.java
@@ -1,0 +1,252 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.arith.BigInteger;
+import edu.jas.arith.PrimeInteger;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.Monomial;
+import edu.jas.structure.Power;
+
+
+/**
+ * Cyclotomic polynomial utilities. Adapted from Sympy Python codes.
+ * @author Heinz Kredel
+ */
+
+public class CycloUtil {
+
+
+    private static final Logger logger = LogManager.getLogger(CycloUtil.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Compute n-th cyclotomic polynomial.
+     * @param n number of polynomial.
+     * @param ring univariate polynomial ring of cyclotomic polynomial.
+     * @return n-th cyclotomic polynomial.
+     */
+    public static GenPolynomial<BigInteger> cyclotomicPolynomial(GenPolynomialRing<BigInteger> ring, long n) {
+        GenPolynomialRing<BigInteger> pfac = ring;
+        if (pfac == null) {
+            throw new IllegalArgumentException("ring must be non null");
+        }
+        GenPolynomial<BigInteger> h = pfac.univariate(0).subtract(pfac.getONE());
+        //System.out.println("h = " + h);
+        SortedMap<Long, Integer> fac = PrimeInteger.factors(n);
+        logger.info("factors = " + fac);
+
+        for (Map.Entry<Long, Integer> m : fac.entrySet()) {
+            // h = dup_quo(dup_inflate(h, p, K), h, K)
+            // h = dup_inflate(h, p**(k - 1), K)
+            long p = m.getKey();
+            int k = m.getValue();
+            GenPolynomial<BigInteger> ih = h.inflate(p);
+            //System.out.println("ih = " + ih);
+            h = ih.divide(h);
+            //System.out.println("h = " + h);
+            h = h.inflate(Power.power(p, k - 1));
+            //System.out.println("h = " + h + ", power = " + Power.power(p, k-1));
+        }
+        return h;
+    }
+
+
+    /**
+     * Compute the factors of the n-th cyclotomic polynomial.
+     * @param n number of polynomial.
+     * @param ring univariate polynomial ring of cyclotomic polynomial.
+     * @return list of factors of n-th cyclotomic polynomial.
+     */
+    public static List<GenPolynomial<BigInteger>> cyclotomicDecompose(GenPolynomialRing<BigInteger> ring,
+                    long n) {
+        GenPolynomialRing<BigInteger> pfac = ring;
+        if (pfac == null) {
+            throw new IllegalArgumentException("ring must be non null");
+        }
+        GenPolynomial<BigInteger> q = pfac.univariate(0).subtract(pfac.getONE());
+        //System.out.println("q = " + q);
+        List<GenPolynomial<BigInteger>> H = new ArrayList<GenPolynomial<BigInteger>>();
+        H.add(q);
+
+        SortedMap<Long, Integer> fac = PrimeInteger.factors(n);
+        logger.info("factors = " + fac);
+
+        for (Map.Entry<Long, Integer> m : fac.entrySet()) {
+            //Q = [ dup_quo(dup_inflate(h, p, K), h, K) for h in H ]
+            //H.extend(Q)
+            long p = m.getKey();
+            int k = m.getValue();
+            List<GenPolynomial<BigInteger>> Q = new ArrayList<GenPolynomial<BigInteger>>();
+            for (GenPolynomial<BigInteger> h : H) {
+                GenPolynomial<BigInteger> g = h.inflate(p).divide(h);
+                Q.add(g);
+            }
+            //System.out.println("Q = " + Q);
+            H.addAll(Q);
+            //for i in xrange(1, k):
+            //    Q = [ dup_inflate(q, p, K) for q in Q ]
+            //    H.extend(Q)
+            for (int i = 1; i < k; i++) {
+                List<GenPolynomial<BigInteger>> P = new ArrayList<GenPolynomial<BigInteger>>();
+                for (GenPolynomial<BigInteger> h : Q) {
+                    GenPolynomial<BigInteger> g = h.inflate(p);
+                    P.add(g);
+                }
+                //System.out.println("P = " + P);
+                Q = P;
+                H.addAll(P);
+            }
+        }
+        return H;
+    }
+
+
+    /**
+     * Compute the factors of the cyclotomic polynomial.
+     * @param p cyclotomic polynomial.
+     * @return list of factors of cyclotomic polynomial p or emtpy list.
+     */
+    public static List<GenPolynomial<BigInteger>> cyclotomicFactors(GenPolynomial<BigInteger> p) {
+        List<GenPolynomial<BigInteger>> H = new ArrayList<GenPolynomial<BigInteger>>();
+        long n = p.degree();
+        if (n <= 0) {
+            return H;
+        }
+        BigInteger lc, tc;
+        lc = p.leadingBaseCoefficient();
+        tc = p.trailingBaseCoefficient();
+        if (!lc.isONE() || (!tc.isONE() && !tc.negate().isONE())) {
+            return H;
+        }
+        if (p.length() != 2) { // other coefficients must be zero
+            return H;
+        }
+        // only case: x**n +/- 1
+        //F = _dup_cyclotomic_decompose(n, K)
+        //if not K.is_one(tc_f):
+        //   return F
+        GenPolynomialRing<BigInteger> pfac = p.ring;
+        List<GenPolynomial<BigInteger>> F = cyclotomicDecompose(pfac, n);
+        if (!tc.isONE()) {
+            return F;
+        }
+        //else:
+        //   H = []
+        //   for h in _dup_cyclotomic_decompose(2*n, K):
+        //       if h not in F:
+        //          H.append(h)
+        //return H                         
+        H = new ArrayList<GenPolynomial<BigInteger>>();
+        List<GenPolynomial<BigInteger>> F2 = cyclotomicDecompose(pfac, 2L * n);
+        for (GenPolynomial<BigInteger> h : F2) {
+            if (!F.contains(h)) {
+                H.add(h);
+            }
+        }
+        return H;
+    }
+
+
+    /**
+     * Test for cyclotomic polynomial.
+     * @param p polynomial.
+     * @return true if p is a cyclotomic polynomial, else false.
+     */
+    public static boolean isCyclotomicPolynomial(GenPolynomial<BigInteger> p) {
+        long n = p.degree();
+        if (n <= 0) {
+            return false;
+        }
+        BigInteger lc, tc;
+        lc = p.leadingBaseCoefficient();
+        tc = p.trailingBaseCoefficient();
+        if (!lc.isONE() || (!tc.isONE() && !tc.negate().isONE())) {
+            //System.out.println("!lc.isONE() || (!tc.isONE() && !tc.negate().isONE())");
+            return false;
+        }
+        if (p.length() == 2) { // other coefficients must be zero
+            return true;
+        }
+        // ignore: if not irreducible:
+        GenPolynomialRing<BigInteger> ring = p.ring;
+        if (ring.nvar != 1) {
+            throw new IllegalArgumentException("not univariate polynomial");
+        }
+        GenPolynomial<BigInteger> g, h, f;
+        g = ring.getZERO().copy();
+        h = ring.getZERO().copy();
+        long x = n % 2;
+        for (Monomial<BigInteger> m : p) {
+            ExpVector e = m.e;
+            long d = e.getVal(0);
+            ExpVector e2 = e.subst(0, d / 2L);
+            if (d % 2 == x) {
+                g.doPutToMap(e2, m.c);
+            } else {
+                h.doPutToMap(e2, m.c);
+            }
+        }
+        //g = dup_sqr(dup_strip(g), K)
+        //h = dup_sqr(dup_strip(h), K)
+        g = g.multiply(g);
+        h = h.multiply(h);
+        //System.out.println("g = " + g);
+        //System.out.println("h = " + h);
+        //F = dup_sub(g, dup_lshift(h, 1, K), K)
+        ExpVector on = ExpVector.create(1, 0, 1L);
+        f = g.subtract(h.multiply(on)).abs();
+        //System.out.println("f = " + f + ", f==p: " + f.equals(p));
+        //if F == f: return True 
+        if (f.equals(p)) {
+            return true;
+        }
+        //g = dup_mirror(f, K)
+        //if F == g and dup_cyclotomic_p(g, K):
+        //   return True
+        g = ring.getZERO().copy();
+        for (Monomial<BigInteger> m : p) {
+            ExpVector e = m.e;
+            long d = e.getVal(0);
+            if (d % 2 == 1) {
+                g.doPutToMap(e, m.c.negate());
+            } else {
+                g.doPutToMap(e, m.c);
+            }
+        }
+        g = g.abs();
+        //System.out.println("g = " + g + ", f==g: " + f.equals(g));
+        if (f.equals(g) && isCyclotomicPolynomial(g)) {
+            return true;
+        }
+        //G = dup_sqf_part(F, K)
+        Squarefree<BigInteger> engine;
+        engine = SquarefreeFactory.getImplementation(lc);
+        GenPolynomial<BigInteger> G;
+        G = engine.squarefreePart(f);
+        //System.out.println("G = " + G + ", G^2==f: " + G.multiply(G).equals(f));
+        //if dup_sqr(G, K) == F and dup_cyclotomic_p(G, K):
+        //   return True
+        if (G.multiply(G).equals(f) && isCyclotomicPolynomial(G)) {
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/Examples.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/Examples.java
@@ -1,0 +1,258 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SortedMap;
+
+import edu.jas.arith.BigInteger;
+import edu.jas.arith.BigRational;
+import edu.jas.kern.ComputerThreads;
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.AlgebraicNumberRing;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.poly.TermOrder;
+import edu.jas.vector.GenMatrix;
+import edu.jas.vector.GenMatrixRing;
+
+
+/**
+ * Examples for ufd and elementaty integration usage.
+ * @author Heinz Kredel
+ */
+
+public class Examples {
+
+
+    /**
+     * main.
+     */
+    public static void main(String[] args) {
+        //// no go: example6();
+        //example9(); 
+        example1();
+        example2();
+        example10();
+        example11();
+        ComputerThreads.terminate();
+    }
+
+
+    /**
+     * example1 with GenMatrix.
+     */
+    public static void example1() {
+        System.out.println("\n\n example 1");
+
+        BigInteger cfac;
+        GenPolynomialRing<BigInteger> fac;
+        QuotientRing<BigInteger> efac;
+        GenPolynomialRing<Quotient<BigInteger>> qfac;
+        GenMatrixRing<GenPolynomial<Quotient<BigInteger>>> mfac;
+
+        cfac = new BigInteger();
+        System.out.println("cfac = " + cfac);
+
+        String[] vc = new String[] { "a", "b" };
+        fac = new GenPolynomialRing<BigInteger>(cfac, vc);
+        System.out.println(" fac = " + fac.toScript());
+
+        efac = new QuotientRing<BigInteger>(fac);
+        System.out.println("efac = " + efac.toScript());
+
+        String[] v = new String[] { "x", "y", "z" };
+        qfac = new GenPolynomialRing<Quotient<BigInteger>>(efac, 3, v);
+        System.out.println("qfac = " + qfac.toScript());
+
+        mfac = new GenMatrixRing<GenPolynomial<Quotient<BigInteger>>>(qfac, 3, 3);
+        System.out.println("mfac = " + mfac.toScript());
+
+        GenPolynomial<Quotient<BigInteger>> p;
+        p = qfac.random(3, 4, 2, 0.3f);
+        System.out.println("\np = " + p);
+
+        GenMatrix<GenPolynomial<Quotient<BigInteger>>> m;
+        m = mfac.random(3, 0.4f);
+        System.out.println("\nm = " + m.toScript());
+    }
+
+
+    /**
+     * example2 with GenPolynomial.
+     */
+    public static void example2() {
+        System.out.println("\n\n example 2");
+
+        BigInteger fac = new BigInteger();
+        String[] var = new String[] { "a", "b", "c", "d" };
+        int numvars = var.length;
+        //not needed: TermOrder tord = new TermOrder(TermOrder.INVLEX);
+        GenPolynomialRing<BigInteger> ring = new GenPolynomialRing<BigInteger>(fac, var);
+        List<GenPolynomial<BigInteger>> vars = new ArrayList<GenPolynomial<BigInteger>>();
+
+        // Build up the polynomial from vars.
+        for (int i = 0; i < numvars; i++)
+            vars.add(ring.univariate(i));
+        System.out.println("vars = " + vars);
+
+        // Silly demo one first. 
+        //  ab+ac+db+dc   ->  (a+d)(b+c)
+        GenPolynomial<BigInteger> tmp = (vars.get(0).multiply(vars.get(1)))
+                        .sum(vars.get(0).multiply(vars.get(2))).sum(vars.get(3).multiply(vars.get(1)))
+                        .sum(vars.get(3).multiply(vars.get(2)));
+
+        //alternative: tmp = ring.parse("a b + a c + d b + d c");
+        System.out.println("tmp = " + tmp);
+
+        Factorization<BigInteger> engine = FactorFactory.getImplementation(fac);
+        SortedMap<GenPolynomial<BigInteger>, Long> factors = engine.factors(tmp);
+
+        System.out.println("factors = " + factors);
+    }
+
+
+    /**
+     * example6. Partial fraction decomposition.
+     */
+    public static void example6() {
+        System.out.println("\n\nexample 6");
+        // http://www.apmaths.uwo.ca/~rcorless/AM563/NOTES/Nov_16_95/node13.html
+
+        TermOrder to = new TermOrder(TermOrder.INVLEX);
+        BigRational cfac = new BigRational(1);
+        //String[] alpha = new String[] { "alpha" };
+        String[] vars = new String[] { "x" };
+        GenPolynomialRing<BigRational> pfac = new GenPolynomialRing<BigRational>(cfac, 1, to, vars);
+
+        // ( 7 x^6 + 1 ) /  ( x^7 + x + 1 )
+        GenPolynomial<BigRational> D = pfac.parse("x^7 + x + 1");
+        GenPolynomial<BigRational> N = PolyUtil.<BigRational> baseDeriviative(D);
+
+        FactorRational engine = new FactorRational();
+
+        PartialFraction<BigRational> F = engine.baseAlgebraicPartialFraction(N, D);
+        System.out.println("\nintegral " + F);
+    }
+
+
+    /**
+     * example9. Rothstein-Trager and absolute factorization algorithm.
+     */
+    public static void example9() {
+        System.out.println("\n\nexample 9");
+
+        TermOrder to = new TermOrder(TermOrder.INVLEX);
+        BigRational cfac = new BigRational(1);
+        //String[] alpha = new String[] { "alpha" };
+        String[] vars = new String[] { "x" };
+        GenPolynomialRing<BigRational> pfac = new GenPolynomialRing<BigRational>(cfac, 1, to, vars);
+
+        // 1 / ( x^5 + x - 7 ) 
+        GenPolynomial<BigRational> D = pfac.parse("( x^5 + x - 7 )");
+        GenPolynomial<BigRational> N = pfac.getONE();
+
+        FactorRational engine = new FactorRational();
+
+        PartialFraction<BigRational> F = engine.baseAlgebraicPartialFraction(N, D);
+        System.out.println("\nintegral " + F);
+
+        //PartialFraction<BigRational> Fa = engine.baseAlgebraicPartialFractionIrreducibleAbsolute(N,D);
+        //System.out.println("\nintegral_a " + Fa);
+
+    }
+
+
+    /**
+     * example10. factorization in Q(sqrt(2))(x)(sqrt(x))[y].
+     */
+    public static void example10() {
+        System.out.println("\n\nexample 10");
+
+        TermOrder to = new TermOrder(TermOrder.INVLEX);
+        BigRational cfac = new BigRational(1);
+
+        String[] var_w2 = new String[] { "w2" };
+        GenPolynomialRing<BigRational> pfac = new GenPolynomialRing<BigRational>(cfac, 1, to, var_w2);
+        System.out.println("pfac   = " + pfac.toScript());
+
+        GenPolynomial<BigRational> w2 = pfac.parse(" w2^2 - 2 ");
+        System.out.println("w2     = " + w2);
+
+        AlgebraicNumberRing<BigRational> a2fac = new AlgebraicNumberRing<BigRational>(w2, true);
+        System.out.println("a2fac  = " + a2fac.toScript());
+
+        String[] var_x = new String[] { "x" };
+        GenPolynomialRing<AlgebraicNumber<BigRational>> apfac = new GenPolynomialRing<AlgebraicNumber<BigRational>>(
+                        a2fac, 1, to, var_x);
+        System.out.println("apfac  = " + apfac.toScript());
+
+        QuotientRing<AlgebraicNumber<BigRational>> qfac = new QuotientRing<AlgebraicNumber<BigRational>>(
+                        apfac);
+        System.out.println("qfac   = " + qfac.toScript());
+
+        String[] var_wx = new String[] { "wx" };
+        GenPolynomialRing<Quotient<AlgebraicNumber<BigRational>>> pqfac = new GenPolynomialRing<Quotient<AlgebraicNumber<BigRational>>>(
+                        qfac, 1, to, var_wx);
+        System.out.println("pqfac  = " + pqfac.toScript());
+
+        GenPolynomial<Quotient<AlgebraicNumber<BigRational>>> wx = pqfac.parse(" wx^2 - { x } ");
+        System.out.println("wx     = " + wx);
+
+        AlgebraicNumberRing<Quotient<AlgebraicNumber<BigRational>>> axfac = new AlgebraicNumberRing<Quotient<AlgebraicNumber<BigRational>>>(
+                        wx, true);
+        System.out.println("axfac  = " + axfac.toScript());
+
+        String[] var_y = new String[] { "y" };
+        GenPolynomialRing<AlgebraicNumber<Quotient<AlgebraicNumber<BigRational>>>> apqfac = new GenPolynomialRing<AlgebraicNumber<Quotient<AlgebraicNumber<BigRational>>>>(
+                        axfac, 1, to, var_y);
+        System.out.println("apqfac = " + apqfac.toScript());
+
+        //  ( y^2 - x ) * ( y^2 - 2 ), need {} for recursive coefficients
+        GenPolynomial<AlgebraicNumber<Quotient<AlgebraicNumber<BigRational>>>> f;
+        f = apqfac.parse(" ( y^2 - { { x } } ) * ( y^2 - 2 )^2 ");
+        System.out.println("f      = " + f);
+
+        FactorAbstract<AlgebraicNumber<Quotient<AlgebraicNumber<BigRational>>>> engine = FactorFactory
+                        .getImplementation(axfac);
+        System.out.println("engine = " + engine);
+
+        SortedMap<GenPolynomial<AlgebraicNumber<Quotient<AlgebraicNumber<BigRational>>>>, Long> F = engine
+                        .factors(f);
+        System.out.println("factors(f) = " + F);
+    }
+
+
+    /**
+     * example11. factorization in Z[a,c,d,e,x].
+     */
+    public static void example11() {
+        System.out.println("\n\nexample 11");
+        for (int i = 0; i < 10; i++) { //100000
+            String[] vars = new String[] { "a", "c", "d", "e", "x" };
+            GenPolynomialRing<edu.jas.arith.BigInteger> fac;
+            fac = new GenPolynomialRing<edu.jas.arith.BigInteger>(edu.jas.arith.BigInteger.ZERO, vars.length,
+                            new TermOrder(TermOrder.INVLEX), vars);
+
+            GenPolynomial<edu.jas.arith.BigInteger> poly = fac.parse("a*d*e + c*d^2*x + a*e^2*x + c*d*e*x^2");
+            //System.out.println("Run " + i + ": " + poly.toString());
+            FactorAbstract<edu.jas.arith.BigInteger> factorAbstract = FactorFactory
+                            .getImplementation(edu.jas.arith.BigInteger.ZERO);
+            long ts = System.currentTimeMillis();
+            SortedMap<GenPolynomial<edu.jas.arith.BigInteger>, Long> map = factorAbstract.factors(poly);
+            ts = System.currentTimeMillis() - ts;
+            //System.out.println("Run Factors " + ts + "ms: " + map.toString());
+            boolean t = factorAbstract.isFactorization(poly, map);
+            if (!t) {
+                System.out.println("Run " + i + ": " + poly.toString());
+                System.out.println("Run not Factors " + ts + "ms: " + map.toString());
+            }
+        }
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/ExamplesPartialFraction.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/ExamplesPartialFraction.java
@@ -1,0 +1,194 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import edu.jas.arith.BigRational;
+import edu.jas.kern.ComputerThreads;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.TermOrder;
+
+
+/**
+ * Examples related to partial fraction decomposition.
+ * 
+ * @author Heinz Kredel
+ */
+
+public class ExamplesPartialFraction {
+
+
+    /**
+     * Main program.
+     * 
+     * @param args
+     */
+    public static void main(String[] args) {
+        example11();
+        example12();
+        example13();
+        example14();
+        example15();
+        example16();
+        example17();
+        ComputerThreads.terminate();
+    }
+
+
+    /**
+     * example11.
+     */
+    public static void example11() {
+        System.out.println("\n\nexample 11");
+
+        TermOrder to = new TermOrder(TermOrder.INVLEX);
+        BigRational cfac = new BigRational(1);
+        String[] vars = new String[] { "x" };
+        GenPolynomialRing<BigRational> pfac = new GenPolynomialRing<BigRational>(cfac, 1, to, vars);
+
+        // 1 / ( x^2 - 2 )
+        GenPolynomial<BigRational> D = pfac.parse("x^2 - 2");
+        GenPolynomial<BigRational> N = pfac.getONE();
+
+        FactorRational engine = (FactorRational) FactorFactory.getImplementation(cfac);
+
+        PartialFraction<BigRational> F = engine.baseAlgebraicPartialFraction(N, D);
+        System.out.println("\npartial fraction " + F);
+    }
+
+
+    /**
+     * example12.
+     */
+    public static void example12() {
+        System.out.println("\n\nexample 12");
+
+        TermOrder to = new TermOrder(TermOrder.INVLEX);
+        BigRational cfac = new BigRational(1);
+        String[] vars = new String[] { "x" };
+        GenPolynomialRing<BigRational> pfac = new GenPolynomialRing<BigRational>(cfac, 1, to, vars);
+
+        // 1 / ( x^3 + x )
+        GenPolynomial<BigRational> D = pfac.parse("x^3 + x");
+        GenPolynomial<BigRational> N = pfac.getONE();
+
+        FactorRational engine = (FactorRational) FactorFactory.getImplementation(cfac);
+
+        PartialFraction<BigRational> F = engine.baseAlgebraicPartialFraction(N, D);
+        System.out.println("\npartial fraction " + F);
+    }
+
+
+    /**
+     * example13.
+     */
+    public static void example13() {
+        System.out.println("\n\nexample 13");
+
+        TermOrder to = new TermOrder(TermOrder.INVLEX);
+        BigRational cfac = new BigRational(1);
+        String[] vars = new String[] { "x" };
+        GenPolynomialRing<BigRational> pfac = new GenPolynomialRing<BigRational>(cfac, 1, to, vars);
+
+        // 1 / ( x^6 - 5 x^4 + 5 x^2 + 4 )
+        GenPolynomial<BigRational> D = pfac.parse("x^6 - 5 x^4 + 5 x^2 + 4");
+        GenPolynomial<BigRational> N = pfac.getONE();
+
+        FactorRational engine = (FactorRational) FactorFactory.getImplementation(cfac);
+
+        PartialFraction<BigRational> F = engine.baseAlgebraicPartialFraction(N, D);
+        System.out.println("\npartial fraction " + F);
+    }
+
+
+    /**
+     * example14.
+     */
+    public static void example14() {
+        System.out.println("\n\nexample 14");
+
+        TermOrder to = new TermOrder(TermOrder.INVLEX);
+        BigRational cfac = new BigRational(1);
+        String[] vars = new String[] { "x" };
+        GenPolynomialRing<BigRational> pfac = new GenPolynomialRing<BigRational>(cfac, 1, to, vars);
+
+        // 1 / ( x^4 + 4 )
+        GenPolynomial<BigRational> D = pfac.parse("x^4 + 4");
+        GenPolynomial<BigRational> N = pfac.getONE();
+
+        FactorRational engine = (FactorRational) FactorFactory.getImplementation(cfac);
+
+        PartialFraction<BigRational> F = engine.baseAlgebraicPartialFraction(N, D);
+        System.out.println("\npartial fraction " + F);
+    }
+
+
+    /**
+     * example15.
+     */
+    public static void example15() {
+        System.out.println("\n\nexample 15");
+
+        TermOrder to = new TermOrder(TermOrder.INVLEX);
+        BigRational cfac = new BigRational(1);
+        String[] vars = new String[] { "x" };
+        GenPolynomialRing<BigRational> pfac = new GenPolynomialRing<BigRational>(cfac, 1, to, vars);
+
+        // 1 / ( x^3 - 2 )
+        GenPolynomial<BigRational> D = pfac.parse("x^3 - 2");
+        GenPolynomial<BigRational> N = pfac.getONE();
+
+        FactorRational engine = (FactorRational) FactorFactory.getImplementation(cfac);
+
+        PartialFraction<BigRational> F = engine.baseAlgebraicPartialFraction(N, D);
+        System.out.println("\npartial fraction " + F);
+    }
+
+
+    /**
+     * example16.
+     */
+    public static void example16() {
+        System.out.println("\n\nexample 16");
+
+        TermOrder to = new TermOrder(TermOrder.INVLEX);
+        BigRational cfac = new BigRational(1);
+        String[] vars = new String[] { "x" };
+        GenPolynomialRing<BigRational> pfac = new GenPolynomialRing<BigRational>(cfac, 1, to, vars);
+
+        // 1 / ( x - 1 ) ( x - 2 ) ( x - 3 ) 
+        GenPolynomial<BigRational> D = pfac.parse("( x - 1 ) * ( x - 2 ) * ( x - 3 )");
+        GenPolynomial<BigRational> N = pfac.getONE();
+
+        FactorRational engine = (FactorRational) FactorFactory.getImplementation(cfac);
+
+        PartialFraction<BigRational> F = engine.baseAlgebraicPartialFraction(N, D);
+        System.out.println("\npartial fraction " + F);
+    }
+
+
+    /**
+     * example17. Absolute factorization of example15.
+     */
+    public static void example17() {
+        System.out.println("\n\nexample 17");
+
+        TermOrder to = new TermOrder(TermOrder.INVLEX);
+        BigRational cfac = new BigRational(1);
+        String[] vars = new String[] { "x" };
+        GenPolynomialRing<BigRational> pfac = new GenPolynomialRing<BigRational>(cfac, 1, to, vars);
+
+        // 1 / ( x^3 - 2 )
+        GenPolynomial<BigRational> D = pfac.parse("x^3 - 2");
+        GenPolynomial<BigRational> N = pfac.getONE();
+
+        FactorRational engine = (FactorRational) FactorFactory.getImplementation(cfac);
+
+        PartialFraction<BigRational> F = engine.baseAlgebraicPartialFractionIrreducibleAbsolute(N, D);
+        System.out.println("\npartial fraction " + F);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/FactorAbsolute.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/FactorAbsolute.java
@@ -1,0 +1,848 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.AlgebraicNumberRing;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Absolute factorization algorithms class. This class contains implementations
+ * of methods for factorization over algebraically closed fields. The required
+ * field extension is computed along with the factors. The methods have been
+ * tested for prime fields of characteristic zero, that is for
+ * <code>BigRational</code>. It might eventually also be used for prime fields
+ * of non-zero characteristic, that is with <code>ModInteger</code>. The field
+ * extension may yet not be minimal.
+ * @author Heinz Kredel
+ * @param <C> coefficient type
+ */
+
+public abstract class FactorAbsolute<C extends GcdRingElem<C>> extends FactorAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(FactorAbsolute.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /*     
+     * Factorization engine for algebraic number coefficients.
+     */
+    //not possible here because of recursion AN -> Int|Mod -> AN -> ...
+    //public final FactorAbstract<AlgebraicNumber<C>> aengine;
+
+    /**
+     * No argument constructor. <b>Note:</b> can't use this constructor.
+     */
+    protected FactorAbsolute() {
+        throw new IllegalArgumentException("don't use this constructor");
+    }
+
+
+    /**
+     * Constructor.
+     * @param cfac coefficient ring factory.
+     */
+    public FactorAbsolute(RingFactory<C> cfac) {
+        super(cfac);
+        //GenPolynomialRing<C> fac = new GenPolynomialRing<C>(cfac,1);
+        //GenPolynomial<C> p = fac.univariate(0);
+        //AlgebraicNumberRing<C> afac = new AlgebraicNumberRing<C>(p);
+        //aengine = null; //FactorFactory.<C>getImplementation(afac); // hack
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return getClass().getName();
+    }
+
+
+    /**
+     * GenPolynomial test if is absolute irreducible.
+     * @param P GenPolynomial.
+     * @return true if P is absolute irreducible, else false.
+     */
+    public boolean isAbsoluteIrreducible(GenPolynomial<C> P) {
+        if (!isIrreducible(P)) {
+            return false;
+        }
+        Factors<C> F = factorsAbsoluteIrreducible(P);
+        if (F.afac == null) {
+            return true;
+        } else if (F.afactors.size() > 2) {
+            return false;
+        } else { //F.size() == 2
+            boolean cnst = false;
+            for (GenPolynomial<AlgebraicNumber<C>> p : F.afactors) {
+                if (p.isConstant()) {
+                    cnst = true;
+                }
+            }
+            return cnst;
+        }
+    }
+
+
+    /**
+     * GenPolynomial absolute base factorization of a polynomial.
+     * @param P univariate GenPolynomial.
+     * @return factors map container: [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with P
+     *         = prod_{i=1,...,k} p_i**e_i. <b>Note:</b> K(alpha) not yet
+     *         minimal.
+     */
+    // @Override
+    public FactorsMap<C> baseFactorsAbsolute(GenPolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P == null");
+        }
+        SortedMap<GenPolynomial<C>, Long> factors = new TreeMap<GenPolynomial<C>, Long>();
+        if (P.isZERO()) {
+            return new FactorsMap<C>(P, factors);
+        }
+        //System.out.println("\nP_base = " + P);
+        GenPolynomialRing<C> pfac = P.ring; // K[x]
+        if (pfac.nvar > 1) {
+            //System.out.println("\nfacs_base: univ");
+            throw new IllegalArgumentException("only for univariate polynomials");
+        }
+        if (!pfac.coFac.isField()) {
+            //System.out.println("\nfacs_base: field");
+            throw new IllegalArgumentException("only for field coefficients");
+        }
+        if (P.degree(0) <= 1) {
+            factors.put(P, 1L);
+            return new FactorsMap<C>(P, factors);
+        }
+        // factor over K (=C)
+        SortedMap<GenPolynomial<C>, Long> facs = baseFactors(P);
+        if (debug && !isFactorization(P, facs)) {
+            System.out.println("facs   = " + facs);
+            throw new ArithmeticException("isFactorization = false");
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("all K factors = " + facs); // Q[X]
+            //System.out.println("\nall K factors = " + facs); // Q[X]
+        }
+        // factor over some K(alpha)
+        SortedMap<Factors<C>, Long> afactors = new TreeMap<Factors<C>, Long>();
+        for (Map.Entry<GenPolynomial<C>, Long> me : facs.entrySet()) {
+            GenPolynomial<C> p = me.getKey();
+            Long e = me.getValue(); //facs.get(p);
+            if (p.degree(0) <= 1) {
+                factors.put(p, e);
+            } else {
+                Factors<C> afacs = baseFactorsAbsoluteIrreducible(p);
+                //System.out.println("afacs   = " + afacs);
+                afactors.put(afacs, e);
+            }
+        }
+        //System.out.println("K(alpha) factors = " + factors);
+        return new FactorsMap<C>(P, factors, afactors);
+    }
+
+
+    /**
+     * GenPolynomial absolute base factorization of a squarefree polynomial.
+     * @param P squarefree and primitive univariate GenPolynomial.
+     * @return factors list container: [p_1,...,p_k] with P = prod_{i=1, ..., k}
+     *         p_i. <b>Note:</b> K(alpha) not yet minimal.
+     */
+    // @Override
+    public FactorsList<C> baseFactorsAbsoluteSquarefree(GenPolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P == null");
+        }
+        List<GenPolynomial<C>> factors = new ArrayList<GenPolynomial<C>>();
+        if (P.isZERO()) {
+            return new FactorsList<C>(P, factors);
+        }
+        //System.out.println("\nP_base_sqf = " + P);
+        GenPolynomialRing<C> pfac = P.ring; // K[x]
+        if (pfac.nvar > 1) {
+            //System.out.println("facs_base_sqf: univ");
+            throw new IllegalArgumentException("only for univariate polynomials");
+        }
+        if (!pfac.coFac.isField()) {
+            //System.out.println("facs_base_sqf: field");
+            throw new IllegalArgumentException("only for field coefficients");
+        }
+        if (P.degree(0) <= 1) {
+            factors.add(P);
+            return new FactorsList<C>(P, factors);
+        }
+        // factor over K (=C)
+        List<GenPolynomial<C>> facs = baseFactorsSquarefree(P);
+        //System.out.println("facs_base_irred = " + facs);
+        if (debug && !isFactorization(P, facs)) {
+            throw new ArithmeticException("isFactorization = false");
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("all K factors = " + facs); // Q[X]
+            //System.out.println("\nall K factors = " + facs); // Q[X]
+        }
+        // factor over K(alpha)
+        List<Factors<C>> afactors = new ArrayList<Factors<C>>();
+        for (GenPolynomial<C> p : facs) {
+            //System.out.println("facs_base_sqf_p = " + p);
+            if (p.degree(0) <= 1) {
+                factors.add(p);
+            } else {
+                Factors<C> afacs = baseFactorsAbsoluteIrreducible(p);
+                //System.out.println("afacs_base_sqf = " + afacs);
+                if (logger.isInfoEnabled()) {
+                    logger.info("K(alpha) factors = " + afacs); // K(alpha)[X]
+                }
+                afactors.add(afacs);
+            }
+        }
+        //System.out.println("K(alpha) factors = " + factors);
+        return new FactorsList<C>(P, factors, afactors);
+    }
+
+
+    /**
+     * GenPolynomial base absolute factorization of a irreducible polynomial.
+     * @param P irreducible! univariate GenPolynomial.
+     * @return factors container: [p_1,...,p_k] with P = prod_{i=1, ..., k} p_i
+     *         in K(alpha)[x] for suitable alpha and p_i irreducible over L[x],
+     *         where K \subset K(alpha) \subset L is an algebraically closed
+     *         field over K. <b>Note:</b> K(alpha) not yet minimal.
+     */
+    public Factors<C> baseFactorsAbsoluteIrreducible(GenPolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P == null");
+        }
+        if (P.isZERO()) {
+            return new Factors<C>(P);
+        }
+        //System.out.println("\nP_base_irred = " + P);
+        GenPolynomialRing<C> pfac = P.ring; // K[x]
+        if (pfac.nvar > 1) {
+            //System.out.println("facs_base_irred: univ");
+            throw new IllegalArgumentException("only for univariate polynomials");
+        }
+        if (!pfac.coFac.isField()) {
+            //System.out.println("facs_base_irred: field");
+            throw new IllegalArgumentException("only for field coefficients");
+        }
+        if (P.degree(0) <= 1) {
+            return new Factors<C>(P);
+        }
+        // setup field extension K(alpha) where alpha = z_xx
+        //String[] vars = new String[] { "z_" + Math.abs(P.hashCode() % 1000) };
+        String[] vars = pfac.newVars("z_");
+        pfac = pfac.copy();
+        vars = pfac.setVars(vars);
+        GenPolynomial<C> aP = pfac.copy(P); // hack to exchange the variables
+        AlgebraicNumberRing<C> afac = new AlgebraicNumberRing<C>(aP, true); // since irreducible
+        if (logger.isInfoEnabled()) {
+            logger.info("K(alpha) = " + afac);
+            logger.info("K(alpha) = " + afac.toScript());
+            //System.out.println("K(alpha) = " + afac);
+        }
+        GenPolynomialRing<AlgebraicNumber<C>> pafac = new GenPolynomialRing<AlgebraicNumber<C>>(afac,
+                        aP.ring.nvar, aP.ring.tord, /*old*/vars);
+        // convert to K(alpha)
+        GenPolynomial<AlgebraicNumber<C>> Pa = PolyUtil.<C> convertToAlgebraicCoefficients(pafac, P);
+        if (logger.isInfoEnabled()) {
+            logger.info("P over K(alpha) = " + Pa);
+            //logger.info("P over K(alpha) = " + Pa.toScript()); 
+            //System.out.println("P in K(alpha) = " + Pa);
+        }
+        // factor over K(alpha)
+        FactorAbstract<AlgebraicNumber<C>> engine = FactorFactory.<C> getImplementation(afac);
+        //System.out.println("K(alpha) engine = " + engine);
+        List<GenPolynomial<AlgebraicNumber<C>>> factors = engine.baseFactorsSquarefree(Pa);
+        //System.out.println("factors = " + factors);
+        if (logger.isInfoEnabled()) {
+            logger.info("factors over K(alpha) = " + factors);
+            //System.out.println("factors over K(alpha) = " + factors);
+        }
+        List<GenPolynomial<AlgebraicNumber<C>>> faca = new ArrayList<GenPolynomial<AlgebraicNumber<C>>>(
+                        factors.size());
+        List<Factors<AlgebraicNumber<C>>> facar = new ArrayList<Factors<AlgebraicNumber<C>>>();
+        for (GenPolynomial<AlgebraicNumber<C>> fi : factors) {
+            if (fi.degree(0) <= 1) {
+                faca.add(fi);
+            } else {
+                //System.out.println("fi.deg > 1 = " + fi);
+                FactorAbsolute<AlgebraicNumber<C>> aengine = (FactorAbsolute<AlgebraicNumber<C>>) FactorFactory
+                                .<C> getImplementation(afac);
+                Factors<AlgebraicNumber<C>> fif = aengine.baseFactorsAbsoluteIrreducible(fi);
+                //System.out.println("fif = " + fif);
+                facar.add(fif);
+            }
+        }
+        if (facar.size() == 0) {
+            facar = null;
+        }
+        // find minimal field extension K(beta) \subset K(alpha)
+        return new Factors<C>(P, afac, Pa, faca, facar);
+    }
+
+
+    /**
+     * Univariate GenPolynomial algebraic partial fraction decomposition,
+     * Absolute factorization for elementary integration algorithm to linear
+     * factors.
+     * @param A univariate GenPolynomial, deg(A) &le; deg(P).
+     * @param P univariate squarefree GenPolynomial, gcd(A,P) == 1.
+     * @return partial fraction container.
+     */
+    public PartialFraction<C> baseAlgebraicPartialFraction(GenPolynomial<C> A, GenPolynomial<C> P) {
+        if (P == null || P.isZERO()) {
+            throw new IllegalArgumentException(" P == null or P == 0");
+        }
+        if (A == null || A.isZERO()) {
+            throw new IllegalArgumentException(" A == null or A == 0");
+            // PartialFraction(A,P,al,pl,empty,empty)
+        }
+        //System.out.println("\nP_base_algeb_part = " + P);
+        GenPolynomialRing<C> pfac = P.ring; // K[x]
+        if (pfac.nvar > 1) {
+            //System.out.println("facs_base_irred: univ");
+            throw new IllegalArgumentException("only for univariate polynomials");
+        }
+        if (!pfac.coFac.isField()) {
+            //System.out.println("facs_base_irred: field");
+            throw new IllegalArgumentException("only for field coefficients");
+        }
+        List<C> cfactors = new ArrayList<C>();
+        List<GenPolynomial<C>> cdenom = new ArrayList<GenPolynomial<C>>();
+        List<AlgebraicNumber<C>> afactors = new ArrayList<AlgebraicNumber<C>>();
+        List<GenPolynomial<AlgebraicNumber<C>>> adenom = new ArrayList<GenPolynomial<AlgebraicNumber<C>>>();
+
+        // P linear
+        if (P.degree(0) <= 1) {
+            cfactors.add(A.leadingBaseCoefficient());
+            cdenom.add(P);
+            return new PartialFraction<C>(A, P, cfactors, cdenom, afactors, adenom);
+        }
+        List<GenPolynomial<C>> Pfac = baseFactorsSquarefree(P);
+        //System.out.println("\nPfac = " + Pfac);
+
+        List<GenPolynomial<C>> Afac = engine.basePartialFraction(A, Pfac);
+
+        GenPolynomial<C> A0 = Afac.remove(0);
+        if (!A0.isZERO()) {
+            throw new ArithmeticException(" A0 != 0: deg(A)>= deg(P)");
+        }
+
+        // algebraic and linear factors
+        int i = 0;
+        for (GenPolynomial<C> pi : Pfac) {
+            GenPolynomial<C> ai = Afac.get(i++);
+            if (pi.degree(0) <= 1) {
+                cfactors.add(ai.leadingBaseCoefficient());
+                cdenom.add(pi);
+                continue;
+            }
+            PartialFraction<C> pf = baseAlgebraicPartialFractionIrreducibleAbsolute(ai, pi);
+            //PartialFraction<C> pf = baseAlgebraicPartialFractionIrreducible(ai,pi);
+            cfactors.addAll(pf.cfactors);
+            cdenom.addAll(pf.cdenom);
+            afactors.addAll(pf.afactors);
+            adenom.addAll(pf.adenom);
+        }
+        return new PartialFraction<C>(A, P, cfactors, cdenom, afactors, adenom);
+    }
+
+
+    /**
+     * Univariate GenPolynomial algebraic partial fraction decomposition, via
+     * absolute factorization to linear factors.
+     * @param A univariate GenPolynomial, deg(A) &lt; deg(P).
+     * @param P univariate irreducible GenPolynomial, gcd(A,P) == 1.
+     * @return partial fraction container.
+     */
+    @SuppressWarnings("unchecked")
+    public PartialFraction<C> baseAlgebraicPartialFractionIrreducibleAbsolute(GenPolynomial<C> A,
+                    GenPolynomial<C> P) {
+        if (P == null || P.isZERO()) {
+            throw new IllegalArgumentException(" P == null or P == 0");
+        }
+        //System.out.println("\nP_base_algeb_part = " + P);
+        GenPolynomialRing<C> pfac = P.ring; // K[x]
+        if (pfac.nvar > 1) {
+            //System.out.println("facs_base_irred: univ");
+            throw new IllegalArgumentException("only for univariate polynomials");
+        }
+        if (!pfac.coFac.isField()) {
+            //System.out.println("facs_base_irred: field");
+            throw new IllegalArgumentException("only for field coefficients");
+        }
+        List<C> cfactors = new ArrayList<C>();
+        List<GenPolynomial<C>> cdenom = new ArrayList<GenPolynomial<C>>();
+        List<AlgebraicNumber<C>> afactors = new ArrayList<AlgebraicNumber<C>>();
+        List<GenPolynomial<AlgebraicNumber<C>>> adenom = new ArrayList<GenPolynomial<AlgebraicNumber<C>>>();
+
+        // P linear
+        if (P.degree(0) <= 1) {
+            cfactors.add(A.leadingBaseCoefficient());
+            cdenom.add(P);
+            return new PartialFraction<C>(A, P, cfactors, cdenom, afactors, adenom);
+        }
+
+        // non linear case
+        Factors<C> afacs = factorsAbsoluteIrreducible(P);
+        //System.out.println("linear algebraic factors = " + afacs);
+        //System.out.println("afactors      = " + afacs.afactors);
+        //System.out.println("arfactors     = " + afacs.arfactors);
+        //System.out.println("arfactors pol = " + afacs.arfactors.get(0).poly);
+        //System.out.println("arfactors2    = " + afacs.arfactors.get(0).afactors);
+
+        List<GenPolynomial<AlgebraicNumber<C>>> fact = afacs.getFactors();
+        //System.out.println("factors       = " + fact);
+        GenPolynomial<AlgebraicNumber<C>> Pa = afacs.apoly;
+        GenPolynomial<AlgebraicNumber<C>> Aa = PolyUtil.<C> convertToRecAlgebraicCoefficients(1, Pa.ring, A);
+
+        GreatestCommonDivisorAbstract<AlgebraicNumber<C>> aengine = GCDFactory.getProxy(afacs.afac);
+        //System.out.println("denom         = " + Pa);
+        //System.out.println("numer         = " + Aa);
+        List<GenPolynomial<AlgebraicNumber<C>>> numers = aengine.basePartialFraction(Aa, fact);
+        //System.out.println("part frac     = " + numers);
+        GenPolynomial<AlgebraicNumber<C>> A0 = numers.remove(0);
+        if (!A0.isZERO()) {
+            throw new ArithmeticException(" A0 != 0: deg(A)>= deg(P)");
+        }
+        int i = 0;
+        for (GenPolynomial<AlgebraicNumber<C>> fa : fact) {
+            GenPolynomial<AlgebraicNumber<C>> an = numers.get(i++);
+            if (fa.degree(0) <= 1) {
+                afactors.add(an.leadingBaseCoefficient());
+                adenom.add(fa);
+                continue;
+            }
+            System.out.println("fa = " + fa);
+            Factors<AlgebraicNumber<C>> faf = afacs.getFactor(fa);
+            System.out.println("faf = " + faf);
+            List<GenPolynomial<AlgebraicNumber<AlgebraicNumber<C>>>> fafact = faf.getFactors();
+            GenPolynomial<AlgebraicNumber<AlgebraicNumber<C>>> Aaa = PolyUtil
+                            .<AlgebraicNumber<C>> convertToRecAlgebraicCoefficients(1, faf.apoly.ring, an);
+
+            GreatestCommonDivisorAbstract<AlgebraicNumber<AlgebraicNumber<C>>> aaengine = GCDFactory
+                            .getImplementation(faf.afac);
+
+            List<GenPolynomial<AlgebraicNumber<AlgebraicNumber<C>>>> anumers = aaengine
+                            .basePartialFraction(Aaa, fafact);
+            System.out.println("algeb part frac = " + anumers);
+            GenPolynomial<AlgebraicNumber<AlgebraicNumber<C>>> A0a = anumers.remove(0);
+            if (!A0a.isZERO()) {
+                throw new ArithmeticException(" A0 != 0: deg(A)>= deg(P)");
+            }
+            int k = 0;
+            for (GenPolynomial<AlgebraicNumber<AlgebraicNumber<C>>> faa : fafact) {
+                GenPolynomial<AlgebraicNumber<AlgebraicNumber<C>>> ana = anumers.get(k++);
+                System.out.println("faa = " + faa);
+                System.out.println("ana = " + ana);
+                if (faa.degree(0) > 1) {
+                    throw new ArithmeticException(" faa not linear");
+                }
+                GenPolynomial<AlgebraicNumber<C>> ana1 = (GenPolynomial<AlgebraicNumber<C>>) (GenPolynomial) ana;
+                GenPolynomial<AlgebraicNumber<C>> faa1 = (GenPolynomial<AlgebraicNumber<C>>) (GenPolynomial) faa;
+
+                afactors.add(ana1.leadingBaseCoefficient());
+                adenom.add(faa1);
+            }
+        }
+        return new PartialFraction<C>(A, P, cfactors, cdenom, afactors, adenom);
+    }
+
+
+    /**
+     * GenPolynomial absolute factorization of a polynomial.
+     * @param P GenPolynomial.
+     * @return factors map container: [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with P
+     *         = prod_{i=1,...,k} p_i**e_i. <b>Note:</b> K(alpha) not yet
+     *         minimal.
+     */
+    public FactorsMap<C> factorsAbsolute(GenPolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P == null");
+        }
+        SortedMap<GenPolynomial<C>, Long> factors = new TreeMap<GenPolynomial<C>, Long>();
+        if (P.isZERO()) {
+            return new FactorsMap<C>(P, factors);
+        }
+        //System.out.println("\nP_mult = " + P);
+        GenPolynomialRing<C> pfac = P.ring; // K[x]
+        if (pfac.nvar <= 1) {
+            return baseFactorsAbsolute(P);
+        }
+        if (!pfac.coFac.isField()) {
+            throw new IllegalArgumentException("only for field coefficients");
+        }
+        if (P.degree() <= 1) {
+            factors.put(P, 1L);
+            return new FactorsMap<C>(P, factors);
+        }
+        // factor over K (=C)
+        SortedMap<GenPolynomial<C>, Long> facs = factors(P);
+        if (debug && !isFactorization(P, facs)) {
+            throw new ArithmeticException("isFactorization = false");
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("all K factors = " + facs); // Q[X]
+            //System.out.println("\nall K factors = " + facs); // Q[X]
+        }
+        SortedMap<Factors<C>, Long> afactors = new TreeMap<Factors<C>, Long>();
+        // factor over K(alpha)
+        for (Map.Entry<GenPolynomial<C>, Long> me : facs.entrySet()) {
+            GenPolynomial<C> p = me.getKey();
+            Long e = me.getValue(); //facs.get(p);
+            if (p.degree() <= 1) {
+                factors.put(p, e);
+            } else {
+                Factors<C> afacs = factorsAbsoluteIrreducible(p);
+                if (afacs.afac == null) { // absolute irreducible
+                    factors.put(p, e);
+                } else {
+                    afactors.put(afacs, e);
+                }
+            }
+        }
+        //System.out.println("K(alpha) factors multi = " + factors);
+        return new FactorsMap<C>(P, factors, afactors);
+    }
+
+
+    /**
+     * GenPolynomial absolute factorization of a squarefree polynomial.
+     * @param P squarefree and primitive GenPolynomial.
+     * @return factors list container: [p_1,...,p_k] with P = prod_{i=1, ..., k}
+     *         p_i. <b>Note:</b> K(alpha) not yet minimal.
+     */
+    // @Override
+    public FactorsList<C> factorsAbsoluteSquarefree(GenPolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P == null");
+        }
+        List<GenPolynomial<C>> factors = new ArrayList<GenPolynomial<C>>();
+        if (P.isZERO()) {
+            return new FactorsList<C>(P, factors);
+        }
+        //System.out.println("\nP = " + P);
+        GenPolynomialRing<C> pfac = P.ring; // K[x]
+        if (pfac.nvar <= 1) {
+            return baseFactorsAbsoluteSquarefree(P);
+        }
+        if (!pfac.coFac.isField()) {
+            throw new IllegalArgumentException("only for field coefficients");
+        }
+        if (P.degree() <= 1) {
+            factors.add(P);
+            return new FactorsList<C>(P, factors);
+        }
+        // factor over K (=C)
+        List<GenPolynomial<C>> facs = factorsSquarefree(P);
+        if (debug && !isFactorization(P, facs)) {
+            throw new ArithmeticException("isFactorization = false");
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("all K factors = " + facs); // Q[X]
+            //System.out.println("\nall K factors = " + facs); // Q[X]
+        }
+        List<Factors<C>> afactors = new ArrayList<Factors<C>>();
+        // factor over K(alpha)
+        for (GenPolynomial<C> p : facs) {
+            if (p.degree() <= 1) {
+                factors.add(p);
+            } else {
+                Factors<C> afacs = factorsAbsoluteIrreducible(p);
+                if (debug) {
+                    logger.info("K(alpha) factors = " + afacs); // K(alpha)[X]
+                }
+                if (afacs.afac == null) { // absolute irreducible
+                    factors.add(p);
+                } else {
+                    afactors.add(afacs);
+                }
+            }
+        }
+        //System.out.println("K(alpha) factors = " + factors);
+        return new FactorsList<C>(P, factors, afactors);
+    }
+
+
+    /**
+     * GenPolynomial absolute factorization of a irreducible polynomial.
+     * @param P irreducible! GenPolynomial.
+     * @return factors container: [p_1,...,p_k] with P = prod_{i=1, ..., k} p_i
+     *         in K(alpha)[x] for suitable alpha and p_i irreducible over L[x],
+     *         where K \subset K(alpha) \subset L is an algebraically closed
+     *         field over K. <b>Note:</b> K(alpha) not yet minimal.
+     */
+    public Factors<C> factorsAbsoluteIrreducible(GenPolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P == null");
+        }
+        if (P.isZERO()) {
+            return new Factors<C>(P);
+        }
+        GenPolynomialRing<C> pfac = P.ring; // K[x]
+        if (pfac.nvar <= 1) {
+            return baseFactorsAbsoluteIrreducible(P);
+        }
+        if (!pfac.coFac.isField()) {
+            throw new IllegalArgumentException("only for field coefficients");
+        }
+        //List<GenPolynomial<C>> factors = new ArrayList<GenPolynomial<C>>();
+        if (P.degree() <= 1) {
+            return new Factors<C>(P);
+        }
+        // find field extension K(alpha)
+        GenPolynomial<C> up = P;
+        RingFactory<C> cf = pfac.coFac;
+        long cr = cf.characteristic().longValueExact(); // char might be larger
+        if (cr == 0L) {
+            cr = Long.MAX_VALUE;
+        }
+        long rp = 0L;
+        for (int i = 0; i < (pfac.nvar - 1); i++) {
+            rp = 0L;
+            GenPolynomialRing<C> nfac = pfac.contract(1);
+            String[] vn = new String[] { pfac.getVars()[pfac.nvar - 1] };
+            GenPolynomialRing<GenPolynomial<C>> rfac = new GenPolynomialRing<GenPolynomial<C>>(nfac, 1,
+                            pfac.tord, vn);
+            GenPolynomial<GenPolynomial<C>> upr = PolyUtil.<C> recursive(rfac, up);
+            //System.out.println("upr = " + upr);
+            GenPolynomial<C> ep;
+            do {
+                if (rp >= cr) {
+                    throw new ArithmeticException("elements of prime field exhausted: " + cr);
+                }
+                C r = cf.fromInteger(rp); //cf.random(rp);
+                //System.out.println("r   = " + r);
+                ep = PolyUtil.<C> evaluateMainRecursive(nfac, upr, r);
+                //System.out.println("ep  = " + ep);
+                rp++;
+            } while (!isSquarefree(ep) /*todo: || ep.degree() <= 1*/); // max deg
+            up = ep;
+            pfac = nfac;
+        }
+        up = up.monic();
+        if (debug) {
+            logger.info("P(" + rp + ") = " + up);
+            //System.out.println("up  = " + up);
+        }
+        if (debug && !isSquarefree(up)) {
+            throw new ArithmeticException("not irreducible up = " + up);
+        }
+        if (up.degree(0) <= 1) {
+            return new Factors<C>(P);
+        }
+        // find irreducible factor of up
+        List<GenPolynomial<C>> UF = baseFactorsSquarefree(up);
+        //System.out.println("UF  = " + UF);
+        FactorsList<C> aUF = baseFactorsAbsoluteSquarefree(up);
+        //System.out.println("aUF  = " + aUF);
+        AlgebraicNumberRing<C> arfac = aUF.findExtensionField();
+        //System.out.println("arfac  = " + arfac);
+
+        long e = up.degree(0);
+        // search factor polynomial with smallest degree 
+        for (int i = 0; i < UF.size(); i++) {
+            GenPolynomial<C> upi = UF.get(i);
+            long d = upi.degree(0);
+            if (1 <= d && d <= e) {
+                up = upi;
+                e = up.degree(0);
+            }
+        }
+        if (up.degree(0) <= 1) {
+            return new Factors<C>(P);
+        }
+        if (debug) {
+            logger.info("field extension by " + up);
+        }
+
+        List<GenPolynomial<AlgebraicNumber<C>>> afactors = new ArrayList<GenPolynomial<AlgebraicNumber<C>>>();
+
+        // setup field extension K(alpha)
+        //String[] vars = new String[] { "z_" + Math.abs(up.hashCode() % 1000) };
+        String[] vars = pfac.newVars("z_");
+        pfac = pfac.copy();
+        //String[] ovars = 
+        pfac.setVars(vars); // side effects! 
+        //GenPolynomial<C> aup = pfac.copy(up); // hack to exchange the variables
+        //AlgebraicNumberRing<C> afac = new AlgebraicNumberRing<C>(aup,true); // since irreducible
+        AlgebraicNumberRing<C> afac = arfac;
+        int depth = afac.depth();
+        //System.out.println("afac = " + afac);
+        GenPolynomialRing<AlgebraicNumber<C>> pafac = new GenPolynomialRing<AlgebraicNumber<C>>(afac,
+                        P.ring.nvar, P.ring.tord, P.ring.getVars());
+        //System.out.println("pafac = " + pafac);
+        // convert to K(alpha)
+        GenPolynomial<AlgebraicNumber<C>> Pa = PolyUtil.<C> convertToRecAlgebraicCoefficients(depth, pafac,
+                        P);
+        //System.out.println("Pa = " + Pa);
+        // factor over K(alpha)
+        FactorAbstract<AlgebraicNumber<C>> engine = FactorFactory.<C> getImplementation(afac);
+        afactors = engine.factorsSquarefree(Pa);
+        if (debug) {
+            logger.info("K(alpha) factors multi = " + afactors);
+            //System.out.println("K(alpha) factors = " + afactors);
+        }
+        if (afactors.size() <= 1) {
+            return new Factors<C>(P);
+        }
+        // normalize first factor to monic
+        GenPolynomial<AlgebraicNumber<C>> p1 = afactors.get(0);
+        AlgebraicNumber<C> p1c = p1.leadingBaseCoefficient();
+        if (!p1c.isONE()) {
+            GenPolynomial<AlgebraicNumber<C>> p2 = afactors.get(1);
+            afactors.remove(p1);
+            afactors.remove(p2);
+            p1 = p1.divide(p1c);
+            p2 = p2.multiply(p1c);
+            afactors.add(p1);
+            afactors.add(p2);
+        }
+        // recursion for splitting field
+        // find minimal field extension K(beta) \subset K(alpha)
+        return new Factors<C>(P, afac, Pa, afactors);
+    }
+
+
+    /**
+     * GenPolynomial is absolute factorization.
+     * @param facs factors container.
+     * @return true if P = prod_{i=1,...,r} p_i, else false.
+     */
+    public boolean isAbsoluteFactorization(Factors<C> facs) {
+        if (facs == null) {
+            throw new IllegalArgumentException("facs may not be null");
+        }
+        if (facs.afac == null) {
+            return true;
+        }
+        GenPolynomial<AlgebraicNumber<C>> fa = facs.apoly;
+        GenPolynomialRing<AlgebraicNumber<C>> pafac = fa.ring;
+        GenPolynomial<AlgebraicNumber<C>> t = pafac.getONE();
+        for (GenPolynomial<AlgebraicNumber<C>> f : facs.afactors) {
+            t = t.multiply(f);
+        }
+        //return fa.equals(t) || fa.equals(t.negate());
+        boolean b = fa.equals(t) || fa.equals(t.negate());
+        if (b) {
+            return b;
+        }
+        if (facs.arfactors == null) {
+            return false;
+        }
+        for (Factors<AlgebraicNumber<C>> arp : facs.arfactors) {
+            t = t.multiply(arp.poly);
+        }
+        b = fa.equals(t) || fa.equals(t.negate());
+        if (!b) {
+            System.out.println("\nFactors: " + facs);
+            System.out.println("fa = " + fa);
+            System.out.println("t = " + t);
+        }
+        return b;
+    }
+
+
+    /**
+     * GenPolynomial is absolute factorization.
+     * @param facs factors list container.
+     * @return true if P = prod_{i=1,...,r} p_i, else false.
+     */
+    public boolean isAbsoluteFactorization(FactorsList<C> facs) {
+        if (facs == null) {
+            throw new IllegalArgumentException("facs may not be null");
+        }
+        GenPolynomial<C> P = facs.poly;
+        GenPolynomial<C> t = P.ring.getONE();
+        for (GenPolynomial<C> f : facs.factors) {
+            t = t.multiply(f);
+        }
+        if (P.equals(t) || P.equals(t.negate())) {
+            return true;
+        }
+        if (facs.afactors == null) {
+            return false;
+        }
+        for (Factors<C> fs : facs.afactors) {
+            if (!isAbsoluteFactorization(fs)) {
+                return false;
+            }
+            t = t.multiply(facs.poly);
+        }
+        //return P.equals(t) || P.equals(t.negate());
+        boolean b = P.equals(t) || P.equals(t.negate());
+        if (!b) {
+            System.out.println("\nFactorsList: " + facs);
+            System.out.println("P = " + P);
+            System.out.println("t = " + t);
+        }
+        return b;
+    }
+
+
+    /**
+     * GenPolynomial is absolute factorization.
+     * @param facs factors map container.
+     * @return true if P = prod_{i=1,...,k} p_i**e_i , else false.
+     */
+    public boolean isAbsoluteFactorization(FactorsMap<C> facs) {
+        if (facs == null) {
+            throw new IllegalArgumentException("facs may not be null");
+        }
+        GenPolynomial<C> P = facs.poly;
+        GenPolynomial<C> t = P.ring.getONE();
+        for (Map.Entry<GenPolynomial<C>, Long> me : facs.factors.entrySet()) {
+            GenPolynomial<C> f = me.getKey();
+            long e = me.getValue();
+            GenPolynomial<C> g = f.power(e);
+            t = t.multiply(g);
+        }
+        if (P.equals(t) || P.equals(t.negate())) {
+            return true;
+        }
+        if (facs.afactors == null) {
+            return false;
+        }
+        for (Map.Entry<Factors<C>, Long> me : facs.afactors.entrySet()) {
+            Factors<C> fs = me.getKey();
+            if (!isAbsoluteFactorization(fs)) {
+                return false;
+            }
+            long e = me.getValue();
+            GenPolynomial<C> g = fs.poly.power(e);
+            t = t.multiply(g);
+        }
+        boolean b = P.equals(t) || P.equals(t.negate());
+        if (!b) {
+            System.out.println("\nFactorsMap: " + facs);
+            System.out.println("P = " + P);
+            System.out.println("t = " + t);
+        }
+        return b;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/FactorAbstract.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/FactorAbstract.java
@@ -1,0 +1,841 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.kern.TimeStatus;
+import edu.jas.kern.StringUtil;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.OptimizedPolynomialList;
+import edu.jas.poly.PolyUtil;
+import edu.jas.poly.TermOrderOptimization;
+import edu.jas.poly.TermOrderByName;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.util.KsubSet;
+
+
+/**
+ * Abstract factorization algorithms class. This class contains implementations
+ * of all methods of the <code>Factorization</code> interface, except the method
+ * for factorization of a squarefree polynomial. The methods to obtain
+ * squarefree polynomials delegate the computation to the
+ * <code>GreatestCommonDivisor</code> classes and are included for convenience.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ * @see edu.jas.ufd.FactorFactory
+ */
+
+public abstract class FactorAbstract<C extends GcdRingElem<C>> implements Factorization<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(FactorAbstract.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Gcd engine for base coefficients.
+     */
+    protected final GreatestCommonDivisorAbstract<C> engine;
+
+
+    /**
+     * Squarefree decompositon engine for base coefficients.
+     */
+    protected final SquarefreeAbstract<C> sengine;
+
+
+    /**
+     * No argument constructor.
+     */
+    protected FactorAbstract() {
+        throw new IllegalArgumentException("don't use this constructor");
+    }
+
+
+    /**
+     * Constructor.
+     * @param cfac coefficient ring factory.
+     */
+    public FactorAbstract(RingFactory<C> cfac) {
+        engine = GCDFactory.<C> getProxy(cfac);
+        //engine = GCDFactory.<C> getImplementation(cfac);
+        sengine = SquarefreeFactory.<C> getImplementation(cfac);
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return getClass().getName();
+    }
+
+
+    /**
+     * GenPolynomial test if is irreducible.
+     * @param P GenPolynomial.
+     * @return true if P is irreducible, else false.
+     */
+    public boolean isIrreducible(GenPolynomial<C> P) {
+        if (!isSquarefree(P)) {
+            return false;
+        }
+        List<GenPolynomial<C>> F = factorsSquarefree(P);
+        if (F.size() == 1) {
+            return true;
+        } else if (F.size() > 2) {
+            return false;
+        } else { //F.size() == 2
+            boolean cnst = false;
+            for (GenPolynomial<C> p : F) {
+                if (p.isConstant()) {
+                    cnst = true;
+                }
+            }
+            return cnst;
+        }
+    }
+
+
+    /**
+     * GenPolynomial test if a non trivial factorization exsists.
+     * @param P GenPolynomial.
+     * @return true if P is reducible, else false.
+     */
+    public boolean isReducible(GenPolynomial<C> P) {
+        return !isIrreducible(P);
+    }
+
+
+    /**
+     * GenPolynomial test if is squarefree.
+     * @param P GenPolynomial.
+     * @return true if P is squarefree, else false.
+     */
+    public boolean isSquarefree(GenPolynomial<C> P) {
+        return sengine.isSquarefree(P);
+    }
+
+
+    /**
+     * GenPolynomial factorization of a multivariate squarefree polynomial,
+     * using Kronecker substitution and variable order optimization.
+     * @param P squarefree and primitive! (respectively monic) multivariate
+     *            GenPolynomial over the ring C.
+     * @return [p_1,...,p_k] with P = prod_{i=1,...,r} p_i.
+     */
+    public List<GenPolynomial<C>> factorsSquarefreeOptimize(GenPolynomial<C> P) {
+        GenPolynomialRing<C> pfac = P.ring;
+        if (pfac.nvar <= 1) {
+            return baseFactorsSquarefree(P);
+        }
+        List<GenPolynomial<C>> topt = new ArrayList<GenPolynomial<C>>(1);
+        topt.add(P);
+        OptimizedPolynomialList<C> opt = TermOrderOptimization.<C> optimizeTermOrder(pfac, topt);
+        P = opt.list.get(0);
+        logger.info("optimized polynomial: " + P);
+        List<Integer> iperm = TermOrderOptimization.inversePermutation(opt.perm);
+        logger.info("optimize perm: " + opt.perm + ", de-optimize perm: " + iperm);
+
+        ExpVector degv = P.degreeVector();
+        int[] donv = degv.dependencyOnVariables();
+        List<GenPolynomial<C>> facs = null;
+        if (degv.length() == donv.length) { // all variables appear
+            logger.info("do.full factorsSquarefreeKronecker: " + P);
+            facs = factorsSquarefreeKronecker(P);
+        } else { // not all variables appear, remove unused variables
+            GenPolynomial<C> pu = PolyUtil.<C> removeUnusedUpperVariables(P);
+            //GenPolynomial<C> pl = PolyUtil.<C> removeUnusedLowerVariables(pu); // not useful after optimize
+            logger.info("do.sparse factorsSquarefreeKronecker: " + pu);
+            facs = factorsSquarefreeKronecker(pu); // pl
+            List<GenPolynomial<C>> fs = new ArrayList<GenPolynomial<C>>(facs.size());
+            GenPolynomialRing<C> pf = P.ring;
+            //GenPolynomialRing<C> pfu = pu.ring;
+            for (GenPolynomial<C> p : facs) {
+                //GenPolynomial<C> pel = p.extendLower(pfu, 0, 0L);
+                GenPolynomial<C> pe = p.extend(pf, 0, 0L); // pel
+                fs.add(pe);
+            }
+            //System.out.println("fs = " + fs);
+            facs = fs;
+        }
+        List<GenPolynomial<C>> iopt = TermOrderOptimization.<C> permutation(iperm, pfac, facs);
+        logger.info("de-optimized polynomials: " + iopt);
+        facs = normalizeFactorization(iopt);
+        return facs;
+    }
+
+
+    /**
+     * GenPolynomial factorization of a squarefree polynomial, using Kronecker
+     * substitution.
+     * @param P squarefree and primitive! (respectively monic) GenPolynomial.
+     * @return [p_1,...,p_k] with P = prod_{i=1,...,r} p_i.
+     */
+    @Override
+    public List<GenPolynomial<C>> factorsSquarefree(GenPolynomial<C> P) {
+        if (P != null && P.ring.nvar > 1) {
+           logger.warn("no multivariate factorization for " + P.toScript() + ": falling back to Kronecker algorithm in " + P.ring.toScript());
+           //if (P.ring.characteristic().signum() == 0) {
+           //    throw new IllegalArgumentException("P.ring.characteristic().signum() == 0");
+           //}
+           //throw new RuntimeException("get stack trace");
+        }
+        //if (logger.isInfoEnabled()) {
+        //    logger.info(StringUtil.selectStackTrace("edu\\.jas.*"));
+        //}
+        return factorsSquarefreeKronecker(P);
+        //return factorsSquarefreeOptimize(P); // test only
+    }
+
+
+    /**
+     * GenPolynomial factorization of a squarefree polynomial, using Kronecker
+     * substitution.
+     * @param P squarefree and primitive! (respectively monic) GenPolynomial.
+     * @return [p_1,...,p_k] with P = prod_{i=1,...,r} p_i.
+     */
+    public List<GenPolynomial<C>> factorsSquarefreeKronecker(GenPolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P != null");
+        }
+        GenPolynomialRing<C> pfac = P.ring;
+        if (pfac.nvar == 1) {
+            return baseFactorsSquarefree(P);
+        }
+        List<GenPolynomial<C>> factors = new ArrayList<GenPolynomial<C>>();
+        if (P.isZERO()) {
+            return factors;
+        }
+        if (P.degreeVector().totalDeg() <= 1L) {
+            factors.add(P);
+            return factors;
+        }
+        long d = P.degree() + 1L;
+        GenPolynomial<C> kr = PolyUfdUtil.<C> substituteKronecker(P, d);
+        GenPolynomialRing<C> ufac = kr.ring;
+        ufac.setVars(ufac.newVars("zz")); // side effects 
+        logger.info("deg(subs(P,d=" + d + ")) = " + kr.degree(0) + ", original degrees: " + P.degreeVector());
+        if (debug) {
+            logger.info("subs(P,d=" + d + ") = " + kr);
+            //System.out.println("subs(P,d=" + d + ") = " + kr);
+        }
+        if (kr.degree(0) > 100) {
+            logger.warn("Kronecker substitution has to high degree " + kr.degree(0));
+            TimeStatus.checkTime("degree > 100");
+        }
+
+        // factor Kronecker polynomial
+        List<GenPolynomial<C>> ulist = new ArrayList<GenPolynomial<C>>();
+        // kr might not be squarefree so complete factor univariate
+        SortedMap<GenPolynomial<C>, Long> slist = baseFactors(kr);
+        if (debug && !isFactorization(kr, slist)) {
+            logger.warn("kr    = " + kr);
+            logger.warn("slist = " + slist);
+            throw new ArithmeticException("no factorization");
+        }
+        for (Map.Entry<GenPolynomial<C>, Long> me : slist.entrySet()) {
+            GenPolynomial<C> g = me.getKey();
+            long e = me.getValue(); // slist.get(g);
+            for (int i = 0; i < e; i++) { // is this really required? yes!
+                ulist.add(g);
+            }
+        }
+        //System.out.println("ulist = " + ulist);
+        if (ulist.size() == 1 && ulist.get(0).degree() == P.degree()) {
+            factors.add(P);
+            return factors;
+        }
+        //wrong: List<GenPolynomial<C>> klist = PolyUfdUtil.<C> backSubstituteKronecker(pfac, ulist, d);
+        //System.out.println("back(klist) = " + PolyUfdUtil.<C> backSubstituteKronecker(pfac, ulist, d));
+        if (logger.isInfoEnabled()) {
+            logger.info("ulist = " + ulist);
+            //System.out.println("ulist = " + ulist);
+        }
+        // combine trial factors
+        int dl = ulist.size() - 1; //(ulist.size() + 1) / 2;
+        //System.out.println("dl = " + dl);
+        int ti = 0;
+        GenPolynomial<C> u = P;
+        long deg = (u.degree() + 1L) / 2L; // max deg
+        ExpVector evl = u.leadingExpVector();
+        ExpVector evt = u.trailingExpVector();
+        //System.out.println("deg = " + deg);
+        for (int j = 1; j <= dl; j++) {
+            KsubSet<GenPolynomial<C>> ps = new KsubSet<GenPolynomial<C>>(ulist, j);
+            for (List<GenPolynomial<C>> flist : ps) {
+                //System.out.println("flist = " + flist);
+                GenPolynomial<C> utrial = ufac.getONE();
+                for (int k = 0; k < flist.size(); k++) {
+                    utrial = utrial.multiply(flist.get(k));
+                }
+                GenPolynomial<C> trial = PolyUfdUtil.<C> backSubstituteKronecker(pfac, utrial, d);
+                ti++;
+                if (ti % 2000 == 0) {
+                    logger.warn("ti(" + ti + ") ");
+                    TimeStatus.checkTime(ti + " % 2000 == 0");
+                }
+                if (!evl.multipleOf(trial.leadingExpVector())) {
+                    continue;
+                }
+                if (!evt.multipleOf(trial.trailingExpVector())) {
+                    continue;
+                }
+                if (trial.degree() > deg || trial.isConstant()) {
+                    continue;
+                }
+                trial = trial.monic();
+                if (ti % 15000 == 0) {
+                    logger.warn("\ndl   = " + dl + ", deg(u) = " + deg);
+                    logger.warn("ulist = " + ulist);
+                    logger.warn("kr    = " + kr);
+                    logger.warn("u     = " + u);
+                    logger.warn("trial = " + trial);
+                }
+                GenPolynomial<C> rem = PolyUtil.<C> baseSparsePseudoRemainder(u, trial);
+                //System.out.println(" rem = " + rem);
+                if (rem.isZERO()) {
+                    logger.info("trial = " + trial);
+                    //System.out.println("trial = " + trial);
+                    factors.add(trial);
+                    u = PolyUtil.<C> basePseudoDivide(u, trial); //u = u.divide( trial );
+                    evl = u.leadingExpVector();
+                    evt = u.trailingExpVector();
+                    if (u.isConstant()) {
+                        j = dl + 1;
+                        break;
+                    }
+                    //if (ulist.removeAll(flist)) { // wrong
+                    ulist = removeOnce(ulist, flist);
+                    //System.out.println("new ulist = " + ulist);
+                    dl = (ulist.size() + 1) / 2;
+                    j = 0; // since j++
+                    break;
+                }
+            }
+        }
+        if (!u.isONE() && !u.equals(P)) {
+            logger.info("rest u = " + u);
+            factors.add(u);
+        }
+        if (factors.size() == 0) {
+            logger.info("irred P = " + P);
+            factors.add(P); // == u
+        }
+        return normalizeFactorization(factors);
+    }
+
+
+    /**
+     * Remove one occurrence of elements.
+     * @param a list of objects.
+     * @param b list of objects.
+     * @return remove every element of b from a, but only one occurrence.
+     *         <b>Note:</b> not available in java.util.
+     */
+    static <T> List<T> removeOnce(List<T> a, List<T> b) {
+        List<T> res = new ArrayList<T>();
+        res.addAll(a);
+        for (T e : b) {
+            @SuppressWarnings("unused")
+            boolean t = res.remove(e);
+        }
+        return res;
+    }
+
+
+    /**
+     * Univariate GenPolynomial factorization ignoring multiplicities.
+     * @param P GenPolynomial in one variable.
+     * @return [p_1, ..., p_k] with P = prod_{i=1,...,k} p_i**{e_i} for some
+     *         e_i.
+     */
+    public List<GenPolynomial<C>> baseFactorsRadical(GenPolynomial<C> P) {
+        return new ArrayList<GenPolynomial<C>>(baseFactors(P).keySet());
+    }
+
+
+    /**
+     * Univariate GenPolynomial factorization.
+     * @param P GenPolynomial in one variable.
+     * @return [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with P = prod_{i=1,...,k}
+     *         p_i**e_i.
+     */
+    public SortedMap<GenPolynomial<C>, Long> baseFactors(GenPolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P != null");
+        }
+        GenPolynomialRing<C> pfac = P.ring;
+        SortedMap<GenPolynomial<C>, Long> factors = new TreeMap<GenPolynomial<C>, Long>(pfac.getComparator());
+        if (P.isZERO()) {
+            return factors;
+        }
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException(this.getClass().getName() + " only for univariate polynomials");
+        }
+        if (P.isConstant()) {
+            factors.put(P, 1L);
+            return factors;
+        }
+        C c;
+        if (pfac.coFac.isField()) { //pfac.characteristic().signum() > 0
+            c = P.leadingBaseCoefficient();
+        } else {
+            c = engine.baseContent(P);
+            // move sign to the content
+            if (P.signum() < 0 && c.signum() > 0) {
+                c = c.negate();
+                //P = P.negate();
+            }
+        }
+        if (!c.isONE()) {
+            GenPolynomial<C> pc = pfac.getONE().multiply(c);
+            factors.put(pc, 1L);
+            P = P.divide(c); // make primitive or monic
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("base facs for P = " + P);
+            //System.out.println(StringUtil.selectStackTrace("edu\\.jas.*"));
+        }
+        SortedMap<GenPolynomial<C>, Long> facs = sengine.baseSquarefreeFactors(P);
+        if (facs == null || facs.size() == 0) {
+            facs = new TreeMap<GenPolynomial<C>, Long>();
+            facs.put(P, 1L);
+        }
+        if (logger.isInfoEnabled()
+                        && (facs.size() > 1 || (facs.size() == 1 && facs.get(facs.firstKey()) > 1))) {
+            logger.info("squarefree facs   = " + facs);
+            //System.out.println("sfacs   = " + facs);
+            //boolean tt = isFactorization(P,facs);
+            //System.out.println("sfacs tt   = " + tt);
+        }
+        for (Map.Entry<GenPolynomial<C>, Long> me : facs.entrySet()) {
+            GenPolynomial<C> g = me.getKey();
+            Long k = me.getValue(); //facs.get(g);
+            //System.out.println("g       = " + g);
+            if (pfac.coFac.isField() && !g.leadingBaseCoefficient().isONE()) {
+                g = g.monic(); // how can this happen?
+                logger.warn("squarefree facs mon = " + g);
+            }
+            if (g.degree(0) <= 1) {
+                if (!g.isONE()) {
+                    factors.put(g, k);
+                }
+            } else {
+                List<GenPolynomial<C>> sfacs = baseFactorsSquarefree(g);
+                if (debug) {
+                    logger.info("factors of squarefree = " + sfacs);
+                    //System.out.println("sfacs   = " + sfacs);
+                }
+                for (GenPolynomial<C> h : sfacs) {
+                    Long j = factors.get(h); // evtl. constants
+                    if (j != null) {
+                        k += j;
+                    }
+                    if (!h.isONE()) {
+                        factors.put(h, k);
+                    }
+                }
+            }
+        }
+        //System.out.println("factors = " + factors);
+        return factors;
+    }
+
+
+    /**
+     * Univariate GenPolynomial factorization of a squarefree polynomial.
+     * @param P squarefree and primitive! GenPolynomial in one variable.
+     * @return [p_1, ..., p_k] with P = prod_{i=1,...,k} p_i.
+     */
+    public abstract List<GenPolynomial<C>> baseFactorsSquarefree(GenPolynomial<C> P);
+
+
+    /**
+     * GenPolynomial factorization ignoring multiplicities.
+     * @param P GenPolynomial.
+     * @return [p_1, ..., p_k] with P = prod_{i=1,...,k} p_i**{e_i} for some
+     *         e_i.
+     */
+    public List<GenPolynomial<C>> factorsRadical(GenPolynomial<C> P) {
+        return new ArrayList<GenPolynomial<C>>(factors(P).keySet());
+    }
+
+
+    /**
+     * GenPolynomial list factorization ignoring multiplicities.
+     * @param L list of GenPolynomials.
+     * @return [p_1, ..., p_k] with p = prod_{i=1,...,k} p_i**{e_i} for some e_i
+     *         for all p in L.
+     */
+    public List<GenPolynomial<C>> factorsRadical(List<GenPolynomial<C>> L) {
+        SortedSet<GenPolynomial<C>> facs = new TreeSet<GenPolynomial<C>>();
+        for (GenPolynomial<C> p : L) {
+            List<GenPolynomial<C>> fs = factorsRadical(p);
+            facs.addAll(fs);
+        }
+        return new ArrayList<GenPolynomial<C>>(facs);
+    }
+
+
+    /**
+     * GenPolynomial factorization.
+     * @param P GenPolynomial.
+     * @return [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with P = prod_{i=1,...,k}
+     *         p_i**e_i.
+     */
+    public SortedMap<GenPolynomial<C>, Long> factors(GenPolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P != null");
+        }
+        GenPolynomialRing<C> pfac = P.ring;
+        if (pfac.nvar == 1) {
+            return baseFactors(P);
+        }
+        SortedMap<GenPolynomial<C>, Long> factors = new TreeMap<GenPolynomial<C>, Long>(pfac.getComparator());
+        if (P.isZERO()) {
+            return factors;
+        }
+        if (P.isConstant()) {
+            factors.put(P, 1L);
+            return factors;
+        }
+        if (!pfac.tord.equals(TermOrderByName.INVLEX)) {
+            logger.warn("wrong term order " + pfac.tord + ", factorization may not be correct, better use " + TermOrderByName.INVLEX);
+        }
+        C c;
+        if (pfac.coFac.isField()) { 
+            c = P.leadingBaseCoefficient();
+        } else {
+            c = engine.baseContent(P);
+            // move sign to the content
+            if (P.signum() < 0 && c.signum() > 0) {
+                c = c.negate();
+                //P = P.negate();
+            }
+        }
+        if (!c.isONE()) {
+            GenPolynomial<C> pc = pfac.getONE().multiply(c);
+            factors.put(pc, 1L);
+            P = P.divide(c); // make base primitive or base monic
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("base primitive part P = " + P);
+        }
+        GenPolynomial<C>[] cpp = engine.contentPrimitivePart(P);
+        GenPolynomial<C> pc = cpp[0];
+        if (!pc.isONE()) {
+            SortedMap<GenPolynomial<C>, Long> rec = factors(pc); // recursion
+            for (Map.Entry<GenPolynomial<C>, Long> me : rec.entrySet()) {
+                GenPolynomial<C> g = me.getKey();
+                Long d = me.getValue();
+                GenPolynomial<C> pn = g.extend(pfac,0,0L);
+                factors.put(pn,d);
+            }
+            if (logger.isInfoEnabled()) {
+                logger.info("content factors = " + factors);
+            }
+        }
+        P = cpp[1];
+        if (logger.isInfoEnabled()) {
+            logger.info("primitive part P = " + P);
+        }
+        if (P.isONE()) {
+            return factors;
+        }
+        SortedMap<GenPolynomial<C>, Long> facs = sengine.squarefreeFactors(P);
+        if (facs == null || facs.size() == 0) {
+            facs = new TreeMap<GenPolynomial<C>, Long>();
+            facs.put(P, 1L);
+            throw new RuntimeException("this should not happen, facs is empty: " + facs);
+        }
+        if (logger.isInfoEnabled()) {
+            if (facs.size() > 1) {
+                logger.info("squarefree mfacs      = " + facs);
+            } else if (facs.size() == 1 && facs.get(facs.firstKey()) > 1L) {
+                logger.info("squarefree #mfacs 1-n = " + facs);
+            } else {
+                logger.info("squarefree #mfacs 1-1 = " + facs);
+            }
+        }
+        for (Map.Entry<GenPolynomial<C>, Long> me : facs.entrySet()) {
+            GenPolynomial<C> g = me.getKey();
+            if (g.isONE()) { // skip 1
+                continue;
+            }
+            Long d = me.getValue(); // facs.get(g);
+            List<GenPolynomial<C>> sfacs = factorsSquarefree(g);
+            if (logger.isInfoEnabled()) {
+                logger.info("factors of squarefree ^" + d + " = " + sfacs);
+                //System.out.println("sfacs   = " + sfacs);
+            }
+            for (GenPolynomial<C> h : sfacs) {
+                long dd = d;
+                Long j = factors.get(h); // evtl. constants
+                if (j != null) {
+                    dd += j;
+                }
+                factors.put(h, dd);
+            }
+        }
+        //System.out.println("factors = " + factors);
+        return factors;
+    }
+
+
+    /**
+     * GenPolynomial greatest squarefree divisor. Delegates computation to a
+     * GreatestCommonDivisor class.
+     * @param P GenPolynomial.
+     * @return squarefree(P).
+     */
+    public GenPolynomial<C> squarefreePart(GenPolynomial<C> P) {
+        return sengine.squarefreePart(P);
+    }
+
+
+    /**
+     * GenPolynomial primitive part. Delegates computation to a
+     * GreatestCommonDivisor class.
+     * @param P GenPolynomial.
+     * @return primitivePart(P).
+     */
+    public GenPolynomial<C> primitivePart(GenPolynomial<C> P) {
+        return engine.primitivePart(P);
+    }
+
+
+    /**
+     * GenPolynomial base primitive part. Delegates computation to a
+     * GreatestCommonDivisor class.
+     * @param P GenPolynomial.
+     * @return basePrimitivePart(P).
+     */
+    public GenPolynomial<C> basePrimitivePart(GenPolynomial<C> P) {
+        return engine.basePrimitivePart(P);
+    }
+
+
+    /**
+     * GenPolynomial squarefree factorization. Delegates computation to a
+     * GreatestCommonDivisor class.
+     * @param P GenPolynomial.
+     * @return [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with P = prod_{i=1,...,k}
+     *         p_i**e_i.
+     */
+    public SortedMap<GenPolynomial<C>, Long> squarefreeFactors(GenPolynomial<C> P) {
+        return sengine.squarefreeFactors(P);
+    }
+
+
+    /**
+     * GenPolynomial is factorization.
+     * @param P GenPolynomial.
+     * @param F = [p_1,...,p_k].
+     * @return true if P = prod_{i=1,...,r} p_i, else false.
+     */
+    public boolean isFactorization(GenPolynomial<C> P, List<GenPolynomial<C>> F) {
+        return sengine.isFactorization(P, F);
+        // test irreducible
+    }
+
+
+    /**
+     * GenPolynomial is factorization.
+     * @param P GenPolynomial.
+     * @param F = [p_1 -&gt; e_1, ..., p_k -&gt; e_k].
+     * @return true if P = prod_{i=1,...,k} p_i**e_i , else false.
+     */
+    public boolean isFactorization(GenPolynomial<C> P, SortedMap<GenPolynomial<C>, Long> F) {
+        return sengine.isFactorization(P, F);
+        // test irreducible
+    }
+
+
+    /**
+     * Degree of a factorization.
+     * @param F a factors map [p_1 -&gt; e_1, ..., p_k -&gt; e_k].
+     * @return sum_{i=1,...,k} degree(p_i)*e_i.
+     */
+    public long factorsDegree(SortedMap<GenPolynomial<C>, Long> F) {
+        long d = 0;
+        for (Map.Entry<GenPolynomial<C>, Long> me : F.entrySet()) {
+            GenPolynomial<C> p = me.getKey();
+            long e = me.getValue(); //F.get(p);
+            d += p.degree() * e;
+        }
+        return d;
+    }
+
+
+    /**
+     * GenPolynomial is factorization.
+     * @param P GenPolynomial.
+     * @param F = [p_1 -&gt; e_1, ..., p_k -&gt; e_k].
+     * @return true if P = prod_{i=1,...,k} p_i**e_i , else false.
+     */
+    public boolean isRecursiveFactorization(GenPolynomial<GenPolynomial<C>> P,
+                    SortedMap<GenPolynomial<GenPolynomial<C>>, Long> F) {
+        return sengine.isRecursiveFactorization(P, F);
+        // test irreducible
+    }
+
+
+    /**
+     * Recursive GenPolynomial factorization of a squarefree polynomial.
+     * @param P squarefree recursive GenPolynomial.
+     * @return [p_1,...,p_k] with P = prod_{i=1, ..., k} p_i.
+     */
+    public List<GenPolynomial<GenPolynomial<C>>> recursiveFactorsSquarefree(GenPolynomial<GenPolynomial<C>> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P == null");
+        }
+        List<GenPolynomial<GenPolynomial<C>>> factors = new ArrayList<GenPolynomial<GenPolynomial<C>>>();
+        if (P.isZERO()) {
+            return factors;
+        }
+        if (P.isONE()) {
+            factors.add(P);
+            return factors;
+        }
+        GenPolynomialRing<GenPolynomial<C>> pfac = P.ring;
+        GenPolynomialRing<C> qi = (GenPolynomialRing<C>) pfac.coFac;
+        GenPolynomialRing<C> ifac = qi.extend(pfac.getVars());
+        GenPolynomial<C> Pi = PolyUtil.<C> distribute(ifac, P);
+        //System.out.println("Pi = " + Pi);
+
+        C ldcf = Pi.leadingBaseCoefficient();
+        if (!ldcf.isONE() && ldcf.isUnit()) {
+            //System.out.println("ldcf = " + ldcf);
+            Pi = Pi.monic();
+        }
+
+        // factor in C[x_1,...,x_n,y_1,...,y_m]
+        List<GenPolynomial<C>> ifacts = factorsSquarefree(Pi);
+        if (logger.isInfoEnabled()) {
+            logger.info("ifacts = " + ifacts);
+        }
+        if (ifacts.size() <= 1) {
+            factors.add(P);
+            return factors;
+        }
+        if (!ldcf.isONE() && ldcf.isUnit()) {
+            GenPolynomial<C> r = ifacts.get(0);
+            ifacts.remove(r);
+            r = r.multiply(ldcf);
+            ifacts.add(0, r);
+        }
+        List<GenPolynomial<GenPolynomial<C>>> rfacts = PolyUtil.<C> recursive(pfac, ifacts);
+        //System.out.println("rfacts = " + rfacts);
+        if (logger.isDebugEnabled()) {
+            logger.info("recfacts = " + rfacts);
+        }
+        factors.addAll(rfacts);
+        return factors;
+    }
+
+
+    /**
+     * Recursive GenPolynomial factorization.
+     * @param P recursive GenPolynomial.
+     * @return [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with P = prod_{i=1,...,k}
+     *         p_i**e_i.
+     */
+    public SortedMap<GenPolynomial<GenPolynomial<C>>, Long> recursiveFactors(GenPolynomial<GenPolynomial<C>> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P != null");
+        }
+        GenPolynomialRing<GenPolynomial<C>> pfac = P.ring;
+        SortedMap<GenPolynomial<GenPolynomial<C>>, Long> factors = new TreeMap<GenPolynomial<GenPolynomial<C>>, Long>(
+                        pfac.getComparator());
+        if (P.isZERO()) {
+            return factors;
+        }
+        if (P.isONE()) {
+            factors.put(P, 1L);
+            return factors;
+        }
+        GenPolynomialRing<C> qi = (GenPolynomialRing<C>) pfac.coFac;
+        GenPolynomialRing<C> ifac = qi.extend(pfac.getVars());
+        GenPolynomial<C> Pi = PolyUtil.<C> distribute(ifac, P);
+        //System.out.println("Pi = " + Pi);
+
+        C ldcf = Pi.leadingBaseCoefficient();
+        if (!ldcf.isONE() && ldcf.isUnit()) {
+            //System.out.println("ldcf = " + ldcf);
+            Pi = Pi.monic();
+        }
+
+        // factor in C[x_1,...,x_n,y_1,...,y_m]
+        SortedMap<GenPolynomial<C>, Long> dfacts = factors(Pi);
+        if (logger.isInfoEnabled()) {
+            logger.info("dfacts = " + dfacts);
+        }
+        if (!ldcf.isONE() && ldcf.isUnit()) {
+            GenPolynomial<C> r = dfacts.firstKey();
+            Long E = dfacts.remove(r);
+            r = r.multiply(ldcf);
+            dfacts.put(r, E);
+        }
+        for (Map.Entry<GenPolynomial<C>, Long> me : dfacts.entrySet()) {
+            GenPolynomial<C> f = me.getKey();
+            Long E = me.getValue(); //dfacts.get(f);
+            GenPolynomial<GenPolynomial<C>> rp = PolyUtil.<C> recursive(pfac, f);
+            factors.put(rp, E);
+        }
+        //System.out.println("rfacts = " + rfacts);
+        if (logger.isInfoEnabled()) {
+            logger.info("recursive factors = " + factors);
+        }
+        return factors;
+    }
+
+
+    /**
+     * Normalize factorization. p'_i &gt; 0 for i &gt; 1 and p'_1 != 1 if k &gt;
+     * 1.
+     * @param F = [p_1,...,p_k].
+     * @return F' = [p'_1,...,p'_k].
+     */
+    public List<GenPolynomial<C>> normalizeFactorization(List<GenPolynomial<C>> F) {
+        if (F == null || F.size() <= 1) {
+            return F;
+        }
+        List<GenPolynomial<C>> Fp = new ArrayList<GenPolynomial<C>>(F.size());
+        GenPolynomial<C> f0 = F.get(0);
+        for (int i = 1; i < F.size(); i++) {
+            GenPolynomial<C> fi = F.get(i);
+            if (fi.signum() < 0) {
+                fi = fi.negate();
+                f0 = f0.negate();
+            }
+            if (!fi.isONE()) {
+                Fp.add(fi);
+            }
+        }
+        if (!f0.isONE()) {
+            Fp.add(0, f0);
+        }
+        return Fp;
+    }
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/FactorAlgebraic.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/FactorAlgebraic.java
@@ -1,0 +1,313 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.AlgebraicNumberRing;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Algebraic number coefficients factorization algorithms. This class implements
+ * factorization methods for polynomials over algebraic numbers over rational
+ * numbers or over (prime) modular integers.
+ * @author Heinz Kredel
+ * @param <C> coefficient type
+ */
+
+public class FactorAlgebraic<C extends GcdRingElem<C>> extends FactorAbsolute<AlgebraicNumber<C>> {
+
+
+    private static final Logger logger = LogManager.getLogger(FactorAlgebraic.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Factorization engine for base coefficients.
+     */
+    public final FactorAbstract<C> factorCoeff;
+
+
+    /**
+     * No argument constructor. <b>Note:</b> can't use this constructor.
+     */
+    protected FactorAlgebraic() {
+        throw new IllegalArgumentException("don't use this constructor");
+    }
+
+
+    /**
+     * Constructor.
+     * @param fac algebraic number factory.
+     */
+    public FactorAlgebraic(AlgebraicNumberRing<C> fac) {
+        this(fac, FactorFactory.<C> getImplementation(fac.ring.coFac));
+    }
+
+
+    /**
+     * Constructor.
+     * @param fac algebraic number factory.
+     * @param factorCoeff factorization engine for polynomials over base
+     *            coefficients.
+     */
+    public FactorAlgebraic(AlgebraicNumberRing<C> fac, FactorAbstract<C> factorCoeff) {
+        super(fac);
+        this.factorCoeff = factorCoeff;
+    }
+
+
+    /**
+     * GenPolynomial base factorization of a squarefree polynomial.
+     * @param P squarefree GenPolynomial&lt;AlgebraicNumber&lt;C&gt;&gt;.
+     * @return [p_1,...,p_k] with P = prod_{i=1, ..., k} p_i.
+     */
+    @Override
+    public List<GenPolynomial<AlgebraicNumber<C>>> baseFactorsSquarefree(
+                    GenPolynomial<AlgebraicNumber<C>> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P == null");
+        }
+        List<GenPolynomial<AlgebraicNumber<C>>> factors = new ArrayList<GenPolynomial<AlgebraicNumber<C>>>();
+        if (P.isZERO()) {
+            return factors;
+        }
+        if (P.isONE()) {
+            factors.add(P);
+            return factors;
+        }
+        GenPolynomialRing<AlgebraicNumber<C>> pfac = P.ring; // Q(alpha)[x]
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException("only for univariate polynomials");
+        }
+        AlgebraicNumberRing<C> afac = (AlgebraicNumberRing<C>) pfac.coFac;
+        AlgebraicNumber<C> ldcf = P.leadingBaseCoefficient();
+        if (!ldcf.isONE()) {
+            P = P.monic();
+            factors.add(pfac.getONE().multiply(ldcf));
+        }
+        //System.out.println("\nP = " + P);
+        if (debug) {
+            Squarefree<AlgebraicNumber<C>> sqengine = SquarefreeFactory
+                            .<AlgebraicNumber<C>> getImplementation(afac);
+            if (!sqengine.isSquarefree(P)) {
+                throw new RuntimeException("P not squarefree: " + sqengine.squarefreeFactors(P));
+            }
+            GenPolynomial<C> modu = afac.modul;
+            if (!factorCoeff.isIrreducible(modu)) {
+                throw new RuntimeException("modul not irreducible: " + factorCoeff.factors(modu));
+            }
+            System.out.println("P squarefree and modul irreducible");
+            //GreatestCommonDivisor<AlgebraicNumber<C>> aengine //= GCDFactory.<AlgebraicNumber<C>> getProxy(afac);
+            //  = new GreatestCommonDivisorSimple<AlgebraicNumber<C>>( /*cfac.coFac*/ );
+        }
+
+        // search squarefree norm
+        long k = 0L;
+        long ks = k;
+        GenPolynomial<C> res = null;
+        boolean sqf = false;
+        //int[] klist = new int[]{ 0, 1, 2, 3, -1, -2, -3 , 5, -5, 7, -7, 101, -101, 1001, -1001 };
+        //int[] klist = new int[]{ 0, 1, 2, 3, -1, -2, -3 , 5, -5, 7, -7, 23, -23, 167, -167 };
+        //int[] klist = new int[] { 0, -1, -2, 1, 2, -3, 3 };
+        int[] klist = new int[] { 0, -1, -2, 1, 2 };
+        int ki = 0;
+        while (!sqf) {
+            // k = 0,1,2,-1,-2
+            if (ki >= klist.length) {
+                break;
+            }
+            k = klist[ki];
+            ki++;
+            // compute norm with x -> ( y - k x )
+            ks = k;
+            res = PolyUfdUtil.<C> norm(P, ks);
+            //System.out.println("res = " + res);
+            if (res.isZERO() || res.isConstant()) {
+                continue;
+            }
+            sqf = factorCoeff.isSquarefree(res);
+        }
+        // if Res is now squarefree, else must take radical factorization
+        List<GenPolynomial<C>> nfacs;
+        if (!sqf) {
+            //System.out.println("\nres = " + res); 
+            logger.warn("sqf(" + ks + ") = " + res.degree());
+            //res = factorCoeff.squarefreePart(res); // better use obtained factors
+            //res = factorCoeff.baseFactors(res).lastKey();
+        }
+        //res = res.monic();
+        if (logger.isInfoEnabled()) {
+            logger.info("res = " + res);
+        }
+        nfacs = factorCoeff.baseFactorsRadical(res);
+        if (logger.isInfoEnabled()) {
+            logger.info("res facs = " + nfacs); // Q[X]
+        }
+        if (nfacs.size() == 1) {
+            factors.add(P);
+            return factors;
+        }
+
+        // compute gcds of factors with polynomial in Q(alpha)[X]
+        GenPolynomial<AlgebraicNumber<C>> Pp = P;
+        //System.out.println("Pp = " + Pp);
+        GenPolynomial<AlgebraicNumber<C>> Ni;
+        for (GenPolynomial<C> nfi : nfacs) {
+            //System.out.println("nfi = " + nfi);
+            Ni = PolyUfdUtil.<C> substituteConvertToAlgebraicCoefficients(pfac, nfi, ks);
+            if (logger.isInfoEnabled()) {
+                logger.info("Ni = " + Ni);
+                //System.out.println("Pp = " + Pp);
+            }
+            // compute gcds of factors with polynomial
+            GenPolynomial<AlgebraicNumber<C>> pni = engine.gcd(Ni, Pp);
+            if (!pni.leadingBaseCoefficient().isONE()) {
+                pni = pni.monic();
+            }
+            if (logger.isInfoEnabled()) {
+                logger.info("gcd(Ni,Pp) = " + pni);
+            }
+            if (!pni.isONE()) {
+                factors.add(pni);
+                Pp = Pp.divide(pni);
+            }
+        }
+        if (!Pp.isZERO() && !Pp.isONE()) { // irreducible rest
+            factors.add(Pp);
+        }
+        //System.out.println("afactors = " + factors);
+        return factors;
+    }
+
+
+    /**
+     * GenPolynomial factorization of a squarefree polynomial.
+     * @param P squarefree and primitive! (respectively monic)
+     *            GenPolynomial&lt;AlgebraicNumber&lt;C&gt;&gt;.
+     * @return [p_1,...,p_k] with P = prod_{i=1, ..., k} p_i.
+     */
+    @Override
+    public List<GenPolynomial<AlgebraicNumber<C>>> factorsSquarefree(GenPolynomial<AlgebraicNumber<C>> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P == null");
+        }
+        List<GenPolynomial<AlgebraicNumber<C>>> factors = new ArrayList<GenPolynomial<AlgebraicNumber<C>>>();
+        if (P.isZERO()) {
+            return factors;
+        }
+        if (P.isONE()) {
+            factors.add(P);
+            return factors;
+        }
+        GenPolynomialRing<AlgebraicNumber<C>> pfac = P.ring; // Q(alpha)[x1,...,xn]
+        if (pfac.nvar <= 1) {
+            throw new IllegalArgumentException("only for multivariate polynomials");
+        }
+        //AlgebraicNumberRing<C> afac = (AlgebraicNumberRing<C>) pfac.coFac;
+        AlgebraicNumber<C> ldcf = P.leadingBaseCoefficient();
+        if (!ldcf.isONE()) {
+            P = P.monic();
+            factors.add(pfac.getONE().multiply(ldcf));
+        }
+        if (P.degreeVector().totalDeg() <= 1L) {
+            factors.add(P);
+            return factors;
+        }
+        //System.out.println("\nP = " + P);
+
+        // search squarefree norm
+        long k = 0L;
+        long ks = k;
+        GenPolynomial<C> res = null;
+        boolean sqf = false;
+        //int[] klist = new int[]{ 0, 1, 2, 3, -1, -2, -3 , 5, -5, 7, -7, 101, -101, 1001, -1001 };
+        //int[] klist = new int[]{ 0, 1, 2, 3, -1, -2, -3 , 5, -5, 7, -7, 23, -23, 167, -167 };
+        //int[] klist = new int[] { 0, -1, -2, 1, 2, -3, 3 };
+        int[] klist = new int[] { 0, -1, -2, 1, 2 };
+        int ki = 0;
+        while (!sqf) {
+            // k = 0,1,2,-1,-2
+            if (ki >= klist.length) {
+                logger.warn("sqf(" + ks + ") = " + res.degree());
+                break;
+            }
+            k = klist[ki];
+            ki++;
+            // compute norm with x -> ( y - k x )
+            ks = k;
+            res = PolyUfdUtil.<C> norm(P, ks);
+            //System.out.println("res = " + res);
+            if (res.isZERO() || res.isConstant()) {
+                continue;
+            }
+            sqf = factorCoeff.isSquarefree(res);
+            //System.out.println("resfact = " + factorCoeff.factors(res) + "\n");
+        }
+        // if Res is now squarefree, else must take radical factorization
+        List<GenPolynomial<C>> nfacs;
+        if (!sqf) {
+            System.out.println("sqf_" + pfac.nvar + "(" + ks + ") = " + res.degree());
+        }
+        //res = res.monic();
+        if (logger.isInfoEnabled()) {
+            logger.info("res = " + res);
+            logger.info("factorCoeff = " + factorCoeff);
+        }
+        nfacs = factorCoeff.factorsRadical(res);
+        //System.out.println("\nnfacs = " + nfacs); // Q[X]
+        if (logger.isInfoEnabled()) {
+            logger.info("res facs = " + nfacs); // Q[X]
+        }
+        if (nfacs.size() == 1) {
+            factors.add(P);
+            return factors;
+        }
+
+        // compute gcds of factors with polynomial in Q(alpha)[X]
+        GenPolynomial<AlgebraicNumber<C>> Pp = P;
+        //System.out.println("Pp = " + Pp);
+        GenPolynomial<AlgebraicNumber<C>> Ni;
+        for (GenPolynomial<C> nfi : nfacs) {
+            //System.out.println("nfi = " + nfi);
+            Ni = PolyUfdUtil.<C> substituteConvertToAlgebraicCoefficients(pfac, nfi, ks);
+            if (logger.isInfoEnabled()) {
+                logger.info("Ni = " + Ni);
+                //System.out.println("Pp = " + Pp);
+            }
+            // compute gcds of factors with polynomial
+            GenPolynomial<AlgebraicNumber<C>> pni = engine.gcd(Ni, Pp);
+            if (!pni.leadingBaseCoefficient().isONE()) {
+                //System.out.println("gcd(Ni,Pp) not monic " + pni);
+                pni = pni.monic();
+            }
+            if (logger.isInfoEnabled()) {
+                logger.info("gcd(Ni,Pp) = " + pni);
+            }
+            //System.out.println("gcd(Ni,Pp) = " + pni);
+            if (!pni.isONE()) {
+                factors.add(pni);
+                Pp = Pp.divide(pni);
+            }
+        }
+        if (!Pp.isZERO() && !Pp.isONE()) { // irreducible rest
+            factors.add(Pp);
+        }
+        //factors.add(P);
+        return factors;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/FactorComplex.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/FactorComplex.java
@@ -1,0 +1,194 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.AlgebraicNumberRing;
+import edu.jas.poly.Complex;
+import edu.jas.poly.ComplexRing;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.TermOrder;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Complex coefficients factorization algorithms. This class implements
+ * factorization methods for polynomials over Complex numbers via the algebraic
+ * number C(i) over rational numbers or over (prime) modular integers. <b>Note:</b>
+ * Decomposition to linear factors is only via absolute factorization since
+ * Complex are not the analytic complex numbers.
+ * @author Heinz Kredel
+ * @param <C> coefficient type
+ */
+
+public class FactorComplex<C extends GcdRingElem<C>> extends FactorAbsolute<Complex<C>> {
+
+
+    private static final Logger logger = LogManager.getLogger(FactorComplex.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Factorization engine for algebraic coefficients.
+     */
+    public final FactorAbstract<AlgebraicNumber<C>> factorAlgeb;
+
+
+    /**
+     * Complex algebraic factory.
+     */
+    public final AlgebraicNumberRing<C> afac;
+
+
+    /**
+     * No argument constructor. <b>Note:</b> can't use this constructor.
+     */
+    protected FactorComplex() {
+        throw new IllegalArgumentException("don't use this constructor");
+    }
+
+
+    /**
+     * Constructor.
+     * @param fac complex number factory.
+     */
+    public FactorComplex(RingFactory<Complex<C>> fac) { // why is this constructor required?
+        this((ComplexRing<C>) fac);
+    }
+
+
+    /**
+     * Constructor.
+     * @param fac complex number factory.
+     */
+    public FactorComplex(ComplexRing<C> fac) {
+        super(fac);
+        this.afac = fac.algebraicRing();
+        this.factorAlgeb = FactorFactory.<C> getImplementation(afac);
+    }
+
+
+    /**
+     * Constructor.
+     * @param fac complex number factory.
+     * @param factorAlgeb factorization engine for polynomials over algebraic coefficients.
+     */
+    public FactorComplex(ComplexRing<C> fac, FactorAbstract<AlgebraicNumber<C>> factorAlgeb) {
+        super(fac);
+        this.afac = fac.algebraicRing();
+        this.factorAlgeb = factorAlgeb;
+    }
+
+
+    /**
+     * GenPolynomial base factorization of a squarefree polynomial.
+     * @param P squarefree GenPolynomial&lt;AlgebraicNumber&lt;C&gt;&gt;.
+     * @return [p_1,...,p_k] with P = prod_{i=1, ..., k} p_i.
+     */
+    @Override
+    public List<GenPolynomial<Complex<C>>> baseFactorsSquarefree(GenPolynomial<Complex<C>> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P == null");
+        }
+        List<GenPolynomial<Complex<C>>> factors = new ArrayList<GenPolynomial<Complex<C>>>();
+        if (P.isZERO()) {
+            return factors;
+        }
+        if (P.isONE()) {
+            factors.add(P);
+            return factors;
+        }
+        GenPolynomialRing<Complex<C>> pfac = P.ring; // CC[x]
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException("only for univariate polynomials");
+        }
+        ComplexRing<C> cfac = (ComplexRing<C>) pfac.coFac;
+        if (!afac.ring.coFac.equals(cfac.ring)) {
+            throw new IllegalArgumentException("coefficient rings do not match");
+        }
+        Complex<C> ldcf = P.leadingBaseCoefficient();
+        if (!ldcf.isONE()) {
+            P = P.monic();
+            factors.add(pfac.getONE().multiply(ldcf));
+        }
+        //System.out.println("\nP = " + P);
+        GenPolynomialRing<AlgebraicNumber<C>> pafac = new GenPolynomialRing<AlgebraicNumber<C>>(afac, pfac);
+        GenPolynomial<AlgebraicNumber<C>> A = PolyUtil.<C> algebraicFromComplex(pafac, P);
+        //System.out.println("A = " + A);
+        List<GenPolynomial<AlgebraicNumber<C>>> afactors = factorAlgeb.baseFactorsSquarefree(A);
+        if (debug) {
+            // System.out.println("complex afactors = " + afactors);
+            logger.info("complex afactors = " + afactors);
+        }
+        for (GenPolynomial<AlgebraicNumber<C>> pa : afactors) {
+            GenPolynomial<Complex<C>> pc = PolyUtil.<C> complexFromAlgebraic(pfac, pa);
+            factors.add(pc);
+        }
+        //System.out.println("cfactors = " + factors);
+        return factors;
+    }
+
+
+    /**
+     * GenPolynomial factorization of a squarefree polynomial.
+     * @param P squarefree GenPolynomial&lt;AlgebraicNumber&lt;C&gt;&gt;.
+     * @return [p_1,...,p_k] with P = prod_{i=1, ..., k} p_i.
+     */
+    @Override
+    public List<GenPolynomial<Complex<C>>> factorsSquarefree(GenPolynomial<Complex<C>> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P == null");
+        }
+        List<GenPolynomial<Complex<C>>> factors = new ArrayList<GenPolynomial<Complex<C>>>();
+        if (P.isZERO()) {
+            return factors;
+        }
+        if (P.isONE()) {
+            factors.add(P);
+            return factors;
+        }
+        GenPolynomialRing<Complex<C>> pfac = P.ring; // CC[x]
+        if (pfac.nvar <= 1) {
+            throw new IllegalArgumentException("only for multivariate polynomials");
+        }
+        ComplexRing<C> cfac = (ComplexRing<C>) pfac.coFac;
+        if (!afac.ring.coFac.equals(cfac.ring)) {
+            throw new IllegalArgumentException("coefficient rings do not match");
+        }
+        Complex<C> ldcf = P.leadingBaseCoefficient();
+        if (!ldcf.isONE()) {
+            P = P.monic();
+            factors.add(pfac.getONE().multiply(ldcf));
+        }
+        //System.out.println("\nP = " + P);
+        GenPolynomialRing<AlgebraicNumber<C>> pafac = new GenPolynomialRing<AlgebraicNumber<C>>(afac, pfac);
+        GenPolynomial<AlgebraicNumber<C>> A = PolyUtil.<C> algebraicFromComplex(pafac, P);
+        //System.out.println("A = " + A);
+        List<GenPolynomial<AlgebraicNumber<C>>> afactors = factorAlgeb.factorsSquarefree(A);
+        if (debug) {
+            // System.out.println("complex afactors = " + afactors);
+            logger.info("complex afactors = " + afactors);
+        }
+        for (GenPolynomial<AlgebraicNumber<C>> pa : afactors) {
+            GenPolynomial<Complex<C>> pc = PolyUtil.<C> complexFromAlgebraic(pfac, pa);
+            factors.add(pc);
+        }
+        //System.out.println("cfactors = " + factors);
+        return factors;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/FactorFactory.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/FactorFactory.java
@@ -1,0 +1,246 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.arith.BigInteger;
+import edu.jas.arith.BigRational;
+import edu.jas.arith.ModInt;
+import edu.jas.arith.ModIntRing;
+import edu.jas.arith.ModInteger;
+import edu.jas.arith.ModIntegerRing;
+import edu.jas.arith.ModLong;
+import edu.jas.arith.ModLongRing;
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.AlgebraicNumberRing;
+import edu.jas.poly.Complex;
+import edu.jas.poly.ComplexRing;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Factorization algorithms factory. Select appropriate factorization engine
+ * based on the coefficient types.
+ * <p>
+ * <b>Usage:</b> To create objects that implement the <code>Factorization</code>
+ * interface use the <code>FactorFactory</code>. It will select an appropriate
+ * implementation based on the types of polynomial coefficients C. To obtain an
+ * implementation use <code>getImplementation()</code>, it returns an object of
+ * a class which extends the <code>FactorAbstract</code> class which implements
+ * the <code>Factorization</code> interface.
+ * 
+ * <pre>
+ * Factorization&lt;CT&gt; engine;
+ * engine = FactorFactory.&lt;CT&gt; getImplementation(cofac);
+ * c = engine.factors(a);
+ * </pre>
+ * 
+ * <p>
+ * For example, if the coefficient type is BigInteger, the usage looks like
+ * 
+ * <pre>
+ * BigInteger cofac = new BigInteger();
+ * Factorization&lt;BigInteger&gt; engine;
+ * engine = FactorFactory.getImplementation(cofac);
+ * Sm = engine.factors(poly);
+ * </pre>
+ * 
+ * @author Heinz Kredel
+ * @see edu.jas.ufd.Factorization#factors(edu.jas.poly.GenPolynomial P)
+ */
+
+public class FactorFactory {
+
+
+    private static final Logger logger = LogManager.getLogger(FactorFactory.class);
+
+
+    /**
+     * Protected factory constructor.
+     */
+    protected FactorFactory() {
+    }
+
+
+    /**
+     * Determine suitable implementation of factorization algorithm, case
+     * ModInteger.
+     * @param fac ModIntegerRing.
+     * @return factorization algorithm implementation.
+     */
+    public static FactorAbstract<ModInteger> getImplementation(ModIntegerRing fac) {
+        return new FactorModular<ModInteger>(fac);
+    }
+
+
+    /**
+     * Determine suitable implementation of factorization algorithm, case
+     * ModInteger.
+     * @param fac ModIntegerRing.
+     * @return factorization algorithm implementation.
+     */
+    public static FactorAbstract<ModLong> getImplementation(ModLongRing fac) {
+        return new FactorModular<ModLong>(fac);
+    }
+
+
+    /**
+     * Determine suitable implementation of factorization algorithm, case
+     * ModInteger.
+     * @param fac ModIntegerRing.
+     * @return factorization algorithm implementation.
+     */
+    public static FactorAbstract<ModInt> getImplementation(ModIntRing fac) {
+        return new FactorModular<ModInt>(fac);
+    }
+
+
+    /**
+     * Determine suitable implementation of factorization algorithm, case
+     * BigInteger.
+     * @param fac BigInteger.
+     * @return factorization algorithm implementation.
+     */
+    public static FactorAbstract<BigInteger> getImplementation(BigInteger fac) {
+        if (fac == null) {
+            throw new IllegalArgumentException("fac == null not supported");
+        }
+        return new FactorInteger<ModLong>();
+    }
+
+
+    /**
+     * Determine suitable implementation of factorization algorithms, case
+     * BigRational.
+     * @param fac BigRational.
+     * @return factorization algorithm implementation.
+     */
+    public static FactorAbstract<BigRational> getImplementation(BigRational fac) {
+        if (fac == null) {
+            throw new IllegalArgumentException("fac == null not supported");
+        }
+        return new FactorRational();
+    }
+
+
+    /**
+     * Determine suitable implementation of factorization algorithms, case
+     * AlgebraicNumber&lt;C&gt;.
+     * @param fac AlgebraicNumberRing&lt;C&gt;.
+     * @param <C> coefficient type, e.g. BigRational, ModInteger.
+     * @return factorization algorithm implementation.
+     */
+    @SuppressWarnings("unchecked")
+    public static <C extends GcdRingElem<C>> FactorAbstract<AlgebraicNumber<C>> getImplementation(
+                    AlgebraicNumberRing<C> fac) {
+        int s = fac.characteristic().signum();
+        if (s > 0) {
+            return new FactorModularBerlekamp/*<AlgebraicNumberRing<C>>*/((RingFactory)fac);
+        } else {
+            return new FactorAlgebraic<C>(fac);
+        }
+    }
+
+
+    /**
+     * Determine suitable implementation of factorization algorithms, case
+     * Complex&lt;C&gt;.
+     * @param fac ComplexRing&lt;C&gt;.
+     * @param <C> coefficient type, e.g. BigRational, ModInteger.
+     * @return factorization algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C>> FactorAbstract<Complex<C>> getImplementation(
+                    ComplexRing<C> fac) {
+        return new FactorComplex<C>(fac);
+    }
+
+
+    /**
+     * Determine suitable implementation of factorization algorithms, case
+     * Quotient&lt;C&gt;.
+     * @param fac QuotientRing&lt;C&gt;.
+     * @param <C> coefficient type, e.g. BigRational, ModInteger.
+     * @return factorization algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C>> FactorAbstract<Quotient<C>> getImplementation(
+                    QuotientRing<C> fac) {
+        return new FactorQuotient<C>(fac);
+    }
+
+
+    /**
+     * Determine suitable implementation of factorization algorithms, case
+     * recursive GenPolynomial&lt;C&gt;. Use <code>recursiveFactors()</code>.
+     * @param fac GenPolynomialRing&lt;C&gt;.
+     * @param <C> coefficient type, e.g. BigRational, ModInteger.
+     * @return factorization algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C>> FactorAbstract<C> getImplementation(GenPolynomialRing<C> fac) {
+        return getImplementation(fac.coFac);
+    }
+
+
+    /**
+     * Determine suitable implementation of factorization algorithms, other
+     * cases.
+     * @param <C> coefficient type
+     * @param fac RingFactory&lt;C&gt;.
+     * @return factorization algorithm implementation.
+     */
+    @SuppressWarnings( "unchecked" )
+    public static <C extends GcdRingElem<C>> FactorAbstract<C> getImplementation(RingFactory<C> fac) {
+        logger.info("factor factory = " + fac.getClass().getName());
+        //System.out.println("fac_o_ufd = " + fac.getClass().getName());
+        FactorAbstract/*raw type<C>*/ ufd = null;
+        AlgebraicNumberRing afac = null;
+        ComplexRing cfac = null;
+        QuotientRing qfac = null;
+        GenPolynomialRing pfac = null;
+        Object ofac = fac;
+        if (ofac instanceof BigInteger) {
+            ufd = new FactorInteger();
+        } else if (ofac instanceof BigRational) {
+            ufd = new FactorRational();
+        } else if (ofac instanceof ModIntegerRing) {
+            ufd = new FactorModular(fac);
+        } else if (ofac instanceof ModLongRing) {
+            ufd = new FactorModular(fac);
+        } else if (ofac instanceof ModIntRing) {
+            ufd = new FactorModular(fac);
+        } else if (ofac instanceof ComplexRing) {
+            cfac = (ComplexRing<C>) ofac;
+            ufd = new FactorComplex(cfac);
+        } else if (ofac instanceof AlgebraicNumberRing) {
+            //System.out.println("afac_o = " + ofac);
+            afac = (AlgebraicNumberRing) ofac;
+            //ofac = afac.ring.coFac;
+            int s = afac.characteristic().signum();
+            if (s > 0) {
+                ufd = new FactorModularBerlekamp/*raw <C>*/(afac);
+            } else {
+                ufd = new FactorAlgebraic/*raw <C>*/(afac);
+            }
+        } else if (ofac instanceof QuotientRing) {
+            //System.out.println("qfac_o = " + ofac);
+            qfac = (QuotientRing) ofac;
+            ufd = new FactorQuotient/*raw <C>*/(qfac);
+        } else if (ofac instanceof GenPolynomialRing) {
+            //System.out.println("qfac_o = " + ofac);
+            pfac = (GenPolynomialRing) ofac;
+            ufd = getImplementation(pfac.coFac);
+        } else {
+            throw new IllegalArgumentException(
+                            "no factorization implementation for " + fac.getClass().getName());
+        }
+        //logger.info("implementation = " + ufd);
+        return (FactorAbstract<C>) ufd;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/FactorFraction.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/FactorFraction.java
@@ -1,0 +1,210 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.Map;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.structure.QuotPair;
+import edu.jas.structure.QuotPairFactory;
+
+
+/**
+ * Fraction factorization algorithms. This class implements
+ * factorization methods for fractions represended as pairs of
+ * polynomials.
+ * @author Heinz Kredel
+ */
+
+public class FactorFraction<C extends GcdRingElem<C>, 
+                                      D extends GcdRingElem<D> & QuotPair<GenPolynomial<C>> > {
+
+
+    private static final Logger logger = LogManager.getLogger(FactorFraction.class);
+
+
+    /**
+     * Quotient pairs ring factory.
+     * D == QuotPair&lt;GenPolynomial&lt;C&gt;&gt; must hold.
+     */
+    protected final QuotPairFactory<GenPolynomial<C>, D> qfac;
+
+
+    /**
+     * Factorization engine for normal coefficients.
+     */
+    protected final FactorAbstract<C> nengine;
+
+
+    /**
+     * No argument constructor.
+     */
+    protected FactorFraction() {
+        throw new IllegalArgumentException("don't use this constructor");
+    }
+
+
+    /**
+     * Constructor.
+     * @param fac coefficient quotient ring factory.
+     */
+    public FactorFraction(QuotPairFactory<GenPolynomial<C>,D> fac) {
+        this(fac, FactorFactory.<C> getImplementation(((GenPolynomialRing<C>) fac.pairFactory()).coFac));
+    }
+
+
+    /**
+     * Constructor.
+     * @param fac coefficient quotient ring factory.
+     * @param nengine factorization engine for polynomials over base
+     *            coefficients.
+     */
+    public FactorFraction(QuotPairFactory<GenPolynomial<C>,D> fac, FactorAbstract<C> nengine) {
+        this.qfac = fac;
+        this.nengine = nengine;
+        logger.info("qfac.fac: " + qfac.pairFactory().toScript());
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return getClass().getName();
+    }
+
+
+    /**
+     * Test if a quotient pair is irreducible.
+     * @param P quotient pair (num,den), with gcd(num,den) == 1.
+     * @return true if P is irreducible, else false.
+     */
+    public boolean isIrreducible(D P) {
+        SortedMap<D, Long> F = factors(P);
+        for (Long e : F.values()) {
+            if (e == null || e != 1L) {
+                return false;
+            }
+        }
+        if (F.size() <= 1) { // x/1
+            return true;
+        } else if (F.size() == 2) { // x/1, 1/y
+            List<D> pp = new ArrayList<D>( F.keySet() );
+            D f = pp.get(0);
+            D g = pp.get(1);
+            if ((f.numerator().isONE() && g.denominator().isONE()) || (g.numerator().isONE() && f.denominator().isONE())) {
+                return true;
+            }
+            return false;
+        } else if (F.size() > 2) {
+            return false;
+        }
+        return false;
+    }
+
+
+    /**
+     * Test if a non trivial factorization exsists.
+     * @param P quotient pair (num,den), with gcd(num,den) == 1.
+     * @return true if P is reducible, else false.
+     */
+    public boolean isReducible(D P) {
+        return !isIrreducible(P);
+    }
+
+
+    /**
+     * Quotient pair factorization.
+     * @param P quotient pair (num,den), with gcd(num,den) == 1.
+     * @return [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with P = prod_{i=1,...,k} p_i**e_i.
+     */
+    public SortedMap<D, Long> factors(D P) {
+        // D == QuotPair<GenPolynomial<C>>
+        SortedMap<D, Long> facs = new TreeMap<D, Long>();
+        if (P == null) {
+            return facs;
+        }
+        GenPolynomial<C> n = P.numerator();
+        GenPolynomial<C> d = P.denominator();
+        if (n.isZERO() || d.isZERO()) {
+            return facs;
+        }
+        if (n.isONE() && d.isONE()) {
+            facs.put(P,1L);
+            return facs;
+        }
+        // assert gcd(n,d) == 1
+        GenPolynomial<C> one = qfac.pairFactory().getONE();
+        if (!n.isONE()) {
+            SortedMap<GenPolynomial<C>, Long> nfacs = nengine.factors(n);
+            for (Map.Entry<GenPolynomial<C>,Long> m : nfacs.entrySet()) {
+                 D q = qfac.create(m.getKey(), one);
+                 facs.put(q, m.getValue());
+            }
+        }
+        if (!d.isONE()) {
+            SortedMap<GenPolynomial<C>, Long> dfacs = nengine.factors(d);
+            for (Map.Entry<GenPolynomial<C>,Long> m : dfacs.entrySet()) {
+                 D q = qfac.create(one, m.getKey());
+                 facs.put(q, m.getValue());
+            }
+        }
+        return facs;
+    }
+
+
+    /**
+     * Test quotient pair factorization.
+     * @param P quotient pair.
+     * @param F = [p_1 -&gt; e_1, ..., p_k -&gt; e_k].
+     * @return true if P = prod_{i=1,...,k} p_i**e_i, else false.
+     */
+    public boolean isFactorization(D P, SortedMap<D, Long> F) {
+        if (P == null || F == null) {
+            throw new IllegalArgumentException("P and F may not be null");
+        }
+        if (P.isZERO() && F.size() == 0) {
+            return true;
+        }
+        D t = null; //P.ring.getONE();
+        for (Map.Entry<D, Long> me : F.entrySet()) {
+            D f = me.getKey();
+            Long E = me.getValue(); 
+            long e = E.longValue();
+            D g = f.power(e); 
+            if (t == null) {
+                t = g;
+            } else {
+                t = t.multiply(g);
+            }
+        }
+        boolean f = P.equals(t) || P.equals(t.negate());
+        if (!f) {
+            System.out.println("\nfactorization(map): " + f);
+            System.out.println("F = " + F);
+            System.out.println("P = " + P);
+            System.out.println("t = " + t);
+            //RuntimeException e = new RuntimeException("fac-map");
+            //e.printStackTrace();
+            //throw e;
+        }
+        return f;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/FactorInteger.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/FactorInteger.java
@@ -1,0 +1,1613 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.Set;
+import java.util.HashSet;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.arith.BigInteger;
+import edu.jas.arith.ModIntegerRing;
+import edu.jas.arith.ModLongRing;
+import edu.jas.arith.Modular;
+import edu.jas.arith.ModularRingFactory;
+import edu.jas.arith.PrimeInteger;
+import edu.jas.arith.PrimeList;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.OptimizedPolynomialList;
+import edu.jas.poly.PolyUtil;
+import edu.jas.poly.TermOrder;
+import edu.jas.poly.TermOrderByName;
+import edu.jas.poly.TermOrderOptimization;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.Power;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.util.KsubSet;
+
+
+/**
+ * Integer coefficients factorization algorithms. This class implements
+ * factorization methods for polynomials over integers.
+ * @param <MOD>
+ * @author Heinz Kredel
+ */
+public class FactorInteger<MOD extends GcdRingElem<MOD> & Modular> extends FactorAbstract<BigInteger> {
+
+
+    private static final Logger logger = LogManager.getLogger(FactorInteger.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Factorization engine for modular base coefficients.
+     */
+    protected final FactorAbstract<MOD> mfactor;
+
+
+    /**
+     * Gcd engine for modular base coefficients.
+     */
+    protected final GreatestCommonDivisorAbstract<MOD> mengine;
+
+
+    /**
+     * No argument constructor.
+     */
+    public FactorInteger() {
+        this(BigInteger.ONE);
+    }
+
+
+    /**
+     * Constructor.
+     * @param cfac coefficient ring factory.
+     */
+    @SuppressWarnings("unchecked")
+    public FactorInteger(RingFactory<BigInteger> cfac) {
+        super(cfac);
+        ModularRingFactory<MOD> mcofac = (ModularRingFactory<MOD>) (Object) new ModLongRing(13, true); // hack
+        mfactor = FactorFactory.getImplementation(mcofac); //new FactorModular(mcofac);
+        mengine = GCDFactory.getImplementation(mcofac);
+        //mengine = GCDFactory.getProxy(mcofac);
+    }
+
+
+    /**
+     * GenPolynomial test if is irreducible.
+     * @param P GenPolynomial.
+     * @return true if P is irreducible, else false.
+     */
+    @Override
+    public boolean isIrreducible(GenPolynomial<BigInteger> P) {
+        if (P.ring.nvar == 1) {
+            if (isIrreducibleEisenstein(P)) {
+                return true;
+            } // else unknown
+        }
+        return super.isIrreducible(P);
+    }
+
+
+    /**
+     * GenPolynomial test if is irreducible with Eisenstein criterion.
+     * @param P univariate polynomial.
+     * @return true if P is irreducible, else false if it is unknown.
+     */
+    public boolean isIrreducibleEisenstein(GenPolynomial<BigInteger> P) {
+        if (P.ring.nvar != 1) {
+            throw new IllegalArgumentException("only for univariate polynomials");
+        }
+        if (P.degree(0) <= 1L) { // linear or constant is irreducible
+            return true;
+        }
+        BigInteger rcont = engine.baseContent(P.reductum());
+        if (rcont.isZERO() || rcont.isONE()) { // case x**n
+            return false;
+        }
+        // todo test
+        if (rcont.compareTo(BigInteger.valueOf(PrimeInteger.BETA)) >= 0) { // integer too big
+            return false;
+        }
+        long lcont = rcont.getVal().longValue();
+        BigInteger lc = P.leadingBaseCoefficient().abs();
+        BigInteger tc = P.trailingBaseCoefficient().abs();
+        SortedMap<Long, Integer> fac = PrimeInteger.factors(lcont);
+        for (Long p : fac.keySet()) {
+            BigInteger pi = BigInteger.valueOf(p);
+            if (!lc.remainder(pi).isZERO() && !tc.remainder(pi.power(2)).isZERO()) {
+                logger.info("isIrreducibleEisenstein: fac = " + fac + ", lc = " + lc + ", tc = " + tc);
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    /**
+     * GenPolynomial base factorization of a squarefree polynomial.
+     * @param P squarefree and primitive! GenPolynomial.
+     * @return [p_1,...,p_k] with P = prod_{i=1, ..., k} p_i.
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<GenPolynomial<BigInteger>> baseFactorsSquarefree(GenPolynomial<BigInteger> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P == null");
+        }
+        List<GenPolynomial<BigInteger>> factors = new ArrayList<GenPolynomial<BigInteger>>();
+        if (P.isZERO()) {
+            return factors;
+        }
+        if (P.isONE()) {
+            factors.add(P);
+            return factors;
+        }
+        GenPolynomialRing<BigInteger> pfac = P.ring;
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException(
+                                               this.getClass().getName() + " only for univariate polynomials");
+        }
+        if (!engine.baseContent(P).isONE()) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P not primitive");
+        }
+        if (P.degree(0) <= 1L) { // linear is irreducible
+            factors.add(P);
+            return normalizeFactorization(factors);
+        }
+        if (isIrreducibleEisenstein(P)) {
+            factors.add(P);
+            return normalizeFactorization(factors);
+        }
+        // check cyclotomic factorization
+        //if (CycloUtil.isCyclotomicPolynomial(P)) {
+        //System.out.println("isCyclotomicPolynomial = " + P);
+        factors = CycloUtil.cyclotomicFactors(P);
+        if (factors.size() > 0) {
+            logger.info("cyclotomicFactors: #factors = " + factors.size());
+            return normalizeFactorization(factors);
+        }
+        //}
+        // compute norm
+        BigInteger an = P.maxNorm();
+        BigInteger ac = P.leadingBaseCoefficient();
+        //compute factor coefficient bounds
+        ExpVector degv = P.degreeVector();
+        int degi = (int) P.degree(0);
+        BigInteger M = an.multiply(PolyUtil.factorBound(degv));
+        M = M.multiply(ac.abs().multiply(ac.fromInteger(8)));
+        //System.out.println("M = " + M);
+        //M = M.multiply(M); // test
+
+        //initialize prime list and degree vector
+        PrimeList primes = new PrimeList(PrimeList.Range.small);
+        int pn = 30; //primes.size();
+        ModularRingFactory<MOD> cofac = null;
+        GenPolynomial<MOD> am = null;
+        GenPolynomialRing<MOD> mfac = null;
+        int TT = 5; // 7
+        if (degi > 100) {
+            TT += 2;
+        }
+        List<GenPolynomial<MOD>>[] modfac = new List[TT];
+        List<GenPolynomial<BigInteger>>[] intfac = new List[TT];
+        BigInteger[] plist = new BigInteger[TT];
+        List<GenPolynomial<MOD>> mlist = null;
+        List<GenPolynomial<BigInteger>> ilist = null;
+        int i = 0;
+        if (debug) {
+            logger.debug("an  = " + an);
+            logger.debug("ac  = " + ac);
+            logger.debug("M   = " + M);
+            logger.info("degv = " + degv);
+        }
+        Iterator<java.math.BigInteger> pit = primes.iterator();
+        pit.next(); // skip p = 2
+        pit.next(); // skip p = 3
+        MOD nf = null;
+        for (int k = 0; k < TT; k++) {
+            if (k == TT - 1) { // -2
+                primes = new PrimeList(PrimeList.Range.medium);
+                pit = primes.iterator();
+            }
+            //if (k == TT + 1) { // -1
+            //    primes = new PrimeList(PrimeList.Range.large);
+            //    pit = primes.iterator();
+            //}
+            while (pit.hasNext()) {
+                java.math.BigInteger p = pit.next();
+                //System.out.println("next run ++++++++++++++++++++++++++++++++++");
+                if (++i >= pn) {
+                    logger.error("prime list exhausted, pn = " + pn);
+                    throw new ArithmeticException("prime list exhausted");
+                }
+                if (ModLongRing.MAX_LONG.compareTo(p) > 0) {
+                    cofac = (ModularRingFactory) new ModLongRing(p, true);
+                } else {
+                    cofac = (ModularRingFactory) new ModIntegerRing(p, true);
+                }
+                logger.info("prime = " + cofac);
+                nf = cofac.fromInteger(ac.getVal());
+                if (nf.isZERO()) {
+                    logger.info("unlucky prime (nf) = " + p);
+                    continue;
+                }
+                // initialize polynomial factory and map polynomial
+                mfac = new GenPolynomialRing<MOD>(cofac, pfac);
+                am = PolyUtil.<MOD> fromIntegerCoefficients(mfac, P);
+                if (!am.degreeVector().equals(degv)) { // allways true
+                    logger.info("unlucky prime (deg) = " + p);
+                    continue;
+                }
+                GenPolynomial<MOD> ap = PolyUtil.<MOD> baseDeriviative(am);
+                if (ap.isZERO()) {
+                    logger.info("unlucky prime (a')= " + p);
+                    continue;
+                }
+                GenPolynomial<MOD> g = mengine.baseGcd(am, ap);
+                if (g.isONE()) {
+                    logger.info("**lucky prime = " + p);
+                    break;
+                }
+            }
+            // now am is squarefree mod p, make monic and factor mod p
+            if (!nf.isONE()) {
+                //System.out.println("nf = " + nf);
+                am = am.divide(nf); // make monic
+            }
+            mlist = mfactor.baseFactorsSquarefree(am);
+            if (logger.isInfoEnabled()) {
+                logger.info("modlist  = " + mlist);
+            }
+            if (mlist.size() <= 1) {
+                factors.add(P);
+                return factors;
+            }
+            if (!nf.isONE()) {
+                GenPolynomial<MOD> mp = mfac.getONE(); //mlist.get(0);
+                //System.out.println("mp = " + mp);
+                mp = mp.multiply(nf);
+                //System.out.println("mp = " + mp);
+                mlist.add(0, mp); // set(0,mp);
+            }
+            modfac[k] = mlist;
+            plist[k] = cofac.getIntegerModul(); // p
+        }
+
+        // search shortest factor list
+        int min = Integer.MAX_VALUE;
+        BitSet AD = null;
+        for (int k = 0; k < TT; k++) {
+            List<ExpVector> ev = PolyUtil.<MOD> leadingExpVector(modfac[k]);
+            BitSet D = factorDegrees(ev, degi);
+            if (AD == null) {
+                AD = D;
+            } else {
+                AD.and(D);
+            }
+            int s = modfac[k].size();
+            logger.info("mod(" + plist[k] + ") #s = " + s + ", D = " + D /*+ ", lt = " + ev*/);
+            //System.out.println("mod s = " + s);
+            if (s < min) {
+                min = s;
+                mlist = modfac[k];
+            }
+        }
+        logger.info("min = " + min + ", AD = " + AD);
+        if (mlist.size() <= 1) {
+            logger.info("mlist.size() = 1");
+            factors.add(P);
+            return factors;
+        }
+        if (AD.cardinality() <= 2) { // only one possible factor
+            logger.info("degree set cardinality = " + AD.cardinality());
+            factors.add(P);
+            return factors;
+        }
+
+        final boolean allLists = false; //true; //false;
+        if (allLists) {
+            // try each factor list
+            for (int k = 0; k < TT; k++) {
+                mlist = modfac[k];
+                if (debug) {
+                    logger.info("lifting from " + mlist);
+                }
+                if (P.leadingBaseCoefficient().isONE()) { // monic case
+                    factors = searchFactorsMonic(P, M, mlist, AD); // does now work in all cases
+                    if (factors.size() == 1) {
+                        factors = searchFactorsNonMonic(P, M, mlist, AD);
+                    }
+                } else {
+                    factors = searchFactorsNonMonic(P, M, mlist, AD);
+                }
+                intfac[k] = factors;
+            }
+        } else {
+            // try only shortest factor list
+            if (debug) {
+                logger.info("lifting shortest from " + mlist);
+            }
+            if (P.leadingBaseCoefficient().isONE()) {
+                long t = System.currentTimeMillis();
+                try {
+                    mlist = PolyUtil.<MOD> monic(mlist);
+                    factors = searchFactorsMonic(P, M, mlist, AD); // does now work in all cases
+                    t = System.currentTimeMillis() - t;
+                    //System.out.println("monic time = " + t);
+                    intfac[0] = factors;
+                    if (debug) {
+                        t = System.currentTimeMillis();
+                        List<GenPolynomial<BigInteger>> fnm = searchFactorsNonMonic(P, M, mlist, AD);
+                        t = System.currentTimeMillis() - t;
+                        System.out.println("non monic time = " + t);
+                        if (!factors.equals(fnm)) {
+                            System.out.println("monic factors     = " + intfac[0]); //factors);
+                            System.out.println("non monic factors = " + fnm);
+                        }
+                    }
+                } catch (RuntimeException e) {
+                    t = System.currentTimeMillis();
+                    factors = searchFactorsNonMonic(P, M, mlist, AD);
+                    t = System.currentTimeMillis() - t;
+                    //System.out.println("only non monic time = " + t);
+                }
+            } else {
+                long t = System.currentTimeMillis();
+                factors = searchFactorsNonMonic(P, M, mlist, AD);
+                t = System.currentTimeMillis() - t;
+                //System.out.println("non monic time = " + t);
+            }
+            return normalizeFactorization(factors);
+        }
+
+        // search longest factor list
+        int max = 0;
+        for (int k = 0; k < TT; k++) {
+            int s = intfac[k].size();
+            logger.info("int s = " + s);
+            if (s > max) {
+                max = s;
+                ilist = intfac[k];
+            }
+        }
+        factors = normalizeFactorization(ilist);
+        return factors;
+    }
+
+
+    /**
+     * BitSet for factor degree list.
+     * @param E exponent vector list.
+     * @return {b_0,...,b_k} a BitSet of possible factor degrees.
+     */
+    public BitSet factorDegrees(List<ExpVector> E, int deg) {
+        BitSet D = new BitSet(deg + 1);
+        D.set(0); // constant factor
+        for (ExpVector e : E) {
+            int i = (int) e.getVal(0);
+            BitSet s = new BitSet(deg + 1);
+            for (int k = 0; k < deg + 1 - i; k++) { // shift by i places
+                s.set(i + k, D.get(k));
+            }
+            //System.out.println("s = " + s);
+            D.or(s);
+            //System.out.println("D = " + D);
+        }
+        return D;
+    }
+
+
+    /**
+     * Sum of all degrees.
+     * @param L univariate polynomial list.
+     * @return sum deg(p) for p in L.
+     */
+    public static <C extends RingElem<C>> long degreeSum(List<GenPolynomial<C>> L) {
+        long s = 0L;
+        for (GenPolynomial<C> p : L) {
+            ExpVector e = p.leadingExpVector();
+            long d = e.getVal(0);
+            s += d;
+        }
+        return s;
+    }
+
+
+    /**
+     * Factor search with modular Hensel lifting algorithm. Let p =
+     * f_i.ring.coFac.modul() i = 0, ..., n-1 and assume C == prod_{0,...,n-1}
+     * f_i mod p with ggt(f_i,f_j) == 1 mod p for i != j
+     * @param C GenPolynomial.
+     * @param M bound on the coefficients of g_i as factors of C.
+     * @param F = [f_0,...,f_{n-1}] List&lt;GenPolynomial&gt;.
+     * @param D bit set of possible factor degrees.
+     * @return [g_0,...,g_{n-1}] = lift(C,F), with C = prod_{0,...,n-1} g_i mod
+     *         p**e. <b>Note:</b> does not work in all cases.
+     */
+    List<GenPolynomial<BigInteger>> searchFactorsMonic(GenPolynomial<BigInteger> C, BigInteger M,
+                                                       List<GenPolynomial<MOD>> F, BitSet D) {
+        //System.out.println("*** monic factor combination ***");
+        if (C == null || C.isZERO() || F == null || F.size() == 0) {
+            throw new IllegalArgumentException("C must be nonzero and F must be nonempty");
+        }
+        GenPolynomialRing<BigInteger> pfac = C.ring;
+        if (pfac.nvar != 1) { // assert ?
+            throw new IllegalArgumentException("polynomial ring not univariate");
+        }
+        List<GenPolynomial<BigInteger>> factors = new ArrayList<GenPolynomial<BigInteger>>(F.size());
+        List<GenPolynomial<MOD>> mlist = F;
+        List<GenPolynomial<MOD>> lift;
+
+        //MOD nf = null;
+        GenPolynomial<MOD> ct = mlist.get(0);
+        if (ct.isConstant()) {
+            //nf = ct.leadingBaseCoefficient();
+            mlist.remove(ct);
+            //System.out.println("=== nf = " + nf);
+            if (mlist.size() <= 1) {
+                factors.add(C);
+                return factors;
+            }
+        } else {
+            //nf = ct.ring.coFac.getONE();
+        }
+        //System.out.println("modlist  = " + mlist); // includes not ldcf
+        ModularRingFactory<MOD> mcfac = (ModularRingFactory<MOD>) ct.ring.coFac;
+        BigInteger m = mcfac.getIntegerModul();
+        long k = 1;
+        BigInteger pi = m;
+        while (pi.compareTo(M) < 0) {
+            k++;
+            pi = pi.multiply(m);
+        }
+        logger.info("p^k = " + m + "^" + k);
+        GenPolynomial<BigInteger> PP = C, P = C;
+        // lift via Hensel
+        try {
+            lift = HenselUtil.<MOD> liftHenselMonic(PP, mlist, k);
+            //System.out.println("lift = " + lift);
+        } catch (NoLiftingException e) {
+            throw new RuntimeException(e);
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("lifted modlist = " + lift);
+        }
+        GenPolynomialRing<MOD> mpfac = lift.get(0).ring;
+
+        // combine trial factors
+        int dl = (lift.size() + 1) / 2;
+        //System.out.println("dl = " + dl); 
+        GenPolynomial<BigInteger> u = PP;
+        long deg = (u.degree(0) + 1L) / 2L;
+        //System.out.println("deg = " + deg); 
+        //BigInteger ldcf = u.leadingBaseCoefficient();
+        //System.out.println("ldcf = " + ldcf); 
+        for (int j = 1; j <= dl; j++) {
+            //System.out.println("j = " + j + ", dl = " + dl + ", lift = " + lift); 
+            KsubSet<GenPolynomial<MOD>> ps = new KsubSet<GenPolynomial<MOD>>(lift, j);
+            for (List<GenPolynomial<MOD>> flist : ps) {
+                //System.out.println("degreeSum = " + degreeSum(flist));
+                if (!D.get((int) FactorInteger.<MOD> degreeSum(flist))) {
+                    logger.info("skipped by degree set " + D + ", deg = " + degreeSum(flist));
+                    continue;
+                }
+                GenPolynomial<MOD> mtrial = Power.<GenPolynomial<MOD>> multiply(mpfac, flist);
+                //GenPolynomial<MOD> mtrial = mpfac.getONE();
+                //for (int kk = 0; kk < flist.size(); kk++) {
+                //    GenPolynomial<MOD> fk = flist.get(kk);
+                //    mtrial = mtrial.multiply(fk);
+                //}
+                //System.out.println("+flist = " + flist + ", mtrial = " + mtrial);
+                if (mtrial.degree(0) > deg) { // this test is sometimes wrong
+                    logger.info("degree " + mtrial.degree(0) + " > deg " + deg);
+                    //continue;
+                }
+                //System.out.println("+flist    = " + flist);
+                GenPolynomial<BigInteger> trial = PolyUtil.integerFromModularCoefficients(pfac, mtrial);
+                //System.out.println("+trial = " + trial);
+                //trial = engine.basePrimitivePart( trial.multiply(ldcf) );
+                trial = engine.basePrimitivePart(trial);
+                //System.out.println("pp(trial)= " + trial);
+                if (PolyUtil.<BigInteger> baseSparsePseudoRemainder(u, trial).isZERO()) {
+                    logger.info("successful trial = " + trial);
+                    //System.out.println("trial    = " + trial);
+                    //System.out.println("flist    = " + flist);
+                    //trial = engine.basePrimitivePart(trial);
+                    //System.out.println("pp(trial)= " + trial);
+                    factors.add(trial);
+                    u = PolyUtil.<BigInteger> basePseudoDivide(u, trial); //u.divide( trial );
+                    //System.out.println("u        = " + u);
+                    //if (lift.removeAll(flist)) {
+                    lift = removeOnce(lift, flist);
+                    logger.info("new lift= " + lift);
+                    dl = (lift.size() + 1) / 2;
+                    //System.out.println("dl = " + dl); 
+                    j = 0; // since j++
+                    break;
+                    //} logger.error("error removing flist from lift = " + lift);
+                }
+            }
+        }
+        if (!u.isONE() && !u.equals(P)) {
+            logger.info("rest u = " + u);
+            //System.out.println("rest u = " + u);
+            factors.add(u);
+        }
+        if (factors.size() == 0) {
+            logger.info("irred u = " + u);
+            //System.out.println("irred u = " + u);
+            factors.add(PP);
+        }
+        return normalizeFactorization(factors);
+    }
+
+
+    /**
+     * Factor search with modular Hensel lifting algorithm. Let p =
+     * f_i.ring.coFac.modul() i = 0, ..., n-1 and assume C == prod_{0,...,n-1}
+     * f_i mod p with ggt(f_i,f_j) == 1 mod p for i != j
+     * @param C GenPolynomial.
+     * @param M bound on the coefficients of g_i as factors of C.
+     * @param F = [f_0,...,f_{n-1}] List&lt;GenPolynomial&gt;.
+     * @param D bit set of possible factor degrees.
+     * @return [g_0,...,g_{n-1}] = lift(C,F), with C = prod_{0,...,n-1} g_i mod
+     *         p**e.
+     */
+    List<GenPolynomial<BigInteger>> searchFactorsNonMonic(GenPolynomial<BigInteger> C, BigInteger M,
+                                                          List<GenPolynomial<MOD>> F, BitSet D) {
+        //System.out.println("*** non monic factor combination ***");
+        if (C == null || C.isZERO() || F == null || F.size() == 0) {
+            throw new IllegalArgumentException("C must be nonzero and F must be nonempty");
+        }
+        GenPolynomialRing<BigInteger> pfac = C.ring;
+        if (pfac.nvar != 1) { // assert ?
+            throw new IllegalArgumentException("polynomial ring not univariate");
+        }
+        List<GenPolynomial<BigInteger>> factors = new ArrayList<GenPolynomial<BigInteger>>(F.size());
+        List<GenPolynomial<MOD>> mlist = F;
+
+        MOD nf = null;
+        GenPolynomial<MOD> ct = mlist.get(0);
+        if (ct.isConstant()) {
+            nf = ct.leadingBaseCoefficient();
+            mlist.remove(ct);
+            //System.out.println("=== nf   = " + nf);
+            //System.out.println("=== ldcf = " + C.leadingBaseCoefficient());
+            if (mlist.size() <= 1) {
+                factors.add(C);
+                return factors;
+            }
+        } else {
+            nf = ct.ring.coFac.getONE();
+        }
+        //System.out.println("modlist  = " + mlist); // includes not ldcf
+        GenPolynomialRing<MOD> mfac = ct.ring;
+        GenPolynomial<MOD> Pm = PolyUtil.<MOD> fromIntegerCoefficients(mfac, C);
+        GenPolynomial<BigInteger> PP = C, P = C;
+
+        // combine trial factors
+        int dl = (mlist.size() + 1) / 2;
+        GenPolynomial<BigInteger> u = PP;
+        long deg = (u.degree(0) + 1L) / 2L;
+        GenPolynomial<MOD> um = Pm;
+        //BigInteger ldcf = u.leadingBaseCoefficient();
+        //System.out.println("ldcf = " + ldcf); 
+        HenselApprox<MOD> ilist = null;
+        for (int j = 1; j <= dl; j++) {
+            //System.out.println("j = " + j + ", dl = " + dl + ", ilist = " + ilist); 
+            KsubSet<GenPolynomial<MOD>> ps = new KsubSet<GenPolynomial<MOD>>(mlist, j);
+            for (List<GenPolynomial<MOD>> flist : ps) {
+                //System.out.println("degreeSum = " + degreeSum(flist));
+                if (!D.get((int) FactorInteger.<MOD> degreeSum(flist))) {
+                    logger.info("skipped by degree set " + D + ", deg = " + degreeSum(flist));
+                    continue;
+                }
+                GenPolynomial<MOD> trial = mfac.getONE().multiply(nf);
+                for (int kk = 0; kk < flist.size(); kk++) {
+                    GenPolynomial<MOD> fk = flist.get(kk);
+                    trial = trial.multiply(fk);
+                }
+                if (trial.degree(0) > deg) { // this test is sometimes wrong
+                    logger.info("degree > deg " + deg + ", degree = " + trial.degree(0));
+                    //continue;
+                }
+                GenPolynomial<MOD> cofactor = um.divide(trial);
+                //System.out.println("trial    = " + trial);
+                //System.out.println("cofactor = " + cofactor);
+
+                // lift via Hensel
+                try {
+                    // ilist = HenselUtil.liftHenselQuadraticFac(PP, M, trial, cofactor);
+                    ilist = HenselUtil.<MOD> liftHenselQuadratic(PP, M, trial, cofactor);
+                    //ilist = HenselUtil.<MOD> liftHensel(PP, M, trial, cofactor);
+                } catch (NoLiftingException e) {
+                    // no liftable factors
+                    if ( /*debug*/logger.isDebugEnabled()) {
+                        logger.info("no liftable factors " + e);
+                        //e.printStackTrace();
+                    }
+                    continue;
+                }
+                GenPolynomial<BigInteger> itrial = ilist.A;
+                GenPolynomial<BigInteger> icofactor = ilist.B;
+                if (logger.isDebugEnabled()) {
+                    logger.info("       modlist = " + trial + ", cofactor " + cofactor);
+                    logger.info("lifted intlist = " + itrial + ", cofactor " + icofactor);
+                }
+                //System.out.println("lifted intlist = " + itrial + ", cofactor " + icofactor); 
+
+                itrial = engine.basePrimitivePart(itrial);
+                //System.out.println("pp(trial)= " + itrial);
+                if (PolyUtil.<BigInteger> baseSparsePseudoRemainder(u, itrial).isZERO()) {
+                    logger.info("successful trial = " + itrial);
+                    //System.out.println("trial    = " + itrial);
+                    //System.out.println("cofactor = " + icofactor);
+                    //System.out.println("flist    = " + flist);
+                    //itrial = engine.basePrimitivePart(itrial);
+                    //System.out.println("pp(itrial)= " + itrial);
+                    factors.add(itrial);
+                    //u = PolyUtil.<BigInteger> basePseudoDivide(u, itrial); //u.divide( trial );
+                    u = icofactor;
+                    PP = u; // fixed finally on 2009-05-03
+                    um = cofactor;
+                    //System.out.println("u        = " + u);
+                    //System.out.println("um       = " + um);
+                    //if (mlist.removeAll(flist)) {
+                    mlist = removeOnce(mlist, flist);
+                    logger.info("new mlist= " + mlist);
+                    dl = (mlist.size() + 1) / 2;
+                    j = 0; // since j++
+                    break;
+                    //} logger.error("error removing flist from ilist = " + mlist);
+                }
+            }
+        }
+        if (!u.isONE() && !u.equals(P)) {
+            logger.info("rest u = " + u);
+            factors.add(u);
+        }
+        if (factors.size() == 0) {
+            logger.info("irred u = " + PP);
+            factors.add(PP);
+        }
+        return normalizeFactorization(factors);
+    }
+
+
+    /**
+     * GenPolynomial factorization of a multivariate squarefree polynomial,
+     * using Hensel lifting if possible.
+     * @param P squarefree and primitive! (respectively monic) multivariate
+     *            GenPolynomial over the integers.
+     * @return [p_1,...,p_k] with P = prod_{i=1,...,r} p_i.
+     */
+    @Override
+    public List<GenPolynomial<BigInteger>> factorsSquarefree(GenPolynomial<BigInteger> P) {
+        GenPolynomialRing<BigInteger> pfac = P.ring;
+        if (pfac.nvar <= 1) {
+            return baseFactorsSquarefree(P);
+        }
+        List<GenPolynomial<BigInteger>> factors;
+        factors = factorsSquarefreeOptions(P, false, false);
+        if (factors != null) {
+            return factors;
+        }
+        factors = factorsSquarefreeOptions(P, false, true);
+        if (factors != null) {
+            return factors;
+        }
+        factors = factorsSquarefreeOptions(P, true, false);
+        if (factors != null) {
+            return factors;
+        }
+        factors = factorsSquarefreeOptions(P, true, true);
+        if (factors != null) {
+            return factors;
+        }
+        logger.warn("factorsSquarefreeHensel not applicable or failed, reverting to Kronecker for: " + P);
+        factors = super.factorsSquarefree(P);
+        return factors;
+    }
+
+
+    /**
+     * GenPolynomial factorization of a multivariate squarefree polynomial,
+     * using Hensel lifting if possible.
+     * @param P squarefree and primitive! (respectively monic) multivariate
+     *            GenPolynomial over the integers.
+     * @param opti true, if polynomial variables should be optimized, else false.
+     * @param tlex true, if INVLEX term order should be forced, else false.
+     * @return [p_1,...,p_k] with P = prod_{i=1,...,r} p_i.
+     */
+    public List<GenPolynomial<BigInteger>> factorsSquarefreeOptions(GenPolynomial<BigInteger> P, boolean opti, boolean tlex) {
+        GenPolynomial<BigInteger> Pp = P;
+        GenPolynomialRing<BigInteger> pfac = Pp.ring;
+        if (pfac.nvar <= 1) {
+            return baseFactorsSquarefree(Pp);
+        }
+        if (tlex) {
+            if (! pfac.tord.equals(TermOrderByName.INVLEX)) {
+                pfac = new GenPolynomialRing<BigInteger>(pfac,TermOrderByName.INVLEX);
+                Pp = pfac.copy(Pp);
+                logger.warn("invlexed polynomial: " + Pp + ", from ring " + P.ring);
+            } else {
+                tlex = false;
+            }
+        }
+        OptimizedPolynomialList<BigInteger> opt = null;
+        List<Integer> iperm = null;
+        final boolean USE_OPT = opti;
+        if (USE_OPT) {
+            List<GenPolynomial<BigInteger>> topt = new ArrayList<GenPolynomial<BigInteger>>(1);
+            topt.add(Pp);
+            opt = TermOrderOptimization.<BigInteger> optimizeTermOrder(pfac, topt);
+            if (!TermOrderOptimization.isIdentityPermutation(opt.perm)) {
+                iperm = TermOrderOptimization.inversePermutation(opt.perm);
+                Pp = opt.list.get(0);
+                logger.info("optimized polynomial: " + Pp);
+                logger.warn("optimized ring: " + opt.ring + ", original ring: " + pfac);
+            }
+        }
+        ExpVector degv = Pp.degreeVector();
+        int[] donv = degv.dependencyOnVariables();
+        List<GenPolynomial<BigInteger>> facs = null;
+        if (degv.length() == donv.length) { // all variables appear, hack for Hensel, check
+            try {
+                logger.info("try factorsSquarefreeHensel: " + Pp);
+                facs = factorsSquarefreeHensel(Pp);
+            } catch (Exception e) {
+                logger.info("exception " + e);
+                //e.printStackTrace();
+            }
+        } else { // not all variables appear, remove unused variables, hack for Hensel, check
+            GenPolynomial<BigInteger> pu = PolyUtil.<BigInteger> removeUnusedUpperVariables(Pp);
+            //GenPolynomial<BigInteger> pl = PolyUtil.<BigInteger> removeUnusedLowerVariables(pu); // not useful
+            try {
+                logger.info("try factorsSquarefreeHensel: " + pu);
+                facs = factorsSquarefreeHensel(pu);
+                List<GenPolynomial<BigInteger>> fs = new ArrayList<GenPolynomial<BigInteger>>(facs.size());
+                GenPolynomialRing<BigInteger> pf = Pp.ring;
+                //GenPolynomialRing<BigInteger> pfu = pu.ring;
+                for (GenPolynomial<BigInteger> p : facs) {
+                    //GenPolynomial<BigInteger> pel = p.extendLower(pfu, 0, 0L);
+                    GenPolynomial<BigInteger> pe = p.extend(pf, 0, 0L);
+                    fs.add(pe);
+                }
+                //System.out.println("fs = " + fs);
+                facs = fs;
+            } catch (Exception e) {
+                logger.info("exception " + e);
+                //e.printStackTrace();
+            }
+        }
+        if (facs == null) {
+            return facs;
+        }
+        if (USE_OPT && iperm != null) {
+            facs = TermOrderOptimization.<BigInteger> permutation(iperm, pfac, facs);
+            logger.warn("de-optimized polynomials: " + facs);
+        }
+        if (tlex) {
+            facs = P.ring.copy(facs);
+            logger.warn("de-invlexed polynomials: " + facs);
+        }
+        facs = normalizeFactorization(facs);
+        return facs;
+    }
+
+
+    /**
+     * GenPolynomial factorization of a multivariate squarefree polynomial,
+     * using Hensel lifting.
+     * @param P squarefree and primitive! (respectively monic) multivariate
+     *            GenPolynomial over the integers.
+     * @return [p_1,...,p_k] with P = prod_{i=1,...,r} p_i.
+     */
+    @SuppressWarnings("unchecked")
+    public List<GenPolynomial<BigInteger>> factorsSquarefreeHensel(GenPolynomial<BigInteger> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P != null");
+        }
+        GenPolynomialRing<BigInteger> pfac = P.ring;
+        if (pfac.nvar == 1) {
+            return baseFactorsSquarefree(P);
+        }
+        List<GenPolynomial<BigInteger>> factors = new ArrayList<GenPolynomial<BigInteger>>();
+        if (P.isZERO()) {
+            return factors;
+        }
+        if (P.degreeVector().totalDeg() <= 1L) {
+            factors.add(P);
+            return factors;
+        }
+        GenPolynomial<BigInteger> pd = P;
+        //System.out.println("pd   = " + pd);
+        // ldcf(pd)
+        BigInteger ac = pd.leadingBaseCoefficient();
+
+        // factor leading coefficient as polynomial in the lowest! variable
+        GenPolynomialRing<GenPolynomial<BigInteger>> rnfac = pfac.recursive(pfac.nvar - 1);
+        GenPolynomial<GenPolynomial<BigInteger>> pr = PolyUtil.<BigInteger> recursive(rnfac, pd);
+        GenPolynomial<GenPolynomial<BigInteger>> prr = PolyUtil.<BigInteger> switchVariables(pr);
+
+        GenPolynomial<BigInteger> prrc = engine.recursiveContent(prr); // can have content wrt this variable
+        List<GenPolynomial<BigInteger>> cfactors = null;
+        if (!prrc.isONE()) {
+            prr = PolyUtil.<BigInteger> recursiveDivide(prr, prrc);
+            GenPolynomial<BigInteger> prrcu = prrc.extendLower(pfac, 0, 0L); // since switched vars
+            pd = PolyUtil.<BigInteger> basePseudoDivide(pd, prrcu);
+            logger.info("recursive content = " + prrc + ", new P = " + pd);
+            cfactors = factorsSquarefree(prrc);
+            List<GenPolynomial<BigInteger>> cff = new ArrayList<GenPolynomial<BigInteger>>(cfactors.size());
+            for (GenPolynomial<BigInteger> fs : cfactors) {
+                GenPolynomial<BigInteger> fsp = fs.extendLower(pfac, 0, 0L); // since switched vars
+                cff.add(fsp);
+            }
+            cfactors = cff;
+            logger.info("cfactors = " + cfactors);
+        }
+        GenPolynomial<BigInteger> lprr = prr.leadingBaseCoefficient();
+        //System.out.println("prr  = " + prr);
+        logger.info("leading coeffcient = " + lprr);
+        boolean isMonic = false; // multivariate monic
+        if (lprr.isConstant()) { // isONE ?
+            isMonic = true;
+        }
+        SortedMap<GenPolynomial<BigInteger>, Long> lfactors = factors(lprr);
+        //System.out.println("lfactors = " + lfactors);
+        List<GenPolynomial<BigInteger>> lfacs = new ArrayList<GenPolynomial<BigInteger>>(lfactors.keySet());
+        logger.info("leading coefficient factors = " + lfacs);
+
+        // search evaluation point and evaluate
+        GenPolynomialRing<BigInteger> cpfac = pfac;
+        GenPolynomial<BigInteger> pe = pd;
+        GenPolynomial<BigInteger> pep;
+        GenPolynomialRing<BigInteger> ccpfac = lprr.ring;
+        List<GenPolynomial<BigInteger>> ce = lfacs;
+        List<GenPolynomial<BigInteger>> cep = null;
+        List<BigInteger> cei = null;
+        List<BigInteger> dei = new ArrayList<BigInteger>();
+        BigInteger pec = null;
+        BigInteger pecw = null;
+        BigInteger ped = null;
+
+        List<GenPolynomial<BigInteger>> ufactors = null;
+        List<TrialParts> tParts = new ArrayList<TrialParts>();
+        List<GenPolynomial<BigInteger>> lf = null;
+        GenPolynomial<BigInteger> lpx = null;
+        List<GenPolynomial<BigInteger>> ln = null;
+        List<GenPolynomial<BigInteger>> un = null;
+        GenPolynomial<BigInteger> pes = null;
+
+        List<BigInteger> V = null;
+        long evStart = 0L; //3L * 5L;
+        List<Long> Evs = new ArrayList<Long>(pfac.nvar + 1); // Evs(0), Evs(1) unused
+        for (int j = 0; j <= pfac.nvar; j++) {
+            Evs.add(evStart++); // bug
+        }
+        //no: Collections.reverse(Evs);
+        evStart = Evs.get(0);
+        final int trials = 4;
+        int countSeparate = 0;
+        final int COUNT_MAX = 50;
+        double ran = 1.001; // higher values not good
+        boolean isPrimitive = true;
+        boolean notLucky = true;
+        while (notLucky) { // for Wang's test
+            if (Math.abs(evStart) > 371L) {
+                logger.warn("found         points   : V = " + V + ", dei = " + dei);
+                //if (tParts != null && tParts.size() > 0) { // at least one successful eval point 
+                //    logger.warn("some evaluation points found after " + Math.abs(evStart) + " iterations, tParts = " + tParts);
+                //    break;
+                //}
+                logger.warn("no evaluation point for: P = " + P + ", prr = " + prr + ", lprr = " + lprr + ", lfacs = " + lfacs);
+                throw new RuntimeException(
+                                           "no evaluation point found after " + Math.abs(evStart) + " iterations");
+            }
+            if (Math.abs(evStart) % 100L <= 3L) {
+                ran = ran * (Math.PI - 2.14);
+            }
+            //System.out.println("-------------------------------------------- Evs = " + Evs);
+            notLucky = false;
+            V = new ArrayList<BigInteger>();
+            cpfac = pfac;
+            pe = pd;
+            ccpfac = lprr.ring;
+            ce = lfacs;
+            cep = null;
+            cei = null;
+            pec = null;
+            ped = null;
+            long vi = 0L;
+            for (int j = pfac.nvar; j > 1; j--) {
+                // evaluation up to univariate case
+                long degp = pe.degree(cpfac.nvar - 2);
+                cpfac = cpfac.contract(1);
+                ccpfac = ccpfac.contract(1);
+                //vi = evStart; // + j;//0L; //(long)(pfac.nvar-j); // 1L; 0 not so good for small p
+                vi = Evs.get(j); //evStart + j;//0L; //(long)(pfac.nvar-j); // 1L; 0 not so good for small p
+                BigInteger Vi;
+
+                // search evaluation point
+                boolean doIt = true;
+                Vi = null;
+                pep = null;
+                while (doIt) {
+                    logger.info("vi(" + j + ") = " + vi);
+                    Vi = new BigInteger(vi);
+                    pep = PolyUtil.<BigInteger> evaluateMain(cpfac, pe, Vi);
+                    //System.out.println("pep = " + pep);
+                    // check lucky evaluation point 
+                    if (degp == pep.degree(cpfac.nvar - 1)) {
+                        logger.info("pep = " + pep);
+                        //System.out.println("deg(pe) = " + degp + ", deg(pep) = " + pep.degree(cpfac.nvar-1));
+                        // check squarefree
+                        if (sengine.isSquarefree(pep)) { // cpfac.nvar == 1 && ?? no, must test on each variable
+                            //if ( isNearlySquarefree(pep) ) {
+                            //System.out.println("squarefeee(pep)"); // + pep);
+                            doIt = false; //break;
+                        } else {
+                            logger.info("pep not squarefree ");
+                        }
+                    }
+                    if (vi > 0L) {
+                        vi = -vi;
+                    } else {
+                        vi = 1L - vi;
+                    }
+                }
+                //if ( !isMonic ) {
+                if (ccpfac.nvar >= 1) {
+                    cep = PolyUtil.<BigInteger> evaluateMain(ccpfac, ce, Vi);
+                } else {
+                    cei = PolyUtil.<BigInteger> evaluateMain(ccpfac.coFac, ce, Vi);
+                }
+                //}
+                int jj = (int) Math.round(ran + 0.52 * Math.random()); // j, random increment
+                //jj = 0; // ...4 test   
+                //System.out.print("minimal jj = " + jj + ", vi_a " + vi);
+                if (vi > 0L) {
+                    Evs.set(j, vi + jj); // record last tested value plus increment
+                    evStart = vi + jj;
+                } else {
+                    Evs.set(j, vi - jj); // record last tested value minus increment
+                    evStart = vi - jj;
+                }
+                // ensure different evaluation points
+                Set<Long> Evset = new HashSet<Long>(Evs);
+                while (Evset.size() != Evs.size()) {
+                    //logger.warn("same eval points: " + Evs + " != " + Evset);
+                    long vgi = Evs.get(j);
+                    if (vgi > 0L) {
+                        vgi += 1L;
+                    } else {
+                        vgi -= 1L;
+                    }
+                    Evs.set(j, vgi);
+                    Evset.clear(); Evset.addAll(Evs); //= new HashSet<Long>(Evs);
+                    evStart = vgi;
+                    //logger.warn("same eval points: " + Evs + ", j = " + j);
+                }
+                //System.out.println(", j = " + j + ", vi_b " + Vi);
+                //evStart = vi+1L;
+                V.add(Vi);
+                pe = pep;
+                ce = cep;
+            }
+            //System.out.println("ce = " + ce + ", pe = " + pe);
+            pecw = engine.baseContent(pe); // original Wang
+            isPrimitive = pecw.isONE();
+            ped = ccpfac.coFac.getONE();
+            pec = pe.ring.coFac.getONE();
+            //System.out.println("cei = " + cei + ", pecw = " + pecw);
+            if (!isMonic) {
+                if (countSeparate > COUNT_MAX) {
+                    pec = pe.ring.coFac.getONE(); // hack is sometimes better
+                } else {
+                    pec = pecw;
+                }
+                //pec = pecw;
+                //System.out.println("cei = " + cei + ", pec = " + pec + ", pe = " + pe);
+                if (lfacs.get(0).isConstant()) {
+                    ped = cei.remove(0);
+                    //lfacs.remove(0); // later
+                }
+                //System.out.println("lfacs = " + lfacs + ", cei = " + cei + ", ped = " + ped + ", pecw = " + pecw);
+                // test Wang's condition
+                dei = new ArrayList<BigInteger>();
+                dei.add(pec.multiply(ped).abs()); // .abs()
+                int i = 1;
+                for (BigInteger ci : cei) {
+                    if (ci.isZERO()) {
+                        logger.info("condition (0) not met for cei = " + cei); // + ", dei = " + dei);
+                        notLucky = true;
+                        break;
+                    }
+                    BigInteger q = ci.abs();
+                    //System.out.println("q = " + q);
+                    for (int ii = i - 1; ii >= 0; ii--) {
+                        BigInteger r = dei.get(ii);
+                        //System.out.println("r = " + r);
+                        while (!r.isONE()) {
+                            r = r.gcd(q);
+                            q = q.divide(r);
+                            //System.out.println("r = " + r + ", q = " + q);
+                        }
+                    }
+                    dei.add(q);
+                    if (q.isONE()) {
+                        logger.info("condition (1) not met for dei = " + dei + ", cei = " + cei);
+                        if (!testSeparate(cei, pecw)) {
+                            countSeparate++;
+                            if (countSeparate > COUNT_MAX) {
+                                logger.info("too many inseparable evaluation points: " + countSeparate
+                                            + ", removing " + pecw);
+                            }
+                        }
+                        notLucky = true;
+                        break;
+                    }
+                    i++;
+                }
+                //System.out.println("dei = " + dei);
+            }
+            if (notLucky) {
+                continue;
+            }
+            logger.info("evaluation points  = " + V + ", dei = " + dei);
+            //System.out.println("Evs = " + Evs);
+            logger.info("univariate polynomial = " + pe + ", pecw = " + pecw);
+            //pe = pe.abs();
+            //ufactors = baseFactorsRadical(pe); //baseFactorsSquarefree(pe); wrong since not primitive
+            ufactors = baseFactorsSquarefree(pe.divide(pecw)); //wrong if not primitive
+            if (!pecw.isONE()) {
+                ufactors.add(0, cpfac.getONE().multiply(pecw));
+            }
+            if (ufactors.size() <= 1) {
+                logger.info("irreducible univariate polynomial");
+                factors.add(pd); // P
+                if (cfactors != null) {
+                    cfactors.addAll(factors);
+                    factors = cfactors;
+                }
+                return factors;
+            }
+            logger.info("univariate factors = " + ufactors); // + ", of " + pe);
+            //System.out.println("lfacs    = " + lfacs);
+            //System.out.println("cei      = " + cei);
+            //System.out.println("pecw     = " + pecw);
+
+            // determine leading coefficient polynomials for factors
+            lf = new ArrayList<GenPolynomial<BigInteger>>();
+            lpx = lprr.ring.getONE();
+            for (int i = 0; i < ufactors.size(); i++) {
+                lf.add(lprr.ring.getONE());
+            }
+            //System.out.println("lf = " + lf);             
+            if (!isMonic || !pecw.isONE()) {
+                if (lfacs.size() > 0 && lfacs.get(0).isConstant()) {
+                    //GenPolynomial<BigInteger> unused = 
+                    lfacs.remove(0);
+                    //BigInteger xxi = xx.leadingBaseCoefficient();
+                    //System.out.println("xx = " + xx + " == ped = " +ped);
+                }
+                for (int i = ufactors.size() - 1; i >= 0; i--) {
+                    GenPolynomial<BigInteger> pp = ufactors.get(i);
+                    BigInteger ppl = pp.leadingBaseCoefficient();
+                    //System.out.println("ppl = " + ppl + ", pp = " + pp);
+                    ppl = ppl.multiply(pec); // content
+                    GenPolynomial<BigInteger> lfp = lf.get(i);
+                    int ii = 0;
+                    for (BigInteger ci : cei) {
+                        //System.out.println("ci = " + ci + ", lfp = " + lfp + ", lfacs.get(ii) = " + lfacs.get(ii));
+                        if (ci.abs().isONE()) {
+                            System.out.println("ppl = " + ppl + ", ci = " + ci + ", lfp = " + lfp
+                                               + ", lfacs.get(ii) = " + lfacs.get(ii));
+                            notLucky = true;
+                            throw new RuntimeException("something is wrong, ci is a unit");
+                        }
+                        while (ppl.remainder(ci).isZERO() && lfacs.size() > ii) {
+                            ppl = ppl.divide(ci);
+                            lfp = lfp.multiply(lfacs.get(ii));
+                        }
+                        ii++;
+                    }
+                    //System.out.println("ppl = " + ppl + ", lfp = " + lfp);
+                    lfp = lfp.multiply(ppl);
+                    lf.set(i, lfp);
+                }
+                // adjust if pec != 1
+                pec = pecw;
+                lpx = Power.<GenPolynomial<BigInteger>> multiply(lprr.ring, lf); // test only, not used
+                //System.out.println("lpx = " + lpx);
+                if (!lprr.degreeVector().equals(lpx.degreeVector())) {
+                    logger.info("deg(lprr) != deg(lpx): lprr = " + lprr + ", lpx = " + lpx);
+                    notLucky = true;
+                    continue;
+                }
+                if (!pec.isONE()) { // content, was always false by hack
+                    // evaluate factors of ldcf
+                    List<GenPolynomial<BigInteger>> lfe = lf;
+                    List<BigInteger> lfei = null;
+                    ccpfac = lprr.ring;
+                    for (int j = lprr.ring.nvar; j > 0; j--) {
+                        ccpfac = ccpfac.contract(1);
+                        BigInteger Vi = V.get(lprr.ring.nvar - j);
+                        if (ccpfac.nvar >= 1) {
+                            lfe = PolyUtil.<BigInteger> evaluateMain(ccpfac, lfe, Vi);
+                        } else {
+                            lfei = PolyUtil.<BigInteger> evaluateMain(ccpfac.coFac, lfe, Vi);
+                        }
+                    }
+                    //System.out.println("lfe = " + lfe + ", lfei = " + lfei + ", V = " + V);
+
+                    ln = new ArrayList<GenPolynomial<BigInteger>>(lf.size());
+                    un = new ArrayList<GenPolynomial<BigInteger>>(lf.size());
+                    for (int jj = 0; jj < lf.size(); jj++) {
+                        GenPolynomial<BigInteger> up = ufactors.get(jj);
+                        BigInteger ui = up.leadingBaseCoefficient();
+                        BigInteger li = lfei.get(jj);
+                        BigInteger di = ui.gcd(li).abs();
+                        BigInteger udi = ui.divide(di);
+                        BigInteger ldi = li.divide(di);
+                        GenPolynomial<BigInteger> lp = lf.get(jj);
+                        GenPolynomial<BigInteger> lpd = lp.multiply(udi);
+                        GenPolynomial<BigInteger> upd = up.multiply(ldi);
+                        if (pec.isONE()) {
+                            ln.add(lp);
+                            un.add(up);
+                        } else {
+                            ln.add(lpd);
+                            un.add(upd);
+                            BigInteger pec1 = pec.divide(ldi);
+                            //System.out.println("pec = " + pec + ", pec1 = " + pec1);
+                            pec = pec1;
+                        }
+                    }
+                    if (!lf.equals(ln) || !un.equals(ufactors)) {
+                        logger.debug("!lf.equals(ln) || !un.equals(ufactors)");
+                        //System.out.println("pe  = " + pe);
+                        //System.out.println("#ln  = " + ln + ", #lf = " + lf);
+                        //System.out.println("#un  = " + un + ", #ufactors = " + ufactors);
+                        //lf = ln;
+                        //ufactors = un;
+                        // adjust pe
+                    }
+                    if (!pec.isONE()) { // still not 1
+                        ln = new ArrayList<GenPolynomial<BigInteger>>(lf.size());
+                        un = new ArrayList<GenPolynomial<BigInteger>>(lf.size());
+                        pes = pe;
+                        for (int jj = 0; jj < lf.size(); jj++) {
+                            GenPolynomial<BigInteger> up = ufactors.get(jj);
+                            GenPolynomial<BigInteger> lp = lf.get(jj);
+                            //System.out.println("up  = " + up + ", lp  = " + lp);
+                            if (!up.isConstant()) {
+                                up = up.multiply(pec);
+                            }
+                            lp = lp.multiply(pec);
+                            if (jj != 0) {
+                                pes = pes.multiply(pec);
+                            }
+                            un.add(up);
+                            ln.add(lp);
+                        }
+                        if (pes.equals(Power.<GenPolynomial<BigInteger>> multiply(pe.ring, un))) {
+                            //System.out.println("*pe  = " + pes + ", pec = " + pec);
+                            //ystem.out.println("*ln  = " + ln + ", *lf = " + lf);
+                            //System.out.println("*un  = " + un + ", *ufactors = " + ufactors);
+                            //System.out.println("*pe == prod(un) ");
+                            isPrimitive = false;
+                            //pe = pes;
+                            //lf = ln;
+                            //ufactors = un;
+                        } else {
+                            //System.out.println("*pe != prod(un): " + Power.<GenPolynomial<BigInteger>> multiply(pe.ring,un));
+                        }
+                    }
+                }
+                //if (notLucky) {
+                //    continue;
+                //}
+                logger.info("distributed factors of leading coefficient = " + lf);
+                lpx = Power.<GenPolynomial<BigInteger>> multiply(lprr.ring, lf);
+                if (!lprr.abs().equals(lpx.abs())) { // not correctly distributed
+                    if (!lprr.degreeVector().equals(lpx.degreeVector())) {
+                        logger.info("lprr != lpx: lprr = " + lprr + ", lpx = " + lpx);
+                        notLucky = true;
+                    }
+                }
+                //logger.warn("V = " + V + ", pe = " + pe + ", cei = " + cei + ", lf = " + lf + ", ln = " + ln);
+            } // end determine leading coefficients for factors
+
+            if (!notLucky) {
+                TrialParts tp = null;
+                if (isPrimitive) {
+                    tp = new TrialParts(V, pe, ufactors, cei, lf);
+                } else {
+                    tp = new TrialParts(V, pes, un, cei, ln);
+                }
+                //System.out.println("trialParts = " + tp);
+                if (tp.univPoly != null) {
+                    if (tp.ldcfEval.size() != 0) {
+                        tParts.add(tp);
+                    }
+                }
+                if (tParts.size() < trials) {
+                    notLucky = true;
+                }
+            }
+        } // end notLucky loop
+        logger.warn("end notLucky loop, trial parts = " + tParts.size());
+
+        // search TrialParts with shortest factorization of univariate polynomial
+        int min = Integer.MAX_VALUE;
+        TrialParts tpmin = null;
+        for (TrialParts tp : tParts) {
+            //logger.info("tp.univFactors.size() = " + tp.univFactors.size());
+            if (tp.univFactors.size() < min) {
+                min = tp.univFactors.size();
+                tpmin = tp;
+            }
+        }
+        for (TrialParts tp : tParts) {
+            if (tp.univFactors.size() == min) {
+                if (!tp.univFactors.get(0).isConstant()) {
+                    logger.info("tp.univFactors = " + tp.univFactors);
+                    tpmin = tp;
+                    break;
+                }
+            }
+        }
+        // set to (first) shortest 
+        V = tpmin.evalPoints;
+        pe = tpmin.univPoly;
+        ufactors = tpmin.univFactors;
+        cei = tpmin.ldcfEval; // unused
+        lf = tpmin.ldcfFactors;
+        logger.info("iterations    = " + Math.abs(evStart));
+        logger.info("minimal trial = " + tpmin);
+
+        GenPolynomialRing<BigInteger> ufac = pe.ring;
+
+        //initialize prime list
+        PrimeList primes = new PrimeList(PrimeList.Range.medium); // PrimeList.Range.medium);
+        Iterator<java.math.BigInteger> primeIter = primes.iterator();
+        int pn = 50; //primes.size();
+        BigInteger ae = pe.leadingBaseCoefficient();
+        GenPolynomial<MOD> Pm = null;
+        ModularRingFactory<MOD> cofac = null;
+        GenPolynomialRing<MOD> mufac = null;
+
+        // search lucky prime
+        for (int i = 0; i < 11; i++) { // prime meta loop
+            //for ( int i = 0; i < 1; i++ ) { // meta loop
+            java.math.BigInteger p = null; //new java.math.BigInteger("19"); //primes.next();
+            // 2 small, 5 medium and 4 large size primes
+            if (i == 0) { // medium size
+                primes = new PrimeList(PrimeList.Range.medium);
+                primeIter = primes.iterator();
+            }
+            if (i == 5) { // small size
+                primes = new PrimeList(PrimeList.Range.small);
+                primeIter = primes.iterator();
+                p = primeIter.next(); // 2
+                p = primeIter.next(); // 3
+                p = primeIter.next(); // 5
+                p = primeIter.next(); // 7
+            }
+            if (i == 7) { // large size
+                primes = new PrimeList(PrimeList.Range.large);
+                primeIter = primes.iterator();
+            }
+            int pi = 0;
+            while (pi++ < pn && primeIter.hasNext()) {
+                p = primeIter.next();
+                logger.info("prime = " + p);
+                // initialize coefficient factory and map normalization factor and polynomials
+                ModularRingFactory<MOD> cf = null;
+                if (ModLongRing.MAX_LONG.compareTo(p) > 0) {
+                    cf = (ModularRingFactory) new ModLongRing(p, true);
+                } else {
+                    cf = (ModularRingFactory) new ModIntegerRing(p, true);
+                }
+                MOD nf = cf.fromInteger(ae.getVal());
+                if (nf.isZERO()) {
+                    continue;
+                }
+                mufac = new GenPolynomialRing<MOD>(cf, ufac);
+                //System.out.println("mufac = " + mufac.toScript());
+                Pm = PolyUtil.<MOD> fromIntegerCoefficients(mufac, pe);
+                //System.out.println("Pm = " + Pm);
+                if (!mfactor.isSquarefree(Pm)) {
+                    continue;
+                }
+                cofac = cf;
+                break;
+            }
+            if (cofac != null) {
+                break;
+            }
+        } // end prime meta loop
+        if (cofac == null) { // no lucky prime found
+            throw new RuntimeException("giving up on Hensel preparation, no lucky prime found");
+        }
+        logger.info("lucky prime = " + cofac.getIntegerModul());
+        if (logger.isDebugEnabled()) {
+            logger.debug("univariate modulo p: = " + Pm);
+        }
+
+        // coefficient bound
+        BigInteger an = pd.maxNorm();
+        BigInteger mn = an.multiply(ac.abs()).multiply(new BigInteger(2L));
+        long k = Power.logarithm(cofac.getIntegerModul(), mn) + 1L;
+        //System.out.println("mn = " + mn + ", k = " +k);
+
+        BigInteger q = cofac.getIntegerModul().power(k);
+        ModularRingFactory<MOD> muqfac;
+        if (ModLongRing.MAX_LONG.compareTo(q.getVal()) > 0) {
+            muqfac = (ModularRingFactory) new ModLongRing(q.getVal());
+        } else {
+            muqfac = (ModularRingFactory) new ModIntegerRing(q.getVal());
+        }
+        //System.out.println("muqfac = " + muqfac);
+        GenPolynomialRing<MOD> mucpfac = new GenPolynomialRing<MOD>(muqfac, ufac);
+
+        List<GenPolynomial<MOD>> muqfactors = PolyUtil.<MOD> fromIntegerCoefficients(mucpfac, ufactors);
+        GenPolynomial<MOD> peqq = PolyUtil.<MOD> fromIntegerCoefficients(mucpfac, pe);
+        if (debug) {
+            if (!mfactor.isFactorization(peqq, muqfactors)) { // should not happen
+                System.out.println("muqfactors = " + muqfactors);
+                System.out.println("peqq       = " + peqq);
+                throw new RuntimeException("something is wrong, no modular p^k factorization");
+            }
+        }
+        logger.info("univariate modulo p^k: " + peqq + " = " + muqfactors);
+
+        // convert C from Z[...] to Z_q[...]
+        GenPolynomialRing<MOD> qcfac = new GenPolynomialRing<MOD>(muqfac, pd.ring);
+        GenPolynomial<MOD> pq = PolyUtil.<MOD> fromIntegerCoefficients(qcfac, pd);
+        //System.out.println("pd = " + pd);
+        logger.info("multivariate modulo p^k: " + pq);
+
+        //List<MOD> Vm = new ArrayList<MOD>(V.size());
+        //for (BigInteger v : V) {
+        //    MOD vm = muqfac.fromInteger(v.getVal());
+        //    Vm.add(vm);
+        //}
+        //System.out.println("Vm = " + Vm);
+
+        // Hensel lifting of factors
+        List<GenPolynomial<MOD>> mlift;
+        try {
+            mlift = HenselMultUtil.<MOD> liftHensel(pd, pq, muqfactors, V, k, lf);
+            logger.info("mlift = " + mlift);
+        } catch (NoLiftingException nle) {
+            //System.out.println("exception : " + nle);
+            //nle.printStackTrace();
+            //mlift = new ArrayList<GenPolynomial<MOD>>();
+            throw new RuntimeException(nle);
+        } catch (ArithmeticException aex) {
+            //System.out.println("exception : " + aex);
+            //aex.printStackTrace();
+            //mlift = new ArrayList<GenPolynomial<MOD>>();
+            throw aex;
+        }
+        if (mlift.size() <= 1) { // irreducible mod I, p^k, can this happen?
+            logger.info("modular lift size == 1: " + mlift);
+            factors.add(pd); // P
+            if (cfactors != null) {
+                cfactors.addAll(factors);
+                factors = cfactors;
+            }
+            return factors;
+        }
+
+        // combine trial factors
+        GenPolynomialRing<MOD> mfac = mlift.get(0).ring;
+        int dl = (mlift.size() + 1) / 2;
+        GenPolynomial<BigInteger> u = P;
+        long deg = (u.degree() + 1L) / 2L;
+
+        GenPolynomial<BigInteger> ui = pd;
+        for (int j = 1; j <= dl; j++) {
+            //System.out.println("j = " + j + ", dl = " + dl + ", mlift = " + mlift); 
+            KsubSet<GenPolynomial<MOD>> subs = new KsubSet<GenPolynomial<MOD>>(mlift, j);
+            for (List<GenPolynomial<MOD>> flist : subs) {
+                //System.out.println("degreeSum = " + degreeSum(flist));
+                GenPolynomial<MOD> mtrial = Power.<GenPolynomial<MOD>> multiply(mfac, flist);
+                if (mtrial.degree() > deg) { // this test is sometimes wrong
+                    logger.info("degree > deg " + deg + ", degree = " + mtrial.degree());
+                    //continue;
+                }
+                GenPolynomial<BigInteger> trial = PolyUtil.integerFromModularCoefficients(pfac, mtrial);
+                trial = engine.basePrimitivePart(trial);
+                //if ( ! isPrimitive ) {
+                //}
+                if (debug) {
+                    logger.info("trial    = " + trial); // + ", mtrial = " + mtrial);
+                }
+                if (PolyUtil.<BigInteger> baseSparsePseudoRemainder(ui, trial).isZERO()) {
+                    logger.info("successful trial = " + trial);
+                    factors.add(trial);
+                    ui = PolyUtil.<BigInteger> basePseudoDivide(ui, trial);
+                    //System.out.println("ui        = " + ui);
+                    mlift = removeOnce(mlift, flist);
+                    logger.info("new mlift= " + mlift);
+                    //System.out.println("dl = " + dl); 
+                    if (mlift.size() > 1) {
+                        dl = (mlift.size() + 1) / 2;
+                        j = 0; // since j++
+                        break;
+                    }
+                    logger.info("last factor = " + ui);
+                    factors.add(ui);
+                    if (cfactors != null) {
+                        cfactors.addAll(factors);
+                        factors = cfactors;
+                    }
+                    return normalizeFactorization(factors);
+                }
+            }
+        }
+        if (!ui.isONE() && !ui.equals(pd)) {
+            logger.info("rest factor = " + ui);
+            // pp(ui) ?? no ??
+            factors.add(ui);
+        }
+        if (factors.size() == 0) {
+            logger.info("irreducible P = " + P);
+            factors.add(pd); // P
+        }
+        if (cfactors != null) {
+            cfactors.addAll(factors);
+            factors = cfactors;
+        }
+        return normalizeFactorization(factors);
+    }
+
+
+    /**
+     * Test if b has a prime factor different to the elements of A.
+     * @param A list of integer with at least one different prime factor.
+     * @param b integer to test with A.
+     * @return true, if b hase a prime factor different to elements of A
+     */
+    boolean testSeparate(List<BigInteger> A, BigInteger b) {
+        int i = 0;
+        //List<BigInteger> gei = new ArrayList<BigInteger>(A.size());
+        for (BigInteger c : A) {
+            BigInteger g = c.gcd(b).abs();
+            //gei.add(g);
+            if (!g.isONE()) {
+                i++;
+            }
+        }
+        //if ( i >= 1 ) {
+        //System.out.println("gei = " + gei + ", cei = " + cei + ", pec(w) = " + pec);
+        //}
+        return (i <= 1);
+    }
+
+
+    // not useable
+    boolean isNearlySquarefree(GenPolynomial<BigInteger> P) { // unused
+        // in main variable
+        GenPolynomialRing<BigInteger> pfac = P.ring;
+        if (pfac.nvar >= 0) { // allways true
+            return sengine.isSquarefree(P);
+        }
+        GenPolynomialRing<GenPolynomial<BigInteger>> rfac = pfac.recursive(1);
+        GenPolynomial<GenPolynomial<BigInteger>> Pr = PolyUtil.<BigInteger> recursive(rfac, P);
+        GenPolynomial<GenPolynomial<BigInteger>> Ps = PolyUtil.<BigInteger> recursiveDeriviative(Pr);
+        System.out.println("Pr = " + Pr);
+        System.out.println("Ps = " + Ps);
+        GenPolynomial<GenPolynomial<BigInteger>> g = engine.recursiveUnivariateGcd(Pr, Ps);
+        System.out.println("g_m = " + g);
+        if (!g.isONE()) {
+            return false;
+        }
+        // in lowest variable
+        rfac = pfac.recursive(pfac.nvar - 1);
+        Pr = PolyUtil.<BigInteger> recursive(rfac, P);
+        Pr = PolyUtil.<BigInteger> switchVariables(Pr);
+        Ps = PolyUtil.<BigInteger> recursiveDeriviative(Pr);
+        System.out.println("Pr = " + Pr);
+        System.out.println("Ps = " + Ps);
+        g = engine.recursiveUnivariateGcd(Pr, Ps);
+        System.out.println("g_1 = " + g);
+        if (!g.isONE()) {
+            return false;
+        }
+        return true;
+    }
+
+}
+
+
+/**
+ * Container for factorization trial lifting parameters.
+ */
+class TrialParts {
+
+
+    /**
+     * evaluation points
+     */
+    public final List<BigInteger> evalPoints;
+
+
+    /**
+     * univariate polynomial
+     */
+    public final GenPolynomial<BigInteger> univPoly;
+
+
+    /**
+     * irreducible factors of univariate polynomial
+     */
+    public final List<GenPolynomial<BigInteger>> univFactors;
+
+
+    /**
+     * irreducible factors of leading coefficient
+     */
+    public final List<GenPolynomial<BigInteger>> ldcfFactors;
+
+
+    /**
+     * evaluated factors of leading coefficient factors by evaluation points
+     */
+    public final List<BigInteger> ldcfEval;
+
+
+    /**
+     * Constructor.
+     * @param ev evaluation points.
+     * @param up univariate polynomial.
+     * @param uf irreducible factors of up.
+     * @param le irreducible factors of leading coefficient.
+     * @param lf evaluated le by evaluation points.
+     */
+    public TrialParts(List<BigInteger> ev, GenPolynomial<BigInteger> up, List<GenPolynomial<BigInteger>> uf,
+                      List<BigInteger> le, List<GenPolynomial<BigInteger>> lf) {
+        evalPoints = ev;
+        univPoly = up;
+        univFactors = uf;
+        //ldcfPoly = lp;
+        ldcfFactors = lf;
+        ldcfEval = le;
+    }
+
+
+    /**
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        sb.append("TrialParts[");
+        sb.append("evalPoints = " + evalPoints);
+        sb.append(", univPoly = " + univPoly);
+        sb.append(", univFactors = " + univFactors);
+        sb.append(", ldcfEval = " + ldcfEval);
+        sb.append(", ldcfFactors = " + ldcfFactors);
+        sb.append("]");
+        return sb.toString();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/FactorModular.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/FactorModular.java
@@ -1,0 +1,236 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.arith.BigInteger;
+import edu.jas.arith.ModLongRing;
+import edu.jas.arith.Modular;
+import edu.jas.arith.ModularRingFactory;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.Power;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Modular coefficients factorization algorithms. This class implements
+ * factorization methods for polynomials over (prime) modular integers.
+ * @author Heinz Kredel
+ */
+
+public class FactorModular<MOD extends GcdRingElem<MOD> & Modular> extends FactorAbsolute<MOD> {
+
+
+    private static final Logger logger = LogManager.getLogger(FactorModular.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * No argument constructor, do not use.
+     */
+    @SuppressWarnings({ "unchecked", "unused" })
+    private FactorModular() {
+        this((RingFactory<MOD>) (Object) new ModLongRing(13, true)); // hack, 13 unimportant
+    }
+
+
+    /**
+     * Constructor.
+     * @param cfac coefficient ring factory.
+     */
+    public FactorModular(RingFactory<MOD> cfac) {
+        super(cfac);
+    }
+
+
+    /**
+     * GenPolynomial base distinct degree factorization.
+     * @param P squarefree and monic GenPolynomial.
+     * @return [e_1 -&gt; p_1, ..., e_k -&gt; p_k] with P = prod_{i=1,...,k} p_i
+     *         and p_i has only irreducible factors of degree e_i.
+     */
+    public SortedMap<Long, GenPolynomial<MOD>> baseDistinctDegreeFactors(GenPolynomial<MOD> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P != null");
+        }
+        SortedMap<Long, GenPolynomial<MOD>> facs = new TreeMap<Long, GenPolynomial<MOD>>();
+        if (P.isZERO()) {
+            return facs;
+        }
+        GenPolynomialRing<MOD> pfac = P.ring;
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException(
+                            this.getClass().getName() + " only for univariate polynomials");
+        }
+        ModularRingFactory<MOD> mr = (ModularRingFactory<MOD>) pfac.coFac;
+        java.math.BigInteger m = mr.getIntegerModul().getVal();
+        //if (m.longValue() == 2L) {
+        //    logger.warn(this.getClass().getName() + " case p = 2 not implemented");
+        //}
+        GenPolynomial<MOD> x = pfac.univariate(0);
+        GenPolynomial<MOD> h = x;
+        GenPolynomial<MOD> f = P;
+        GenPolynomial<MOD> g;
+        Power<GenPolynomial<MOD>> pow = new Power<GenPolynomial<MOD>>(pfac);
+        long d = 0;
+        while (d + 1 <= f.degree(0) / 2) {
+            d++;
+            h = pow.modPower(h, m, f);
+            g = engine.gcd(h.subtract(x), f);
+            if (!g.isONE()) {
+                facs.put(d, g);
+                f = f.divide(g);
+            }
+        }
+        if (!f.isONE()) {
+            d = f.degree(0);
+            facs.put(d, f);
+        }
+        return facs;
+    }
+
+
+    /**
+     * GenPolynomial base equal degree factorization.
+     * @param P squarefree and monic GenPolynomial.
+     * @param deg such that P has only irreducible factors of degree deg.
+     * @return [p_1,...,p_k] with P = prod_{i=1,...,r} p_i.
+     */
+    public List<GenPolynomial<MOD>> baseEqualDegreeFactors(GenPolynomial<MOD> P, long deg) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P != null");
+        }
+        List<GenPolynomial<MOD>> facs = new ArrayList<GenPolynomial<MOD>>();
+        if (P.isZERO()) {
+            return facs;
+        }
+        GenPolynomialRing<MOD> pfac = P.ring;
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException(
+                            this.getClass().getName() + " only for univariate polynomials");
+        }
+        if (P.degree(0) == deg) {
+            facs.add(P);
+            return facs;
+        }
+        ModularRingFactory<MOD> mr = (ModularRingFactory<MOD>) pfac.coFac;
+        java.math.BigInteger m = mr.getIntegerModul().getVal();
+        //System.out.println("m = " + m);
+        boolean p2 = false;
+        if (m.equals(java.math.BigInteger.valueOf(2L))) {
+            p2 = true;
+            //throw new RuntimeException(this.getClass().getName() + " case p = 2 not implemented");
+        }
+        GenPolynomial<MOD> one = pfac.getONE();
+        GenPolynomial<MOD> t = pfac.univariate(0, 1L);
+        GenPolynomial<MOD> r;
+        GenPolynomial<MOD> h;
+        GenPolynomial<MOD> f = P;
+        //GreatestCommonDivisor<MOD> engine = GCDFactory.<MOD> getImplementation(pfac.coFac);
+        Power<GenPolynomial<MOD>> pow = new Power<GenPolynomial<MOD>>(pfac);
+        GenPolynomial<MOD> g = null;
+        int degi = (int) deg; //f.degree(0);
+        //System.out.println("deg = " + deg);
+        BigInteger di = (new BigInteger(m)).power(deg);
+        //System.out.println("di = " + di);
+        java.math.BigInteger d = di.getVal(); //.longValue()-1;
+        //System.out.println("d = " + d);
+        d = d.shiftRight(1); // divide by 2
+        do {
+            if (p2) {
+                h = t;
+                for (int i = 1; i < degi; i++) {
+                    h = t.sum(h.multiply(h));
+                    h = h.remainder(f);
+                }
+                t = t.multiply(pfac.univariate(0, 2L));
+                //System.out.println("h = " + h);
+            } else {
+                r = pfac.random(17, degi, 2 * degi, 1.0f);
+                if (r.degree(0) >= f.degree(0)) {
+                    r = r.remainder(f);
+                }
+                r = r.monic();
+                //System.out.println("r = " + r);
+                h = pow.modPower(r, d, f).subtract(one);
+                degi++;
+            }
+            g = engine.gcd(h, f);
+            //System.out.println("g = " + g);
+        } while (g.degree(0) == 0 || g.degree(0) == f.degree(0));
+        f = f.divide(g);
+        facs.addAll(baseEqualDegreeFactors(f, deg));
+        facs.addAll(baseEqualDegreeFactors(g, deg));
+        return facs;
+    }
+
+
+    /**
+     * GenPolynomial base factorization of a squarefree polynomial.
+     * @param P squarefree and monic! GenPolynomial.
+     * @return [p_1,...,p_k] with P = prod_{i=1,...,r} p_i.
+     */
+    @Override
+    public List<GenPolynomial<MOD>> baseFactorsSquarefree(GenPolynomial<MOD> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P == null");
+        }
+        List<GenPolynomial<MOD>> factors = new ArrayList<GenPolynomial<MOD>>();
+        if (P.isZERO()) {
+            return factors;
+        }
+        if (P.isONE()) {
+            factors.add(P);
+            return factors;
+        }
+        GenPolynomialRing<MOD> pfac = P.ring;
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException(
+                            this.getClass().getName() + " only for univariate polynomials");
+        }
+        if (!P.leadingBaseCoefficient().isONE()) {
+            throw new IllegalArgumentException("ldcf(P) != 1: " + P);
+        }
+        SortedMap<Long, GenPolynomial<MOD>> dfacs = baseDistinctDegreeFactors(P);
+        if (debug) {
+            logger.info("dfacs    = " + dfacs);
+            //System.out.println("dfacs    = " + dfacs);
+        }
+        for (Map.Entry<Long, GenPolynomial<MOD>> me : dfacs.entrySet()) {
+            Long e = me.getKey();
+            GenPolynomial<MOD> f = me.getValue(); // dfacs.get(e);
+            List<GenPolynomial<MOD>> efacs = baseEqualDegreeFactors(f, e);
+            if (debug) {
+                logger.info("efacs " + e + "   = " + efacs);
+                //System.out.println("efacs " + e + "   = " + efacs);
+            }
+            factors.addAll(efacs);
+        }
+        //System.out.println("factors  = " + factors);
+        factors = PolyUtil.<MOD> monic(factors);
+        SortedSet<GenPolynomial<MOD>> ss = new TreeSet<GenPolynomial<MOD>>(factors);
+        //System.out.println("sorted   = " + ss);
+        factors.clear();
+        factors.addAll(ss);
+        return factors;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/FactorModularBerlekamp.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/FactorModularBerlekamp.java
@@ -1,0 +1,324 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.arith.ModLongRing;
+import edu.jas.arith.ModularRingFactory;
+import edu.jas.poly.AlgebraicNumberRing;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.Power;
+import edu.jas.structure.RingFactory;
+import edu.jas.vector.GenMatrix;
+import edu.jas.vector.GenMatrixRing;
+import edu.jas.vector.GenVector;
+import edu.jas.vector.GenVectorModul;
+import edu.jas.vector.LinAlg;
+
+
+/**
+ * Modular coefficients Berlekamp factorization algorithms. This class
+ * implements Berlekamp, Cantor and Zassenhaus factorization methods for
+ * polynomials over (prime) modular integers.
+ * @author Heinz Kredel
+ */
+
+public class FactorModularBerlekamp<MOD extends GcdRingElem<MOD>> extends FactorAbsolute<MOD> {
+
+
+    private static final Logger logger = LogManager.getLogger(FactorModularBerlekamp.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * No argument constructor, do not use.
+     */
+    @SuppressWarnings({ "unchecked", "unused" })
+    private FactorModularBerlekamp() {
+        this((RingFactory<MOD>) (Object) new ModLongRing(13, true)); // hack, 13 unimportant
+    }
+
+
+    /**
+     * Constructor.
+     * @param cfac coefficient ring factory.
+     */
+    public FactorModularBerlekamp(RingFactory<MOD> cfac) {
+        super(cfac);
+    }
+
+
+    /**
+     * GenPolynomial base factorization of a squarefree polynomial.
+     * @param P squarefree and monic! GenPolynomial.
+     * @return [p_1,...,p_k] with P = prod_{i=1,...,r} p_i.
+     */
+    @Override
+    public List<GenPolynomial<MOD>> baseFactorsSquarefree(GenPolynomial<MOD> P) {
+        if (P == null) {
+            throw new IllegalArgumentException("P == null not allowed");
+        }
+        //ModularRingFactory cfac = (ModularRingFactory) P.ring.coFac;
+        long q = P.ring.coFac.characteristic().longValueExact();
+        if (q < 100) { // todo, 32003 too high
+            return baseFactorsSquarefreeSmallPrime(P);
+        }
+        return baseFactorsSquarefreeBigPrime(P);
+    }
+
+
+    /**
+     * GenPolynomial base factorization of a squarefree polynomial. Small prime
+     * version of Berlekamps algorithm.
+     * @param P squarefree and monic! GenPolynomial.
+     * @return [p_1,...,p_k] with P = prod_{i=1,...,r} p_i.
+     */
+    @SuppressWarnings("unchecked")
+    public List<GenPolynomial<MOD>> baseFactorsSquarefreeSmallPrime(GenPolynomial<MOD> P) {
+        if (P == null) {
+            throw new IllegalArgumentException("P == null");
+        }
+        List<GenPolynomial<MOD>> factors = new ArrayList<GenPolynomial<MOD>>();
+        if (P.isZERO()) {
+            return factors;
+        }
+        GenPolynomialRing<MOD> pfac = P.ring;
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException("only for univariate polynomials");
+        }
+        if (!P.leadingBaseCoefficient().isONE()) {
+            throw new IllegalArgumentException("ldcf(P) != 1: " + P);
+        }
+        if (P.isONE() || P.degree(0) <= 1) {
+            factors.add(P);
+            return factors;
+        }
+        ArrayList<ArrayList<MOD>> Q = PolyUfdUtil.<MOD> constructQmatrix(P);
+        //System.out.println("Q = " + Q);
+        int n = Q.size();
+        int m = Q.get(0).size();
+        GenMatrixRing<MOD> mfac = new GenMatrixRing<MOD>(pfac.coFac, n, m);
+        GenMatrix<MOD> Qm = new GenMatrix<MOD>(mfac, Q);
+        GenMatrix<MOD> Qm1 = Qm.subtract(mfac.getONE());
+        //System.out.println("Qm1 = " + Qm1);
+        LinAlg<MOD> lu = new LinAlg<MOD>();
+        List<GenVector<MOD>> Nsb = lu.nullSpaceBasis(Qm1);
+        logger.info("Nsb = " + Nsb);
+        int k = Nsb.size();
+        if (k == 1) {
+            factors.add(P);
+            return factors;
+        }
+        //int d = (int) P.degree(0);
+        GenMatrix<MOD> Ns = mfac.fromVectors(Nsb);
+        GenMatrix<MOD> L1 = Ns.negate(); //mfac.getONE().subtract(Ns);
+        //System.out.println("L1 = " + L1);
+        List<GenPolynomial<MOD>> trials = new ArrayList<GenPolynomial<MOD>>();
+        for (int i = 0; i < L1.ring.rows; i++) {
+            GenVector<MOD> rv = L1.getRow(i);
+            GenPolynomial<MOD> rp = pfac.fromVector(rv);
+            if (!rp.isONE()) {
+                trials.add(rp);
+            }
+        }
+        logger.info("#ofFactors k = " + k);
+        logger.info("trials = " + trials);
+        factors.add(P);
+        for (GenPolynomial<MOD> t : trials) {
+            if (factors.size() == k) {
+                break;
+            }
+            //System.out.println("t = " + t);
+            // depth first search, since Iterator is finite
+            GenPolynomial<MOD> a = factors.remove(0);
+            //System.out.println("a = " + a);
+            MOD s = null;
+            Iterator<MOD> eit = null;
+            if (pfac.coFac instanceof ModularRingFactory) {
+                eit = ((ModularRingFactory) pfac.coFac).iterator();
+            } else if (pfac.coFac instanceof AlgebraicNumberRing) {
+                eit = ((AlgebraicNumberRing) pfac.coFac).iterator();
+            } else {
+                throw new IllegalArgumentException("no iterator for: " + pfac.coFac);
+            }
+            //System.out.println("eit = " + eit);
+            while (eit.hasNext()) {
+                s = eit.next();
+                //System.out.println("s = " + s);
+                GenPolynomial<MOD> v = t.subtract(s);
+                GenPolynomial<MOD> g = v.gcd(a);
+                if (g.isONE() || g.equals(a)) {
+                    continue;
+                }
+                factors.add(g);
+                a = a.divide(g);
+                logger.info("s = " + s + ", g = " + g + ", a = " + a);
+                if (a.isONE()) {
+                    break;
+                }
+            }
+            if (!a.isONE()) {
+                factors.add(a);
+            }
+        }
+        //System.out.println("factors  = " + factors);
+        factors = PolyUtil.<MOD> monic(factors);
+        SortedSet<GenPolynomial<MOD>> ss = new TreeSet<GenPolynomial<MOD>>(factors);
+        //System.out.println("sorted   = " + ss);
+        factors.clear();
+        factors.addAll(ss);
+        return factors;
+    }
+
+
+    /**
+     * GenPolynomial base factorization of a squarefree polynomial. Big prime
+     * version of Berlekamps algorithm.
+     * @param P squarefree and monic! GenPolynomial.
+     * @return [p_1,...,p_k] with P = prod_{i=1,...,r} p_i.
+     */
+    public List<GenPolynomial<MOD>> baseFactorsSquarefreeBigPrime(GenPolynomial<MOD> P) {
+        if (P == null) {
+            throw new IllegalArgumentException("P == null");
+        }
+        List<GenPolynomial<MOD>> factors = new ArrayList<GenPolynomial<MOD>>();
+        if (P.isZERO()) {
+            return factors;
+        }
+        GenPolynomialRing<MOD> pfac = P.ring;
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException("only for univariate polynomials");
+        }
+        if (!P.leadingBaseCoefficient().isONE()) {
+            throw new IllegalArgumentException("ldcf(P) != 1: " + P);
+        }
+        if (P.isONE() || P.degree(0) <= 1) {
+            factors.add(P);
+            return factors;
+        }
+        ArrayList<ArrayList<MOD>> Q = PolyUfdUtil.<MOD> constructQmatrix(P);
+        //System.out.println("Q = " + Q);
+        int n = Q.size();
+        int m = Q.get(0).size();
+        GenMatrixRing<MOD> mfac = new GenMatrixRing<MOD>(pfac.coFac, n, m);
+        GenMatrix<MOD> Qm = new GenMatrix<MOD>(mfac, Q);
+        GenMatrix<MOD> Qm1 = Qm.subtract(mfac.getONE());
+        //System.out.println("Qm1 = " + Qm1);
+        LinAlg<MOD> lu = new LinAlg<MOD>();
+        List<GenVector<MOD>> Nsb = lu.nullSpaceBasis(Qm1);
+        logger.info("Nsb = " + Nsb);
+        int k = Nsb.size();
+        if (k == 1) {
+            factors.add(P);
+            return factors;
+        }
+        //int d = (int) P.degree(0);
+        GenMatrix<MOD> Ns = mfac.fromVectors(Nsb);
+        GenMatrix<MOD> L1 = Ns.negate(); //mfac.getONE().subtract(Ns);
+        //System.out.println("L1 = " + L1);
+        List<GenPolynomial<MOD>> trials = new ArrayList<GenPolynomial<MOD>>();
+        for (int i = 0; i < L1.ring.rows; i++) {
+            GenVector<MOD> rv = L1.getRow(i);
+            GenPolynomial<MOD> rp = pfac.fromVector(rv);
+            trials.add(rp);
+        }
+        logger.info("#ofFactors k = " + k);
+        logger.info("trials = " + trials);
+        factors.add(P);
+        GenVectorModul<MOD> vfac = new GenVectorModul<MOD>(pfac.coFac, k);
+        //long q = pfac.coFac.characteristic().longValueExact();
+        //long lq = Power.logarithm(2, q);
+        java.math.BigInteger q = pfac.coFac.characteristic(); //.longValueExact();
+        int lq = q.bitLength(); //Power.logarithm(2, q);
+        if (pfac.coFac instanceof AlgebraicNumberRing) {
+            lq = (int) ((AlgebraicNumberRing) pfac.coFac).extensionDegree();
+            q = q.pow(lq); //Power.power(q, lq);
+        }
+        logger.info("char = " + pfac.coFac.characteristic() + ", q = " + q + ", lq = " + lq);
+        do {
+            // breadth first search, since some a might be irreducible
+            GenPolynomial<MOD> a = factors.remove(0);
+            //System.out.println("a = " + a);
+            if (a.degree(0) <= 1) {
+                factors.add(a);
+                continue;
+            }
+            GenVector<MOD> rv = vfac.random(8, 0.95f);
+            //System.out.println("rv = " + rv.toScript());
+            GenPolynomial<MOD> rpol = pfac.getZERO();
+            int i = 0;
+            for (GenPolynomial<MOD> t : trials) {
+                MOD c = rv.get(i++);
+                GenPolynomial<MOD> s = t.multiply(c);
+                rpol = rpol.sum(s);
+            }
+            rpol = rpol.monic();
+            if (rpol.isONE()) {
+                factors.add(a);
+                continue;
+            }
+            //System.out.println("rpol = " + rpol.toScript());
+            if (!q.testBit(0)) { // q % 2 == 0
+                long e = lq - 1;
+                //System.out.println("q = " + q + ", e = " + e);
+                GenPolynomial<MOD> pow = rpol;
+                GenPolynomial<MOD> v = rpol;
+                for (int l = 1; l < e; l++) {
+                    pow = pow.multiply(pow).remainder(a);
+                    v = v.sum(pow);
+                }
+                rpol = v.remainder(a).monic(); // automatic monic
+                //System.out.println("sum_l rpol^l = " + rpol.toScript());
+            } else {
+                //long e = (q - 1) / 2;
+                java.math.BigInteger e = q.subtract(java.math.BigInteger.ONE).shiftRight(1);
+                //System.out.println("q = " + q + ", e = " + e);
+                GenPolynomial<MOD> pow = Power.<GenPolynomial<MOD>> modPositivePower(rpol, e, a);
+                rpol = pow.subtract(pfac.getONE()).monic();
+                //System.out.println("rpol^e-1 = " + rpol.toScript());
+            }
+            if (rpol.isZERO() || rpol.isONE()) {
+                factors.add(a);
+                continue;
+            }
+            GenPolynomial<MOD> g = rpol.gcd(a);
+            if (g.isONE()) {
+                factors.add(a);
+                continue;
+            }
+            factors.add(g);
+            //System.out.println("a = " + a);
+            a = a.divide(g);
+            logger.info("rv = " + rv + ", g = " + g + ", a/g = " + a);
+            if (!a.isONE()) {
+                factors.add(a);
+            }
+            //System.out.println("factors  = " + factors);
+        } while (factors.size() < k);
+
+        //System.out.println("factors  = " + factors);
+        factors = PolyUtil.<MOD> monic(factors);
+        SortedSet<GenPolynomial<MOD>> ss = new TreeSet<GenPolynomial<MOD>>(factors);
+        //System.out.println("sorted   = " + ss);
+        factors.clear();
+        factors.addAll(ss);
+        return factors;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/FactorQuotient.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/FactorQuotient.java
@@ -1,0 +1,140 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Rational function coefficients factorization algorithms. This class
+ * implements factorization methods for polynomials over rational functions,
+ * that is, with coefficients from class <code>application.Quotient</code>.
+ * @author Heinz Kredel
+ */
+
+public class FactorQuotient<C extends GcdRingElem<C>> extends FactorAbstract<Quotient<C>> {
+
+
+    private static final Logger logger = LogManager.getLogger(FactorQuotient.class);
+
+
+    //private static final boolean debug = logger.isInfoEnabled();
+
+
+    /**
+     * Factorization engine for normal coefficients.
+     */
+    protected final FactorAbstract<C> nengine;
+
+
+    /**
+     * No argument constructor.
+     */
+    protected FactorQuotient() {
+        throw new IllegalArgumentException("don't use this constructor");
+    }
+
+
+    /**
+     * Constructor.
+     * @param fac coefficient quotient ring factory.
+     */
+    public FactorQuotient(QuotientRing<C> fac) {
+        this(fac, FactorFactory.<C> getImplementation(fac.ring.coFac));
+    }
+
+
+    /**
+     * Constructor.
+     * @param fac coefficient quotient ring factory.
+     * @param nengine factorization engine for polynomials over base
+     *            coefficients.
+     */
+    public FactorQuotient(QuotientRing<C> fac, FactorAbstract<C> nengine) {
+        super(fac);
+        this.nengine = nengine;
+    }
+
+
+    /**
+     * GenPolynomial base factorization of a squarefree polynomial.
+     * @param P squarefree GenPolynomial.
+     * @return [p_1,...,p_k] with P = prod_{i=1, ..., k} p_i.
+     */
+    @Override
+    public List<GenPolynomial<Quotient<C>>> baseFactorsSquarefree(GenPolynomial<Quotient<C>> P) {
+        return factorsSquarefree(P);
+    }
+
+
+    /**
+     * GenPolynomial factorization of a squarefree polynomial.
+     * @param P squarefree GenPolynomial.
+     * @return [p_1,...,p_k] with P = prod_{i=1, ..., k} p_i.
+     */
+    @Override
+    public List<GenPolynomial<Quotient<C>>> factorsSquarefree(GenPolynomial<Quotient<C>> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P == null");
+        }
+        //System.out.println("factorsSquarefree, P = " + P);
+        List<GenPolynomial<Quotient<C>>> factors = new ArrayList<GenPolynomial<Quotient<C>>>();
+        if (P.isZERO()) {
+            return factors;
+        }
+        if (P.isONE()) {
+            factors.add(P);
+            return factors;
+        }
+        GenPolynomialRing<Quotient<C>> pfac = P.ring;
+        GenPolynomial<Quotient<C>> Pr = P;
+        Quotient<C> ldcf = P.leadingBaseCoefficient();
+        if (!ldcf.isONE()) {
+            //System.out.println("ldcf = " + ldcf);
+            Pr = Pr.monic();
+        }
+        QuotientRing<C> qi = (QuotientRing<C>) pfac.coFac;
+        GenPolynomialRing<C> ci = qi.ring;
+        GenPolynomialRing<GenPolynomial<C>> ifac = new GenPolynomialRing<GenPolynomial<C>>(ci, pfac);
+        GenPolynomial<GenPolynomial<C>> Pi = PolyUfdUtil.<C> integralFromQuotientCoefficients(ifac, Pr);
+        //System.out.println("Pi = " + Pi);
+
+        // factor in C[x_1,...,x_n][y_1,...,y_m]
+        List<GenPolynomial<GenPolynomial<C>>> irfacts = nengine.recursiveFactorsSquarefree(Pi);
+        if (logger.isInfoEnabled()) {
+            logger.info("irfacts = " + irfacts);
+        }
+        if (irfacts.size() <= 1) {
+            factors.add(P);
+            return factors;
+        }
+        List<GenPolynomial<Quotient<C>>> qfacts = PolyUfdUtil.<C> quotientFromIntegralCoefficients(pfac,
+                        irfacts);
+        //System.out.println("qfacts = " + qfacts);
+        //qfacts = PolyUtil.monic(qfacts);
+        //System.out.println("qfacts = " + qfacts);
+        if (!ldcf.isONE()) {
+            GenPolynomial<Quotient<C>> r = qfacts.get(0);
+            qfacts.remove(r);
+            r = r.multiply(ldcf);
+            qfacts.add(0, r);
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("qfacts = " + qfacts);
+        }
+        factors.addAll(qfacts);
+        return factors;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/FactorRational.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/FactorRational.java
@@ -1,0 +1,222 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.arith.BigInteger;
+import edu.jas.arith.BigRational;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+
+
+/**
+ * Rational number coefficients factorization algorithms. This class implements
+ * factorization methods for polynomials over rational numbers.
+ * @author Heinz Kredel
+ */
+
+public class FactorRational extends FactorAbsolute<BigRational> {
+
+
+    private static final Logger logger = LogManager.getLogger(FactorRational.class);
+
+
+    private static final boolean debug = logger.isInfoEnabled();
+
+
+    /**
+     * Factorization engine for integer base coefficients.
+     */
+    protected final FactorAbstract<BigInteger> iengine;
+
+
+    /**
+     * No argument constructor.
+     */
+    protected FactorRational() {
+        super(BigRational.ONE);
+        iengine = FactorFactory.getImplementation(BigInteger.ONE);
+    }
+
+
+    /**
+     * GenPolynomial base factorization of a squarefree polynomial.
+     * @param P squarefree GenPolynomial.
+     * @return [p_1,...,p_k] with P = prod_{i=1, ..., k} p_i.
+     */
+    @Override
+    public List<GenPolynomial<BigRational>> baseFactorsSquarefree(GenPolynomial<BigRational> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P == null");
+        }
+        List<GenPolynomial<BigRational>> factors = new ArrayList<GenPolynomial<BigRational>>();
+        if (P.isZERO()) {
+            return factors;
+        }
+        if (P.isONE()) {
+            factors.add(P);
+            return factors;
+        }
+        GenPolynomialRing<BigRational> pfac = P.ring;
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException(
+                            this.getClass().getName() + " only for univariate polynomials");
+        }
+        GenPolynomial<BigRational> Pr = P;
+        BigRational ldcf = P.leadingBaseCoefficient();
+        if (!ldcf.isONE()) {
+            //System.out.println("ldcf = " + ldcf);
+            Pr = Pr.monic();
+        }
+        BigInteger bi = BigInteger.ONE;
+        GenPolynomialRing<BigInteger> ifac = new GenPolynomialRing<BigInteger>(bi, pfac);
+        GenPolynomial<BigInteger> Pi = PolyUtil.integerFromRationalCoefficients(ifac, Pr);
+        if (debug) {
+            logger.info("Pi = " + Pi);
+        }
+        List<GenPolynomial<BigInteger>> ifacts = iengine.baseFactorsSquarefree(Pi);
+        if (logger.isInfoEnabled()) {
+            logger.info("ifacts = " + ifacts);
+        }
+        if (ifacts.size() <= 1) {
+            factors.add(P);
+            return factors;
+        }
+        List<GenPolynomial<BigRational>> rfacts = PolyUtil.fromIntegerCoefficients(pfac, ifacts);
+        //System.out.println("rfacts = " + rfacts);
+        rfacts = PolyUtil.monic(rfacts);
+        //System.out.println("rfacts = " + rfacts);
+        if (!ldcf.isONE()) {
+            GenPolynomial<BigRational> r = rfacts.get(0);
+            rfacts.remove(r);
+            r = r.multiply(ldcf);
+            rfacts.set(0, r);
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("rfacts = " + rfacts);
+        }
+        factors.addAll(rfacts);
+        return factors;
+    }
+
+
+    /**
+     * GenPolynomial factorization of a squarefree polynomial.
+     * @param P squarefree GenPolynomial.
+     * @return [p_1,...,p_k] with P = prod_{i=1, ..., k} p_i.
+     */
+    @Override
+    public List<GenPolynomial<BigRational>> factorsSquarefree(GenPolynomial<BigRational> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P == null");
+        }
+        List<GenPolynomial<BigRational>> factors = new ArrayList<GenPolynomial<BigRational>>();
+        if (P.isZERO()) {
+            return factors;
+        }
+        if (P.isONE()) {
+            factors.add(P);
+            return factors;
+        }
+        GenPolynomialRing<BigRational> pfac = P.ring;
+        if (pfac.nvar == 1) {
+            return baseFactorsSquarefree(P);
+        }
+        GenPolynomial<BigRational> Pr = P;
+        BigRational ldcf = P.leadingBaseCoefficient();
+        if (!ldcf.isONE()) {
+            //System.out.println("ldcf = " + ldcf);
+            Pr = Pr.monic();
+        }
+        BigInteger bi = BigInteger.ONE;
+        GenPolynomialRing<BigInteger> ifac = new GenPolynomialRing<BigInteger>(bi, pfac);
+        GenPolynomial<BigInteger> Pi = PolyUtil.integerFromRationalCoefficients(ifac, Pr);
+        if (debug) {
+            logger.info("Pi = " + Pi);
+        }
+        List<GenPolynomial<BigInteger>> ifacts = iengine.factorsSquarefree(Pi);
+        if (logger.isInfoEnabled()) {
+            logger.info("ifacts = " + ifacts);
+        }
+        if (ifacts.size() <= 1) {
+            factors.add(P);
+            return factors;
+        }
+        List<GenPolynomial<BigRational>> rfacts = PolyUtil.fromIntegerCoefficients(pfac, ifacts);
+        //System.out.println("rfacts = " + rfacts);
+        rfacts = PolyUtil.monic(rfacts);
+        //System.out.println("rfacts = " + rfacts);
+        if (!ldcf.isONE()) {
+            GenPolynomial<BigRational> r = rfacts.get(0);
+            rfacts.remove(r);
+            r = r.multiply(ldcf);
+            rfacts.set(0, r);
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("rfacts = " + rfacts);
+        }
+        factors.addAll(rfacts);
+        return factors;
+    }
+
+
+    /**
+     * GenPolynomial factorization of a polynomial.
+     * @param P GenPolynomial.
+     * @return [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with P = prod_{i=1,...,k}
+     *         p_i**e_i and p_i irreducible.
+     */
+    @Override
+    public SortedMap<GenPolynomial<BigRational>, Long> factors(GenPolynomial<BigRational> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P == null");
+        }
+        GenPolynomialRing<BigRational> pfac = P.ring;
+        SortedMap<GenPolynomial<BigRational>, Long> factors = new TreeMap<GenPolynomial<BigRational>, Long>(
+                        pfac.getComparator());
+        if (P.isZERO()) {
+            return factors;
+        }
+        if (P.isONE()) {
+            factors.put(P, 1L);
+            return factors;
+        }
+        if (pfac.nvar == 1) {
+            return baseFactors(P);
+        }
+        GenPolynomial<BigRational> Pr = P;
+        BigInteger bi = BigInteger.ONE;
+        GenPolynomialRing<BigInteger> ifac = new GenPolynomialRing<BigInteger>(bi, pfac);
+        GenPolynomial<BigInteger> Pi = PolyUtil.integerFromRationalCoefficients(ifac, Pr);
+        if (debug) {
+            logger.info("Pi = " + Pi);
+        }
+        SortedMap<GenPolynomial<BigInteger>, Long> ifacts = iengine.factors(Pi);
+        if (logger.isInfoEnabled()) {
+            logger.info("ifacts = " + ifacts);
+        }
+        for (Map.Entry<GenPolynomial<BigInteger>, Long> me : ifacts.entrySet()) {
+            GenPolynomial<BigInteger> g = me.getKey();
+            if (g.isONE()) { // skip 1
+                continue;
+            }
+            Long d = me.getValue(); // facs.get(g);
+            GenPolynomial<BigRational> rp = PolyUtil.fromIntegerCoefficients(pfac, g);
+            factors.put(rp, d);
+        }
+        return factors;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/Factorization.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/Factorization.java
@@ -1,0 +1,133 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.SortedMap;
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Factorization algorithms interface.
+ * <p>
+ * <b>Usage:</b> To create objects that implement the <code>Factorization</code>
+ * interface use the <code>FactorFactory</code>. It will select an appropriate
+ * implementation based on the types of polynomial coefficients C. To obtain an
+ * implementation use <code>getImplementation()</code>, it returns an object of
+ * a class which extends the <code>FactorAbstract</code> class which implements
+ * the <code>Factorization</code> interface.
+ * <p>
+ * 
+ * <pre>
+ * Factorization&lt;CT&gt; engine;
+ * engine = FactorFactory.&lt;CT&gt; getImplementation(cofac);
+ * c = engine.factors(a);
+ * </pre>
+ * <p>
+ * For example, if the coefficient type is BigInteger, the usage looks like
+ * 
+ * <pre>
+ * BigInteger cofac = new BigInteger();
+ * Factorization&lt;BigInteger&gt; engine;
+ * engine = FactorFactory.getImplementation(cofac);
+ * Sm = engine.factors(poly);
+ * </pre>
+ * 
+ * @author Heinz Kredel
+ * @see edu.jas.ufd.FactorFactory#getImplementation
+ */
+
+public interface Factorization<C extends GcdRingElem<C>> extends Serializable {
+
+
+    /**
+     * GenPolynomial test if is irreducible.
+     * @param P GenPolynomial.
+     * @return true if P is irreducible, else false.
+     */
+    public boolean isIrreducible(GenPolynomial<C> P);
+
+
+    /**
+     * GenPolynomial test if a non trivial factorization exsists.
+     * @param P GenPolynomial.
+     * @return true if P is reducible, else false.
+     */
+    public boolean isReducible(GenPolynomial<C> P);
+
+
+    /**
+     * GenPolynomial test if is squarefree.
+     * @param P GenPolynomial.
+     * @return true if P is squarefree, else false.
+     */
+    public boolean isSquarefree(GenPolynomial<C> P);
+
+
+    /**
+     * GenPolynomial factorization of a squarefree polynomial.
+     * @param P squarefree and primitive! or monic! GenPolynomial.
+     * @return [p_1,...,p_k] with P = prod_{i=1,...,r} p_i.
+     */
+    public List<GenPolynomial<C>> factorsSquarefree(GenPolynomial<C> P);
+
+
+    /**
+     * GenPolynomial factorization.
+     * @param P GenPolynomial.
+     * @return [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with P = prod_{i=1,...,k}
+     *         p_i**e_i.
+     */
+    public SortedMap<GenPolynomial<C>, Long> factors(GenPolynomial<C> P);
+
+
+    /**
+     * GenPolynomial factorization ignoring multiplicities.
+     * @param P GenPolynomial.
+     * @return [p_1, ..., p_k] with P = prod_{i=1,...,k} p_i**{e_i} for some
+     *         e_i.
+     */
+    public List<GenPolynomial<C>> factorsRadical(GenPolynomial<C> P);
+
+
+    /**
+     * GenPolynomial greatest squarefree divisor.
+     * @param P GenPolynomial.
+     * @return squarefree(P).
+     */
+    public GenPolynomial<C> squarefreePart(GenPolynomial<C> P);
+
+
+    /**
+     * GenPolynomial squarefree factorization.
+     * @param P GenPolynomial.
+     * @return [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with P = prod_{i=1,...,k}
+     *         p_i^{e_i} and p_i squarefree.
+     */
+    public SortedMap<GenPolynomial<C>, Long> squarefreeFactors(GenPolynomial<C> P);
+
+
+    /**
+     * GenPolynomial is factorization.
+     * @param P GenPolynomial
+     * @param F = [p_1,...,p_k].
+     * @return true if P = prod_{i=1,...,r} p_i, else false.
+     */
+    public boolean isFactorization(GenPolynomial<C> P, List<GenPolynomial<C>> F);
+
+
+    /**
+     * GenPolynomial is factorization.
+     * @param P GenPolynomial.
+     * @param F = [p_1 -&gt; e_1, ..., p_k -&gt; e_k].
+     * @return true if P = prod_{i=1,...,k} p_i**e_i , else false.
+     */
+    public boolean isFactorization(GenPolynomial<C> P, SortedMap<GenPolynomial<C>, Long> F);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/Factors.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/Factors.java
@@ -1,0 +1,378 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.AlgebraicNumberRing;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolynomialList;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Container for the factors of absolute factorization.
+ * @author Heinz Kredel
+ * @param <C> coefficient type
+ */
+
+public class Factors<C extends GcdRingElem<C>> implements Comparable<Factors<C>>, Serializable {
+
+
+    /**
+     * Original (irreducible) polynomial to be factored with coefficients from
+     * C.
+     */
+    public final GenPolynomial<C> poly;
+
+
+    /**
+     * Algebraic field extension over C. Should be null, if p is absolutely
+     * irreducible.
+     */
+    public final AlgebraicNumberRing<C> afac;
+
+
+    /**
+     * Original polynomial to be factored with coefficients from
+     * AlgebraicNumberRing&lt;C&gt;. Should be null, if p is absolutely
+     * irreducible.
+     */
+    public final GenPolynomial<AlgebraicNumber<C>> apoly;
+
+
+    /**
+     * List of factors with coefficients from AlgebraicNumberRing&lt;C&gt;.
+     * Should be null, if p is absolutely irreducible.
+     */
+    public final List<GenPolynomial<AlgebraicNumber<C>>> afactors;
+
+
+    /**
+     * List of factors with coefficients from
+     * AlgebraicNumberRing&lt;AlgebraicNumber&lt;C&gt;&gt;. Should be null, if p
+     * is absolutely irreducible.
+     */
+    public final List<Factors<AlgebraicNumber<C>>> arfactors;
+
+
+    /**
+     * Constructor.
+     * @param p absolute irreducible GenPolynomial.
+     */
+    public Factors(GenPolynomial<C> p) {
+        this(p, null, null, null, null);
+    }
+
+
+    /**
+     * Constructor.
+     * @param p irreducible GenPolynomial over C.
+     * @param af algebraic extension field of C where p has factors from afact.
+     * @param ap GenPolynomial p represented with coefficients from af.
+     * @param afact absolute irreducible factors of p with coefficients from af.
+     */
+    public Factors(GenPolynomial<C> p, AlgebraicNumberRing<C> af, GenPolynomial<AlgebraicNumber<C>> ap,
+                    List<GenPolynomial<AlgebraicNumber<C>>> afact) {
+        this(p, af, ap, afact, null);
+    }
+
+
+    /**
+     * Constructor.
+     * @param p irreducible GenPolynomial over C.
+     * @param af algebraic extension field of C where p has factors from afact.
+     * @param ap GenPolynomial p represented with coefficients from af.
+     * @param afact absolute irreducible factors of p with coefficients from af.
+     * @param arfact further absolute irreducible factors of p with coefficients
+     *            from extensions of af.
+     */
+    public Factors(GenPolynomial<C> p, AlgebraicNumberRing<C> af, GenPolynomial<AlgebraicNumber<C>> ap,
+                    List<GenPolynomial<AlgebraicNumber<C>>> afact, List<Factors<AlgebraicNumber<C>>> arfact) {
+        poly = p;
+        afac = af;
+        apoly = ap;
+        afactors = afact;
+        arfactors = arfact;
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        sb.append(poly.toString());
+        if (afac == null) {
+            return sb.toString();
+        }
+        sb.append(" = ");
+        boolean first = true;
+        for (GenPolynomial<AlgebraicNumber<C>> ap : afactors) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append(", ");
+            }
+            sb.append(ap.toString());
+        }
+        sb.append("\n  ## over " + afac.toString() + "\n");
+        if (arfactors == null) {
+            return sb.toString();
+        }
+        first = true;
+        for (Factors<AlgebraicNumber<C>> arp : arfactors) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append(",\n");
+            }
+            sb.append(arp.toString());
+        }
+        return sb.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this container.
+     * @see edu.jas.structure.ElemFactory#toScript()
+     */
+    public String toScript() {
+        // Python case
+        StringBuffer sb = new StringBuffer();
+        //sb.append(poly.toScript());
+        if (afac == null) {
+            return sb.toString();
+        }
+        //sb.append(" =\n");
+        boolean first = true;
+        for (GenPolynomial<AlgebraicNumber<C>> ap : afactors) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append("\n * ");
+            }
+            //sb.append("( " + ap.toScript() + " )");
+            sb.append(ap.toScript());
+        }
+        sb.append("   #:: " + afac.toScript() + "");
+        if (arfactors == null) {
+            return sb.toString();
+        }
+        for (Factors<AlgebraicNumber<C>> arp : arfactors) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append("\n * ");
+            }
+            sb.append(arp.toScript());
+        }
+        return sb.toString();
+    }
+
+
+    /**
+     * Length. Number of factors.
+     * @return number of factors.
+     */
+    public int length() {
+        int i = 0;
+        if (afac == null) {
+            return i;
+        }
+        i += afactors.size();
+        if (arfactors == null) {
+            return i;
+        }
+        for (Factors<AlgebraicNumber<C>> f : arfactors) {
+            i += f.length();
+        }
+        return i;
+    }
+
+
+    /**
+     * Hash code for this Factors.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = poly.hashCode();
+        if (afac == null) {
+            return h;
+        }
+        h = (h << 27);
+        h += afac.hashCode();
+        if (afactors != null) {
+            h = (h << 27);
+            h += afactors.hashCode();
+        }
+        if (arfactors != null) {
+            h = (h << 27);
+            h += arfactors.hashCode();
+        }
+        return h;
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object B) {
+        if (B == null) {
+            return false;
+        }
+        if (!(B instanceof Factors)) {
+            return false;
+        }
+        Factors<C> a = (Factors<C>) B;
+        return this.compareTo(a) == 0;
+    }
+
+
+    /**
+     * Comparison.
+     * @param facs factors container.
+     * @return sign(this.poly-facs.poly) lexicographic &gt;
+     *         sign(afac.modul-facs.afac.modul) lexicographic &gt;
+     *         afactors.compareTo(facs.afactors) lexicographic &gt;
+     *         arfactors[i].compareTo(facs.arfactors[i])
+     */
+    public int compareTo(Factors<C> facs) {
+        int s = poly.compareTo(facs.poly);
+        //System.out.println("s1 = " + s); 
+        if (s != 0) {
+            return s;
+        }
+        if (afac == null) {
+            return -1;
+        }
+        if (facs.afac == null) {
+            return +1;
+        }
+        s = afac.modul.compareTo(facs.afac.modul);
+        //System.out.println("s2 = " + s); 
+        if (s != 0) {
+            return s;
+        }
+        GenPolynomialRing<AlgebraicNumber<C>> ar = afactors.get(0).ring;
+        GenPolynomialRing<AlgebraicNumber<C>> br = facs.afactors.get(0).ring;
+        PolynomialList<AlgebraicNumber<C>> ap = new PolynomialList<AlgebraicNumber<C>>(ar, afactors);
+        PolynomialList<AlgebraicNumber<C>> bp = new PolynomialList<AlgebraicNumber<C>>(br, facs.afactors);
+        s = ap.compareTo(bp);
+        //System.out.println("s3 = " + s); 
+        if (s != 0) {
+            return s;
+        }
+        if (arfactors == null && facs.arfactors == null) {
+            return 0;
+        }
+        if (arfactors == null) {
+            return -1;
+        }
+        if (facs.arfactors == null) {
+            return +1;
+        }
+        // lexicographic (?)
+        int i = 0;
+        for (Factors<AlgebraicNumber<C>> arp : arfactors) {
+            if (i >= facs.arfactors.size()) {
+                return +1;
+            }
+            Factors<AlgebraicNumber<C>> brp = facs.arfactors.get(i);
+            //System.out.println("arp = " + arp); 
+            //System.out.println("brp = " + brp); 
+            s = arp.compareTo(brp);
+            //System.out.println("s4 = " + s); 
+            if (s != 0) {
+                return s;
+            }
+            i++;
+        }
+        if (i < facs.arfactors.size()) {
+            return -1;
+        }
+        return 0;
+    }
+
+
+    /**
+     * Find largest extension field.
+     * @return largest extension field or null if no extension field
+     */
+    @SuppressWarnings("unchecked")
+    public AlgebraicNumberRing<C> findExtensionField() {
+        if (afac == null) {
+            return null;
+        }
+        if (arfactors == null) {
+            return afac;
+        }
+        AlgebraicNumberRing<C> arr = afac;
+        int depth = 1;
+        for (Factors<AlgebraicNumber<C>> af : arfactors) {
+            AlgebraicNumberRing<AlgebraicNumber<C>> aring = af.findExtensionField();
+            if (aring == null) {
+                continue;
+            }
+            int d = aring.depth();
+            if (d > depth) {
+                depth = d;
+                arr = (AlgebraicNumberRing<C>) (Object) aring;
+            }
+        }
+        return arr;
+    }
+
+
+    /**
+     * Get the list of factors at one level.
+     * @return list of algebraic factors
+     */
+    public List<GenPolynomial<AlgebraicNumber<C>>> getFactors() {
+        List<GenPolynomial<AlgebraicNumber<C>>> af = new ArrayList<GenPolynomial<AlgebraicNumber<C>>>();
+        if (afac == null) {
+            return af;
+        }
+        af.addAll(afactors);
+        if (arfactors == null) {
+            return af;
+        }
+        for (Factors<AlgebraicNumber<C>> arp : arfactors) {
+            af.add(arp.poly);
+        }
+        return af;
+    }
+
+
+    /**
+     * Get the factor for polynomial.
+     * @return algebraic factor
+     */
+    public Factors<AlgebraicNumber<C>> getFactor(GenPolynomial<AlgebraicNumber<C>> p) {
+        if (afac == null) {
+            return null;
+        }
+        for (Factors<AlgebraicNumber<C>> arp : arfactors) {
+            if (p.equals(arp.poly)) {
+                return arp;
+            }
+        }
+        return null;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/FactorsList.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/FactorsList.java
@@ -1,0 +1,158 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.io.Serializable;
+import java.util.List;
+
+import edu.jas.poly.AlgebraicNumberRing;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Container for the factors of a squarefree factorization.
+ * @author Heinz Kredel
+ * @param <C> coefficient type
+ */
+
+public class FactorsList<C extends GcdRingElem<C>> implements Serializable {
+
+
+    /**
+     * Original polynomial to be factored with coefficients from C.
+     */
+    public final GenPolynomial<C> poly;
+
+
+    /**
+     * List of factors with coefficients from C.
+     */
+    public final List<GenPolynomial<C>> factors;
+
+
+    /**
+     * List of factors with coefficients from AlgebraicNumberRings.
+     */
+    public final List<Factors<C>> afactors;
+
+
+    /**
+     * Constructor.
+     * @param p given GenPolynomial over C.
+     * @param list irreducible factors of p with coefficients from C.
+     */
+    public FactorsList(GenPolynomial<C> p, List<GenPolynomial<C>> list) {
+        this(p, list, null);
+    }
+
+
+    /**
+     * Constructor.
+     * @param p given GenPolynomial over C.
+     * @param list irreducible factors of p with coefficients from C.
+     * @param alist irreducible factors of p with coefficients from an algebraic
+     *            number field.
+     */
+    public FactorsList(GenPolynomial<C> p, List<GenPolynomial<C>> list, List<Factors<C>> alist) {
+        poly = p;
+        factors = list;
+        afactors = alist;
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        //sb.append(poly.toString());
+        //sb.append(" =\n");
+        boolean first = true;
+        for (GenPolynomial<C> p : factors) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append(",\n ");
+            }
+            sb.append(p.toString());
+        }
+        if (afactors == null) {
+            return sb.toString();
+        }
+        for (Factors<C> f : afactors) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append(",\n ");
+            }
+            sb.append(f.toString());
+        }
+        return sb.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this container.
+     * @see edu.jas.structure.ElemFactory#toScript()
+     */
+    public String toScript() {
+        // Python case
+        StringBuffer sb = new StringBuffer();
+        sb.append(poly.toScript());
+        sb.append(" =\n");
+        boolean first = true;
+        for (GenPolynomial<C> p : factors) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append("\n * ");
+            }
+            sb.append(p.toScript());
+        }
+        if (afactors == null) {
+            return sb.toString();
+        }
+        for (Factors<C> f : afactors) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append("\n * ");
+            }
+            sb.append(f.toScript());
+        }
+        return sb.toString();
+    }
+
+
+    /**
+     * Find largest extension field.
+     * @return largest extension field or null if no extension field
+     */
+    public AlgebraicNumberRing<C> findExtensionField() {
+        if (afactors == null) {
+            return null;
+        }
+        AlgebraicNumberRing<C> ar = null;
+        int depth = 0;
+        for (Factors<C> f : afactors) {
+            AlgebraicNumberRing<C> aring = f.findExtensionField();
+            if (aring == null) {
+                continue;
+            }
+            int d = aring.depth();
+            if (d > depth) {
+                depth = d;
+                ar = aring;
+            }
+        }
+        return ar;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/FactorsMap.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/FactorsMap.java
@@ -1,0 +1,207 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.io.Serializable;
+import java.util.SortedMap;
+import java.util.Map;
+
+import edu.jas.poly.AlgebraicNumberRing;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Container for the factors of a eventually non-squarefree factorization.
+ * @author Heinz Kredel
+ * @param <C> coefficient type
+ */
+
+public class FactorsMap<C extends GcdRingElem<C>> implements Serializable {
+
+
+    /**
+     * Original polynomial to be factored with coefficients from C.
+     */
+    public final GenPolynomial<C> poly;
+
+
+    /**
+     * List of factors with coefficients from C.
+     */
+    public final SortedMap<GenPolynomial<C>, Long> factors;
+
+
+    /**
+     * List of factors with coefficients from AlgebraicNumberRings.
+     */
+    public final SortedMap<Factors<C>, Long> afactors;
+
+
+    /**
+     * Constructor.
+     * @param p given GenPolynomial over C.
+     * @param map irreducible factors of p with coefficients from C.
+     */
+    public FactorsMap(GenPolynomial<C> p, SortedMap<GenPolynomial<C>, Long> map) {
+        this(p, map, null);
+    }
+
+
+    /**
+     * Constructor.
+     * @param p given GenPolynomial over C.
+     * @param map irreducible factors of p with coefficients from C.
+     * @param amap irreducible factors of p with coefficients from an algebraic
+     *            number field.
+     */
+    public FactorsMap(GenPolynomial<C> p, SortedMap<GenPolynomial<C>, Long> map,
+                    SortedMap<Factors<C>, Long> amap) {
+        poly = p;
+        factors = map;
+        afactors = amap;
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        sb.append(poly.toString());
+        sb.append(" =\n");
+        boolean first = true;
+        for (Map.Entry<GenPolynomial<C>,Long> me : factors.entrySet()) {
+            GenPolynomial<C> p = me.getKey();
+            if (first) {
+                first = false;
+            } else {
+                sb.append(",\n ");
+            }
+            sb.append(p.toString());
+            long e = me.getValue();
+            if (e > 1) {
+                sb.append("**" + e);
+            }
+        }
+        if (afactors == null) {
+            return sb.toString();
+        }
+        for (Map.Entry<Factors<C>,Long> me : afactors.entrySet()) {
+            Factors<C> f = me.getKey();
+            if (first) {
+                first = false;
+            } else {
+                sb.append(",\n ");
+            }
+            sb.append(f.toString());
+            Long e = me.getValue();
+            if (e == null) {
+                continue;
+            }
+            if (e > 1) {
+                sb.append("**" + e);
+            }
+        }
+        return sb.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this container.
+     * @see edu.jas.structure.ElemFactory#toScript()
+     */
+    public String toScript() {
+        // Python case
+        StringBuffer sb = new StringBuffer();
+        //sb.append(poly.toScript());
+        //sb.append(" =\n");
+        boolean first = true;
+        for (Map.Entry<GenPolynomial<C>,Long> me : factors.entrySet()) {
+            GenPolynomial<C> p = me.getKey();
+            if (first) {
+                first = false;
+            } else {
+                sb.append("\n * ");
+            }
+            sb.append(p.toScript());
+            long e = me.getValue();
+            if (e > 1) {
+                sb.append("**" + e);
+            }
+        }
+        if (afactors == null) {
+            return sb.toString();
+        }
+        for (Map.Entry<Factors<C>,Long> me : afactors.entrySet()) {
+            Factors<C> f = me.getKey();
+            if (first) {
+                first = false;
+            } else {
+                sb.append("\n * ");
+            }
+            Long e = me.getValue();
+            if (e == null) { // should not happen
+                System.out.println("f = " + f);
+                System.out.println("afactors = " + afactors);
+                throw new RuntimeException("this should not happen");
+            }
+            if (e == 1) {
+                sb.append(f.toScript());
+            } else {
+                sb.append("(\n");
+                sb.append(f.toScript());
+                sb.append("\n)**" + e);
+            }
+        }
+        return sb.toString();
+    }
+
+
+    /**
+     * Length. Number of factors.
+     * @return number of distinct factors.
+     */
+    public int length() {
+        int i = factors.keySet().size();
+        if (afactors == null) {
+            return i;
+        }
+        for (Factors<C> f : afactors.keySet()) {
+             i += f.length();
+        }
+        return i;
+    }
+
+
+    /**
+     * Find largest extension field.
+     * @return largest extension field or null if no extension field
+     */
+    public AlgebraicNumberRing<C> findExtensionField() {
+        if (afactors == null) {
+            return null;
+        }
+        AlgebraicNumberRing<C> ar = null;
+        int depth = 0;
+        for (Factors<C> f : afactors.keySet()) {
+            AlgebraicNumberRing<C> aring = f.findExtensionField();
+            if (aring == null) {
+                continue;
+            }
+            int d = aring.depth();
+            if (d > depth) {
+                depth = d;
+                ar = aring;
+            }
+        }
+        return ar;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/GCDFactory.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/GCDFactory.java
@@ -1,0 +1,341 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.arith.BigInteger;
+import edu.jas.arith.BigRational;
+import edu.jas.arith.ModInt;
+import edu.jas.arith.ModIntRing;
+import edu.jas.arith.ModInteger;
+import edu.jas.arith.ModIntegerRing;
+import edu.jas.arith.ModLong;
+import edu.jas.arith.ModLongRing;
+import edu.jas.kern.ComputerThreads;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Greatest common divisor algorithms factory. Select appropriate GCD engine
+ * based on the coefficient types.
+ * <p>
+ * <b>Usage:</b> To create objects that implement the
+ * <code>GreatestCommonDivisor</code> interface use the <code>GCDFactory</code>.
+ * It will select an appropriate implementation based on the types of polynomial
+ * coefficients C. There are two methods to obtain an implementation:
+ * <code>getProxy()</code> and <code>getImplementation()</code>.
+ * <code>getImplementation()</code> returns an object of a class which
+ * implements the <code>GreatestCommonDivisor</code> interface.
+ * <code>getProxy()</code> returns a proxy object of a class which implements
+ * the <code>GreatestCommonDivisor</code>r interface. The proxy will run two
+ * implementations in parallel, return the first computed result and cancel the
+ * second running task. On systems with one CPU the computing time will be two
+ * times the time of the fastest algorithm implmentation. On systems with more
+ * than two CPUs the computing time will be the time of the fastest algorithm
+ * implmentation.
+ * 
+ * <pre>
+ * GreatestCommonDivisor&lt;CT&gt; engine;
+ * engine = GCDFactory.&lt;CT&gt; getImplementation(cofac);
+ * or engine = GCDFactory.&lt;CT&gt; getProxy(cofac);
+ * c = engine.gcd(a, b);
+ * </pre>
+ * 
+ * <p>
+ * For example, if the coefficient type is <code>BigInteger</code>, the usage
+ * looks like
+ * 
+ * <pre>
+ * BigInteger cofac = new BigInteger();
+ * GreatestCommonDivisor&lt;BigInteger&gt; engine;
+ * engine = GCDFactory.getImplementation(cofac);
+ * or engine = GCDFactory.getProxy(cofac);
+ * c = engine.gcd(a, b);
+ * </pre>
+ *
+ * <p>
+ * <b>Todo:</b> Base decision also on degree vectors and number of variables of
+ * polynomials. Incorporate also number of CPUs / threads available (done with
+ * <code>GCDProxy</code>).
+ * 
+ * @author Heinz Kredel
+ * @see edu.jas.ufd.GreatestCommonDivisor#gcd(edu.jas.poly.GenPolynomial P,
+ *      edu.jas.poly.GenPolynomial S)
+ */
+
+public class GCDFactory {
+
+
+    private static final Logger logger = LogManager.getLogger(GCDFactory.class);
+
+
+    /**
+     * Protected factory constructor.
+     */
+    protected GCDFactory() {
+    }
+
+
+    /**
+     * Determine suitable implementation of gcd algorithms, case ModLong.
+     * @param fac ModLongRing.
+     * @return gcd algorithm implementation.
+     */
+    public static GreatestCommonDivisorAbstract<ModLong> getImplementation(ModLongRing fac) {
+        GreatestCommonDivisorAbstract<ModLong> ufd;
+        if (fac.isField()) {
+            ufd = new GreatestCommonDivisorSubres<ModLong>();
+            //ufd = new GreatestCommonDivisorModEval<ModLong>();
+            //ufd = new GreatestCommonDivisorSimple<ModLong>();
+            return ufd;
+        }
+        ufd = new GreatestCommonDivisorPrimitive<ModLong>();
+        return ufd;
+    }
+
+
+    /**
+     * Determine suitable proxy for gcd algorithms, case ModLong.
+     * @param fac ModLongRing.
+     * @return gcd algorithm implementation.
+     */
+    public static GreatestCommonDivisorAbstract<ModLong> getProxy(ModLongRing fac) {
+        GreatestCommonDivisorAbstract<ModLong> ufd1, ufd2;
+        ufd1 = new GreatestCommonDivisorSubres<ModLong>();
+        if (fac.isField()) {
+            ufd2 = new GreatestCommonDivisorPrimitive<ModLong>();
+            //ufd2 = new GreatestCommonDivisorModEval<ModLong>();
+        } else {
+            ufd2 = new GreatestCommonDivisorPrimitive<ModLong>();
+            //ufd2 = new GreatestCommonDivisorSimple<ModLong>();
+        }
+        return new GCDProxy<ModLong>(ufd1, ufd2);
+    }
+
+
+    /**
+     * Determine suitable implementation of gcd algorithms, case ModInt.
+     * @param fac ModIntRing.
+     * @return gcd algorithm implementation.
+     */
+    public static GreatestCommonDivisorAbstract<ModInt> getImplementation(ModIntRing fac) {
+        GreatestCommonDivisorAbstract<ModInt> ufd;
+        if (fac.isField()) {
+            ufd = new GreatestCommonDivisorSubres<ModInt>();
+            //ufd = new GreatestCommonDivisorModEval<ModInt>();
+            //ufd = new GreatestCommonDivisorSimple<ModInt>();
+            return ufd;
+        }
+        ufd = new GreatestCommonDivisorPrimitive<ModInt>();
+        //ufd = new GreatestCommonDivisorSubres<ModInt>();
+        return ufd;
+    }
+
+
+    /**
+     * Determine suitable proxy for gcd algorithms, case ModInt.
+     * @param fac ModIntRing.
+     * @return gcd algorithm implementation.
+     */
+    public static GreatestCommonDivisorAbstract<ModInt> getProxy(ModIntRing fac) {
+        GreatestCommonDivisorAbstract<ModInt> ufd1, ufd2;
+        ufd1 = new GreatestCommonDivisorSubres<ModInt>();
+        if (fac.isField()) {
+            ufd2 = new GreatestCommonDivisorPrimitive<ModInt>();
+            //ufd2 = new GreatestCommonDivisorModEval<ModInt>();
+        } else {
+            ufd2 = new GreatestCommonDivisorPrimitive<ModInt>();
+            //ufd2 = new GreatestCommonDivisorSimple<ModInt>();
+        }
+        return new GCDProxy<ModInt>(ufd1, ufd2);
+    }
+
+
+    /**
+     * Determine suitable implementation of gcd algorithms, case ModInteger.
+     * @param fac ModIntegerRing.
+     * @return gcd algorithm implementation.
+     */
+    public static GreatestCommonDivisorAbstract<ModInteger> getImplementation(ModIntegerRing fac) {
+        GreatestCommonDivisorAbstract<ModInteger> ufd;
+        if (fac.isField()) {
+            ufd = new GreatestCommonDivisorModEval<ModInteger>();
+            //ufd = new GreatestCommonDivisorSimple<ModInteger>();
+            return ufd;
+        }
+        ufd = new GreatestCommonDivisorSubres<ModInteger>();
+        return ufd;
+    }
+
+
+    /**
+     * Determine suitable proxy for gcd algorithms, case ModInteger.
+     * @param fac ModIntegerRing.
+     * @return gcd algorithm implementation.
+     */
+    public static GreatestCommonDivisorAbstract<ModInteger> getProxy(ModIntegerRing fac) {
+        GreatestCommonDivisorAbstract<ModInteger> ufd1, ufd2;
+        ufd1 = new GreatestCommonDivisorSubres<ModInteger>();
+        if (fac.isField()) {
+            ufd2 = new GreatestCommonDivisorModEval<ModInteger>();
+        } else {
+            ufd2 = new GreatestCommonDivisorPrimitive<ModInteger>();
+            //ufd2 = new GreatestCommonDivisorSubres<ModInteger>();
+        }
+        return new GCDProxy<ModInteger>(ufd1, ufd2);
+    }
+
+
+    /**
+     * Determine suitable implementation of gcd algorithms, case BigInteger.
+     * @param fac BigInteger.
+     * @return gcd algorithm implementation.
+     */
+    @SuppressWarnings("unused")
+    public static GreatestCommonDivisorAbstract<BigInteger> getImplementation(BigInteger fac) {
+        GreatestCommonDivisorAbstract<BigInteger> ufd;
+        if (true) {
+            ufd = new GreatestCommonDivisorModular<ModLong>(); // dummy type
+        } else {
+            ufd = new GreatestCommonDivisorSubres<BigInteger>();
+            //ufd = new GreatestCommonDivisorPrimitive<BigInteger>();
+        }
+        return ufd;
+    }
+
+
+    /**
+     * Determine suitable procy for gcd algorithms, case BigInteger.
+     * @param fac BigInteger.
+     * @return gcd algorithm implementation.
+     */
+    public static GreatestCommonDivisorAbstract<BigInteger> getProxy(BigInteger fac) {
+        if (fac == null) {
+            throw new IllegalArgumentException("fac == null not supported");
+        }
+        GreatestCommonDivisorAbstract<BigInteger> ufd1, ufd2;
+        ufd1 = new GreatestCommonDivisorSubres<BigInteger>();
+        ufd2 = new GreatestCommonDivisorModular<ModLong>(); // dummy type
+        return new GCDProxy<BigInteger>(ufd1, ufd2);
+    }
+
+
+    /**
+     * Determine suitable implementation of gcd algorithms, case BigRational.
+     * @param fac BigRational.
+     * @return gcd algorithm implementation.
+     */
+    public static GreatestCommonDivisorAbstract<BigRational> getImplementation(BigRational fac) {
+        if (fac == null) {
+            throw new IllegalArgumentException("fac == null not supported");
+        }
+        GreatestCommonDivisorAbstract<BigRational> ufd;
+        ufd = new GreatestCommonDivisorPrimitive<BigRational>();
+        return ufd;
+    }
+
+
+    /**
+     * Determine suitable proxy for gcd algorithms, case BigRational.
+     * @param fac BigRational.
+     * @return gcd algorithm implementation.
+     */
+    public static GreatestCommonDivisorAbstract<BigRational> getProxy(BigRational fac) {
+        if (fac == null) {
+            throw new IllegalArgumentException("fac == null not supported");
+        }
+        GreatestCommonDivisorAbstract<BigRational> ufd1, ufd2;
+        ufd1 = new GreatestCommonDivisorSubres<BigRational>();
+        ufd2 = new GreatestCommonDivisorSimple<BigRational>();
+        return new GCDProxy<BigRational>(ufd1, ufd2);
+    }
+
+
+    /**
+     * Determine suitable implementation of gcd algorithms, other cases.
+     * @param fac RingFactory&lt;C&gt;.
+     * @return gcd algorithm implementation.
+     */
+    @SuppressWarnings("unchecked")
+    public static <C extends GcdRingElem<C>> GreatestCommonDivisorAbstract<C> getImplementation(
+                    RingFactory<C> fac) {
+        GreatestCommonDivisorAbstract/*raw type<C>*/ ufd;
+        logger.debug("fac = " + fac.getClass().getName());
+        Object ofac = fac;
+        if (ofac instanceof BigInteger) {
+            ufd = new GreatestCommonDivisorModular<ModInteger>();
+            //ufd = new GreatestCommonDivisorSubres<BigInteger>();
+            //ufd = new GreatestCommonDivisorModular<ModInteger>(true);
+        } else if (ofac instanceof ModIntegerRing) {
+            ufd = new GreatestCommonDivisorModEval<ModInteger>();
+            //ufd = new GreatestCommonDivisorSimple<ModInteger>();
+        } else if (ofac instanceof ModLongRing) {
+            ufd = new GreatestCommonDivisorSubres<ModLong>();
+            //ufd = new GreatestCommonDivisorSimple<ModLong>();
+        } else if (ofac instanceof ModIntRing) {
+            ufd = new GreatestCommonDivisorSubres<ModInt>();
+            //ufd = new GreatestCommonDivisorSimple<ModInt>();
+        } else if (ofac instanceof BigRational) {
+            ufd = new GreatestCommonDivisorSubres<BigRational>();
+        } else {
+            if (fac.isField()) {
+                ufd = new GreatestCommonDivisorSimple<C>();
+            } else {
+                ufd = new GreatestCommonDivisorSubres<C>();
+            }
+        }
+        logger.debug("implementation = " + ufd);
+        return ufd;
+    }
+
+
+    /**
+     * Determine suitable proxy for gcd algorithms, other cases.
+     * @param fac RingFactory&lt;C&gt;.
+     * @return gcd algorithm implementation. <b>Note:</b> This method contains a
+     *         hack for Google app engine to not use threads.
+     * @see edu.jas.kern.ComputerThreads#NO_THREADS
+     */
+    @SuppressWarnings("unchecked")
+    public static <C extends GcdRingElem<C>> GreatestCommonDivisorAbstract<C> getProxy(RingFactory<C> fac) {
+        if (ComputerThreads.NO_THREADS) { // hack for Google app engine
+            return GCDFactory.<C> getImplementation(fac);
+        }
+        GreatestCommonDivisorAbstract/*raw type<C>*/ ufd;
+        logger.debug("fac = " + fac.getClass().getName());
+        Object ofac = fac;
+        if (ofac instanceof BigInteger) {
+            ufd = new GCDProxy<BigInteger>(new GreatestCommonDivisorSubres<BigInteger>(),
+                            new GreatestCommonDivisorModular<ModInteger>());
+        } else if (ofac instanceof ModIntegerRing) {
+            ufd = new GCDProxy<ModInteger>(new GreatestCommonDivisorSubres<ModInteger>(), // or Primitive
+                            new GreatestCommonDivisorModEval<ModInteger>());
+        } else if (ofac instanceof ModLongRing) {
+            ufd = new GCDProxy<ModLong>(new GreatestCommonDivisorSimple<ModLong>(), // or Primitive
+                            new GreatestCommonDivisorSubres<ModLong>());
+        } else if (ofac instanceof ModIntRing) {
+            ufd = new GCDProxy<ModInt>(new GreatestCommonDivisorSimple<ModInt>(), // or Primitive
+                            new GreatestCommonDivisorSubres<ModInt>());
+        } else if (ofac instanceof BigRational) {
+            ufd = new GCDProxy<BigRational>(new GreatestCommonDivisorSubres<BigRational>(),
+                            new GreatestCommonDivisorPrimitive<BigRational>()); //Simple
+        } else {
+            if (fac.isField()) {
+                ufd = new GCDProxy<C>(new GreatestCommonDivisorSimple<C>(),
+                                new GreatestCommonDivisorSubres<C>());
+            } else {
+                ufd = new GCDProxy<C>(new GreatestCommonDivisorSubres<C>(),
+                                new GreatestCommonDivisorPrimitive<C>()); // no resultant
+            }
+        }
+        logger.debug("ufd = " + ufd);
+        return ufd;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/GCDProxy.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/GCDProxy.java
@@ -1,0 +1,586 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.kern.ComputerThreads;
+import edu.jas.kern.PreemptingException;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Greatest common divisor parallel proxy.  
+ * Executes methods from two implementations in parallel and 
+ * returns the result from the fastest run.
+ * @author Heinz Kredel
+ */
+
+public class GCDProxy<C extends GcdRingElem<C>> extends GreatestCommonDivisorAbstract<C> {
+
+
+    //       implements GreatestCommonDivisor<C> {
+
+    private static final Logger logger = LogManager.getLogger(GCDProxy.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled(); //logger.isInfoEnabled();
+
+
+    /**
+     * GCD and resultant engines.
+     */
+    public final GreatestCommonDivisorAbstract<C> e1;
+
+
+    public final GreatestCommonDivisorAbstract<C> e2;
+
+
+    /**
+     * Thread pool.
+     */
+    protected transient ExecutorService pool;
+
+
+    /**
+     * Proxy constructor.
+     */
+    public GCDProxy(GreatestCommonDivisorAbstract<C> e1, GreatestCommonDivisorAbstract<C> e2) {
+        this.e1 = e1;
+        this.e2 = e2;
+        pool = ComputerThreads.getPool();
+        //System.out.println("pool 2 = "+pool);
+    }
+
+
+    /**
+     * Get the String representation with gcd engines.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "GCDProxy[ " + e1.getClass().getName() + ", " + e2.getClass().getName() + " ]";
+    }
+
+
+    /**
+     * Univariate GenPolynomial greatest common divisor. 
+     * @param P univariate GenPolynomial.
+     * @param S univariate GenPolynomial.
+     * @return gcd(P,S).
+     */
+    @Override
+    public GenPolynomial<C> baseGcd(final GenPolynomial<C> P, final GenPolynomial<C> S) {
+        if ( debug ) {
+            if ( ComputerThreads.NO_THREADS ) {
+                throw new RuntimeException("this should not happen");
+            }
+        }
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        // parallel case
+        GenPolynomial<C> g = null;
+        //Callable<GenPolynomial<C>> c0;
+        //Callable<GenPolynomial<C>> c1;
+        List<Callable<GenPolynomial<C>>> cs = new ArrayList<Callable<GenPolynomial<C>>>(2);
+        cs.add(new Callable<GenPolynomial<C>>() {
+
+
+            public GenPolynomial<C> call() {
+                try {
+                    //System.out.println("starting e1 " + e1.getClass().getName());
+                    GenPolynomial<C> g = e1.baseGcd(P, S);
+                    if (debug) {
+                        logger.info("GCDProxy done e1 " + e1.getClass().getName());
+                    }
+                    return g;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("GCDProxy e1 pre " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("GCDProxy e1 " + e);
+                    logger.info("GCDProxy P = " + P);
+                    logger.info("GCDProxy S = " + S);
+                    throw new RuntimeException("GCDProxy e1 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        cs.add(new Callable<GenPolynomial<C>>() {
+
+
+            public GenPolynomial<C> call() {
+                try {
+                    //System.out.println("starting e2 " + e2.getClass().getName());
+                    GenPolynomial<C> g = e2.baseGcd(P, S);
+                    if (debug) {
+                        logger.info("GCDProxy done e2 " + e2.getClass().getName());
+                    }
+                    return g;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("GCDProxy e2 pre " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("GCDProxy e2 " + e);
+                    logger.info("GCDProxy P = " + P);
+                    logger.info("GCDProxy S = " + S);
+                    throw new RuntimeException("GCDProxy e2 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        try {
+            g = pool.invokeAny(cs);
+        } catch (InterruptedException ignored) {
+            logger.info("InterruptedException " + ignored);
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
+            logger.info("ExecutionException " + e);
+            Thread.currentThread().interrupt();
+        }
+        return g;
+    }
+
+
+    /**
+     * Univariate GenPolynomial recursive greatest common divisor.
+     * @param P univariate recursive GenPolynomial.
+     * @param S univariate recursive GenPolynomial.
+     * @return gcd(P,S).
+     */
+    @Override
+    public GenPolynomial<GenPolynomial<C>> recursiveUnivariateGcd(final GenPolynomial<GenPolynomial<C>> P,
+            final GenPolynomial<GenPolynomial<C>> S) {
+        if ( debug ) {
+            if ( ComputerThreads.NO_THREADS ) {
+                throw new RuntimeException("this should not happen");
+            }
+        }
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        // parallel case
+        GenPolynomial<GenPolynomial<C>> g = null;
+        //Callable<GenPolynomial<GenPolynomial<C>>> c0;
+        //Callable<GenPolynomial<GenPolynomial<C>>> c1;
+        List<Callable<GenPolynomial<GenPolynomial<C>>>> cs = new ArrayList<Callable<GenPolynomial<GenPolynomial<C>>>>(
+                2);
+        cs.add(new Callable<GenPolynomial<GenPolynomial<C>>>() {
+
+
+            public GenPolynomial<GenPolynomial<C>> call() {
+                try {
+                    GenPolynomial<GenPolynomial<C>> g = e1.recursiveUnivariateGcd(P, S);
+                    if (debug) {
+                        logger.info("GCDProxy done e1 " + e1.getClass().getName());
+                    }
+                    return g;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("GCDProxy e1 pre " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("GCDProxy e1 " + e);
+                    logger.info("GCDProxy P = " + P);
+                    logger.info("GCDProxy S = " + S);
+                    throw new RuntimeException("GCDProxy e1 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        cs.add(new Callable<GenPolynomial<GenPolynomial<C>>>() {
+
+
+            public GenPolynomial<GenPolynomial<C>> call() {
+                try {
+                    GenPolynomial<GenPolynomial<C>> g = e2.recursiveUnivariateGcd(P, S);
+                    if (debug) {
+                        logger.info("GCDProxy done e2 " + e2.getClass().getName());
+                    }
+                    return g;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("GCDProxy e2 pre " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("GCDProxy e2 " + e);
+                    logger.info("GCDProxy P = " + P);
+                    logger.info("GCDProxy S = " + S);
+                    throw new RuntimeException("GCDProxy e2 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        try {
+            g = pool.invokeAny(cs);
+        } catch (InterruptedException ignored) {
+            logger.info("InterruptedException " + ignored);
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
+            logger.info("ExecutionException " + e);
+            Thread.currentThread().interrupt();
+        }
+        return g;
+    }
+
+
+    /**
+     * GenPolynomial greatest common divisor. 
+     * @param P GenPolynomial.
+     * @param S GenPolynomial.
+     * @return gcd(P,S).
+     */
+    @Override
+    public GenPolynomial<C> gcd(final GenPolynomial<C> P, final GenPolynomial<C> S) {
+        if ( debug ) {
+            if ( ComputerThreads.NO_THREADS ) {
+                throw new RuntimeException("this should not happen");
+            }
+        }
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        // parallel case
+        GenPolynomial<C> g = null;
+        //Callable<GenPolynomial<C>> c0;
+        //Callable<GenPolynomial<C>> c1;
+        List<Callable<GenPolynomial<C>>> cs = new ArrayList<Callable<GenPolynomial<C>>>(2);
+        cs.add(new Callable<GenPolynomial<C>>() {
+
+
+            public GenPolynomial<C> call() {
+                try {
+                    //System.out.println("starting e1 " + e1.getClass().getName());
+                    GenPolynomial<C> g = e1.gcd(P, S);
+                    if (debug) {
+                        logger.info("GCDProxy done e1 " + e1.getClass().getName());
+                    }
+                    return g;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("GCDProxy e1 pre " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("GCDProxy e1 " + e);
+                    logger.info("GCDProxy P = " + P);
+                    logger.info("GCDProxy S = " + S);
+                    throw new RuntimeException("GCDProxy e1 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        cs.add(new Callable<GenPolynomial<C>>() {
+
+
+            public GenPolynomial<C> call() {
+                try {
+                    //System.out.println("starting e2 " + e2.getClass().getName());
+                    GenPolynomial<C> g = e2.gcd(P, S);
+                    if (debug) {
+                        logger.info("GCDProxy done e2 " + e2.getClass().getName());
+                    }
+                    return g;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("GCDProxy e2 pre " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("GCDProxy e2 " + e);
+                    logger.info("GCDProxy P = " + P);
+                    logger.info("GCDProxy S = " + S);
+                    throw new RuntimeException("GCDProxy e2 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        try {
+            g = pool.invokeAny(cs);
+        } catch (InterruptedException ignored) {
+            logger.info("InterruptedException " + ignored);
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
+            logger.info("ExecutionException " + e);
+            Thread.currentThread().interrupt();
+        }
+        return g;
+    }
+
+
+    /**
+     * Univariate GenPolynomial resultant. 
+     * @param P univariate GenPolynomial.
+     * @param S univariate GenPolynomial.
+     * @return res(P,S).
+     */
+    @Override
+    public GenPolynomial<C> baseResultant(final GenPolynomial<C> P, final GenPolynomial<C> S) {
+        if ( debug ) {
+            if ( ComputerThreads.NO_THREADS ) {
+                throw new RuntimeException("this should not happen");
+            }
+        }
+        if (S == null || S.isZERO()) {
+            return S;
+        }
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        // parallel case
+        GenPolynomial<C> g = null;
+        //Callable<GenPolynomial<C>> c0;
+        //Callable<GenPolynomial<C>> c1;
+        List<Callable<GenPolynomial<C>>> cs = new ArrayList<Callable<GenPolynomial<C>>>(2);
+        cs.add(new Callable<GenPolynomial<C>>() {
+
+
+            public GenPolynomial<C> call() {
+                try {
+                    //System.out.println("starting e1 " + e1.getClass().getName());
+                    GenPolynomial<C> g = e1.baseResultant(P, S);
+                    if (debug) {
+                        logger.info("GCDProxy done e1 " + e1.getClass().getName());
+                    }
+                    return g;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("GCDProxy e1 pre " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("GCDProxy e1 " + e);
+                    logger.info("GCDProxy P = " + P);
+                    logger.info("GCDProxy S = " + S);
+                    throw new RuntimeException("GCDProxy e1 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        cs.add(new Callable<GenPolynomial<C>>() {
+
+
+            public GenPolynomial<C> call() {
+                try {
+                    //System.out.println("starting e2 " + e2.getClass().getName());
+                    GenPolynomial<C> g = e2.baseResultant(P, S);
+                    if (debug) {
+                        logger.info("GCDProxy done e2 " + e2.getClass().getName());
+                    }
+                    return g;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("GCDProxy e2 pre " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("GCDProxy e2 " + e);
+                    logger.info("GCDProxy P = " + P);
+                    logger.info("GCDProxy S = " + S);
+                    throw new RuntimeException("GCDProxy e2 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        try {
+            g = pool.invokeAny(cs);
+        } catch (InterruptedException ignored) {
+            logger.info("InterruptedException " + ignored);
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
+            logger.info("ExecutionException " + e);
+            Thread.currentThread().interrupt();
+        }
+        return g;
+    }
+
+
+    /**
+     * Univariate GenPolynomial resultant. 
+     * @param P univariate recursive GenPolynomial.
+     * @param S univariate recursive GenPolynomial.
+     * @return res(P,S).
+     */
+    @Override
+    public GenPolynomial<GenPolynomial<C>> recursiveUnivariateResultant(final GenPolynomial<GenPolynomial<C>> P,
+            final GenPolynomial<GenPolynomial<C>> S) {
+        if ( debug ) {
+            if ( ComputerThreads.NO_THREADS ) {
+                throw new RuntimeException("this should not happen");
+            }
+        }
+        if (S == null || S.isZERO()) {
+            return S;
+        }
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        // parallel case
+        GenPolynomial<GenPolynomial<C>> g = null;
+        //Callable<GenPolynomial<GenPolynomial<C>>> c0;
+        //Callable<GenPolynomial<GenPolynomial<C>>> c1;
+        List<Callable<GenPolynomial<GenPolynomial<C>>>> cs = new ArrayList<Callable<GenPolynomial<GenPolynomial<C>>>>(
+                2);
+        cs.add(new Callable<GenPolynomial<GenPolynomial<C>>>() {
+
+
+            public GenPolynomial<GenPolynomial<C>> call() {
+                try {
+                    GenPolynomial<GenPolynomial<C>> g = e1.recursiveUnivariateResultant(P, S);
+                    if (debug) {
+                        logger.info("GCDProxy done e1 " + e1.getClass().getName());
+                    }
+                    return g;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("GCDProxy e1 pre " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("GCDProxy e1 " + e);
+                    logger.info("GCDProxy P = " + P);
+                    logger.info("GCDProxy S = " + S);
+                    throw new RuntimeException("GCDProxy e1 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        cs.add(new Callable<GenPolynomial<GenPolynomial<C>>>() {
+
+
+            public GenPolynomial<GenPolynomial<C>> call() {
+                try {
+                    GenPolynomial<GenPolynomial<C>> g = e2.recursiveUnivariateResultant(P, S);
+                    if (debug) {
+                        logger.info("GCDProxy done e2 " + e2.getClass().getName());
+                    }
+                    return g;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("GCDProxy e2 pre " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("GCDProxy e2 " + e);
+                    logger.info("GCDProxy P = " + P);
+                    logger.info("GCDProxy S = " + S);
+                    throw new RuntimeException("GCDProxy e2 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        try {
+            g = pool.invokeAny(cs);
+        } catch (InterruptedException ignored) {
+            logger.info("InterruptedException " + ignored);
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
+            logger.info("ExecutionException " + e);
+            Thread.currentThread().interrupt();
+        }
+        return g;
+    }
+
+
+    /**
+     * GenPolynomial resultant. Main entry driver method.
+     * @param P GenPolynomial.
+     * @param S GenPolynomial.
+     * @return res(P,S).
+     */
+    @Override
+    public GenPolynomial<C> resultant(final GenPolynomial<C> P, final GenPolynomial<C> S) {
+        if ( debug ) {
+            if ( ComputerThreads.NO_THREADS ) {
+                throw new RuntimeException("this should not happen");
+            }
+        }
+        if (S == null || S.isZERO()) {
+            return S;
+        }
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        // parallel case
+        GenPolynomial<C> g = null;
+        //Callable<GenPolynomial<C>> c0;
+        //Callable<GenPolynomial<C>> c1;
+        List<Callable<GenPolynomial<C>>> cs = new ArrayList<Callable<GenPolynomial<C>>>(2);
+        cs.add(new Callable<GenPolynomial<C>>() {
+
+
+            public GenPolynomial<C> call() {
+                try {
+                    //System.out.println("starting e1 " + e1.getClass().getName());
+                    GenPolynomial<C> g = e1.resultant(P, S);
+                    if (debug) {
+                        logger.info("GCDProxy done e1 " + e1.getClass().getName());
+                    }
+                    return g;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("GCDProxy e1 pre " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("GCDProxy e1 " + e);
+                    logger.info("GCDProxy P = " + P);
+                    logger.info("GCDProxy S = " + S);
+                    throw new RuntimeException("GCDProxy e1 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        cs.add(new Callable<GenPolynomial<C>>() {
+
+
+            public GenPolynomial<C> call() {
+                try {
+                    //System.out.println("starting e2 " + e2.getClass().getName());
+                    GenPolynomial<C> g = e2.resultant(P, S);
+                    if (debug) {
+                        logger.info("GCDProxy done e2 " + e2.getClass().getName());
+                    }
+                    return g;
+                } catch (PreemptingException e) {
+                    throw new RuntimeException("GCDProxy e2 pre " + e);
+                    //return P.ring.getONE();
+                } catch (Exception e) {
+                    //e.printStackTrace();
+                    logger.info("GCDProxy e2 " + e);
+                    logger.info("GCDProxy P = " + P);
+                    logger.info("GCDProxy S = " + S);
+                    throw new RuntimeException("GCDProxy e2 " + e);
+                    //return P.ring.getONE();
+                }
+            }
+        });
+        try {
+            g = pool.invokeAny(cs);
+        } catch (InterruptedException ignored) {
+            logger.info("InterruptedException " + ignored);
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
+            logger.info("ExecutionException " + e);
+            Thread.currentThread().interrupt();
+        }
+        return g;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/GreatestCommonDivisor.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/GreatestCommonDivisor.java
@@ -1,0 +1,110 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.io.Serializable;
+import java.util.List;
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Greatest common divisor algorithm interface.
+ * <p>
+ * <b>Usage:</b> To create classes that implement this interface use the
+ * GreatestCommonDivisorFactory. It will select an appropriate implementation
+ * based on the types of polynomial coefficients CT.
+ * <p>
+ * 
+ * <pre>
+ * 
+ * GreatestCommonDivisor&lt;CT&gt; engine = GCDFactory.&lt;CT&gt; getImplementation(cofac);
+ * c = engine.gcd(a, b);
+ * </pre>
+ * 
+ * <p>
+ * For example, if the coefficient type is BigInteger, the usage looks like
+ * 
+ * <p>
+ * 
+ * <pre>
+ * BigInteger cofac = new BigInteger();
+ * GreatestCommonDivisor&lt;BigInteger&gt; engine = GCDFactory.getImplementation(cofac);
+ * c = engine.gcd(a, b);
+ * </pre>
+ * 
+ * @author Heinz Kredel
+ * @see edu.jas.ufd.GCDFactory#getImplementation
+ */
+
+public interface GreatestCommonDivisor<C extends GcdRingElem<C>> extends Serializable {
+
+
+    /**
+     * GenPolynomial content.
+     * @param P GenPolynomial.
+     * @return cont(P).
+     */
+    public GenPolynomial<C> content(GenPolynomial<C> P);
+
+
+    /**
+     * GenPolynomial primitive part.
+     * @param P GenPolynomial.
+     * @return pp(P).
+     */
+    public GenPolynomial<C> primitivePart(GenPolynomial<C> P);
+
+
+    /**
+     * GenPolynomial greatest comon divisor.
+     * @param P GenPolynomial.
+     * @param S GenPolynomial.
+     * @return gcd(P,S).
+     */
+    public GenPolynomial<C> gcd(GenPolynomial<C> P, GenPolynomial<C> S);
+
+
+    /**
+     * GenPolynomial least comon multiple.
+     * @param P GenPolynomial.
+     * @param S GenPolynomial.
+     * @return lcm(P,S).
+     */
+    public GenPolynomial<C> lcm(GenPolynomial<C> P, GenPolynomial<C> S);
+
+
+    /**
+     * GenPolynomial resultant. The input polynomials are considered as
+     * univariate polynomials in the main variable.
+     * @param P GenPolynomial.
+     * @param S GenPolynomial.
+     * @return res(P,S).
+     * @throws UnsupportedOperationException if there is no implementation in
+     *             the sub-class.
+     */
+    public GenPolynomial<C> resultant(GenPolynomial<C> P, GenPolynomial<C> S);
+
+
+    /**
+     * GenPolynomial co-prime list.
+     * @param A list of GenPolynomials.
+     * @return B with gcd(b,c) = 1 for all b != c in B and for all non-constant
+     *         a in A there exists b in B with b|a. B does not contain zero or
+     *         constant polynomials.
+     */
+    public List<GenPolynomial<C>> coPrime(List<GenPolynomial<C>> A);
+
+
+    /**
+     * GenPolynomial test for co-prime list.
+     * @param A list of GenPolynomials.
+     * @return true if gcd(b,c) = 1 for all b != c in B, else false.
+     */
+    public boolean isCoPrime(List<GenPolynomial<C>> A);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/GreatestCommonDivisorAbstract.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/GreatestCommonDivisorAbstract.java
@@ -1,0 +1,1096 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Greatest common divisor algorithms.
+ * @author Heinz Kredel
+ */
+
+public abstract class GreatestCommonDivisorAbstract<C extends GcdRingElem<C>>
+                implements GreatestCommonDivisor<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GreatestCommonDivisorAbstract.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return getClass().getName();
+    }
+
+
+    /**
+     * GenPolynomial base coefficient content.
+     * @param P GenPolynomial.
+     * @return cont(P).
+     */
+    public C baseContent(GenPolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P != null");
+        }
+        if (P.isZERO()) {
+            return P.ring.getZEROCoefficient();
+        }
+        C d = null;
+        for (C c : P.getMap().values()) {
+            if (d == null) {
+                d = c;
+            } else {
+                d = d.gcd(c);
+            }
+            if (d.isONE()) {
+                return d;
+            }
+        }
+        if (d.signum() < 0) {
+            d = d.negate();
+        }
+        return d;
+    }
+
+
+    /**
+     * GenPolynomial base coefficient primitive part.
+     * @param P GenPolynomial.
+     * @return pp(P).
+     */
+    public GenPolynomial<C> basePrimitivePart(GenPolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P != null");
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        C d = baseContent(P);
+        if (d.isONE()) {
+            return P;
+        }
+        GenPolynomial<C> pp = P.divide(d);
+        if (debug) {
+            GenPolynomial<C> p = pp.multiply(d);
+            if (!p.equals(P)) {
+                throw new ArithmeticException("pp(p)*cont(p) != p: ");
+            }
+        }
+        return pp;
+    }
+
+
+    /**
+     * List of GenPolynomial base coefficient primitive part.
+     * @param F list of GenPolynomials.
+     * @return pp(F).
+     */
+    public List<GenPolynomial<C>> basePrimitivePart(List<GenPolynomial<C>> F) {
+        if (F == null || F.isEmpty()) {
+            return F;
+        }
+        List<GenPolynomial<C>> Pp = new ArrayList<GenPolynomial<C>>(F.size());
+        for (GenPolynomial<C> f : F) {
+            GenPolynomial<C> p = basePrimitivePart(f);
+            Pp.add(p);
+        }
+        return Pp;
+    }
+
+
+    /**
+     * Univariate GenPolynomial greatest common divisor. Uses sparse
+     * pseudoRemainder for remainder.
+     * @param P univariate GenPolynomial.
+     * @param S univariate GenPolynomial.
+     * @return gcd(P,S).
+     */
+    public abstract GenPolynomial<C> baseGcd(GenPolynomial<C> P, GenPolynomial<C> S);
+
+
+    /**
+     * GenPolynomial recursive content.
+     * @param P recursive GenPolynomial.
+     * @return cont(P).
+     */
+    public GenPolynomial<C> recursiveContent(GenPolynomial<GenPolynomial<C>> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P != null");
+        }
+        if (P.isZERO()) {
+            return P.ring.getZEROCoefficient();
+        }
+        GenPolynomial<C> d = null;
+        for (GenPolynomial<C> c : P.getMap().values()) {
+            if (d == null) {
+                d = c;
+            } else {
+                d = gcd(d, c); // go to recursion
+            }
+            if (d.isONE()) {
+                return d;
+            }
+        }
+        return d.abs();
+    }
+
+
+    /**
+     * GenPolynomial recursive primitive part.
+     * @param P recursive GenPolynomial.
+     * @return pp(P).
+     */
+    public GenPolynomial<GenPolynomial<C>> recursivePrimitivePart(GenPolynomial<GenPolynomial<C>> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P != null");
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        GenPolynomial<C> d = recursiveContent(P);
+        if (d.isONE()) {
+            return P;
+        }
+        GenPolynomial<GenPolynomial<C>> pp = PolyUtil.<C> recursiveDivide(P, d);
+        return pp;
+    }
+
+
+    /**
+     * List of recursive GenPolynomial base coefficient primitive part.
+     * @param F list of recursive GenPolynomials.
+     * @return pp(F).
+     */
+    public List<GenPolynomial<GenPolynomial<C>>> recursivePrimitivePart(
+                    List<GenPolynomial<GenPolynomial<C>>> F) {
+        if (F == null || F.isEmpty()) {
+            return F;
+        }
+        List<GenPolynomial<GenPolynomial<C>>> Pp = new ArrayList<GenPolynomial<GenPolynomial<C>>>(F.size());
+        for (GenPolynomial<GenPolynomial<C>> f : F) {
+            GenPolynomial<GenPolynomial<C>> p = recursivePrimitivePart(f);
+            Pp.add(p);
+        }
+        return Pp;
+    }
+
+
+    /**
+     * GenPolynomial base recursive content.
+     * @param P recursive GenPolynomial.
+     * @return baseCont(P).
+     */
+    public C baseRecursiveContent(GenPolynomial<GenPolynomial<C>> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P != null");
+        }
+        if (P.isZERO()) {
+            GenPolynomialRing<C> cf = (GenPolynomialRing<C>) P.ring.coFac;
+            return cf.coFac.getZERO();
+        }
+        C d = null;
+        for (GenPolynomial<C> c : P.getMap().values()) {
+            C cc = baseContent(c);
+            if (d == null) {
+                d = cc;
+            } else {
+                d = gcd(d, cc);
+            }
+            if (d.isONE()) {
+                return d;
+            }
+        }
+        if (d.signum() < 0) {
+            d = d.negate();
+        }
+        return d;
+    }
+
+
+    /**
+     * GenPolynomial base recursive primitive part.
+     * @param P recursive GenPolynomial.
+     * @return basePP(P).
+     */
+    public GenPolynomial<GenPolynomial<C>> baseRecursivePrimitivePart(GenPolynomial<GenPolynomial<C>> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P != null");
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        C d = baseRecursiveContent(P);
+        if (d.isONE()) {
+            return P;
+        }
+        GenPolynomial<GenPolynomial<C>> pp = PolyUtil.<C> baseRecursiveDivide(P, d);
+        return pp;
+    }
+
+
+    /**
+     * GenPolynomial recursive greatest common divisor. Uses pseudoRemainder for
+     * remainder.
+     * @param P recursive GenPolynomial.
+     * @param S recursive GenPolynomial.
+     * @return gcd(P,S).
+     */
+    public GenPolynomial<GenPolynomial<C>> recursiveGcd(GenPolynomial<GenPolynomial<C>> P,
+                    GenPolynomial<GenPolynomial<C>> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.ring.nvar <= 1) {
+            return recursiveUnivariateGcd(P, S);
+        }
+        // distributed polynomials gcd
+        GenPolynomialRing<GenPolynomial<C>> rfac = P.ring;
+        RingFactory<GenPolynomial<C>> rrfac = rfac.coFac;
+        GenPolynomialRing<C> cfac = (GenPolynomialRing<C>) rrfac;
+        GenPolynomialRing<C> dfac = cfac.extend(rfac.nvar);
+        GenPolynomial<C> Pd = PolyUtil.<C> distribute(dfac, P);
+        GenPolynomial<C> Sd = PolyUtil.<C> distribute(dfac, S);
+        GenPolynomial<C> Dd = gcd(Pd, Sd);
+        // convert to recursive
+        GenPolynomial<GenPolynomial<C>> C = PolyUtil.<C> recursive(rfac, Dd);
+        return C;
+    }
+
+
+    /**
+     * Univariate GenPolynomial recursive greatest common divisor. Uses
+     * pseudoRemainder for remainder.
+     * @param P univariate recursive GenPolynomial.
+     * @param S univariate recursive GenPolynomial.
+     * @return gcd(P,S).
+     */
+    public abstract GenPolynomial<GenPolynomial<C>> recursiveUnivariateGcd(GenPolynomial<GenPolynomial<C>> P,
+                    GenPolynomial<GenPolynomial<C>> S);
+
+
+    /**
+     * GenPolynomial content.
+     * @param P GenPolynomial.
+     * @return cont(P).
+     */
+    public GenPolynomial<C> content(GenPolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P != null");
+        }
+        GenPolynomialRing<C> pfac = P.ring;
+        if (pfac.nvar <= 1) {
+            // baseContent not possible by return type
+            throw new IllegalArgumentException(
+                            this.getClass().getName() + " use baseContent for univariate polynomials");
+
+        }
+        GenPolynomialRing<GenPolynomial<C>> rfac = pfac.recursive(1);
+        GenPolynomial<GenPolynomial<C>> Pr = PolyUtil.<C> recursive(rfac, P);
+        GenPolynomial<C> D = recursiveContent(Pr);
+        return D;
+    }
+
+
+    /**
+     * GenPolynomial primitive part.
+     * @param P GenPolynomial.
+     * @return pp(P).
+     */
+    public GenPolynomial<C> primitivePart(GenPolynomial<C> P) {
+        return contentPrimitivePart(P)[1];
+    }
+
+
+    /**
+     * GenPolynomial content and primitive part.
+     * @param P GenPolynomial.
+     * @return { cont(P), pp(P) }
+     */
+    @SuppressWarnings("unchecked")
+    public GenPolynomial<C>[] contentPrimitivePart(GenPolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P != null");
+        }
+        GenPolynomial<C>[] ret = new GenPolynomial[2];
+        GenPolynomialRing<C> pfac = P.ring;
+        if (P.isZERO()) {
+            ret[0] = pfac.getZERO();
+            ret[1] = pfac.getZERO();
+            return ret;
+        }
+        if (pfac.nvar <= 1) {
+            C Pc = baseContent(P);
+            GenPolynomial<C> Pp = P;
+            if (!Pc.isONE()) {
+                Pp = P.divide(Pc);
+            }
+            ret[0] = pfac.valueOf(Pc);
+            ret[1] = Pp;
+            return ret;
+        }
+        GenPolynomialRing<GenPolynomial<C>> rfac = pfac.recursive(1);
+        //GenPolynomialRing<C> cfac = rfac.coFac;
+        GenPolynomial<GenPolynomial<C>> Pr = PolyUtil.<C> recursive(rfac, P);
+        GenPolynomial<C> Pc = recursiveContent(Pr);
+        // primitive part
+        GenPolynomial<GenPolynomial<C>> Pp = Pr;
+        if (!Pc.isONE()) {
+            Pp = PolyUtil.<C> recursiveDivide(Pr, Pc);
+        }
+        GenPolynomial<C> Ppd = PolyUtil.<C> distribute(pfac, Pp);
+        ret[0] = Pc; // sic!
+        ret[1] = Ppd;
+        return ret;
+    }
+
+
+    /**
+     * GenPolynomial division. Indirection to GenPolynomial method.
+     * @param a GenPolynomial.
+     * @param b coefficient.
+     * @return a/b.
+     */
+    public GenPolynomial<C> divide(GenPolynomial<C> a, C b) {
+        if (b == null || b.isZERO()) {
+            throw new IllegalArgumentException("division by zero");
+
+        }
+        if (a == null || a.isZERO()) {
+            return a;
+        }
+        return a.divide(b);
+    }
+
+
+    /**
+     * Coefficient greatest common divisor. Indirection to coefficient method.
+     * @param a coefficient.
+     * @param b coefficient.
+     * @return gcd(a,b).
+     */
+    public C gcd(C a, C b) {
+        if (b == null || b.isZERO()) {
+            return a;
+        }
+        if (a == null || a.isZERO()) {
+            return b;
+        }
+        return a.gcd(b);
+    }
+
+
+    /**
+     * GenPolynomial greatest common divisor.
+     * @param P GenPolynomial.
+     * @param S GenPolynomial.
+     * @return gcd(P,S).
+     */
+    public GenPolynomial<C> gcd(GenPolynomial<C> P, GenPolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        GenPolynomialRing<C> pfac = P.ring;
+        if (pfac.nvar <= 1) {
+            GenPolynomial<C> T = baseGcd(P, S);
+            return T;
+        }
+        GenPolynomialRing<GenPolynomial<C>> rfac = pfac.recursive(1);
+        GenPolynomial<GenPolynomial<C>> Pr = PolyUtil.<C> recursive(rfac, P);
+        GenPolynomial<GenPolynomial<C>> Sr = PolyUtil.<C> recursive(rfac, S);
+        GenPolynomial<GenPolynomial<C>> Dr = recursiveUnivariateGcd(Pr, Sr);
+        GenPolynomial<C> D = PolyUtil.<C> distribute(pfac, Dr);
+        return D;
+    }
+
+
+    /**
+     * GenPolynomial least common multiple.
+     * @param P GenPolynomial.
+     * @param S GenPolynomial.
+     * @return lcm(P,S).
+     */
+    public GenPolynomial<C> lcm(GenPolynomial<C> P, GenPolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            return S;
+        }
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        GenPolynomial<C> C = gcd(P, S);
+        GenPolynomial<C> A = P.multiply(S);
+        return PolyUtil.<C> basePseudoDivide(A, C);
+    }
+
+
+    /**
+     * List of GenPolynomials greatest common divisor.
+     * @param A non empty list of GenPolynomials.
+     * @return gcd(A_i).
+     */
+    public GenPolynomial<C> gcd(List<GenPolynomial<C>> A) {
+        if (A == null || A.isEmpty()) {
+            throw new IllegalArgumentException("A may not be empty");
+        }
+        GenPolynomial<C> g = A.get(0);
+        for (int i = 1; i < A.size(); i++) {
+            GenPolynomial<C> f = A.get(i);
+            g = gcd(g, f);
+        }
+        return g;
+    }
+
+
+    /**
+     * Univariate GenPolynomial resultant.
+     * @param P univariate GenPolynomial.
+     * @param S univariate GenPolynomial.
+     * @return res(P,S).
+     * @throws UnsupportedOperationException if there is no implementation in
+     *             the sub-class.
+     */
+    @SuppressWarnings("unused")
+    public GenPolynomial<C> baseResultant(GenPolynomial<C> P, GenPolynomial<C> S) {
+        throw new UnsupportedOperationException("not implmented");
+    }
+
+
+    /**
+     * Univariate GenPolynomial recursive resultant.
+     * @param P univariate recursive GenPolynomial.
+     * @param S univariate recursive GenPolynomial.
+     * @return res(P,S).
+     * @throws UnsupportedOperationException if there is no implementation in
+     *             the sub-class.
+     */
+    @SuppressWarnings("unused")
+    public GenPolynomial<GenPolynomial<C>> recursiveUnivariateResultant(GenPolynomial<GenPolynomial<C>> P,
+                    GenPolynomial<GenPolynomial<C>> S) {
+        throw new UnsupportedOperationException("not implmented");
+    }
+
+
+    /**
+     * GenPolynomial recursive resultant.
+     * @param P univariate recursive GenPolynomial.
+     * @param S univariate recursive GenPolynomial.
+     * @return res(P,S).
+     * @throws UnsupportedOperationException if there is no implementation in
+     *             the sub-class.
+     */
+    public GenPolynomial<GenPolynomial<C>> recursiveResultant(GenPolynomial<GenPolynomial<C>> P,
+                    GenPolynomial<GenPolynomial<C>> S) {
+        if (S == null || S.isZERO()) {
+            return S;
+        }
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        GenPolynomialRing<GenPolynomial<C>> rfac = P.ring;
+        GenPolynomialRing<C> cfac = (GenPolynomialRing<C>) rfac.coFac;
+        GenPolynomialRing<C> dfac = cfac.extend(rfac.getVars());
+        GenPolynomial<C> Pp = PolyUtil.<C> distribute(dfac, P);
+        GenPolynomial<C> Sp = PolyUtil.<C> distribute(dfac, S);
+        GenPolynomial<C> res = resultant(Pp, Sp);
+        GenPolynomial<GenPolynomial<C>> Rr = PolyUtil.<C> recursive(rfac, res);
+        return Rr;
+    }
+
+
+    /**
+     * GenPolynomial resultant. The input polynomials are considered as
+     * univariate polynomials in the main variable.
+     * @param P GenPolynomial.
+     * @param S GenPolynomial.
+     * @return res(P,S).
+     * @see edu.jas.ufd.GreatestCommonDivisorSubres#recursiveResultant
+     * @throws UnsupportedOperationException if there is no implementation in
+     *             the sub-class.
+     */
+    public GenPolynomial<C> resultant(GenPolynomial<C> P, GenPolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            return S;
+        }
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        // no more hacked: GreatestCommonDivisorSubres<C> ufd_sr = new GreatestCommonDivisorSubres<C>();
+        GenPolynomialRing<C> pfac = P.ring;
+        if (pfac.nvar <= 1) {
+            return baseResultant(P, S);
+        }
+        GenPolynomialRing<GenPolynomial<C>> rfac = pfac.recursive(1);
+        GenPolynomial<GenPolynomial<C>> Pr = PolyUtil.<C> recursive(rfac, P);
+        GenPolynomial<GenPolynomial<C>> Sr = PolyUtil.<C> recursive(rfac, S);
+
+        GenPolynomial<GenPolynomial<C>> Dr = recursiveUnivariateResultant(Pr, Sr);
+        GenPolynomial<C> D = PolyUtil.<C> distribute(pfac, Dr);
+        return D;
+    }
+
+
+    /**
+     * GenPolynomial co-prime list.
+     * @param A list of GenPolynomials.
+     * @return B with gcd(b,c) = 1 for all b != c in B and for all non-constant
+     *         a in A there exists b in B with b|a. B does not contain zero or
+     *         constant polynomials.
+     */
+    public List<GenPolynomial<C>> coPrime(List<GenPolynomial<C>> A) {
+        if (A == null || A.isEmpty()) {
+            return A;
+        }
+        List<GenPolynomial<C>> B = new ArrayList<GenPolynomial<C>>(A.size());
+        // make a coprime to rest of list
+        GenPolynomial<C> a = A.get(0);
+        //System.out.println("a = " + a);
+        if (!a.isZERO() && !a.isConstant()) {
+            for (int i = 1; i < A.size(); i++) {
+                GenPolynomial<C> b = A.get(i);
+                GenPolynomial<C> g = gcd(a, b).abs();
+                if (!g.isONE()) {
+                    a = PolyUtil.<C> basePseudoDivide(a, g);
+                    b = PolyUtil.<C> basePseudoDivide(b, g);
+                    GenPolynomial<C> gp = gcd(a, g).abs();
+                    while (!gp.isONE()) {
+                        a = PolyUtil.<C> basePseudoDivide(a, gp);
+                        g = PolyUtil.<C> basePseudoDivide(g, gp);
+                        B.add(g); // gcd(a,g) == 1
+                        g = gp;
+                        gp = gcd(a, gp).abs();
+                    }
+                    if (!g.isZERO() && !g.isConstant() /*&& !B.contains(g)*/) {
+                        B.add(g); // gcd(a,g) == 1
+                    }
+                }
+                if (!b.isZERO() && !b.isConstant()) {
+                    B.add(b); // gcd(a,b) == 1
+                }
+            }
+        } else {
+            B.addAll(A.subList(1, A.size()));
+        }
+        // make rest coprime
+        B = coPrime(B);
+        //System.out.println("B = " + B);
+        if (!a.isZERO() && !a.isConstant() /*&& !B.contains(a)*/) {
+            a = a.abs();
+            B.add(a);
+        }
+        return B;
+    }
+
+
+    /**
+     * GenPolynomial co-prime list.
+     * @param A list of GenPolynomials.
+     * @return B with gcd(b,c) = 1 for all b != c in B and for all non-constant
+     *         a in A there exists b in B with b|a. B does not contain zero or
+     *         constant polynomials.
+     */
+    public List<GenPolynomial<C>> coPrimeRec(List<GenPolynomial<C>> A) {
+        if (A == null || A.isEmpty()) {
+            return A;
+        }
+        List<GenPolynomial<C>> B = new ArrayList<GenPolynomial<C>>();
+        // make a co-prime to rest of list
+        for (GenPolynomial<C> a : A) {
+            //System.out.println("a = " + a);
+            B = coPrime(a, B);
+            //System.out.println("B = " + B);
+        }
+        return B;
+    }
+
+
+    /**
+     * GenPolynomial co-prime list.
+     * @param a GenPolynomial.
+     * @param P co-prime list of GenPolynomials.
+     * @return B with gcd(b,c) = 1 for all b != c in B and for non-constant a
+     *         there exists b in P with b|a. B does not contain zero or constant
+     *         polynomials.
+     */
+    public List<GenPolynomial<C>> coPrime(GenPolynomial<C> a, List<GenPolynomial<C>> P) {
+        if (a == null || a.isZERO() || a.isConstant()) {
+            return P;
+        }
+        List<GenPolynomial<C>> B = new ArrayList<GenPolynomial<C>>(P.size() + 1);
+        // make a coprime to elements of the list P
+        for (int i = 0; i < P.size(); i++) {
+            GenPolynomial<C> b = P.get(i);
+            GenPolynomial<C> g = gcd(a, b).abs();
+            if (!g.isONE()) {
+                a = PolyUtil.<C> basePseudoDivide(a, g);
+                b = PolyUtil.<C> basePseudoDivide(b, g);
+                // make g co-prime to new a, g is co-prime to c != b in P, B
+                GenPolynomial<C> gp = gcd(a, g).abs();
+                while (!gp.isONE()) {
+                    a = PolyUtil.<C> basePseudoDivide(a, gp);
+                    g = PolyUtil.<C> basePseudoDivide(g, gp);
+                    if (!g.isZERO() && !g.isConstant() /*&& !B.contains(g)*/) {
+                        B.add(g); // gcd(a,g) == 1 and gcd(g,c) == 1 for c != b in P, B
+                    }
+                    g = gp;
+                    gp = gcd(a, gp).abs();
+                }
+                // make new g co-prime to new b
+                gp = gcd(b, g).abs();
+                while (!gp.isONE()) {
+                    b = PolyUtil.<C> basePseudoDivide(b, gp);
+                    g = PolyUtil.<C> basePseudoDivide(g, gp);
+                    if (!g.isZERO() && !g.isConstant() /*&& !B.contains(g)*/) {
+                        B.add(g); // gcd(a,g) == 1 and gcd(g,c) == 1 for c != b in P, B
+                    }
+                    g = gp;
+                    gp = gcd(b, gp).abs();
+                }
+                if (!g.isZERO() && !g.isConstant() /*&& !B.contains(g)*/) {
+                    B.add(g); // gcd(a,g) == 1 and gcd(g,c) == 1 for c != b in P, B
+                }
+            }
+            if (!b.isZERO() && !b.isConstant() /*&& !B.contains(b)*/) {
+                B.add(b); // gcd(a,b) == 1 and gcd(b,c) == 1 for c != b in P, B
+            }
+        }
+        if (!a.isZERO() && !a.isConstant() /*&& !B.contains(a)*/) {
+            B.add(a);
+        }
+        return B;
+    }
+
+
+    /**
+     * GenPolynomial test for co-prime list.
+     * @param A list of GenPolynomials.
+     * @return true if gcd(b,c) = 1 for all b != c in B, else false.
+     */
+    public boolean isCoPrime(List<GenPolynomial<C>> A) {
+        if (A == null || A.isEmpty()) {
+            return true;
+        }
+        if (A.size() == 1) {
+            return true;
+        }
+        for (int i = 0; i < A.size(); i++) {
+            GenPolynomial<C> a = A.get(i);
+            for (int j = i + 1; j < A.size(); j++) {
+                GenPolynomial<C> b = A.get(j);
+                GenPolynomial<C> g = gcd(a, b);
+                if (!g.isONE()) {
+                    System.out.println("not co-prime, a: " + a);
+                    System.out.println("not co-prime, b: " + b);
+                    System.out.println("not co-prime, g: " + g);
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * GenPolynomial test for co-prime list of given list.
+     * @param A list of GenPolynomials.
+     * @param P list of co-prime GenPolynomials.
+     * @return true if isCoPrime(P) and for all a in A exists p in P with p | a,
+     *         else false.
+     */
+    public boolean isCoPrime(List<GenPolynomial<C>> P, List<GenPolynomial<C>> A) {
+        if (!isCoPrime(P)) {
+            return false;
+        }
+        if (A == null || A.isEmpty()) {
+            return true;
+        }
+        for (GenPolynomial<C> q : A) {
+            if (q.isZERO() || q.isConstant()) {
+                continue;
+            }
+            boolean divides = false;
+            for (GenPolynomial<C> p : P) {
+                GenPolynomial<C> a = PolyUtil.<C> baseSparsePseudoRemainder(q, p);
+                if (a.isZERO()) { // p divides q
+                    divides = true;
+                    break;
+                }
+            }
+            if (!divides) {
+                System.out.println("no divisor for: " + q);
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Univariate GenPolynomial extended greatest common divisor. Uses sparse
+     * pseudoRemainder for remainder.
+     * @param P univariate GenPolynomial.
+     * @param S univariate GenPolynomial.
+     * @return [ gcd(P,S), a, b ] with a*P + b*S = gcd(P,S).
+     */
+    @SuppressWarnings("unchecked")
+    public GenPolynomial<C>[] baseExtendedGcd(GenPolynomial<C> P, GenPolynomial<C> S) {
+        //return P.egcd(S);
+        GenPolynomial<C>[] hegcd = baseHalfExtendedGcd(P, S);
+        GenPolynomial<C>[] ret = (GenPolynomial<C>[]) new GenPolynomial[3];
+        ret[0] = hegcd[0];
+        ret[1] = hegcd[1];
+        GenPolynomial<C> x = hegcd[0].subtract(hegcd[1].multiply(P));
+        GenPolynomial<C>[] qr = PolyUtil.<C> basePseudoQuotientRemainder(x, S);
+        // assert qr[1].isZERO() 
+        ret[2] = qr[0];
+        return ret;
+    }
+
+
+    /**
+     * Univariate GenPolynomial half extended greatest comon divisor. Uses
+     * sparse pseudoRemainder for remainder.
+     * @param S GenPolynomial.
+     * @return [ gcd(P,S), a ] with a*P + b*S = gcd(P,S).
+     */
+    @SuppressWarnings("unchecked")
+    public GenPolynomial<C>[] baseHalfExtendedGcd(GenPolynomial<C> P, GenPolynomial<C> S) {
+        //if ( P == null ) {
+        //    throw new IllegalArgumentException("null P not allowed");
+        //}
+        GenPolynomial<C>[] ret = (GenPolynomial<C>[]) new GenPolynomial[2];
+        ret[0] = null;
+        ret[1] = null;
+        if (S == null || S.isZERO()) {
+            ret[0] = P;
+            ret[1] = P.ring.getONE();
+            return ret;
+        }
+        if (P == null || P.isZERO()) {
+            ret[0] = S;
+            ret[1] = S.ring.getZERO();
+            return ret;
+        }
+        if (P.ring.nvar != 1) {
+            throw new IllegalArgumentException(
+                            this.getClass().getName() + " not univariate polynomials " + P.ring);
+        }
+        GenPolynomial<C> q = P;
+        GenPolynomial<C> r = S;
+        GenPolynomial<C> c1 = P.ring.getONE().copy();
+        GenPolynomial<C> d1 = P.ring.getZERO().copy();
+        while (!r.isZERO()) {
+            GenPolynomial<C>[] qr = PolyUtil.<C> basePseudoQuotientRemainder(q, r);
+            //q.divideAndRemainder(r);
+            q = qr[0];
+            GenPolynomial<C> x = c1.subtract(q.multiply(d1));
+            c1 = d1;
+            d1 = x;
+            q = r;
+            r = qr[1];
+        }
+        // normalize ldcf(q) to 1, i.e. make monic
+        C g = q.leadingBaseCoefficient();
+        if (g.isUnit()) {
+            C h = g.inverse();
+            q = q.multiply(h);
+            c1 = c1.multiply(h);
+        }
+        //assert ( ((c1.multiply(P)).remainder(S).equals(q) )); 
+        ret[0] = q;
+        ret[1] = c1;
+        return ret;
+    }
+
+
+    /**
+     * Univariate GenPolynomial greatest common divisor diophantine version.
+     * @param P univariate GenPolynomial.
+     * @param S univariate GenPolynomial.
+     * @param c univariate GenPolynomial.
+     * @return [ a, b ] with a*P + b*S = c and deg(a) &lt; deg(S).
+     */
+    @SuppressWarnings("unchecked")
+    public GenPolynomial<C>[] baseGcdDiophant(GenPolynomial<C> P, GenPolynomial<C> S, GenPolynomial<C> c) {
+        GenPolynomial<C>[] egcd = baseExtendedGcd(P, S);
+        GenPolynomial<C> g = egcd[0];
+        GenPolynomial<C>[] qr = PolyUtil.<C> basePseudoQuotientRemainder(c, g);
+        if (!qr[1].isZERO()) {
+            throw new ArithmeticException("not solvable, r = " + qr[1] + ", c = " + c + ", g = " + g);
+        }
+        GenPolynomial<C> q = qr[0];
+        GenPolynomial<C> a = egcd[1].multiply(q);
+        GenPolynomial<C> b = egcd[2].multiply(q);
+        if (!a.isZERO() && a.degree(0) >= S.degree(0)) {
+            qr = PolyUtil.<C> basePseudoQuotientRemainder(a, S);
+            a = qr[1];
+            b = b.sum(P.multiply(qr[0]));
+        }
+        GenPolynomial<C>[] ret = (GenPolynomial<C>[]) new GenPolynomial[2];
+        ret[0] = a;
+        ret[1] = b;
+
+        if (debug) {
+            GenPolynomial<C> y = ret[0].multiply(P).sum(ret[1].multiply(S));
+            if (!y.equals(c)) {
+                System.out.println("P  = " + P);
+                System.out.println("S  = " + S);
+                System.out.println("c  = " + c);
+                System.out.println("a  = " + a);
+                System.out.println("b  = " + b);
+                System.out.println("y  = " + y);
+                throw new ArithmeticException("not diophant, x = " + y.subtract(c));
+            }
+        }
+        return ret;
+    }
+
+
+    /**
+     * Univariate GenPolynomial partial fraction decomposition.
+     * @param A univariate GenPolynomial.
+     * @param P univariate GenPolynomial.
+     * @param S univariate GenPolynomial.
+     * @return [ A0, Ap, As ] with A/(P*S) = A0 + Ap/P + As/S with deg(Ap) &lt;
+     *         deg(P) and deg(As) &lt; deg(S).
+     */
+    @SuppressWarnings("unchecked")
+    public GenPolynomial<C>[] basePartialFraction(GenPolynomial<C> A, GenPolynomial<C> P,
+                    GenPolynomial<C> S) {
+        GenPolynomial<C>[] ret = (GenPolynomial<C>[]) new GenPolynomial[3];
+        ret[0] = null;
+        ret[1] = null;
+        ret[2] = null;
+        GenPolynomial<C> ps = P.multiply(S);
+        GenPolynomial<C>[] qr = PolyUtil.<C> basePseudoQuotientRemainder(A, ps);
+        ret[0] = qr[0];
+        GenPolynomial<C> r = qr[1];
+        GenPolynomial<C>[] diop = baseGcdDiophant(S, P, r); // switch arguments
+
+        //         GenPolynomial<C> x = diop[0].multiply(S).sum( diop[1].multiply(P) );
+        //         if ( !x.equals(r) ) {
+        //             System.out.println("r  = " + r);
+        //             System.out.println("x  = " + x);
+        //             throw new RuntimeException("not partial fraction, x = " + x);
+        //         }
+
+        ret[1] = diop[0];
+        ret[2] = diop[1];
+        if (ret[1].degree(0) >= P.degree(0)) {
+            qr = PolyUtil.<C> basePseudoQuotientRemainder(ret[1], P);
+            ret[0] = ret[0].sum(qr[0]);
+            ret[1] = qr[1];
+        }
+        if (ret[2].degree(0) >= S.degree(0)) {
+            qr = PolyUtil.<C> basePseudoQuotientRemainder(ret[2], S);
+            ret[0] = ret[0].sum(qr[0]);
+            ret[2] = qr[1];
+        }
+        return ret;
+    }
+
+
+    /**
+     * Univariate GenPolynomial partial fraction decomposition.
+     * @param A univariate GenPolynomial.
+     * @param P univariate GenPolynomial.
+     * @param e exponent for P.
+     * @return [ F0, F1, ..., Fe ] with A/(P^e) = sum( Fi / P^i ) with deg(Fi) &lt;
+     *         deg(P).
+     */
+    public List<GenPolynomial<C>> basePartialFraction(GenPolynomial<C> A, GenPolynomial<C> P, int e) {
+        if (A == null || P == null || e == 0) {
+            throw new IllegalArgumentException("null A, P or e = 0 not allowed");
+        }
+        List<GenPolynomial<C>> pf = new ArrayList<GenPolynomial<C>>(e);
+        if (A.isZERO()) {
+            for (int i = 0; i < e; i++) {
+                pf.add(A);
+            }
+            return pf;
+        }
+        if (e == 1) {
+            GenPolynomial<C>[] qr = PolyUtil.<C> basePseudoQuotientRemainder(A, P);
+            pf.add(qr[0]);
+            pf.add(qr[1]);
+            return pf;
+        }
+        GenPolynomial<C> a = A;
+        for (int j = e; j > 0; j--) {
+            GenPolynomial<C>[] qr = PolyUtil.<C> basePseudoQuotientRemainder(a, P);
+            a = qr[0];
+            pf.add(0, qr[1]);
+        }
+        pf.add(0, a);
+        return pf;
+    }
+
+
+    /**
+     * Univariate GenPolynomial partial fraction decomposition.
+     * @param A univariate GenPolynomial.
+     * @param D list of co-prime univariate GenPolynomials.
+     * @return [ A0, A1,..., An ] with A/prod(D) = A0 + sum( Ai/Di ) with
+     *         deg(Ai) &lt; deg(Di).
+     */
+    public List<GenPolynomial<C>> basePartialFraction(GenPolynomial<C> A, List<GenPolynomial<C>> D) {
+        if (D == null || A == null) {
+            throw new IllegalArgumentException("null A or D not allowed");
+        }
+        List<GenPolynomial<C>> pf = new ArrayList<GenPolynomial<C>>(D.size() + 1);
+        if (A.isZERO() || D.size() == 0) {
+            pf.add(A);
+            for (int i = 0; i < D.size(); i++) {
+                pf.add(A);
+            }
+            return pf;
+        }
+        List<GenPolynomial<C>> Dp = new ArrayList<GenPolynomial<C>>(D.size() - 1);
+        GenPolynomial<C> P = A.ring.getONE();
+        GenPolynomial<C> d1 = null;
+        for (GenPolynomial<C> d : D) {
+            if (d1 == null) {
+                d1 = d;
+            } else {
+                P = P.multiply(d);
+                Dp.add(d);
+            }
+        }
+        GenPolynomial<C>[] qr = PolyUtil.<C> basePseudoQuotientRemainder(A, P.multiply(d1));
+        GenPolynomial<C> A0 = qr[0];
+        GenPolynomial<C> r = qr[1];
+        if (D.size() == 1) {
+            pf.add(A0);
+            pf.add(r);
+            return pf;
+        }
+        GenPolynomial<C>[] diop = baseGcdDiophant(P, d1, r); // switch arguments
+        GenPolynomial<C> A1 = diop[0];
+        GenPolynomial<C> S = diop[1];
+        List<GenPolynomial<C>> Fr = basePartialFraction(S, Dp);
+        A0 = A0.sum(Fr.remove(0));
+        pf.add(A0);
+        pf.add(A1);
+        pf.addAll(Fr);
+        return pf;
+    }
+
+
+    /**
+     * Test for Univariate GenPolynomial partial fraction decomposition.
+     * @param A univariate GenPolynomial.
+     * @param D list of (co-prime) univariate GenPolynomials.
+     * @param F list of univariate GenPolynomials from a partial fraction
+     *            computation.
+     * @return true if A/prod(D) = F0 + sum( Fi/Di ) with deg(Fi) &lt; deg(Di), Fi
+     *         in F, else false.
+     */
+    public boolean isBasePartialFraction(GenPolynomial<C> A, List<GenPolynomial<C>> D,
+                    List<GenPolynomial<C>> F) {
+        if (D == null || A == null || F == null) {
+            throw new IllegalArgumentException("null A, F or D not allowed");
+        }
+        if (D.size() != F.size() - 1) {
+            return false;
+        }
+        // A0*prod(D) + sum( Ai * Dip ), Dip = prod(D,j!=i)
+        GenPolynomial<C> P = A.ring.getONE();
+        for (GenPolynomial<C> d : D) {
+            P = P.multiply(d);
+        }
+        List<GenPolynomial<C>> Fp = new ArrayList<GenPolynomial<C>>(F);
+        GenPolynomial<C> A0 = Fp.remove(0).multiply(P);
+        //System.out.println("A0 = " + A0);
+        int j = 0;
+        for (GenPolynomial<C> Fi : Fp) {
+            P = A.ring.getONE();
+            int i = 0;
+            for (GenPolynomial<C> d : D) {
+                if (i != j) {
+                    P = P.multiply(d);
+                }
+                i++;
+            }
+            //System.out.println("Fi = " + Fi);
+            //System.out.println("P  = " + P);
+            A0 = A0.sum(Fi.multiply(P));
+            //System.out.println("A0 = " + A0);
+            j++;
+        }
+        boolean t = A.equals(A0);
+        if (!t) {
+            System.out.println("not isPartFrac = " + A0);
+        }
+        return t;
+    }
+
+
+    /**
+     * Test for Univariate GenPolynomial partial fraction decomposition.
+     * @param A univariate GenPolynomial.
+     * @param P univariate GenPolynomial.
+     * @param e exponent for P.
+     * @param F list of univariate GenPolynomials from a partial fraction
+     *            computation.
+     * @return true if A/(P^e) = F0 + sum( Fi / P^i ) with deg(Fi) &lt; deg(P), Fi
+     *         in F, else false.
+     */
+    public boolean isBasePartialFraction(GenPolynomial<C> A, GenPolynomial<C> P, int e,
+                    List<GenPolynomial<C>> F) {
+        if (A == null || P == null || F == null || e == 0) {
+            throw new IllegalArgumentException("null A, P, F or e = 0 not allowed");
+        }
+        GenPolynomial<C> A0 = basePartialFractionValue(P, e, F);
+        boolean t = A.equals(A0);
+        if (!t) {
+            System.out.println("not isPartFrac = " + A0);
+        }
+        return t;
+    }
+
+
+    /**
+     * Test for Univariate GenPolynomial partial fraction decomposition.
+     * @param P univariate GenPolynomial.
+     * @param e exponent for P.
+     * @param F list of univariate GenPolynomials from a partial fraction
+     *            computation.
+     * @return (F0 + sum( Fi / P^i )) * P^e.
+     */
+    public GenPolynomial<C> basePartialFractionValue(GenPolynomial<C> P, int e, List<GenPolynomial<C>> F) {
+        if (P == null || F == null || e == 0) {
+            throw new IllegalArgumentException("null P, F or e = 0 not allowed");
+        }
+        GenPolynomial<C> A0 = P.ring.getZERO();
+        for (GenPolynomial<C> Fi : F) {
+            A0 = A0.multiply(P);
+            A0 = A0.sum(Fi);
+        }
+        return A0;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/GreatestCommonDivisorFake.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/GreatestCommonDivisorFake.java
@@ -1,0 +1,156 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Greatest common divisor algorithms with gcd always 1. The computation is
+ * faked as the gcd is always 1.
+ * @author Heinz Kredel
+ */
+
+public class GreatestCommonDivisorFake<C extends GcdRingElem<C>> extends GreatestCommonDivisorAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GreatestCommonDivisorFake.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * GenPolynomial base coefficient content. Always returns 1.
+     * @param P GenPolynomial.
+     * @return cont(P).
+     */
+    @Override
+    public C baseContent(GenPolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P != null");
+        }
+        if (P.isZERO()) {
+            return P.ring.getZEROCoefficient();
+        }
+        return P.ring.getONECoefficient();
+    }
+
+
+    /**
+     * GenPolynomial base coefficient primitive part. Always returns P.
+     * @param P GenPolynomial.
+     * @return pp(P).
+     */
+    @Override
+    public GenPolynomial<C> basePrimitivePart(GenPolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P != null");
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        if (P.isConstant()) {
+            return P.ring.getONE();
+        }
+        if (P.length() == 1) { // one term
+            //System.out.println("P = " + P);
+            return P.ring.valueOf(P.leadingExpVector());
+        }
+        return P;
+    }
+
+
+    /**
+     * Univariate GenPolynomial greatest comon divisor. Always returns 1.
+     * @param P univariate GenPolynomial.
+     * @param S univariate GenPolynomial.
+     * @return gcd(P,S).
+     */
+    @Override
+    public GenPolynomial<C> baseGcd(GenPolynomial<C> P, GenPolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.ring.nvar > 1) {
+            throw new IllegalArgumentException(this.getClass().getName() + " no univariate polynomial");
+        }
+        return P.ring.getONE();
+    }
+
+
+    /**
+     * GenPolynomial recursive content. Always returns 1.
+     * @param P recursive GenPolynomial.
+     * @return cont(P).
+     */
+    @Override
+    public GenPolynomial<C> recursiveContent(GenPolynomial<GenPolynomial<C>> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P != null");
+        }
+        if (P.isZERO()) {
+            return P.ring.getZEROCoefficient();
+        }
+        return P.ring.getONECoefficient();
+    }
+
+
+    /**
+     * GenPolynomial recursive primitive part. Always returns P.
+     * @param P recursive GenPolynomial.
+     * @return pp(P).
+     */
+    @Override
+    public GenPolynomial<GenPolynomial<C>> recursivePrimitivePart(GenPolynomial<GenPolynomial<C>> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P != null");
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        if (P.isConstant()) {
+            return P.ring.getONE();
+        }
+        if (P.length() == 1) { // one term
+            //System.out.println("P = " + P);
+            return P.ring.valueOf(P.leadingExpVector());
+        }
+        return P;
+    }
+
+
+    /**
+     * Univariate GenPolynomial recursive greatest comon divisor. Always returns
+     * 1.
+     * @param P univariate recursive GenPolynomial.
+     * @param S univariate recursive GenPolynomial.
+     * @return gcd(P,S).
+     */
+    @Override
+    public GenPolynomial<GenPolynomial<C>> recursiveUnivariateGcd(GenPolynomial<GenPolynomial<C>> P,
+                    GenPolynomial<GenPolynomial<C>> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.ring.nvar > 1) {
+            throw new IllegalArgumentException(this.getClass().getName() + " no univariate polynomial");
+        }
+        logger.debug("returning 1");
+        return P.ring.getONE();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/GreatestCommonDivisorHensel.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/GreatestCommonDivisorHensel.java
@@ -1,0 +1,740 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.arith.BigInteger;
+import edu.jas.arith.ModIntegerRing;
+import edu.jas.arith.ModLongRing;
+import edu.jas.arith.Modular;
+import edu.jas.arith.ModularRingFactory;
+import edu.jas.arith.PrimeList;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.NotInvertibleException;
+import edu.jas.structure.Power;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Greatest common divisor algorithms with subresultant polynomial remainder
+ * sequence and univariate Hensel lifting.
+ * @author Heinz Kredel
+ */
+
+public class GreatestCommonDivisorHensel<MOD extends GcdRingElem<MOD> & Modular>
+                extends GreatestCommonDivisorAbstract<BigInteger> {
+
+
+    private static final Logger logger = LogManager.getLogger(GreatestCommonDivisorHensel.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Flag for linear or quadratic Hensel lift.
+     */
+    public final boolean quadratic;
+
+
+    /**
+     * Fall back gcd algorithm.
+     */
+    public final GreatestCommonDivisorAbstract<BigInteger> iufd;
+
+
+    /*
+     * Internal dispatcher.
+     */
+    private final GreatestCommonDivisorAbstract<BigInteger> ufd;
+
+
+    /**
+     * Constructor.
+     */
+    public GreatestCommonDivisorHensel() {
+        this(true);
+    }
+
+
+    /**
+     * Constructor.
+     * @param quadratic use quadratic Hensel lift.
+     */
+    public GreatestCommonDivisorHensel(boolean quadratic) {
+        this.quadratic = quadratic;
+        iufd = new GreatestCommonDivisorSubres<BigInteger>();
+        ufd = this; //iufd;
+    }
+
+
+    /**
+     * Univariate GenPolynomial greatest comon divisor. Uses univariate Hensel
+     * lifting.
+     * @param P univariate GenPolynomial.
+     * @param S univariate GenPolynomial.
+     * @return gcd(P,S).
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public GenPolynomial<BigInteger> baseGcd(GenPolynomial<BigInteger> P, GenPolynomial<BigInteger> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.ring.nvar > 1) {
+            throw new IllegalArgumentException(this.getClass().getName() + " no univariate polynomial");
+        }
+        GenPolynomialRing<BigInteger> fac = P.ring;
+        long e = P.degree(0);
+        long f = S.degree(0);
+        GenPolynomial<BigInteger> q;
+        GenPolynomial<BigInteger> r;
+        if (f > e) {
+            r = P;
+            q = S;
+            long g = f;
+            f = e;
+            e = g;
+        } else {
+            q = P;
+            r = S;
+        }
+        if (debug) {
+            logger.debug("degrees: e = " + e + ", f = " + f);
+        }
+        r = r.abs();
+        q = q.abs();
+        // compute contents and primitive parts
+        BigInteger a = baseContent(r);
+        BigInteger b = baseContent(q);
+        // gcd of coefficient contents
+        BigInteger c = gcd(a, b); // indirection
+        r = divide(r, a); // indirection
+        q = divide(q, b); // indirection
+        if (r.isONE()) {
+            return r.multiply(c);
+        }
+        if (q.isONE()) {
+            return q.multiply(c);
+        }
+        // compute normalization factor
+        BigInteger ac = r.leadingBaseCoefficient();
+        BigInteger bc = q.leadingBaseCoefficient();
+        BigInteger cc = gcd(ac, bc); // indirection
+        // compute degree vectors, only univeriate
+        ExpVector rdegv = r.degreeVector();
+        ExpVector qdegv = q.degreeVector();
+        //initialize prime list and degree vector
+        PrimeList primes = new PrimeList(PrimeList.Range.medium);
+        int pn = 50; //primes.size();
+
+        ModularRingFactory<MOD> cofac;
+        GenPolynomial<MOD> qm;
+        GenPolynomial<MOD> qmf;
+        GenPolynomial<MOD> rm;
+        GenPolynomial<MOD> rmf;
+        GenPolynomial<MOD> cmf;
+        GenPolynomialRing<MOD> mfac;
+        GenPolynomial<MOD> cm = null;
+        GenPolynomial<MOD>[] ecm = null;
+        GenPolynomial<MOD> sm = null;
+        GenPolynomial<MOD> tm = null;
+        HenselApprox<MOD> lift = null;
+        if (debug) {
+            logger.debug("c = " + c);
+            logger.debug("cc = " + cc);
+            logger.debug("primes = " + primes);
+        }
+
+        int i = 0;
+        for (java.math.BigInteger p : primes) {
+            //System.out.println("next run ++++++++++++++++++++++++++++++++++");
+            if (++i >= pn) {
+                logger.error("prime list exhausted, pn = " + pn);
+                //logger.info("primes = " + primes);
+                return iufd.baseGcd(P, S);
+                //throw new ArithmeticException("prime list exhausted");
+            }
+            // initialize coefficient factory and map normalization factor
+            //cofac = new ModIntegerRing(p, true);
+            if (ModLongRing.MAX_LONG.compareTo(p) > 0) {
+                cofac = (ModularRingFactory) new ModLongRing(p, true);
+            } else {
+                cofac = (ModularRingFactory) new ModIntegerRing(p, true);
+            }
+            MOD nf = cofac.fromInteger(cc.getVal());
+            if (nf.isZERO()) {
+                continue;
+            }
+            nf = cofac.fromInteger(q.leadingBaseCoefficient().getVal());
+            if (nf.isZERO()) {
+                continue;
+            }
+            nf = cofac.fromInteger(r.leadingBaseCoefficient().getVal());
+            if (nf.isZERO()) {
+                continue;
+            }
+            // initialize polynomial factory and map polynomials
+            mfac = new GenPolynomialRing<MOD>(cofac, fac.nvar, fac.tord, fac.getVars());
+            qm = PolyUtil.<MOD> fromIntegerCoefficients(mfac, q);
+            if (!qm.degreeVector().equals(qdegv)) {
+                continue;
+            }
+            rm = PolyUtil.<MOD> fromIntegerCoefficients(mfac, r);
+            if (!rm.degreeVector().equals(rdegv)) {
+                continue;
+            }
+            if (debug) {
+                logger.info("cofac = " + cofac.getIntegerModul());
+            }
+
+            // compute univariate modular gcd
+            cm = qm.gcd(rm);
+
+            // test for constant g.c.d
+            if (cm.isConstant()) {
+                logger.debug("cm, constant = " + cm);
+                return fac.getONE().multiply(c);
+            }
+
+            // compute factors and gcd with factor
+            GenPolynomial<BigInteger> crq;
+            rmf = rm.divide(cm); // rm = cm * rmf
+            ecm = cm.egcd(rmf);
+            if (ecm[0].isONE()) {
+                //logger.debug("gcd() first factor " + rmf);
+                crq = r;
+                cmf = rmf;
+                sm = ecm[1];
+                tm = ecm[2];
+            } else {
+                qmf = qm.divide(cm); // qm = cm * qmf
+                ecm = cm.egcd(qmf);
+                if (ecm[0].isONE()) {
+                    //logger.debug("gcd() second factor " + qmf);
+                    crq = q;
+                    cmf = qmf;
+                    sm = ecm[1];
+                    tm = ecm[2];
+                } else {
+                    logger.info("both gcd != 1: Hensel not applicable");
+                    return iufd.baseGcd(P, S);
+                }
+            }
+            BigInteger cn = crq.maxNorm();
+            cn = cn.multiply(crq.leadingBaseCoefficient().abs());
+            cn = cn.multiply(cn.fromInteger(2));
+            if (debug) {
+                System.out.println("crq = " + crq);
+                System.out.println("cm  = " + cm);
+                System.out.println("cmf = " + cmf);
+                System.out.println("sm  = " + sm);
+                System.out.println("tm  = " + tm);
+                System.out.println("cn  = " + cn);
+            }
+            try {
+                if (quadratic) {
+                    lift = HenselUtil.liftHenselQuadratic(crq, cn, cm, cmf, sm, tm);
+                } else {
+                    lift = HenselUtil.liftHensel(crq, cn, cm, cmf, sm, tm);
+                }
+            } catch (NoLiftingException nle) {
+                logger.info("giving up on Hensel gcd reverting to Subres gcd " + nle);
+                return iufd.baseGcd(P, S);
+            }
+            q = lift.A;
+            if (debug) {
+                System.out.println("q   = " + q);
+                System.out.println("qf  = " + lift.B);
+            }
+            q = basePrimitivePart(q);
+            q = q.multiply(c).abs();
+            if (PolyUtil.<BigInteger> baseSparsePseudoRemainder(P, q).isZERO()
+                            && PolyUtil.<BigInteger> baseSparsePseudoRemainder(S, q).isZERO()) {
+                break;
+            }
+            logger.info("final devision not successfull");
+            //System.out.println("P rem q = " + PolyUtil.<BigInteger>baseSparsePseudoRemainder(P,q));
+            //System.out.println("S rem q = " + PolyUtil.<BigInteger>baseSparsePseudoRemainder(S,q));
+            //break;
+        }
+        return q;
+    }
+
+
+    /**
+     * Univariate GenPolynomial recursive greatest comon divisor. Uses
+     * multivariate Hensel list.
+     * @param P univariate recursive GenPolynomial.
+     * @param S univariate recursive GenPolynomial.
+     * @return gcd(P,S).
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public GenPolynomial<GenPolynomial<BigInteger>> recursiveUnivariateGcd(
+                    GenPolynomial<GenPolynomial<BigInteger>> P, GenPolynomial<GenPolynomial<BigInteger>> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.ring.nvar > 1) {
+            throw new IllegalArgumentException(this.getClass().getName() + " no univariate polynomial");
+        }
+        long e = P.degree(0);
+        long f = S.degree(0);
+        GenPolynomial<GenPolynomial<BigInteger>> q, r; //, s;
+        if (f > e) {
+            r = P;
+            q = S;
+            long g = f;
+            f = e;
+            e = g;
+        } else {
+            q = P;
+            r = S;
+        }
+        if (debug) {
+            logger.debug("degrees: e = " + e + ", f = " + f);
+        }
+        r = r.abs();
+        q = q.abs();
+        //logger.info("r: " + r + ", q: " + q);
+
+        GenPolynomial<BigInteger> a = ufd.recursiveContent(r);
+        GenPolynomial<BigInteger> b = ufd.recursiveContent(q);
+
+        GenPolynomial<BigInteger> c = ufd.gcd(a, b); // go to recursion
+        //System.out.println("rgcd c = " + c);
+        r = PolyUtil.<BigInteger> recursiveDivide(r, a);
+        q = PolyUtil.<BigInteger> recursiveDivide(q, b);
+        //a = PolyUtil.<BigInteger> basePseudoDivide(a, c); // unused ?
+        //b = PolyUtil.<BigInteger> basePseudoDivide(b, c); // unused ?
+        if (r.isONE()) {
+            return r.multiply(c);
+        }
+        if (q.isONE()) {
+            return q.multiply(c);
+        }
+        // check constant ldcf, TODO general case
+        GenPolynomial<BigInteger> la, lb, lc, lh;
+        la = r.leadingBaseCoefficient();
+        lb = q.leadingBaseCoefficient();
+        lc = ufd.gcd(la, lb);
+        //logger.info("la = " + la + ", lb = " + lb + ", lc = " + lc);
+        if (!lc.isConstant()) {
+            //continue; // easy way out
+            GenPolynomial<GenPolynomial<BigInteger>> T = iufd.recursiveUnivariateGcd(r, q);
+            T = T.abs().multiply(c);
+            logger.info("non monic ldcf (" + lc + ") not implemented: " + T + "= gcd(" + r + "," + q + ") * "
+                            + c);
+            return T;
+        }
+
+        // convert from Z[y1,...,yr][x] to Z[x][y1,...,yr] to Z[x,y1,...,yr]
+        GenPolynomial<GenPolynomial<BigInteger>> qs = PolyUtil.<BigInteger> switchVariables(q);
+        GenPolynomial<GenPolynomial<BigInteger>> rs = PolyUtil.<BigInteger> switchVariables(r);
+
+        GenPolynomialRing<GenPolynomial<BigInteger>> rfac = qs.ring;
+        RingFactory<GenPolynomial<BigInteger>> rrfac = rfac.coFac;
+        GenPolynomialRing<BigInteger> cfac = (GenPolynomialRing<BigInteger>) rrfac;
+        GenPolynomialRing<BigInteger> dfac = cfac.extend(rfac.getVars());
+        //System.out.println("pfac = " + P.ring.toScript());
+        //System.out.println("rfac = " + rfac.toScript());
+        //System.out.println("dfac = " + dfac.toScript());
+        GenPolynomial<BigInteger> qd = PolyUtil.<BigInteger> distribute(dfac, qs);
+        GenPolynomial<BigInteger> rd = PolyUtil.<BigInteger> distribute(dfac, rs);
+
+        // compute normalization factor
+        BigInteger ac = rd.leadingBaseCoefficient();
+        BigInteger bc = qd.leadingBaseCoefficient();
+        BigInteger cc = gcd(ac, bc); // indirection
+
+        //initialize prime list
+        PrimeList primes = new PrimeList(PrimeList.Range.medium);
+        Iterator<java.math.BigInteger> primeIter = primes.iterator();
+        int pn = 50; //primes.size();
+
+        // double check variables
+        // need qe,re,qd,rd,a,b
+        GenPolynomial<BigInteger> ce0 = null; // qe0, re0,
+
+        for (int i = 0; i < 11; i++) { // meta loop
+            //System.out.println("======== run " + dfac.nvar + ", " + i);
+            java.math.BigInteger p = null; //new java.math.BigInteger("19"); //primes.next();
+            // 5 small, 4 medium and 2 large size primes
+            if (i == 0) { // medium size
+                primes = new PrimeList(PrimeList.Range.medium);
+                primeIter = primes.iterator();
+            }
+            if (i == 4) { // small size
+                primes = new PrimeList(PrimeList.Range.small);
+                primeIter = primes.iterator();
+                p = primeIter.next(); // 2
+                p = primeIter.next(); // 3
+                p = primeIter.next(); // 5
+                p = primeIter.next(); // 7
+            }
+            if (i == 9) { // large size
+                primes = new PrimeList(PrimeList.Range.large);
+                primeIter = primes.iterator();
+            }
+            ModularRingFactory<MOD> cofac = null;
+            int pi = 0;
+            while (pi++ < pn && primeIter.hasNext()) {
+                p = primeIter.next();
+                //p = new java.math.BigInteger("19");
+                logger.info("prime = " + p);
+                // initialize coefficient factory and map normalization factor and polynomials
+                ModularRingFactory<MOD> cf = null;
+                if (ModLongRing.MAX_LONG.compareTo(p) > 0) {
+                    cf = (ModularRingFactory) new ModLongRing(p, true);
+                } else {
+                    cf = (ModularRingFactory) new ModIntegerRing(p, true);
+                }
+                MOD nf = cf.fromInteger(cc.getVal());
+                if (nf.isZERO()) {
+                    continue;
+                }
+                nf = cf.fromInteger(q.leadingBaseCoefficient().leadingBaseCoefficient().getVal());
+                if (nf.isZERO()) {
+                    continue;
+                }
+                nf = cf.fromInteger(r.leadingBaseCoefficient().leadingBaseCoefficient().getVal());
+                if (nf.isZERO()) {
+                    continue;
+                }
+                cofac = cf;
+                break;
+            }
+            if (cofac == null) { // no lucky prime found
+                GenPolynomial<GenPolynomial<BigInteger>> T = iufd.recursiveUnivariateGcd(q, r);
+                logger.info("no lucky prime, gave up on Hensel: " + T + "= gcd(" + r + "," + q + ")");
+                return T.abs().multiply(c); //.abs();
+            }
+            //System.out.println("cofac = " + cofac);
+
+            // search evaluation points and evaluate
+            List<BigInteger> V = new ArrayList<BigInteger>(P.ring.nvar);
+            GenPolynomialRing<BigInteger> ckfac = dfac;
+            GenPolynomial<BigInteger> qe = qd;
+            GenPolynomial<BigInteger> re = rd;
+            GenPolynomial<BigInteger> qei;
+            GenPolynomial<BigInteger> rei;
+            for (int j = dfac.nvar; j > 1; j--) {
+                // evaluation to univariate case
+                long degq = qe.degree(ckfac.nvar - 2);
+                long degr = re.degree(ckfac.nvar - 2);
+                ckfac = ckfac.contract(1);
+                long vi = 1L; //(long)(dfac.nvar-j); // 1L; 0 not so good for small p
+                if (p.longValueExact() > 1000L) {
+                    //vi = (long)j+1L;
+                    vi = 0L;
+                }
+                // search small evaluation point
+                while (true) {
+                    MOD vp = cofac.fromInteger(vi++);
+                    //System.out.println("vp = " + vp);
+                    if (vp.isZERO() && vi != 1L) { // all elements of Z_p exhausted
+                        qe = null;
+                        re = null;
+                        break;
+                    }
+                    BigInteger vii = new BigInteger(vi - 1);
+                    qei = PolyUtil.<BigInteger> evaluateMain(ckfac, qe, vii);
+                    rei = PolyUtil.<BigInteger> evaluateMain(ckfac, re, vii);
+                    //System.out.println("qei = " + qei);
+                    //System.out.println("rei = " + rei);
+
+                    // check lucky evaluation point 
+                    if (degq != qei.degree(ckfac.nvar - 1)) {
+                        //System.out.println("degv(qe) = " + qe.degreeVector());
+                        //System.out.println("deg(qe) = " + degq + ", deg(qe) = " + qei.degree(ckfac.nvar-1));
+                        continue;
+                    }
+                    if (degr != rei.degree(ckfac.nvar - 1)) {
+                        //System.out.println("degv(re) = " + re.degreeVector());
+                        //System.out.println("deg(re) = " + degr + ", deg(re) = " + rei.degree(ckfac.nvar-1));
+                        continue;
+                    }
+                    V.add(vii);
+                    qe = qei;
+                    re = rei;
+                    break;
+                }
+                if (qe == null && re == null) {
+                    break;
+                }
+            }
+            if (qe == null && re == null) {
+                continue;
+            }
+            logger.info("evaluation points  = " + V);
+
+            // recursion base:
+            GenPolynomial<BigInteger> ce = ufd.baseGcd(qe, re);
+            if (ce.isConstant()) {
+                return P.ring.getONE().multiply(c);
+            }
+            logger.info("base gcd = " + ce);
+
+            // double check 
+            // need qe,re,qd,rd,a,b
+            if (i == 0) {
+                //qe0 = qe;
+                //re0 = re;
+                ce0 = ce;
+                continue;
+            }
+            long d0 = ce0.degree(0);
+            long d1 = ce.degree(0);
+            //System.out.println("d0, d1 = " + d0 + ", " + d1);
+            if (d1 < d0) {
+                //qe0 = qe;
+                //re0 = re;
+                ce0 = ce;
+                continue;
+            } else if (d1 > d0) {
+                continue;
+            }
+            // d0 == d1 is ok
+            long dx = r.degree(0);
+            //System.out.println("d0, dx = " + d0 + ", " + dx);
+            if (d0 == dx) { // gcd == r ?
+                if (PolyUtil.<BigInteger> recursiveSparsePseudoRemainder(q, r).isZERO()) {
+                    r = r.abs().multiply(c); //.abs();
+                    logger.info("exit with r | q : " + r);
+                    return r;
+                }
+                continue;
+            }
+            // norm
+            BigInteger mn = null; //mn = mn.multiply(cc).multiply(mn.fromInteger(2));
+            // prepare lifting, chose factor polynomials
+            GenPolynomial<BigInteger> re1 = PolyUtil.<BigInteger> basePseudoDivide(re, ce);
+            GenPolynomial<BigInteger> qe1 = PolyUtil.<BigInteger> basePseudoDivide(qe, ce);
+            GenPolynomial<BigInteger> ui, he; //, pe;
+            GenPolynomial<BigInteger> g, gi, lui;
+            GenPolynomial<BigInteger> gcr, gcq;
+            gcr = ufd.baseGcd(re1, ce);
+            gcq = ufd.baseGcd(qe1, ce);
+            if (gcr.isONE() && gcq.isONE()) { // both gcds == 1: chose smaller ldcf
+                if (la.totalDegree() > lb.totalDegree()) {
+                    ui = qd;
+                    //s = q;
+                    he = qe1;
+                    //pe = qe;
+                    BigInteger bn = qd.maxNorm();
+                    mn = bn.multiply(cc).multiply(new BigInteger(2L));
+                    g = lb;
+                    logger.debug("select deg: ui = qd, g = b"); //, qe1 = " + qe1); // + ", qe = " + qe);
+                } else {
+                    ui = rd;
+                    //s = r;
+                    he = re1;
+                    //pe = re;
+                    BigInteger an = rd.maxNorm();
+                    mn = an.multiply(cc).multiply(new BigInteger(2L));
+                    g = la;
+                    logger.debug("select deg: ui = rd, g = a"); //, re1 = " + re1); // + ", re = " + re);
+                }
+            } else if (gcr.isONE()) {
+                ui = rd;
+                //s = r;
+                he = re1;
+                //pe = re;
+                BigInteger an = rd.maxNorm();
+                mn = an.multiply(cc).multiply(new BigInteger(2L));
+                g = la;
+                logger.debug("select: ui = rd, g = a"); //, re1 = " + re1); // + ", re = " + re);
+            } else if (gcq.isONE()) {
+                ui = qd;
+                //s = q;
+                he = qe1;
+                //pe = qe;
+                BigInteger bn = qd.maxNorm();
+                mn = bn.multiply(cc).multiply(new BigInteger(2L));
+                g = lb;
+                logger.debug("select: ui = qd, g = b"); //, qe1 = " + qe1); // + ", qe = " + qe);
+            } else { // both gcds != 1: method not applicable
+                logger.info("both gcds != 1: method not applicable");
+                break;
+            }
+            lui = lc; //s.leadingBaseCoefficient();
+            lh = PolyUtil.<BigInteger> basePseudoDivide(g, lui);
+            BigInteger ge = PolyUtil.<BigInteger> evaluateAll(g.ring.coFac, lui, V);
+            if (ge.isZERO()) {
+                continue;
+            }
+            BigInteger geh = PolyUtil.<BigInteger> evaluateAll(g.ring.coFac, lh, V);
+            if (geh.isZERO()) {
+                continue;
+            }
+            BigInteger gg = PolyUtil.<BigInteger> evaluateAll(g.ring.coFac, g, V);
+            if (gg.isZERO()) {
+                continue;
+            }
+            //System.out.println("ge = " + ge + ", geh = " + geh + ", gg = " + gg + ", pe = " + pe); 
+            // 
+            //ce = ce.multiply(geh); //ge);
+            // 
+            he = he.multiply(ge); //gg); //ge); //geh);
+            //
+            gi = lui.extendLower(dfac, 0, 0L); //lui. // g.
+            //
+            ui = ui.multiply(gi); // gi !.multiply(gi) 
+            //System.out.println("ui = " + ui + ", deg(ui) = " + ui.degreeVector());
+            //System.out.println("ce = " + ce + ", he = " + he + ", ge = " + ge);
+            logger.info("gcd(ldcf): " + lui + ", ldcf cofactor: " + lh + ", base cofactor: " + he);
+
+            long k = Power.logarithm(new BigInteger(p), mn);
+            //System.out.println("mn = " + mn);
+            //System.out.println("k = " + k);
+
+            BigInteger qp = cofac.getIntegerModul().power(k);
+            ModularRingFactory<MOD> muqfac;
+            if (ModLongRing.MAX_LONG.compareTo(qp.getVal()) > 0) {
+                muqfac = (ModularRingFactory) new ModLongRing(qp.getVal(), true); // nearly a field
+            } else {
+                muqfac = (ModularRingFactory) new ModIntegerRing(qp.getVal(), true); // nearly a field
+            }
+            GenPolynomialRing<MOD> mucpfac = new GenPolynomialRing<MOD>(muqfac, ckfac);
+            //System.out.println("mucpfac = " + mucpfac.toScript());
+            if (muqfac.fromInteger(ge.getVal()).isZERO()) {
+                continue;
+            }
+            //GenPolynomial<BigInteger> xxx = invertPoly(muqfac,lui,V);
+            //System.out.println("inv(lui) = " + xxx + ", muqfac = " + muqfac + ", lui = " + lui);
+            //ce = ce.multiply(xxx); //.leadingBaseCoefficient()); 
+            //xxx = invertPoly(muqfac,lh,V);
+            //System.out.println("inv(lh) = " + xxx + ", muqfac = " + muqfac + ", lh = " + lh);
+            //he = he.multiply(xxx); //.leadingBaseCoefficient()); 
+
+            GenPolynomial<MOD> cm = PolyUtil.<MOD> fromIntegerCoefficients(mucpfac, ce);
+            GenPolynomial<MOD> hm = PolyUtil.<MOD> fromIntegerCoefficients(mucpfac, he);
+            if (cm.degree(0) != ce.degree(0) || hm.degree(0) != he.degree(0)) {
+                continue;
+            }
+            if (cm.isZERO() || hm.isZERO()) {
+                continue;
+            }
+            logger.info("univariate modulo p^k: " + cm + ", " + hm);
+
+            // convert C from Z[...] to Z_q[...]
+            GenPolynomialRing<MOD> qcfac = new GenPolynomialRing<MOD>(muqfac, dfac);
+            GenPolynomial<MOD> uq = PolyUtil.<MOD> fromIntegerCoefficients(qcfac, ui);
+            if (!ui.leadingExpVector().equals(uq.leadingExpVector())) {
+                logger.info("ev(ui) = " + ui.leadingExpVector() + ", ev(uq) = " + uq.leadingExpVector());
+                continue;
+            }
+            logger.info("multivariate modulo p^k: " + uq);
+
+            List<GenPolynomial<MOD>> F = new ArrayList<GenPolynomial<MOD>>(2);
+            F.add(cm);
+            F.add(hm);
+            List<GenPolynomial<BigInteger>> G = new ArrayList<GenPolynomial<BigInteger>>(2);
+            G.add(lui.ring.getONE()); //lui: lui.ring.getONE()); // TODO 
+            G.add(lui.ring.getONE()); //lh: lui);
+            List<GenPolynomial<MOD>> lift;
+            try {
+                //lift = HenselMultUtil.<MOD> liftHenselFull(ui, F, V, k, G);
+                lift = HenselMultUtil.<MOD> liftHensel(ui, uq, F, V, k, G);
+                logger.info("lift = " + lift);
+            } catch (NoLiftingException nle) {
+                logger.info("NoLiftingException");
+                //System.out.println("exception : " + nle);
+                continue;
+            } catch (ArithmeticException ae) {
+                logger.info("ArithmeticException");
+                //System.out.println("exception : " + ae);
+                continue;
+            } catch (NotInvertibleException ni) {
+                logger.info("NotInvertibleException");
+                //System.out.println("exception : " + ni);
+                continue;
+            }
+            //if (!HenselMultUtil.<MOD> isHenselLift(ui, uq, F, k, lift)) { // not meaningfull test
+            //    logger.info("isHenselLift: false");
+            //    //continue;
+            //}
+
+            // convert Ci from Z_{p^k}[x,y1,...,yr] to Z[x,y1,...,yr] to Z[x][y1,...,yr] to Z[y1,...,yr][x]
+            GenPolynomial<BigInteger> ci = PolyUtil.integerFromModularCoefficients(dfac, lift.get(0));
+            ci = basePrimitivePart(ci);
+            GenPolynomial<GenPolynomial<BigInteger>> Cr = PolyUtil.<BigInteger> recursive(rfac, ci);
+            GenPolynomial<GenPolynomial<BigInteger>> Cs = PolyUtil.<BigInteger> switchVariables(Cr);
+            if (!Cs.ring.equals(P.ring)) {
+                System.out.println("Cs.ring = " + Cs.ring + ", P.ring = " + P.ring);
+            }
+            GenPolynomial<GenPolynomial<BigInteger>> Q = ufd.recursivePrimitivePart(Cs);
+            Q = ufd.baseRecursivePrimitivePart(Q);
+            Q = Q.abs().multiply(c); //.abs();
+            GenPolynomial<GenPolynomial<BigInteger>> Pq, Sq;
+            Pq = PolyUtil.<BigInteger> recursiveSparsePseudoRemainder(P, Q);
+            Sq = PolyUtil.<BigInteger> recursiveSparsePseudoRemainder(S, Q);
+            if (Pq.isZERO() && Sq.isZERO()) {
+                logger.info("gcd normal exit: " + Q);
+                return Q;
+            }
+            logger.info("bad Q = " + Q); // + ", Pq = " + Pq + ", Sq = " + Sq);
+        } // end for meta loop
+          // Hensel gcd failed
+        GenPolynomial<GenPolynomial<BigInteger>> T = iufd.recursiveUnivariateGcd(r, q);
+        T = T.abs().multiply(c);
+        logger.info("no lucky prime or evaluation points, gave up on Hensel: " + T + "= gcd(" + r + "," + q
+                        + ")");
+        return T;
+    }
+
+
+    /* move to Ideal ?
+    GenPolynomial<BigInteger> invertPoly(ModularRingFactory<MOD> mfac, GenPolynomial<BigInteger> li,
+                    List<BigInteger> V) {
+        if (li == null || li.isZERO()) {
+            throw new RuntimeException("li not invertible: " + li);
+        }
+        if (li.isONE()) {
+            return li;
+        }
+        //System.out.println("mfac = " + mfac + ", V = " + V +", li = " + li);
+        GenPolynomialRing<BigInteger> pfac = li.ring;
+        GenPolynomialRing<MOD> mpfac = new GenPolynomialRing<MOD>(mfac, pfac);
+        GenPolynomial<MOD> lm = PolyUtil.<MOD> fromIntegerCoefficients(mpfac, li);
+        //System.out.println("pfac = " + pfac + ", lm = " + lm);
+        List<GenPolynomial<MOD>> lid = new ArrayList<GenPolynomial<MOD>>(V.size());
+        int i = 0;
+        for (BigInteger bi : V) {
+            MOD m = mfac.fromInteger(bi.getVal());
+            GenPolynomial<MOD> mp = mpfac.univariate(i);
+            mp = mp.subtract(m); // X_i - v_i
+            lid.add(mp);
+            i++;
+        }
+        //System.out.println("lid = " + lid);
+        //Ideal<MOD> id = new Ideal<MOD>(mpfac,lid,true); // is a GB
+        //System.out.println("id = " + id);
+        GenPolynomial<MOD> mi = lm; //id.inverse(lm);
+        //System.out.println("mi = " + mi);
+        GenPolynomial<BigInteger> inv = PolyUtil.integerFromModularCoefficients(pfac, mi);
+        return inv;
+    }
+    */
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/GreatestCommonDivisorModEval.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/GreatestCommonDivisorModEval.java
@@ -1,0 +1,495 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.arith.Modular;
+import edu.jas.arith.ModularRingFactory;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Greatest common divisor algorithms with modular evaluation algorithm for
+ * recursion.
+ * @author Heinz Kredel
+ */
+
+public class GreatestCommonDivisorModEval<MOD extends GcdRingElem<MOD> & Modular>
+                extends GreatestCommonDivisorAbstract<MOD> {
+
+
+    private static final Logger logger = LogManager.getLogger(GreatestCommonDivisorModEval.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Modular gcd algorithm to use.
+     */
+    protected final GreatestCommonDivisorAbstract<MOD> mufd = new GreatestCommonDivisorSimple<MOD>();
+    // not okay = new GreatestCommonDivisorPrimitive<MOD>();
+    // not okay = new GreatestCommonDivisorSubres<MOD>();
+
+
+    /**
+     * Univariate GenPolynomial greatest common divisor.
+     * @param P univariate GenPolynomial.
+     * @param S univariate GenPolynomial.
+     * @return gcd(P,S).
+     */
+    @Override
+    public GenPolynomial<MOD> baseGcd(GenPolynomial<MOD> P, GenPolynomial<MOD> S) {
+        // required as recursion base
+        return mufd.baseGcd(P, S);
+    }
+
+
+    /**
+     * Recursive univariate GenPolynomial greatest common divisor.
+     * @param P univariate recursive GenPolynomial.
+     * @param S univariate recursive GenPolynomial.
+     * @return gcd(P,S).
+     */
+    @Override
+    public GenPolynomial<GenPolynomial<MOD>> recursiveUnivariateGcd(GenPolynomial<GenPolynomial<MOD>> P,
+                    GenPolynomial<GenPolynomial<MOD>> S) {
+        //return mufd.recursiveUnivariateGcd(P, S);
+        // distributed polynomials gcd
+        GenPolynomialRing<GenPolynomial<MOD>> rfac = P.ring;
+        RingFactory<GenPolynomial<MOD>> rrfac = rfac.coFac;
+        GenPolynomialRing<MOD> cfac = (GenPolynomialRing<MOD>) rrfac;
+        GenPolynomialRing<MOD> dfac = cfac.extend(rfac.nvar);
+        GenPolynomial<MOD> Pd = PolyUtil.<MOD> distribute(dfac, P);
+        GenPolynomial<MOD> Sd = PolyUtil.<MOD> distribute(dfac, S);
+        GenPolynomial<MOD> Dd = gcd(Pd, Sd);
+        // convert to recursive
+        GenPolynomial<GenPolynomial<MOD>> C = PolyUtil.<MOD> recursive(rfac, Dd);
+        return C;
+    }
+
+
+    /**
+     * GenPolynomial greatest common divisor, modular evaluation algorithm.
+     * @param P GenPolynomial.
+     * @param S GenPolynomial.
+     * @return gcd(P,S).
+     */
+    @Override
+    public GenPolynomial<MOD> gcd(GenPolynomial<MOD> P, GenPolynomial<MOD> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        GenPolynomialRing<MOD> fac = P.ring;
+        // recusion base case for univariate polynomials
+        if (fac.nvar <= 1) {
+            GenPolynomial<MOD> T = baseGcd(P, S);
+            return T;
+        }
+        long e = P.degree(fac.nvar - 1);
+        long f = S.degree(fac.nvar - 1);
+        if (e == 0 && f == 0) {
+            GenPolynomialRing<GenPolynomial<MOD>> rfac = fac.recursive(1);
+            GenPolynomial<MOD> Pc = PolyUtil.<MOD> recursive(rfac, P).leadingBaseCoefficient();
+            GenPolynomial<MOD> Sc = PolyUtil.<MOD> recursive(rfac, S).leadingBaseCoefficient();
+            GenPolynomial<MOD> r = gcd(Pc, Sc);
+            return r.extend(fac, 0, 0L);
+        }
+        GenPolynomial<MOD> q;
+        GenPolynomial<MOD> r;
+        if (f > e) {
+            r = P;
+            q = S;
+            long g = f;
+            f = e;
+            e = g;
+        } else {
+            q = P;
+            r = S;
+        }
+        if (debug) {
+            logger.debug("degrees: e = " + e + ", f = " + f);
+        }
+        r = r.abs();
+        q = q.abs();
+        // setup factories
+        ModularRingFactory<MOD> cofac = (ModularRingFactory<MOD>) P.ring.coFac;
+        if (!cofac.isField()) {
+            logger.warn("cofac is not a field: " + cofac);
+        }
+        GenPolynomialRing<GenPolynomial<MOD>> rfac = fac.recursive(fac.nvar - 1);
+        GenPolynomialRing<MOD> mfac = new GenPolynomialRing<MOD>(cofac, rfac);
+        GenPolynomialRing<MOD> ufac = (GenPolynomialRing<MOD>) rfac.coFac;
+        // convert polynomials
+        GenPolynomial<GenPolynomial<MOD>> qr;
+        GenPolynomial<GenPolynomial<MOD>> rr;
+        qr = PolyUtil.<MOD> recursive(rfac, q);
+        rr = PolyUtil.<MOD> recursive(rfac, r);
+
+        // compute univariate contents and primitive parts
+        GenPolynomial<MOD> a = recursiveContent(rr);
+        GenPolynomial<MOD> b = recursiveContent(qr);
+        // gcd of univariate coefficient contents
+        GenPolynomial<MOD> c = gcd(a, b);
+        rr = PolyUtil.<MOD> recursiveDivide(rr, a);
+        qr = PolyUtil.<MOD> recursiveDivide(qr, b);
+        if (rr.isONE()) {
+            rr = rr.multiply(c);
+            r = PolyUtil.<MOD> distribute(fac, rr);
+            return r;
+        }
+        if (qr.isONE()) {
+            qr = qr.multiply(c);
+            q = PolyUtil.<MOD> distribute(fac, qr);
+            return q;
+        }
+        // compute normalization factor
+        GenPolynomial<MOD> ac = rr.leadingBaseCoefficient();
+        GenPolynomial<MOD> bc = qr.leadingBaseCoefficient();
+        GenPolynomial<MOD> cc = gcd(ac, bc);
+        // compute degrees and degree vectors
+        ExpVector rdegv = rr.degreeVector();
+        ExpVector qdegv = qr.degreeVector();
+        long rd0 = PolyUtil.<MOD> coeffMaxDegree(rr);
+        long qd0 = PolyUtil.<MOD> coeffMaxDegree(qr);
+        long cd0 = cc.degree(0);
+        long G = (rd0 < qd0 ? rd0 : qd0) + cd0 + 1L; // >=
+        //long Gm = (e < f ? e : f);
+
+        // initialize element and degree vector
+        ExpVector wdegv = rdegv.subst(0, rdegv.getVal(0) + 1);
+        // +1 seems to be a hack for the unlucky evaluation point test
+        MOD inc = cofac.getONE();
+        long i = 0;
+        long en = cofac.getIntegerModul().longValueExact() - 1; // just a stopper
+        MOD end = cofac.fromInteger(en);
+        MOD mi;
+        GenPolynomial<MOD> M = null;
+        GenPolynomial<MOD> mn;
+        GenPolynomial<MOD> qm;
+        GenPolynomial<MOD> rm;
+        GenPolynomial<MOD> cm;
+        GenPolynomial<GenPolynomial<MOD>> cp = null;
+        if (debug) {
+            logger.debug("c = " + c);
+            logger.debug("cc = " + cc);
+            logger.debug("G = " + G);
+            logger.info("wdegv = " + wdegv + ", in " + rfac.toScript());
+        }
+        for (MOD d = cofac.getZERO(); d.compareTo(end) <= 0; d = d.sum(inc)) {
+            if (++i >= en) {
+                logger.warn("elements of Z_p exhausted, en = " + en);
+                return mufd.gcd(P, S);
+                //throw new ArithmeticException("elements of Z_p exhausted, en = " + en);
+            }
+            // map normalization factor
+            MOD nf = PolyUtil.<MOD> evaluateMain(cofac, cc, d);
+            if (nf.isZERO()) {
+                continue;
+            }
+            // map polynomials
+            qm = PolyUtil.<MOD> evaluateFirstRec(ufac, mfac, qr, d);
+            if (qm.isZERO() || !qm.degreeVector().equals(qdegv)) {
+                continue;
+            }
+            rm = PolyUtil.<MOD> evaluateFirstRec(ufac, mfac, rr, d);
+            if (rm.isZERO() || !rm.degreeVector().equals(rdegv)) {
+                continue;
+            }
+            if (debug) {
+                logger.debug("eval d = " + d);
+            }
+            // compute modular gcd in recursion
+            cm = gcd(rm, qm);
+            if (debug) {
+                logger.debug("cm = " + cm + ", rm = " + rm + ", qm = " + qm);
+                //cm = mufd.gcd(rm,qm);
+                //logger.debug("cm = " + cm + ", rm = " + rm + ", qm = " + qm);
+            }
+            // test for constant g.c.d
+            if (cm.isConstant()) {
+                logger.debug("cm.isConstant = " + cm + ", c = " + c);
+                if (c.ring.nvar < cm.ring.nvar) {
+                    c = c.extend(mfac, 0, 0);
+                }
+                cm = cm.abs().multiply(c);
+                q = cm.extend(fac, 0, 0);
+                //logger.debug("q             = " + q + ", c = " + c);
+                return q;
+            }
+            // test for unlucky evaluation point
+            ExpVector mdegv = cm.degreeVector();
+            if (wdegv.equals(mdegv)) { // TL = 0
+                // evaluation point ok, next round
+                if (M != null) {
+                    if (M.degree(0) > G) {
+                        logger.info("deg(M) > G: " + M.degree(0) + " > " + G);
+                        // continue; // why should this be required?
+                    }
+                }
+            } else { // TL = 3
+                boolean ok = false;
+                if (wdegv.multipleOf(mdegv)) { // TL = 2
+                    M = null; // init chinese remainder
+                    ok = true; // evaluation point ok
+                }
+                if (mdegv.multipleOf(wdegv)) { // TL = 1
+                    continue; // skip this evaluation point
+                }
+                if (!ok) {
+                    M = null; // discard chinese remainder and previous work
+                    continue; // evaluation point not ok
+                }
+            }
+            // prepare interpolation algorithm
+            cm = cm.multiply(nf);
+            if (M == null) {
+                // initialize interpolation
+                M = ufac.getONE();
+                cp = rfac.getZERO();
+                wdegv = wdegv.gcd(mdegv); //EVGCD(wdegv,mdegv);
+            }
+            // interpolate
+            mi = PolyUtil.<MOD> evaluateMain(cofac, M, d);
+            mi = mi.inverse(); // mod p
+            cp = PolyUtil.interpolate(rfac, cp, M, mi, cm, d);
+            if (debug) {
+                logger.debug("cp = " + cp + ", cm = " + cm + ", M = " + M + " :: " + M.ring.toScript());
+            }
+            mn = ufac.getONE().multiply(d);
+            mn = ufac.univariate(0).subtract(mn);
+            M = M.multiply(mn); // M * (x-d)
+            // test for divisibility
+            boolean tt = false;
+            if (cp.leadingBaseCoefficient().equals(cc)) {
+                cp = recursivePrimitivePart(cp).abs();
+                logger.debug("test cp == cc: " + cp + " == " + cc);
+                tt = PolyUtil.<MOD> recursiveSparsePseudoRemainder(qr, cp).isZERO();
+                tt = tt && PolyUtil.<MOD> recursiveSparsePseudoRemainder(rr, cp).isZERO();
+                if (tt) {
+                    logger.debug("break: is gcd");
+                    break;
+                }
+                if (M.degree(0) > G) { // no && cp.degree(0) > Gm
+                    logger.debug("break: fail 1, cp = " + cp);
+                    cp = rfac.getONE();
+                    break;
+                }
+            }
+            // test for completion
+            if (M.degree(0) > G) { //  no && cp.degree(0) > Gm
+                logger.debug("break: M = " + M + ", G = " + G + ", mn = " + mn + ", M.deg(0) = "
+                                + M.degree(0));
+                cp = recursivePrimitivePart(cp).abs();
+                tt = PolyUtil.<MOD> recursiveSparsePseudoRemainder(qr, cp).isZERO();
+                tt = tt && PolyUtil.<MOD> recursiveSparsePseudoRemainder(rr, cp).isZERO();
+                if (!tt) {
+                    logger.debug("break: fail 2, cp = " + cp);
+                    cp = rfac.getONE();
+                }
+                break;
+            }
+            //long cmn = PolyUtil.<MOD>coeffMaxDegree(cp);
+            //if ( M.degree(0) > cmn ) {
+            // does not work: only if cofactors are also considered?
+            // break;
+            //}
+        }
+        // remove normalization
+        cp = recursivePrimitivePart(cp).abs();
+        cp = cp.multiply(c);
+        q = PolyUtil.<MOD> distribute(fac, cp);
+        return q;
+    }
+
+
+    /**
+     * Univariate GenPolynomial resultant.
+     * @param P univariate GenPolynomial.
+     * @param S univariate GenPolynomial.
+     * @return res(P,S).
+     */
+    @Override
+    public GenPolynomial<MOD> baseResultant(GenPolynomial<MOD> P, GenPolynomial<MOD> S) {
+        // required as recursion base
+        return mufd.baseResultant(P, S);
+    }
+
+
+    /**
+     * Univariate GenPolynomial recursive resultant.
+     * @param P univariate recursive GenPolynomial.
+     * @param S univariate recursive GenPolynomial.
+     * @return res(P,S).
+     */
+    @Override
+    public GenPolynomial<GenPolynomial<MOD>> recursiveUnivariateResultant(GenPolynomial<GenPolynomial<MOD>> P,
+                    GenPolynomial<GenPolynomial<MOD>> S) {
+        // only in this class
+        return recursiveResultant(P, S);
+    }
+
+
+    /**
+     * GenPolynomial resultant, modular evaluation algorithm.
+     * @param P GenPolynomial.
+     * @param S GenPolynomial.
+     * @return res(P,S).
+     */
+    @Override
+    public GenPolynomial<MOD> resultant(GenPolynomial<MOD> P, GenPolynomial<MOD> S) {
+        if (S == null || S.isZERO()) {
+            return S;
+        }
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        GenPolynomialRing<MOD> fac = P.ring;
+        // recusion base case for univariate polynomials
+        if (fac.nvar <= 1) {
+            GenPolynomial<MOD> T = baseResultant(P, S);
+            return T;
+        }
+        long e = P.degree(fac.nvar - 1);
+        long f = S.degree(fac.nvar - 1);
+        if (e == 0 && f == 0) {
+            GenPolynomialRing<GenPolynomial<MOD>> rfac = fac.recursive(1);
+            GenPolynomial<MOD> Pc = PolyUtil.<MOD> recursive(rfac, P).leadingBaseCoefficient();
+            GenPolynomial<MOD> Sc = PolyUtil.<MOD> recursive(rfac, S).leadingBaseCoefficient();
+            GenPolynomial<MOD> r = resultant(Pc, Sc);
+            return r.extend(fac, 0, 0L);
+        }
+        GenPolynomial<MOD> q;
+        GenPolynomial<MOD> r;
+        if (f > e) {
+            r = P;
+            q = S;
+            long g = f;
+            f = e;
+            e = g;
+        } else {
+            q = P;
+            r = S;
+        }
+        if (debug) {
+            logger.debug("degrees: e = " + e + ", f = " + f);
+        }
+        // setup factories
+        ModularRingFactory<MOD> cofac = (ModularRingFactory<MOD>) P.ring.coFac;
+        if (!cofac.isField()) {
+            logger.warn("cofac is not a field: " + cofac);
+        }
+        GenPolynomialRing<GenPolynomial<MOD>> rfac = fac.recursive(fac.nvar - 1);
+        GenPolynomialRing<MOD> mfac = new GenPolynomialRing<MOD>(cofac, rfac);
+        GenPolynomialRing<MOD> ufac = (GenPolynomialRing<MOD>) rfac.coFac;
+
+        // convert polynomials
+        GenPolynomial<GenPolynomial<MOD>> qr = PolyUtil.<MOD> recursive(rfac, q);
+        GenPolynomial<GenPolynomial<MOD>> rr = PolyUtil.<MOD> recursive(rfac, r);
+
+        // compute degrees and degree vectors
+        ExpVector qdegv = qr.degreeVector();
+        ExpVector rdegv = rr.degreeVector();
+
+        long qd0 = PolyUtil.<MOD> coeffMaxDegree(qr);
+        long rd0 = PolyUtil.<MOD> coeffMaxDegree(rr);
+        qd0 = (qd0 == 0 ? 1 : qd0);
+        rd0 = (rd0 == 0 ? 1 : rd0);
+        long qd1 = qr.degree();
+        long rd1 = rr.degree();
+        qd1 = (qd1 == 0 ? 1 : qd1);
+        rd1 = (rd1 == 0 ? 1 : rd1);
+        long G = qd0 * rd1 + rd0 * qd1 + 1;
+
+        // initialize element
+        MOD inc = cofac.getONE();
+        long i = 0;
+        long en = cofac.getIntegerModul().longValueExact() - 1; // just a stopper
+        MOD end = cofac.fromInteger(en);
+        MOD mi;
+        GenPolynomial<MOD> M = null;
+        GenPolynomial<MOD> mn;
+        GenPolynomial<MOD> qm;
+        GenPolynomial<MOD> rm;
+        GenPolynomial<MOD> cm;
+        GenPolynomial<GenPolynomial<MOD>> cp = null;
+        if (debug) {
+            //logger.info("qr    = " + qr + ", q = " + q);
+            //logger.info("rr    = " + rr + ", r = " + r);
+            //logger.info("qd0   = " + qd0);
+            //logger.info("rd0   = " + rd0);
+            logger.info("G     = " + G);
+            //logger.info("rdegv = " + rdegv); // + ", rr.degree(0) = " + rr.degree(0));
+            //logger.info("qdegv = " + qdegv); // + ", qr.degree(0) = " + qr.degree(0));
+        }
+        for (MOD d = cofac.getZERO(); d.compareTo(end) <= 0; d = d.sum(inc)) {
+            if (++i >= en) {
+                logger.warn("elements of Z_p exhausted, en = " + en + ", p = " + cofac.getIntegerModul());
+                return mufd.resultant(P, S);
+                //throw new ArithmeticException("prime list exhausted");
+            }
+            // map polynomials
+            qm = PolyUtil.<MOD> evaluateFirstRec(ufac, mfac, qr, d);
+            //logger.info("qr(" + d + ") = " + qm + ", qr = " + qr);
+            if (qm.isZERO() || !qm.degreeVector().equals(qdegv)) {
+                if (debug) {
+                    logger.info("un-lucky evaluation point " + d + ", qm = " + qm.degreeVector() + " < "
+                                    + qdegv);
+                }
+                continue;
+            }
+            rm = PolyUtil.<MOD> evaluateFirstRec(ufac, mfac, rr, d);
+            //logger.info("rr(" + d + ") = " + rm + ", rr = " + rr);
+            if (rm.isZERO() || !rm.degreeVector().equals(rdegv)) {
+                if (debug) {
+                    logger.info("un-lucky evaluation point " + d + ", rm = " + rm.degreeVector() + " < "
+                                    + rdegv);
+                }
+                continue;
+            }
+            // compute modular resultant in recursion
+            cm = resultant(rm, qm);
+            //System.out.println("cm = " + cm);
+
+            // prepare interpolation algorithm
+            if (M == null) {
+                // initialize interpolation
+                M = ufac.getONE();
+                cp = rfac.getZERO();
+            }
+            // interpolate
+            mi = PolyUtil.<MOD> evaluateMain(cofac, M, d);
+            mi = mi.inverse(); // mod p
+            cp = PolyUtil.interpolate(rfac, cp, M, mi, cm, d);
+            //logger.info("cp = " + cp);
+            mn = ufac.getONE().multiply(d);
+            mn = ufac.univariate(0).subtract(mn);
+            M = M.multiply(mn);
+            // test for completion
+            if (M.degree(0) > G) {
+                if (debug) {
+                    logger.info("last lucky evaluation point " + d);
+                }
+                break;
+            }
+            //logger.info("M  = " + M);
+        }
+        // distribute
+        q = PolyUtil.<MOD> distribute(fac, cp);
+        return q;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/GreatestCommonDivisorModular.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/GreatestCommonDivisorModular.java
@@ -1,0 +1,553 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.arith.BigInteger;
+import edu.jas.arith.Combinatoric;
+import edu.jas.arith.ModIntegerRing;
+import edu.jas.arith.ModLongRing;
+import edu.jas.arith.Modular;
+import edu.jas.arith.ModularRingFactory;
+import edu.jas.arith.PrimeList;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Greatest common divisor algorithms with modular computation and Chinese
+ * remainder algorithm.
+ * @author Heinz Kredel
+ */
+
+public class GreatestCommonDivisorModular<MOD extends GcdRingElem<MOD> & Modular>
+                extends GreatestCommonDivisorAbstract<BigInteger> {
+
+
+    private static final Logger logger = LogManager.getLogger(GreatestCommonDivisorModular.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled(); //logger.isInfoEnabled();
+
+
+    /*
+     * Modular gcd algorithm to use.
+     */
+    protected final GreatestCommonDivisorAbstract<MOD> mufd;
+
+
+    /*
+     * Integer gcd algorithm for fall back.
+     */
+    protected final GreatestCommonDivisorAbstract<BigInteger> iufd = new GreatestCommonDivisorSubres<BigInteger>();
+
+
+    /**
+     * Constructor to set recursive algorithm. Use modular evaluation GCD
+     * algorithm.
+     */
+    public GreatestCommonDivisorModular() {
+        this(false);
+    }
+
+
+    /**
+     * Constructor to set recursive algorithm.
+     * @param simple , true if the simple PRS should be used.
+     */
+    public GreatestCommonDivisorModular(boolean simple) {
+        if (simple) {
+            mufd = new GreatestCommonDivisorSimple<MOD>();
+        } else {
+            mufd = new GreatestCommonDivisorModEval<MOD>();
+        }
+    }
+
+
+    /**
+     * Univariate GenPolynomial greatest comon divisor. Delegate to subresultant
+     * baseGcd, should not be needed.
+     * @param P univariate GenPolynomial.
+     * @param S univariate GenPolynomial.
+     * @return gcd(P,S).
+     */
+    @Override
+    public GenPolynomial<BigInteger> baseGcd(GenPolynomial<BigInteger> P, GenPolynomial<BigInteger> S) {
+        return iufd.baseGcd(P, S);
+    }
+
+
+    /**
+     * Univariate GenPolynomial recursive greatest comon divisor. Delegate to
+     * subresultant recursiveGcd, should not be needed.
+     * @param P univariate recursive GenPolynomial.
+     * @param S univariate recursive GenPolynomial.
+     * @return gcd(P,S).
+     */
+    @Override
+    public GenPolynomial<GenPolynomial<BigInteger>> recursiveUnivariateGcd(
+                    GenPolynomial<GenPolynomial<BigInteger>> P, GenPolynomial<GenPolynomial<BigInteger>> S) {
+        //return iufd.recursiveUnivariateGcd(P, S); // bad performance
+        // distributed polynomials gcd
+        GenPolynomialRing<GenPolynomial<BigInteger>> rfac = P.ring;
+        RingFactory<GenPolynomial<BigInteger>> rrfac = rfac.coFac;
+        GenPolynomialRing<BigInteger> cfac = (GenPolynomialRing<BigInteger>) rrfac;
+        GenPolynomialRing<BigInteger> dfac = cfac.extend(rfac.getVars());
+        GenPolynomial<BigInteger> Pd = PolyUtil.<BigInteger> distribute(dfac, P);
+        GenPolynomial<BigInteger> Sd = PolyUtil.<BigInteger> distribute(dfac, S);
+        GenPolynomial<BigInteger> Dd = gcd(Pd, Sd);
+        // convert to recursive
+        GenPolynomial<GenPolynomial<BigInteger>> C = PolyUtil.<BigInteger> recursive(rfac, Dd);
+        return C;
+    }
+
+
+    /**
+     * GenPolynomial greatest comon divisor, modular algorithm.
+     * @param P GenPolynomial.
+     * @param S GenPolynomial.
+     * @return gcd(P,S).
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public GenPolynomial<BigInteger> gcd(GenPolynomial<BigInteger> P, GenPolynomial<BigInteger> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        GenPolynomialRing<BigInteger> fac = P.ring;
+        // special case for univariate polynomials
+        if (fac.nvar <= 1) {
+            GenPolynomial<BigInteger> T = baseGcd(P, S);
+            return T;
+        }
+        long e = P.degree(0);
+        long f = S.degree(0);
+        GenPolynomial<BigInteger> q;
+        GenPolynomial<BigInteger> r;
+        if (f > e) {
+            r = P;
+            q = S;
+            long g = f;
+            f = e;
+            e = g;
+        } else {
+            q = P;
+            r = S;
+        }
+        if (debug) {
+            logger.debug("degrees: e = " + e + ", f = " + f);
+        }
+        r = r.abs();
+        q = q.abs();
+        // compute contents and primitive parts
+        BigInteger a = baseContent(r);
+        BigInteger b = baseContent(q);
+        // gcd of coefficient contents
+        BigInteger c = gcd(a, b); // indirection
+        r = divide(r, a); // indirection
+        q = divide(q, b); // indirection
+        if (r.isONE()) {
+            return r.multiply(c);
+        }
+        if (q.isONE()) {
+            return q.multiply(c);
+        }
+        // compute normalization factor
+        BigInteger ac = r.leadingBaseCoefficient();
+        BigInteger bc = q.leadingBaseCoefficient();
+        BigInteger cc = gcd(ac, bc); // indirection
+        // compute norms
+        BigInteger an = r.maxNorm();
+        BigInteger bn = q.maxNorm();
+        BigInteger n = (an.compareTo(bn) < 0 ? bn : an);
+        n = n.multiply(cc).multiply(n.fromInteger(2));
+        // compute degree vectors
+        ExpVector rdegv = r.degreeVector();
+        ExpVector qdegv = q.degreeVector();
+        //compute factor coefficient bounds
+        BigInteger af = an.multiply(PolyUtil.factorBound(rdegv));
+        BigInteger bf = bn.multiply(PolyUtil.factorBound(qdegv));
+        BigInteger cf = (af.compareTo(bf) < 0 ? bf : af);
+        cf = cf.multiply(cc.multiply(cc.fromInteger(8)));
+        //initialize prime list and degree vector
+        PrimeList primes = new PrimeList();
+        int pn = 10; //primes.size();
+        ExpVector wdegv = rdegv.subst(0, rdegv.getVal(0) + 1);
+        // +1 seems to be a hack for the unlucky prime test
+        ModularRingFactory<MOD> cofac;
+        ModularRingFactory<MOD> cofacM = null;
+        GenPolynomial<MOD> qm;
+        GenPolynomial<MOD> rm;
+        GenPolynomialRing<MOD> mfac;
+        GenPolynomialRing<MOD> rfac = null;
+        int i = 0;
+        BigInteger M = null;
+        BigInteger cfe = null;
+        GenPolynomial<MOD> cp = null;
+        GenPolynomial<MOD> cm = null;
+        GenPolynomial<BigInteger> cpi = null;
+        if (debug) {
+            logger.debug("c = " + c);
+            logger.debug("cc = " + cc);
+            logger.debug("n  = " + n);
+            logger.debug("cf = " + cf);
+            logger.info("wdegv = " + wdegv + ", in " + fac.toScript());
+        }
+        for (java.math.BigInteger p : primes) {
+            //System.out.println("next run ++++++++++++++++++++++++++++++++++");
+            if (p.longValue() == 2L) { // skip 2
+                continue;
+            }
+            if (++i >= pn) {
+                logger.warn("prime list exhausted, pn = " + pn);
+                return iufd.gcd(P, S);
+                //throw new ArithmeticException("prime list exhausted");
+            }
+            // initialize coefficient factory and map normalization factor
+            if (ModLongRing.MAX_LONG.compareTo(p) > 0) {
+                cofac = (ModularRingFactory) new ModLongRing(p, true);
+            } else {
+                cofac = (ModularRingFactory) new ModIntegerRing(p, true);
+            }
+            MOD nf = cofac.fromInteger(cc.getVal());
+            if (nf.isZERO()) {
+                continue;
+            }
+            // initialize polynomial factory and map polynomials
+            mfac = new GenPolynomialRing<MOD>(cofac, fac.nvar, fac.tord, fac.getVars());
+            qm = PolyUtil.<MOD> fromIntegerCoefficients(mfac, q);
+            if (qm.isZERO() || !qm.degreeVector().equals(qdegv)) {
+                continue;
+            }
+            rm = PolyUtil.<MOD> fromIntegerCoefficients(mfac, r);
+            if (rm.isZERO() || !rm.degreeVector().equals(rdegv)) {
+                continue;
+            }
+            if (debug) {
+                logger.info("cofac = " + cofac.getIntegerModul());
+            }
+            // compute modular gcd
+            cm = mufd.gcd(rm, qm);
+            // test for constant g.c.d
+            if (cm.isConstant()) {
+                logger.debug("cm, constant = " + cm);
+                return fac.getONE().multiply(c);
+                //return cm.abs().multiply( c );
+            }
+            // test for unlucky prime
+            ExpVector mdegv = cm.degreeVector();
+            if (wdegv.equals(mdegv)) { // TL = 0
+                // prime ok, next round
+                if (M != null) {
+                    if (M.compareTo(cfe) > 0) {
+                        System.out.println("M > cfe: " + M + " > " + cfe);
+                        // continue; // why should this be required?
+                    }
+                }
+            } else { // TL = 3
+                boolean ok = false;
+                if (wdegv.multipleOf(mdegv)) { // TL = 2 // EVMT(wdegv,mdegv)
+                    M = null; // init chinese remainder
+                    ok = true; // prime ok
+                }
+                if (mdegv.multipleOf(wdegv)) { // TL = 1 // EVMT(mdegv,wdegv)
+                    continue; // skip this prime
+                }
+                if (!ok) {
+                    M = null; // discard chinese remainder and previous work
+                    continue; // prime not ok
+                }
+            }
+            //--wdegv = mdegv;
+            // prepare chinese remainder algorithm
+            cm = cm.multiply(nf);
+            if (M == null) {
+                // initialize chinese remainder algorithm
+                M = new BigInteger(p);
+                cofacM = cofac;
+                rfac = mfac;
+                cp = cm;
+                wdegv = wdegv.gcd(mdegv); //EVGCD(wdegv,mdegv);
+                cfe = cf;
+                for (int k = 0; k < wdegv.length(); k++) {
+                    cfe = cfe.multiply(new BigInteger(wdegv.getVal(k) + 1));
+                }
+            } else {
+                // apply chinese remainder algorithm
+                BigInteger Mp = M;
+                MOD mi = cofac.fromInteger(Mp.getVal());
+                mi = mi.inverse(); // mod p
+                M = M.multiply(new BigInteger(p));
+                if (ModLongRing.MAX_LONG.compareTo(M.getVal()) > 0) {
+                    cofacM = (ModularRingFactory) new ModLongRing(M.getVal());
+                } else {
+                    cofacM = (ModularRingFactory) new ModIntegerRing(M.getVal());
+                }
+                rfac = new GenPolynomialRing<MOD>(cofacM, fac);
+                if (!cofac.getClass().equals(cofacM.getClass())) {
+                    logger.info("adjusting coefficents: cofacM = " + cofacM.getClass() + ", cofacP = "
+                                    + cofac.getClass());
+                    cofac = (ModularRingFactory) new ModIntegerRing(p);
+                    mfac = new GenPolynomialRing<MOD>(cofac, fac);
+                    GenPolynomial<BigInteger> mm = PolyUtil.<MOD> integerFromModularCoefficients(fac, cm);
+                    cm = PolyUtil.<MOD> fromIntegerCoefficients(mfac, mm);
+                    mi = cofac.fromInteger(Mp.getVal());
+                    mi = mi.inverse(); // mod p
+                }
+                if (!cp.ring.coFac.getClass().equals(cofacM.getClass())) {
+                    logger.info("adjusting coefficents: cofacM = " + cofacM.getClass() + ", cofacM' = "
+                                    + cp.ring.coFac.getClass());
+                    ModularRingFactory cop = (ModularRingFactory) cp.ring.coFac;
+                    cofac = (ModularRingFactory) new ModIntegerRing(cop.getIntegerModul().getVal());
+                    mfac = new GenPolynomialRing<MOD>(cofac, fac);
+                    GenPolynomial<BigInteger> mm = PolyUtil.<MOD> integerFromModularCoefficients(fac, cp);
+                    cp = PolyUtil.<MOD> fromIntegerCoefficients(mfac, mm);
+                }
+                cp = PolyUtil.<MOD> chineseRemainder(rfac, cp, mi, cm);
+            }
+            // test for completion
+            if (n.compareTo(M) <= 0) {
+                break;
+            }
+            // must use integer.sumNorm
+            cpi = PolyUtil.<MOD> integerFromModularCoefficients(fac, cp);
+            BigInteger cmn = cpi.sumNorm();
+            cmn = cmn.multiply(cmn.fromInteger(4));
+            //if ( cmn.compareTo( M ) <= 0 ) {
+            // does not work: only if cofactors are also considered?
+            // break;
+            //}
+            if (i % 2 != 0 && !cp.isZERO()) {
+                // check if done on every second prime
+                GenPolynomial<BigInteger> x;
+                x = PolyUtil.<MOD> integerFromModularCoefficients(fac, cp);
+                x = basePrimitivePart(x);
+                if (!PolyUtil.<BigInteger> baseSparsePseudoRemainder(q, x).isZERO()) {
+                    continue;
+                }
+                if (!PolyUtil.<BigInteger> baseSparsePseudoRemainder(r, x).isZERO()) {
+                    continue;
+                }
+                logger.info("done on exact division, #primes = " + i);
+                break;
+            }
+        }
+        if (debug) {
+            logger.info("done on M = " + M + ", #primes = " + i);
+        }
+        // remove normalization
+        q = PolyUtil.<MOD> integerFromModularCoefficients(fac, cp);
+        q = basePrimitivePart(q);
+        return q.abs().multiply(c);
+    }
+
+
+    /**
+     * Univariate GenPolynomial resultant.
+     * @param P univariate GenPolynomial.
+     * @param S univariate GenPolynomial.
+     * @return res(P,S).
+     */
+    @Override
+    public GenPolynomial<BigInteger> baseResultant(GenPolynomial<BigInteger> P, GenPolynomial<BigInteger> S) {
+        // not a special case here
+        return resultant(P, S);
+    }
+
+
+    /**
+     * Univariate GenPolynomial recursive resultant.
+     * @param P univariate recursive GenPolynomial.
+     * @param S univariate recursive GenPolynomial.
+     * @return res(P,S).
+     */
+    @Override
+    public GenPolynomial<GenPolynomial<BigInteger>> recursiveUnivariateResultant(
+                    GenPolynomial<GenPolynomial<BigInteger>> P, GenPolynomial<GenPolynomial<BigInteger>> S) {
+        // only in this class
+        return recursiveResultant(P, S);
+    }
+
+
+    /**
+     * GenPolynomial resultant, modular algorithm.
+     * @param P GenPolynomial.
+     * @param S GenPolynomial.
+     * @return res(P,S).
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public GenPolynomial<BigInteger> resultant(GenPolynomial<BigInteger> P, GenPolynomial<BigInteger> S) {
+        if (S == null || S.isZERO()) {
+            return S;
+        }
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        GenPolynomialRing<BigInteger> fac = P.ring;
+        // no special case for univariate polynomials in this class !
+        //if (fac.nvar <= 1) {
+        //    GenPolynomial<BigInteger> T = iufd.baseResultant(P, S);
+        //    return T;
+        //}
+        long e = P.degree(0);
+        long f = S.degree(0);
+        GenPolynomial<BigInteger> q;
+        GenPolynomial<BigInteger> r;
+        if (f > e) {
+            r = P;
+            q = S;
+            long g = f;
+            f = e;
+            e = g;
+        } else {
+            q = P;
+            r = S;
+        }
+        // compute norms
+        BigInteger an = r.maxNorm();
+        BigInteger bn = q.maxNorm();
+        an = an.power(f);
+        bn = bn.power(e);
+        BigInteger cn = Combinatoric.factorial(e + f);
+        BigInteger n = cn.multiply(an).multiply(bn);
+
+        // compute degree vectors
+        ExpVector rdegv = r.leadingExpVector(); //degreeVector();
+        ExpVector qdegv = q.leadingExpVector(); //degreeVector();
+
+        //initialize prime list and degree vector
+        PrimeList primes = new PrimeList();
+        int pn = 30; //primes.size();
+        ModularRingFactory<MOD> cofac;
+        ModularRingFactory<MOD> cofacM = null;
+        GenPolynomial<MOD> qm;
+        GenPolynomial<MOD> rm;
+        GenPolynomialRing<MOD> mfac;
+        GenPolynomialRing<MOD> rfac = null;
+        int i = 0;
+        BigInteger M = null;
+        GenPolynomial<MOD> cp = null;
+        GenPolynomial<MOD> cm = null;
+        //GenPolynomial<BigInteger> cpi = null;
+        if (debug) {
+            logger.debug("an  = " + an);
+            logger.debug("bn  = " + bn);
+            logger.debug("e+f = " + (e + f));
+            logger.debug("cn  = " + cn);
+            logger.info("n     = " + n);
+            //logger.info("q     = " + q);
+            //logger.info("r     = " + r);
+            //logger.info("rdegv = " + rdegv.toString(fac.getVars()));
+            //logger.info("qdegv = " + qdegv.toString(fac.getVars()));
+        }
+        for (java.math.BigInteger p : primes) {
+            //System.out.println("next run ++++++++++++++++++++++++++++++++++");
+            if (p.longValue() == 2L) { // skip 2
+                continue;
+            }
+            if (++i >= pn) {
+                logger.warn("prime list exhausted, pn = " + pn);
+                return iufd.resultant(P, S);
+                //throw new ArithmeticException("prime list exhausted");
+            }
+            // initialize coefficient factory and map normalization factor
+            if (ModLongRing.MAX_LONG.compareTo(p) > 0) {
+                cofac = (ModularRingFactory) new ModLongRing(p, true);
+            } else {
+                cofac = (ModularRingFactory) new ModIntegerRing(p, true);
+            }
+            // initialize polynomial factory and map polynomials
+            mfac = new GenPolynomialRing<MOD>(cofac, fac);
+            qm = PolyUtil.<MOD> fromIntegerCoefficients(mfac, q);
+            if (qm.isZERO() || !qm.leadingExpVector().equals(qdegv)) { //degreeVector()
+                //logger.info("qm = " + qm);
+                if (debug) {
+                    logger.info("unlucky prime = " + cofac.getIntegerModul() + ", degv = "
+                                    + qm.leadingExpVector());
+                }
+                continue;
+            }
+            rm = PolyUtil.<MOD> fromIntegerCoefficients(mfac, r);
+            if (rm.isZERO() || !rm.leadingExpVector().equals(rdegv)) { //degreeVector()
+                //logger.info("rm = " + rm);
+                if (debug) {
+                    logger.info("unlucky prime = " + cofac.getIntegerModul() + ", degv = "
+                                    + rm.leadingExpVector());
+                }
+                continue;
+            }
+            logger.info("lucky prime = " + cofac.getIntegerModul());
+
+            // compute modular resultant
+            cm = mufd.resultant(qm, rm);
+            if (debug) {
+                logger.info("res_p = " + cm);
+            }
+
+            // prepare chinese remainder algorithm
+            if (M == null) {
+                // initialize chinese remainder algorithm
+                M = new BigInteger(p);
+                cofacM = cofac;
+                //rfac = mfac;
+                cp = cm;
+            } else {
+                // apply chinese remainder algorithm
+                BigInteger Mp = M;
+                MOD mi = cofac.fromInteger(Mp.getVal());
+                mi = mi.inverse(); // mod p
+                M = M.multiply(new BigInteger(p));
+                if (ModLongRing.MAX_LONG.compareTo(M.getVal()) > 0) {
+                    cofacM = (ModularRingFactory) new ModLongRing(M.getVal());
+                } else {
+                    cofacM = (ModularRingFactory) new ModIntegerRing(M.getVal());
+                }
+                rfac = new GenPolynomialRing<MOD>(cofacM, fac);
+                if (!cofac.getClass().equals(cofacM.getClass())) {
+                    logger.info("adjusting coefficents: cofacM = " + cofacM.getClass() + ", cofacP = "
+                                    + cofac.getClass());
+                    cofac = (ModularRingFactory) new ModIntegerRing(p);
+                    mfac = new GenPolynomialRing<MOD>(cofac, fac);
+                    GenPolynomial<BigInteger> mm = PolyUtil.<MOD> integerFromModularCoefficients(fac, cm);
+                    cm = PolyUtil.<MOD> fromIntegerCoefficients(mfac, mm);
+                    mi = cofac.fromInteger(Mp.getVal());
+                    mi = mi.inverse(); // mod p
+                }
+                if (!cp.ring.coFac.getClass().equals(cofacM.getClass())) {
+                    logger.info("adjusting coefficents: cofacM = " + cofacM.getClass() + ", cofacM' = "
+                                    + cp.ring.coFac.getClass());
+                    ModularRingFactory cop = (ModularRingFactory) cp.ring.coFac;
+                    cofac = (ModularRingFactory) new ModIntegerRing(cop.getIntegerModul().getVal());
+                    mfac = new GenPolynomialRing<MOD>(cofac, fac);
+                    GenPolynomial<BigInteger> mm = PolyUtil.<MOD> integerFromModularCoefficients(fac, cp);
+                    cp = PolyUtil.<MOD> fromIntegerCoefficients(mfac, mm);
+                }
+                cp = PolyUtil.<MOD> chineseRemainder(rfac, cp, mi, cm);
+            }
+            // test for completion
+            if (n.compareTo(M) <= 0) {
+                break;
+            }
+        }
+        if (debug) {
+            logger.info("done on M = " + M + ", #primes = " + i);
+        }
+        // convert to integer polynomial
+        q = PolyUtil.<MOD> integerFromModularCoefficients(fac, cp);
+        return q;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/GreatestCommonDivisorPrimitive.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/GreatestCommonDivisorPrimitive.java
@@ -1,0 +1,153 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Greatest common divisor algorithms with primitive polynomial remainder
+ * sequence.
+ * @author Heinz Kredel
+ */
+
+public class GreatestCommonDivisorPrimitive<C extends GcdRingElem<C>>
+                extends GreatestCommonDivisorAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GreatestCommonDivisorPrimitive.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Univariate GenPolynomial greatest comon divisor. Uses pseudoRemainder for
+     * remainder.
+     * @param P univariate GenPolynomial.
+     * @param S univariate GenPolynomial.
+     * @return gcd(P,S).
+     */
+    @Override
+    public GenPolynomial<C> baseGcd(GenPolynomial<C> P, GenPolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.ring.nvar > 1) {
+            throw new IllegalArgumentException(this.getClass().getName() + " no univariate polynomial");
+        }
+        long e = P.degree(0);
+        long f = S.degree(0);
+        GenPolynomial<C> q;
+        GenPolynomial<C> r;
+        if (f > e) {
+            r = P;
+            q = S;
+            long g = f;
+            f = e;
+            e = g;
+        } else {
+            q = P;
+            r = S;
+        }
+        if (debug) {
+            logger.debug("degrees: e = " + e + ", f = " + f);
+        }
+        r = r.abs();
+        q = q.abs();
+        C a = baseContent(r);
+        C b = baseContent(q);
+        C c = gcd(a, b); // indirection
+        r = divide(r, a); // indirection
+        q = divide(q, b); // indirection
+        if (r.isONE()) {
+            return r.multiply(c);
+        }
+        if (q.isONE()) {
+            return q.multiply(c);
+        }
+        GenPolynomial<C> x;
+        while (!r.isZERO()) {
+            x = PolyUtil.<C> baseSparsePseudoRemainder(q, r);
+            q = r;
+            r = basePrimitivePart(x);
+        }
+        return (q.multiply(c)).abs();
+    }
+
+
+    /**
+     * Univariate GenPolynomial recursive greatest comon divisor. Uses
+     * pseudoRemainder for remainder.
+     * @param P univariate recursive GenPolynomial.
+     * @param S univariate recursive GenPolynomial.
+     * @return gcd(P,S).
+     */
+    @Override
+    public GenPolynomial<GenPolynomial<C>> recursiveUnivariateGcd(GenPolynomial<GenPolynomial<C>> P,
+                    GenPolynomial<GenPolynomial<C>> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.ring.nvar > 1) {
+            throw new IllegalArgumentException(this.getClass().getName() + " no univariate polynomial");
+        }
+        long e = P.degree(0);
+        long f = S.degree(0);
+        GenPolynomial<GenPolynomial<C>> q;
+        GenPolynomial<GenPolynomial<C>> r;
+        if (f > e) {
+            r = P;
+            q = S;
+            long g = f;
+            f = e;
+            e = g;
+        } else {
+            q = P;
+            r = S;
+        }
+        if (debug) {
+            logger.debug("degrees: e = " + e + ", f = " + f);
+        }
+        r = r.abs();
+        q = q.abs();
+        GenPolynomial<C> a = recursiveContent(r);
+        GenPolynomial<C> b = recursiveContent(q);
+
+        GenPolynomial<C> c = gcd(a, b); // go to recursion
+        //System.out.println("rgcd c = " + c);
+        r = PolyUtil.<C> recursiveDivide(r, a);
+        q = PolyUtil.<C> recursiveDivide(q, b);
+        if (r.isONE()) {
+            return r.multiply(c);
+        }
+        if (q.isONE()) {
+            return q.multiply(c);
+        }
+        GenPolynomial<GenPolynomial<C>> x;
+        while (!r.isZERO()) {
+            x = PolyUtil.<C> recursiveSparsePseudoRemainder(q, r);
+            if (logger.isDebugEnabled()) {
+                logger.info("recursiveSparsePseudoRemainder.bits = " + x.bitLength());
+            }
+            q = r;
+            r = recursivePrimitivePart(x);
+        }
+        return q.abs().multiply(c); //.abs();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/GreatestCommonDivisorSimple.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/GreatestCommonDivisorSimple.java
@@ -1,0 +1,353 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Greatest common divisor algorithms with monic polynomial remainder sequence.
+ * If C is a field, then the monic PRS (on coefficients) is computed otherwise
+ * no simplifications in the reduction are made.
+ * @author Heinz Kredel
+ */
+
+public class GreatestCommonDivisorSimple<C extends GcdRingElem<C>> extends GreatestCommonDivisorAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GreatestCommonDivisorSimple.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Univariate GenPolynomial greatest comon divisor. Uses pseudoRemainder for
+     * remainder.
+     * @param P univariate GenPolynomial.
+     * @param S univariate GenPolynomial.
+     * @return gcd(P,S).
+     */
+    @Override
+    public GenPolynomial<C> baseGcd(GenPolynomial<C> P, GenPolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.ring.nvar > 1) {
+            throw new IllegalArgumentException(this.getClass().getName() + " no univariate polynomial");
+        }
+        boolean field = P.ring.coFac.isField();
+        long e = P.degree(0);
+        long f = S.degree(0);
+        GenPolynomial<C> q;
+        GenPolynomial<C> r;
+        if (f > e) {
+            r = P;
+            q = S;
+            long g = f;
+            f = e;
+            e = g;
+        } else {
+            q = P;
+            r = S;
+        }
+        if (debug) {
+            logger.debug("degrees: e = " + e + ", f = " + f);
+        }
+        C c;
+        if (field) {
+            r = r.monic();
+            q = q.monic();
+            c = P.ring.getONECoefficient();
+        } else {
+            r = r.abs();
+            q = q.abs();
+            C a = baseContent(r);
+            C b = baseContent(q);
+            c = gcd(a, b); // indirection
+            r = divide(r, a); // indirection
+            q = divide(q, b); // indirection
+        }
+        if (r.isONE()) {
+            return r.multiply(c);
+        }
+        if (q.isONE()) {
+            return q.multiply(c);
+        }
+        GenPolynomial<C> x;
+        //System.out.println("q = " + q);
+        //System.out.println("r = " + r);
+        while (!r.isZERO()) {
+            x = PolyUtil.<C> baseSparsePseudoRemainder(q, r);
+            q = r;
+            if (field) {
+                r = x.monic();
+            } else {
+                r = x;
+            }
+            //System.out.println("q = " + q);
+            //System.out.println("r = " + r);
+        }
+        q = basePrimitivePart(q);
+        return (q.multiply(c)).abs();
+    }
+
+
+    /**
+     * Univariate GenPolynomial recursive greatest comon divisor. Uses
+     * pseudoRemainder for remainder.
+     * @param P univariate recursive GenPolynomial.
+     * @param S univariate recursive GenPolynomial.
+     * @return gcd(P,S).
+     */
+    @Override
+    public GenPolynomial<GenPolynomial<C>> recursiveUnivariateGcd(GenPolynomial<GenPolynomial<C>> P,
+                    GenPolynomial<GenPolynomial<C>> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.ring.nvar > 1) {
+            throw new IllegalArgumentException(this.getClass().getName() + " no univariate polynomial");
+        }
+        boolean field = P.leadingBaseCoefficient().ring.coFac.isField();
+        long e = P.degree(0);
+        long f = S.degree(0);
+        GenPolynomial<GenPolynomial<C>> q;
+        GenPolynomial<GenPolynomial<C>> r;
+        if (f > e) {
+            r = P;
+            q = S;
+            long g = f;
+            f = e;
+            e = g;
+        } else {
+            q = P;
+            r = S;
+        }
+        if (debug) {
+            logger.debug("degrees: e = " + e + ", f = " + f);
+        }
+        if (field) {
+            r = PolyUtil.<C> monic(r);
+            q = PolyUtil.<C> monic(q);
+        } else {
+            r = r.abs();
+            q = q.abs();
+        }
+        GenPolynomial<C> a = recursiveContent(r);
+        GenPolynomial<C> b = recursiveContent(q);
+
+        GenPolynomial<C> c = gcd(a, b); // go to recursion
+        //System.out.println("rgcd c = " + c);
+        r = PolyUtil.<C> recursiveDivide(r, a);
+        q = PolyUtil.<C> recursiveDivide(q, b);
+        if (r.isONE()) {
+            return r.multiply(c);
+        }
+        if (q.isONE()) {
+            return q.multiply(c);
+        }
+        GenPolynomial<GenPolynomial<C>> x;
+        while (!r.isZERO()) {
+            x = PolyUtil.<C> recursiveSparsePseudoRemainder(q, r);
+            if (logger.isDebugEnabled()) {
+                logger.info("recursiveSparsePseudoRemainder.bits = " + x.bitLength());
+            }
+            q = r;
+            if (field) {
+                r = PolyUtil.<C> monic(x);
+            } else {
+                r = x;
+            }
+        }
+        q = recursivePrimitivePart(q);
+        q = q.abs().multiply(c);
+        return q;
+    }
+
+
+    /**
+     * Univariate GenPolynomial resultant.
+     * @param P univariate GenPolynomial.
+     * @param S univariate GenPolynomial.
+     * @return res(P,S).
+     */
+    @Override
+    public GenPolynomial<C> baseResultant(GenPolynomial<C> P, GenPolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            return S;
+        }
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        if (P.ring.nvar > 1 || P.ring.nvar == 0) {
+            throw new IllegalArgumentException("no univariate polynomial");
+        }
+        long e = P.degree(0);
+        long f = S.degree(0);
+        if (f == 0 && e == 0) {
+            return P.ring.getONE();
+        }
+        if (e == 0) {
+            return P.power(f);
+        }
+        if (f == 0) {
+            return S.power(e);
+        }
+        GenPolynomial<C> q;
+        GenPolynomial<C> r;
+        int s = 0; // sign is +, 1 for sign is -
+        if (e < f) {
+            r = P;
+            q = S;
+            long t = e;
+            e = f;
+            f = t;
+            if ((e % 2 != 0) && (f % 2 != 0)) { // odd(e) && odd(f)
+                s = 1;
+            }
+        } else {
+            q = P;
+            r = S;
+        }
+        RingFactory<C> cofac = P.ring.coFac;
+        boolean field = cofac.isField();
+        C c = cofac.getONE();
+        GenPolynomial<C> x;
+        long g;
+        do {
+            if (field) {
+                x = q.remainder(r);
+            } else {
+                x = PolyUtil.<C> baseSparsePseudoRemainder(q, r);
+                //System.out.println("x_s = " + x + ", lbcf(r) = " + r.leadingBaseCoefficient());
+            }
+            if (x.isZERO()) {
+                return x;
+            }
+            //System.out.println("x = " + x);
+            e = q.degree(0);
+            f = r.degree(0);
+            if ((e % 2 != 0) && (f % 2 != 0)) { // odd(e) && odd(f)
+                s = 1 - s;
+            }
+            g = x.degree(0);
+            C c2 = r.leadingBaseCoefficient();
+            for (int i = 0; i < (e - g); i++) {
+                c = c.multiply(c2);
+            }
+            q = r;
+            r = x;
+        } while (g != 0);
+        C c2 = r.leadingBaseCoefficient();
+        for (int i = 0; i < f; i++) {
+            c = c.multiply(c2);
+        }
+        if (s == 1) {
+            c = c.negate();
+        }
+        x = P.ring.getONE().multiply(c);
+        return x;
+    }
+
+
+    /**
+     * Univariate GenPolynomial recursive resultant.
+     * @param P univariate recursive GenPolynomial.
+     * @param S univariate recursive GenPolynomial.
+     * @return res(P,S).
+     */
+    @Override
+    public GenPolynomial<GenPolynomial<C>> recursiveUnivariateResultant(GenPolynomial<GenPolynomial<C>> P,
+                    GenPolynomial<GenPolynomial<C>> S) {
+        if (S == null || S.isZERO()) {
+            return S;
+        }
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        if (P.ring.nvar > 1 || P.ring.nvar == 0) {
+            throw new IllegalArgumentException("no recursive univariate polynomial");
+        }
+        long e = P.degree(0);
+        long f = S.degree(0);
+        if (f == 0 && e == 0) {
+            // if coeffs are multivariate (and non constant)
+            // otherwise it would be 1
+            GenPolynomial<C> t = resultant(P.leadingBaseCoefficient(), S.leadingBaseCoefficient());
+            return P.ring.getONE().multiply(t);
+        }
+        if (e == 0) {
+            return P.power(f);
+        }
+        if (f == 0) {
+            return S.power(e);
+        }
+        GenPolynomial<GenPolynomial<C>> q;
+        GenPolynomial<GenPolynomial<C>> r;
+        int s = 0; // sign is +, 1 for sign is -
+        if (f > e) {
+            r = P;
+            q = S;
+            long g = f;
+            f = e;
+            e = g;
+            if ((e % 2 != 0) && (f % 2 != 0)) { // odd(e) && odd(f)
+                s = 1;
+            }
+        } else {
+            q = P;
+            r = S;
+        }
+        GenPolynomial<GenPolynomial<C>> x;
+        RingFactory<GenPolynomial<C>> cofac = P.ring.coFac;
+        GenPolynomial<C> c = cofac.getONE();
+        long g;
+        do {
+            x = PolyUtil.<C> recursiveSparsePseudoRemainder(q, r);
+            //x = PolyUtil.<C>recursiveDensePseudoRemainder(q,r);
+            if (x.isZERO()) {
+                return x;
+            }
+            //no: x = recursivePrimitivePart(x);
+            //System.out.println("x = " + x);
+            e = q.degree(0);
+            f = r.degree(0);
+            if ((e % 2 != 0) && (f % 2 != 0)) { // odd(e) && odd(f)
+                s = 1 - s;
+            }
+            g = x.degree(0);
+            GenPolynomial<C> c2 = r.leadingBaseCoefficient();
+            for (int i = 0; i < (e - g); i++) {
+                c = c.multiply(c2);
+            }
+            q = r;
+            r = x;
+        } while (g != 0);
+        GenPolynomial<C> c2 = r.leadingBaseCoefficient();
+        for (int i = 0; i < f; i++) {
+            c = c.multiply(c2);
+        }
+        if (s == 1) {
+            c = c.negate();
+        }
+        x = P.ring.getONE().multiply(c);
+        return x;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/GreatestCommonDivisorSubres.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/GreatestCommonDivisorSubres.java
@@ -1,0 +1,514 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Greatest common divisor algorithms with subresultant polynomial remainder
+ * sequence.
+ * @author Heinz Kredel
+ * @author Youssef Elbarbary
+ */
+
+public class GreatestCommonDivisorSubres<C extends GcdRingElem<C>> extends GreatestCommonDivisorAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GreatestCommonDivisorSubres.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * GenPolynomial pseudo remainder. For univariate polynomials.
+     * @param P GenPolynomial.
+     * @param S nonzero GenPolynomial.
+     * @return remainder with ldcf(S)<sup>m</sup> P = quotient * S + remainder.
+     * @see edu.jas.poly.GenPolynomial#remainder(edu.jas.poly.GenPolynomial).
+     * @deprecated(forRemoval=true) Use
+     *                              {@link edu.jas.poly.PolyUtil#baseDensePseudoRemainder(edu.jas.poly.GenPolynomial,edu.jas.poly.GenPolynomial)}
+     *                              instead
+     */
+    @Deprecated
+    public GenPolynomial<C> basePseudoRemainder(GenPolynomial<C> P, GenPolynomial<C> S) {
+        return PolyUtil.<C> baseDensePseudoRemainder(P, S);
+    }
+
+
+    /**
+     * GenPolynomial pseudo remainder. For recursive polynomials.
+     * @param P recursive GenPolynomial.
+     * @param S nonzero recursive GenPolynomial.
+     * @return remainder with ldcf(S)<sup>m</sup> P = quotient * S + remainder.
+     * @see edu.jas.poly.GenPolynomial#remainder(edu.jas.poly.GenPolynomial).
+     * @deprecated(forRemoval=true) Use
+     *                              {@link edu.jas.poly.PolyUtil#recursiveDensePseudoRemainder(edu.jas.poly.GenPolynomial,edu.jas.poly.GenPolynomial)}
+     *                              instead
+     */
+    @Deprecated
+    public GenPolynomial<GenPolynomial<C>> recursivePseudoRemainder(GenPolynomial<GenPolynomial<C>> P,
+                    GenPolynomial<GenPolynomial<C>> S) {
+        return PolyUtil.<C> recursiveDensePseudoRemainder(P, S);
+    }
+
+
+    /**
+     * Univariate GenPolynomial greatest comon divisor. Uses pseudoRemainder for
+     * remainder.
+     * @param P univariate GenPolynomial.
+     * @param S univariate GenPolynomial.
+     * @return gcd(P,S).
+     */
+    @Override
+    public GenPolynomial<C> baseGcd(GenPolynomial<C> P, GenPolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.ring.nvar > 1) {
+            throw new IllegalArgumentException(this.getClass().getName() + " no univariate polynomial");
+        }
+        long e = P.degree(0);
+        long f = S.degree(0);
+        GenPolynomial<C> q;
+        GenPolynomial<C> r;
+        if (f > e) {
+            r = P;
+            q = S;
+            long g = f;
+            f = e;
+            e = g;
+        } else {
+            q = P;
+            r = S;
+        }
+        if (debug) {
+            logger.debug("degrees: e = " + e + ", f = " + f);
+        }
+        r = r.abs();
+        q = q.abs();
+        C a = baseContent(r);
+        C b = baseContent(q);
+        C c = gcd(a, b); // indirection
+        r = divide(r, a); // indirection
+        q = divide(q, b); // indirection
+        if (r.isONE()) {
+            return r.multiply(c);
+        }
+        if (q.isONE()) {
+            return q.multiply(c);
+        }
+        C g = r.ring.getONECoefficient();
+        C h = r.ring.getONECoefficient();
+        GenPolynomial<C> x;
+        C z;
+        while (!r.isZERO()) {
+            long delta = q.degree(0) - r.degree(0);
+            //System.out.println("delta    = " + delta);
+            x = PolyUtil.<C> baseDensePseudoRemainder(q, r);
+            q = r;
+            if (!x.isZERO()) {
+                z = g.multiply(h.power(delta)); //power(P.ring.coFac, h, delta));
+                //System.out.println("z  = " + z);
+                r = x.divide(z);
+                g = q.leadingBaseCoefficient();
+                z = g.power(delta); //power(P.ring.coFac, g, delta);
+                h = z.divide(h.power(delta - 1)); //power(P.ring.coFac, h, delta - 1));
+                //System.out.println("g  = " + g);
+                //System.out.println("h  = " + h);
+            } else {
+                r = x;
+            }
+        }
+        q = basePrimitivePart(q);
+        return (q.multiply(c)).abs();
+    }
+
+
+    /**
+     * Univariate GenPolynomial recursive greatest comon divisor. Uses
+     * pseudoRemainder for remainder.
+     * @param P univariate recursive GenPolynomial.
+     * @param S univariate recursive GenPolynomial.
+     * @return gcd(P,S).
+     */
+    @Override
+    public GenPolynomial<GenPolynomial<C>> recursiveUnivariateGcd(GenPolynomial<GenPolynomial<C>> P,
+                    GenPolynomial<GenPolynomial<C>> S) {
+        if (S == null || S.isZERO()) {
+            return P;
+        }
+        if (P == null || P.isZERO()) {
+            return S;
+        }
+        if (P.ring.nvar > 1) {
+            throw new IllegalArgumentException(this.getClass().getName() + " no univariate polynomial");
+        }
+        long e = P.degree(0);
+        long f = S.degree(0);
+        GenPolynomial<GenPolynomial<C>> q;
+        GenPolynomial<GenPolynomial<C>> r;
+        if (f > e) {
+            r = P;
+            q = S;
+            long g = f;
+            f = e;
+            e = g;
+        } else {
+            q = P;
+            r = S;
+        }
+        if (debug) {
+            logger.debug("degrees: e = " + e + ", f = " + f);
+        }
+        r = r.abs();
+        q = q.abs();
+        GenPolynomial<C> a = recursiveContent(r);
+        GenPolynomial<C> b = recursiveContent(q);
+
+        GenPolynomial<C> c = gcd(a, b); // go to recursion
+        //System.out.println("rgcd c = " + c);
+        r = PolyUtil.<C> recursiveDivide(r, a);
+        q = PolyUtil.<C> recursiveDivide(q, b);
+        if (r.isONE()) {
+            return r.multiply(c);
+        }
+        if (q.isONE()) {
+            return q.multiply(c);
+        }
+        GenPolynomial<C> g = r.ring.getONECoefficient();
+        GenPolynomial<C> h = r.ring.getONECoefficient();
+        GenPolynomial<GenPolynomial<C>> x;
+        GenPolynomial<C> z = null;
+        while (!r.isZERO()) {
+            long delta = q.degree(0) - r.degree(0);
+            //System.out.println("rgcd delta = " + delta);
+            x = PolyUtil.<C> recursiveDensePseudoRemainder(q, r);
+            if (logger.isDebugEnabled()) {
+                logger.info("recursiveDensePseudoRemainder.bits = " + x.bitLength());
+            }
+            q = r;
+            if (!x.isZERO()) {
+                z = g.multiply(h.power(delta)); //power(P.ring.coFac, h, delta));
+                r = PolyUtil.<C> recursiveDivide(x, z);
+                g = q.leadingBaseCoefficient();
+                z = g.power(delta); //power(P.ring.coFac, g, delta);
+                h = PolyUtil.<C> basePseudoDivide(z, h.power(delta - 1)); // power(P.ring.coFac, h, delta - 1)
+            } else {
+                r = x;
+            }
+        }
+        q = recursivePrimitivePart(q);
+        return q.abs().multiply(c); //.abs();
+    }
+
+
+    /**
+     * Univariate GenPolynomial resultant. Uses pseudoRemainder for remainder.
+     * @param P univariate GenPolynomial.
+     * @param S univariate GenPolynomial.
+     * @return res(P,S).
+     */
+    @Override
+    public GenPolynomial<C> baseResultant(GenPolynomial<C> P, GenPolynomial<C> S) {
+        if (S == null || S.isZERO()) {
+            return S;
+        }
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        if (P.ring.nvar > 1) {
+            throw new IllegalArgumentException(this.getClass().getName() + " no univariate polynomial");
+        }
+        long e = P.degree(0);
+        long f = S.degree(0);
+        GenPolynomial<C> q;
+        GenPolynomial<C> r;
+        if (f > e) {
+            r = P;
+            q = S;
+            long g = f;
+            f = e;
+            e = g;
+        } else {
+            q = P;
+            r = S;
+        }
+        //r = r.abs();
+        //q = q.abs();
+        C a = baseContent(r);
+        C b = baseContent(q);
+        r = divide(r, a); // indirection
+        q = divide(q, b); // indirection
+        RingFactory<C> cofac = P.ring.coFac;
+        C g = cofac.getONE();
+        C h = cofac.getONE();
+        C t = a.power(e); //power(cofac, a, e);
+        t = t.multiply(b.power(f)); //power(cofac, b, f));
+        long s = 1;
+        GenPolynomial<C> x;
+        C z;
+        while (r.degree(0) > 0) {
+            long delta = q.degree(0) - r.degree(0);
+            //System.out.println("delta    = " + delta);
+            if ((q.degree(0) % 2 != 0) && (r.degree(0) % 2 != 0)) {
+                s = -s;
+            }
+            x = PolyUtil.<C> baseDensePseudoRemainder(q, r);
+            //System.out.println("x  = " + x);
+            q = r;
+            if (x.degree(0) > 0) {
+                z = g.multiply(h.power(delta)); //power(cofac, h, delta));
+                //System.out.println("z  = " + z);
+                r = x.divide(z);
+                g = q.leadingBaseCoefficient();
+                z = g.power(delta); //power(cofac, g, delta);
+                h = z.divide(h.power(delta - 1));
+            } else {
+                r = x;
+            }
+        }
+        z = r.leadingBaseCoefficient().power(q.degree(0)); //power(cofac, r.leadingBaseCoefficient(), q.degree(0));
+        h = z.divide(h.power(q.degree() - 1)); //power(cofac, h, q.degree(0) - 1));
+        z = h.multiply(t);
+        if (s < 0) {
+            z = z.negate();
+        }
+        x = P.ring.getONE().multiply(z);
+        return x;
+    }
+
+
+    /**
+     * Univariate GenPolynomial recursive resultant. Uses pseudoRemainder for
+     * remainder.
+     * @param P univariate recursive GenPolynomial.
+     * @param S univariate recursive GenPolynomial.
+     * @return res(P,S).
+     */
+    @Override
+    public GenPolynomial<GenPolynomial<C>> recursiveUnivariateResultant(GenPolynomial<GenPolynomial<C>> P,
+                    GenPolynomial<GenPolynomial<C>> S) {
+        if (S == null || S.isZERO()) {
+            return S;
+        }
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        if (P.ring.nvar > 1) {
+            throw new IllegalArgumentException(this.getClass().getName() + " no univariate polynomial");
+        }
+        long e = P.degree(0);
+        long f = S.degree(0);
+        GenPolynomial<GenPolynomial<C>> q;
+        GenPolynomial<GenPolynomial<C>> r;
+        if (f > e) {
+            r = P;
+            q = S;
+            long g = f;
+            f = e;
+            e = g;
+        } else {
+            q = P;
+            r = S;
+        }
+        r = r.abs();
+        q = q.abs();
+        GenPolynomial<C> a = recursiveContent(r);
+        GenPolynomial<C> b = recursiveContent(q);
+        r = PolyUtil.<C> recursiveDivide(r, a);
+        q = PolyUtil.<C> recursiveDivide(q, b);
+        RingFactory<GenPolynomial<C>> cofac = P.ring.coFac;
+        GenPolynomial<C> g = cofac.getONE();
+        GenPolynomial<C> h = cofac.getONE();
+        GenPolynomial<GenPolynomial<C>> x;
+        GenPolynomial<C> t;
+        if (f == 0 && e == 0 && g.ring.nvar > 0) {
+            // if coeffs are multivariate (and non constant)
+            // otherwise it would be 1
+            t = resultant(a, b);
+            x = P.ring.getONE().multiply(t);
+            return x;
+        }
+        t = a.power(e); //power(cofac, a, e);
+        t = t.multiply(b.power(f)); //power(cofac, b, f));
+        long s = 1;
+        GenPolynomial<C> z;
+        while (r.degree(0) > 0) {
+            long delta = q.degree(0) - r.degree(0);
+            //System.out.println("delta    = " + delta);
+            if ((q.degree(0) % 2 != 0) && (r.degree(0) % 2 != 0)) {
+                s = -s;
+            }
+            x = PolyUtil.<C> recursiveDensePseudoRemainder(q, r);
+            //System.out.println("x  = " + x);
+            q = r;
+            if (x.degree(0) > 0) {
+                z = g.multiply(h.power(delta)); //power(P.ring.coFac, h, delta));
+                r = PolyUtil.<C> recursiveDivide(x, z);
+                g = q.leadingBaseCoefficient();
+                z = g.power(delta); //power(cofac, g, delta);
+                h = PolyUtil.<C> basePseudoDivide(z, h.power(delta - 1)); //power(cofac, h, delta - 1));
+            } else {
+                r = x;
+            }
+        }
+        z = r.leadingBaseCoefficient().power(q.degree(0)); //power(cofac, r.leadingBaseCoefficient(), q.degree(0));
+        h = PolyUtil.<C> basePseudoDivide(z, h.power(q.degree() - 1)); //power(cofac, h, q.degree(0) - 1));
+        z = h.multiply(t);
+        if (s < 0) {
+            z = z.negate();
+        }
+        x = P.ring.getONE().multiply(z);
+        return x;
+    }
+
+
+    /**
+     * Univariate GenPolynomial recursive Subresultant list. Uses
+     * pseudoRemainder for remainder. <b>Author:</b> Youssef Elbarbary
+     * @param P univariate recursive GenPolynomial.
+     * @param S univariate recursive GenPolynomial.
+     * @return subResList(P,S).
+     */
+    public List<GenPolynomial<GenPolynomial<C>>> recursiveUnivariateSubResultantList(
+                    GenPolynomial<GenPolynomial<C>> P, GenPolynomial<GenPolynomial<C>> S) {
+        List<GenPolynomial<GenPolynomial<C>>> myList = new ArrayList<GenPolynomial<GenPolynomial<C>>>();
+        if (S == null || S.isZERO()) {
+            myList.add(S);
+            return myList;
+        }
+        if (P == null || P.isZERO()) {
+            myList.add(P);
+            return myList;
+        }
+        if (P.ring.nvar > 1) {
+            throw new IllegalArgumentException(this.getClass().getName() + " no univariate polynomial");
+        }
+        long e = P.degree(0);
+        long f = S.degree(0);
+        GenPolynomial<GenPolynomial<C>> q;
+        GenPolynomial<GenPolynomial<C>> r;
+        if (f > e) {
+            r = P;
+            q = S;
+            long g = f;
+            f = e;
+            e = g;
+        } else {
+            q = P;
+            r = S;
+        }
+        r = r.abs();
+        q = q.abs();
+        GenPolynomial<C> a = recursiveContent(r);
+        GenPolynomial<C> b = recursiveContent(q);
+        r = PolyUtil.<C> recursiveDivide(r, a);
+        q = PolyUtil.<C> recursiveDivide(q, b);
+        RingFactory<GenPolynomial<C>> cofac = P.ring.coFac;
+        GenPolynomial<C> g = cofac.getONE();
+        GenPolynomial<C> h = cofac.getONE();
+        GenPolynomial<GenPolynomial<C>> x;
+        GenPolynomial<C> t;
+        if (f == 0 && e == 0 && g.ring.nvar > 0) {
+            // if coeffs are multivariate (and non constant)
+            // otherwise it would be 1
+            t = resultant(a, b);
+            x = P.ring.getONE().multiply(t);
+            myList.add(x);
+            return myList;
+        }
+        t = a.power(e); // power(cofac, a, e);
+        t = t.multiply(b.power(f)); // power(cofac, b, f));
+        long s = 1;
+        GenPolynomial<C> z;
+        myList.add(P); // adding R0
+        myList.add(S); // adding R1
+        while (r.degree(0) > 0) {
+            long delta = q.degree(0) - r.degree(0);
+            if ((q.degree(0) % 2 != 0) && (r.degree(0) % 2 != 0)) {
+                s = -s;
+            }
+            x = PolyUtil.<C> recursiveDensePseudoRemainder(q, r);
+            q = r;
+            if (x.degree(0) >= 0) { // fixed: this was changed from > to >=
+                z = g.multiply(h.power(delta)); // power(P.ring.coFac, h, delta));
+                r = PolyUtil.<C> recursiveDivide(x, z);
+                myList.add(r);
+                g = q.leadingBaseCoefficient();
+                z = g.power(delta); // power(cofac, g, delta);
+                h = PolyUtil.<C> basePseudoDivide(z, h.power(delta - 1)); // power(cofac, h, delta - 1));
+            } else {
+                r = x;
+                myList.add(r);
+            }
+        }
+        z = r.leadingBaseCoefficient().power(q.degree(0)); // power(cofac, r.leadingBaseCoefficient(), q.degree(0));
+        h = PolyUtil.<C> basePseudoDivide(z, h.power(q.degree() - 1)); // power(cofac, h, q.degree(0) - 1));
+        z = h.multiply(t);
+        if (s < 0) {
+            z = z.negate();
+        }
+        x = P.ring.getONE().multiply(z);
+        myList.add(x);
+        // Printing the Subresultant List
+        //System.out.println("Liste von den SubResultanten(A - tD'):");
+        //for (int i = 0; i < myList.size(); i++) { // just for printing the list
+        //    System.out.println(myList.get(i));
+        //}
+        if (logger.isInfoEnabled()) {
+            System.out.println("subResCoeffs: " + myList);
+            //logger.info("subResCoeffs: " + myList);
+        }
+        return myList;
+    }
+
+
+    /**
+     * GenPolynomial base coefficient discriminant.
+     * @param P GenPolynomial.
+     * @return discriminant(P).
+     */
+    public GenPolynomial<C> baseDiscriminant(GenPolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P != null");
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        GenPolynomialRing<C> pfac = P.ring;
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P not univariate");
+        }
+        C a = P.leadingBaseCoefficient();
+        a = a.inverse();
+        GenPolynomial<C> Pp = PolyUtil.<C> baseDeriviative(P);
+        GenPolynomial<C> res = baseResultant(P, Pp);
+        GenPolynomial<C> disc = res.multiply(a);
+        long n = P.degree(0);
+        n = n * (n - 1);
+        n = n / 2;
+        if (n % 2L != 0L) {
+            disc = disc.negate();
+        }
+        return disc;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/HenselApprox.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/HenselApprox.java
@@ -1,0 +1,144 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.io.Serializable;
+
+import edu.jas.arith.BigInteger;
+import edu.jas.arith.Modular;
+import edu.jas.arith.ModularRingFactory;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Container for the approximation result from a Hensel algorithm.
+ * @author Heinz Kredel
+ * @param <MOD> coefficient type
+ */
+
+public class HenselApprox<MOD extends GcdRingElem<MOD> & Modular> implements Serializable {
+
+
+    /**
+     * Approximated polynomial with integer coefficients.
+     */
+    public final GenPolynomial<BigInteger> A;
+
+
+    /**
+     * Approximated polynomial with integer coefficients.
+     */
+    public final GenPolynomial<BigInteger> B;
+
+
+    /**
+     * Modular approximated polynomial with modular coefficients.
+     */
+    public final GenPolynomial<MOD> Am;
+
+
+    /**
+     * Modular approximated polynomial with modular coefficients.
+     */
+    public final GenPolynomial<MOD> Bm;
+
+
+    /**
+     * Constructor.
+     * @param A approximated polynomial.
+     * @param B approximated polynomial.
+     * @param Am approximated modular polynomial.
+     * @param Bm approximated modular polynomial.
+     */
+    public HenselApprox(GenPolynomial<BigInteger> A, GenPolynomial<BigInteger> B, GenPolynomial<MOD> Am,
+            GenPolynomial<MOD> Bm) {
+        this.A = A;
+        this.B = B;
+        this.Am = Am;
+        this.Bm = Bm;
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        sb.append(A.toString());
+        sb.append(",");
+        sb.append(B.toString());
+        sb.append(",");
+        sb.append(Am.toString());
+        sb.append(",");
+        sb.append(Bm.toString());
+        return sb.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this container.
+     * @see edu.jas.structure.ElemFactory#toScript()
+     */
+    public String toScript() {
+        // Python case
+        StringBuffer sb = new StringBuffer();
+        sb.append(A.toScript());
+        sb.append(",");
+        sb.append(B.toScript());
+        sb.append(",");
+        sb.append(Am.toScript());
+        sb.append(",");
+        sb.append(Bm.toScript());
+        return sb.toString();
+    }
+
+
+    /**
+     * Hash code for this Factors.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h = A.hashCode();
+        h = 37 * h + B.hashCode();
+        h = 37 * h + Am.hashCode();
+        h = 37 * h + Bm.hashCode();
+        return h;
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object B) {
+        if (B == null) {
+            return false;
+        }
+        if (!(B instanceof HenselApprox)) {
+            return false;
+        }
+        HenselApprox<MOD> a = (HenselApprox<MOD>) B;
+        return A.equals(a.A) && B.equals(a.B) && Am.equals(a.Am) && Bm.equals(a.Bm);
+    }
+
+
+    /**
+     * Get modul of modular polynomial.
+     * @return coefficient modul of polynomial mpol.
+     */
+    public BigInteger approximationSize() {
+        ModularRingFactory fac = (ModularRingFactory) Am.ring.coFac;
+        return fac.getIntegerModul();
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/HenselMultUtil.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/HenselMultUtil.java
@@ -1,0 +1,1098 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.arith.BigInteger;
+import edu.jas.arith.ModIntegerRing;
+import edu.jas.arith.ModLongRing;
+import edu.jas.arith.Modular;
+import edu.jas.arith.ModularRingFactory;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.ps.PolynomialTaylorFunction;
+import edu.jas.ps.TaylorFunction;
+import edu.jas.ps.UnivPowerSeries;
+import edu.jas.ps.UnivPowerSeriesRing;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Hensel multivariate lifting utilities.
+ * @author Heinz Kredel
+ */
+
+public class HenselMultUtil {
+
+
+    private static final Logger logger = LogManager.getLogger(HenselMultUtil.class);
+
+
+    private static final boolean debug = logger.isInfoEnabled();
+
+
+    /**
+     * Modular diophantine equation solution and lifting algorithm. Let p =
+     * A_i.ring.coFac.modul() and assume ggt(A,B) == 1 mod p.
+     * @param A modular GenPolynomial, mod p^k
+     * @param B modular GenPolynomial, mod p^k
+     * @param C modular GenPolynomial, mod p^k
+     * @param V list of substitution values, mod p^k
+     * @param d desired approximation exponent (x_i-v_i)^d.
+     * @param k desired approximation exponent p^k.
+     * @return [s, t] with s A' + t B' = C mod p^k, with A' = B, B' = A.
+     */
+    public static <MOD extends GcdRingElem<MOD> & Modular> List<GenPolynomial<MOD>> liftDiophant(
+                    GenPolynomial<MOD> A, GenPolynomial<MOD> B, GenPolynomial<MOD> C, List<MOD> V, long d,
+                    long k) throws NoLiftingException {
+        GenPolynomialRing<MOD> pkfac = C.ring;
+        if (pkfac.nvar == 1) { // V, d ignored
+            return HenselUtil.<MOD> liftDiophant(A, B, C, k);
+        }
+        if (!pkfac.equals(A.ring)) {
+            throw new IllegalArgumentException("A.ring != pkfac: " + A.ring + " != " + pkfac);
+        }
+
+        // evaluate at v_n:
+        List<MOD> Vp = new ArrayList<MOD>(V);
+        MOD v = Vp.remove(Vp.size() - 1);
+        //GenPolynomial<MOD> zero = pkfac.getZERO();
+        // (x_n - v)
+        GenPolynomial<MOD> mon = pkfac.getONE();
+        GenPolynomial<MOD> xv = pkfac.univariate(0, 1);
+        xv = xv.subtract(pkfac.fromInteger(v.getSymmetricInteger().getVal()));
+        //System.out.println("xv = " + xv);
+        // A(v), B(v), C(v)
+        ModularRingFactory<MOD> cf = (ModularRingFactory<MOD>) pkfac.coFac;
+        MOD vp = cf.fromInteger(v.getSymmetricInteger().getVal());
+        //System.out.println("v = " + v + ", vp = " + vp);
+        GenPolynomialRing<MOD> ckfac = pkfac.contract(1);
+        GenPolynomial<MOD> Ap = PolyUtil.<MOD> evaluateMain(ckfac, A, vp);
+        GenPolynomial<MOD> Bp = PolyUtil.<MOD> evaluateMain(ckfac, B, vp);
+        GenPolynomial<MOD> Cp = PolyUtil.<MOD> evaluateMain(ckfac, C, vp);
+        //System.out.println("Ap = " + Ap);
+        //System.out.println("Bp = " + Bp);
+        //System.out.println("Cp = " + Cp);
+
+        // recursion:
+        List<GenPolynomial<MOD>> su = HenselMultUtil.<MOD> liftDiophant(Ap, Bp, Cp, Vp, d, k);
+        //System.out.println("su@p^" + k + " = " + su);
+        //System.out.println("coFac = " + su.get(0).ring.coFac.toScript());
+        if (pkfac.nvar == 2 && !HenselUtil.<MOD> isDiophantLift(Bp, Ap, su.get(0), su.get(1), Cp)) {
+            //System.out.println("isDiophantLift: false");
+            throw new NoLiftingException("isDiophantLift: false");
+        }
+        if (!ckfac.equals(su.get(0).ring)) {
+            throw new IllegalArgumentException("qfac != ckfac: " + su.get(0).ring + " != " + ckfac);
+        }
+        GenPolynomialRing<BigInteger> ifac = new GenPolynomialRing<BigInteger>(new BigInteger(), pkfac);
+        //System.out.println("ifac = " + ifac.toScript());
+        String[] mn = new String[] { pkfac.getVars()[pkfac.nvar - 1] };
+        GenPolynomialRing<GenPolynomial<MOD>> qrfac = new GenPolynomialRing<GenPolynomial<MOD>>(ckfac, 1, mn);
+        //System.out.println("qrfac = " + qrfac);
+
+        List<GenPolynomial<MOD>> sup = new ArrayList<GenPolynomial<MOD>>(su.size());
+        List<GenPolynomial<BigInteger>> supi = new ArrayList<GenPolynomial<BigInteger>>(su.size());
+        for (GenPolynomial<MOD> s : su) {
+            GenPolynomial<MOD> sp = s.extend(pkfac, 0, 0L);
+            sup.add(sp);
+            GenPolynomial<BigInteger> spi = PolyUtil.integerFromModularCoefficients(ifac, sp);
+            supi.add(spi);
+        }
+        //System.out.println("sup  = " + sup);
+        //System.out.println("supi = " + supi);
+        GenPolynomial<BigInteger> Ai = PolyUtil.integerFromModularCoefficients(ifac, A);
+        GenPolynomial<BigInteger> Bi = PolyUtil.integerFromModularCoefficients(ifac, B);
+        GenPolynomial<BigInteger> Ci = PolyUtil.integerFromModularCoefficients(ifac, C);
+        //System.out.println("Ai = " + Ai);
+        //System.out.println("Bi = " + Bi);
+        //System.out.println("Ci = " + Ci);
+        //GenPolynomial<MOD> aq = PolyUtil.<MOD> fromIntegerCoefficients(pkfac, Ai);
+        //GenPolynomial<MOD> bq = PolyUtil.<MOD> fromIntegerCoefficients(pkfac, Bi);
+        //System.out.println("aq = " + aq);
+        //System.out.println("bq = " + bq);
+
+        // compute error:
+        GenPolynomial<BigInteger> E = Ci; // - sum_i s_i b_i
+        E = E.subtract(Bi.multiply(supi.get(0)));
+        E = E.subtract(Ai.multiply(supi.get(1)));
+        //System.out.println("E     = " + E);
+        if (E.isZERO()) {
+            logger.info("liftDiophant leaving on zero E");
+            return sup;
+        }
+        GenPolynomial<MOD> Ep = PolyUtil.<MOD> fromIntegerCoefficients(pkfac, E);
+        //System.out.println("Ep(0," + pkfac.nvar + ") = " + Ep);
+        logger.info("Ep(0," + pkfac.nvar + ") = " + Ep);
+        if (Ep.isZERO()) {
+            logger.info("liftDiophant leaving on zero Ep mod p^k");
+            return sup;
+        }
+        for (int e = 1; e <= d; e++) {
+            //System.out.println("\ne = " + e + " -------------------------------------- " + pkfac.nvar);
+            GenPolynomial<GenPolynomial<MOD>> Epr = PolyUtil.<MOD> recursive(qrfac, Ep);
+            //System.out.println("Epr   = " + Epr);
+            UnivPowerSeriesRing<GenPolynomial<MOD>> psfac = new UnivPowerSeriesRing<GenPolynomial<MOD>>(
+                            qrfac);
+            //System.out.println("psfac = " + psfac);
+            TaylorFunction<GenPolynomial<MOD>> F = new PolynomialTaylorFunction<GenPolynomial<MOD>>(Epr);
+            //System.out.println("F     = " + F);
+            //List<GenPolynomial<MOD>> Vs = new ArrayList<GenPolynomial<MOD>>(1);
+            GenPolynomial<MOD> vq = ckfac.fromInteger(v.getSymmetricInteger().getVal());
+            //Vs.add(vq);
+            //System.out.println("Vs    = " + Vs);
+            UnivPowerSeries<GenPolynomial<MOD>> Epst = psfac.seriesOfTaylor(F, vq);
+            //System.out.println("Epst  = " + Epst);
+            GenPolynomial<MOD> cm = Epst.coefficient(e);
+            //System.out.println("cm   = " + cm + ", cm.ring   = " + cm.ring.toScript());
+
+            // recursion:
+            List<GenPolynomial<MOD>> S = HenselMultUtil.<MOD> liftDiophant(Ap, Bp, cm, Vp, d, k);
+            //System.out.println("S    = " + S);
+            if (!ckfac.coFac.equals(S.get(0).ring.coFac)) {
+                throw new IllegalArgumentException(
+                                "ckfac != pkfac: " + ckfac.coFac + " != " + S.get(0).ring.coFac);
+            }
+            if (pkfac.nvar == 2 && !HenselUtil.<MOD> isDiophantLift(Ap, Bp, S.get(1), S.get(0), cm)) {
+                //System.out.println("isDiophantLift: false");
+                throw new NoLiftingException("isDiophantLift: false");
+            }
+            mon = mon.multiply(xv); // Power.<GenPolynomial<MOD>> power(pkfac,xv,e);
+            //System.out.println("mon  = " + mon);
+            //List<GenPolynomial<MOD>> Sp = new ArrayList<GenPolynomial<MOD>>(S.size());
+            int i = 0;
+            supi = new ArrayList<GenPolynomial<BigInteger>>(su.size());
+            for (GenPolynomial<MOD> dd : S) {
+                //System.out.println("dd = " + dd);
+                GenPolynomial<MOD> de = dd.extend(pkfac, 0, 0L);
+                GenPolynomial<MOD> dm = de.multiply(mon);
+                //Sp.add(dm);
+                de = sup.get(i).sum(dm);
+                //System.out.println("dd = " + dd);
+                sup.set(i++, de);
+                GenPolynomial<BigInteger> spi = PolyUtil.integerFromModularCoefficients(ifac, dm);
+                supi.add(spi);
+            }
+            //System.out.println("Sp   = " + Sp);
+            //System.out.println("sup  = " + sup);
+            //System.out.println("supi = " + supi);
+            // compute new error
+            //E = E; // - sum_i s_i b_i
+            E = E.subtract(Bi.multiply(supi.get(0)));
+            E = E.subtract(Ai.multiply(supi.get(1)));
+            //System.out.println("E     = " + E);
+            if (E.isZERO()) {
+                logger.info("liftDiophant leaving on zero E");
+                return sup;
+            }
+            Ep = PolyUtil.<MOD> fromIntegerCoefficients(pkfac, E);
+            //System.out.println("Ep(" + e + "," + pkfac.nvar + ") = " + Ep); 
+            logger.info("Ep(" + e + "," + pkfac.nvar + ") = " + Ep);
+            if (Ep.isZERO()) {
+                logger.info("liftDiophant leaving on zero Ep mod p^k");
+                return sup;
+            }
+        }
+        //System.out.println("*** done: " + pkfac.nvar);
+        return sup;
+    }
+
+
+    /**
+     * Modular diophantine equation solution and lifting algorithm. Let p =
+     * A_i.ring.coFac.modul() and assume ggt(a,b) == 1 mod p, for a, b in A.
+     * @param A list of modular GenPolynomials, mod p^k
+     * @param C modular GenPolynomial, mod p^k
+     * @param V list of substitution values, mod p^k
+     * @param d desired approximation exponent (x_i-v_i)^d.
+     * @param k desired approximation exponent p^k.
+     * @return [s_1,..., s_n] with sum_i s_i A_i' = C mod p^k, with Ai' =
+     *         prod_{j!=i} A_j.
+     */
+    public static <MOD extends GcdRingElem<MOD> & Modular> List<GenPolynomial<MOD>> liftDiophant(
+                    List<GenPolynomial<MOD>> A, GenPolynomial<MOD> C, List<MOD> V, long d, long k)
+                    throws NoLiftingException {
+        GenPolynomialRing<MOD> pkfac = C.ring;
+        if (pkfac.nvar == 1) { // V, d ignored
+            return HenselUtil.<MOD> liftDiophant(A, C, k);
+        }
+        if (!pkfac.equals(A.get(0).ring)) {
+            throw new IllegalArgumentException("A.ring != pkfac: " + A.get(0).ring + " != " + pkfac);
+        }
+        // co-products
+        GenPolynomial<MOD> As = pkfac.getONE();
+        for (GenPolynomial<MOD> a : A) {
+            As = As.multiply(a);
+        }
+        List<GenPolynomial<MOD>> Bp = new ArrayList<GenPolynomial<MOD>>(A.size());
+        for (GenPolynomial<MOD> a : A) {
+            GenPolynomial<MOD> b = PolyUtil.<MOD> basePseudoDivide(As, a);
+            Bp.add(b);
+        }
+
+        // evaluate at v_n:
+        List<MOD> Vp = new ArrayList<MOD>(V);
+        MOD v = Vp.remove(Vp.size() - 1);
+        // (x_n - v)
+        GenPolynomial<MOD> mon = pkfac.getONE();
+        GenPolynomial<MOD> xv = pkfac.univariate(0, 1);
+        xv = xv.subtract(pkfac.fromInteger(v.getSymmetricInteger().getVal()));
+        //System.out.println("xv = " + xv);
+        // A(v), B(v), C(v)
+        ModularRingFactory<MOD> cf = (ModularRingFactory<MOD>) pkfac.coFac;
+        MOD vp = cf.fromInteger(v.getSymmetricInteger().getVal());
+        //System.out.println("v = " + v + ", vp = " + vp);
+        GenPolynomialRing<MOD> ckfac = pkfac.contract(1);
+        List<GenPolynomial<MOD>> Ap = new ArrayList<GenPolynomial<MOD>>(A.size());
+        for (GenPolynomial<MOD> a : A) {
+            GenPolynomial<MOD> ap = PolyUtil.<MOD> evaluateMain(ckfac, a, vp);
+            Ap.add(ap);
+        }
+        GenPolynomial<MOD> Cp = PolyUtil.<MOD> evaluateMain(ckfac, C, vp);
+        //System.out.println("Ap = " + Ap);
+        //System.out.println("Cp = " + Cp);
+
+        // recursion:
+        List<GenPolynomial<MOD>> su = HenselMultUtil.<MOD> liftDiophant(Ap, Cp, Vp, d, k);
+        //System.out.println("su@p^" + k + " = " + su);
+        //System.out.println("coFac = " + su.get(0).ring.coFac.toScript());
+        if (pkfac.nvar == 2 && !HenselUtil.<MOD> isDiophantLift(Ap, su, Cp)) {
+            //System.out.println("isDiophantLift: false");
+            throw new NoLiftingException("isDiophantLift: false");
+        }
+        if (!ckfac.equals(su.get(0).ring)) {
+            throw new IllegalArgumentException("qfac != ckfac: " + su.get(0).ring + " != " + ckfac);
+        }
+        GenPolynomialRing<BigInteger> ifac = new GenPolynomialRing<BigInteger>(new BigInteger(), pkfac);
+        //System.out.println("ifac = " + ifac.toScript());
+        String[] mn = new String[] { pkfac.getVars()[pkfac.nvar - 1] };
+        GenPolynomialRing<GenPolynomial<MOD>> qrfac = new GenPolynomialRing<GenPolynomial<MOD>>(ckfac, 1, mn);
+        //System.out.println("qrfac = " + qrfac);
+
+        List<GenPolynomial<MOD>> sup = new ArrayList<GenPolynomial<MOD>>(su.size());
+        List<GenPolynomial<BigInteger>> supi = new ArrayList<GenPolynomial<BigInteger>>(su.size());
+        for (GenPolynomial<MOD> s : su) {
+            GenPolynomial<MOD> sp = s.extend(pkfac, 0, 0L);
+            sup.add(sp);
+            GenPolynomial<BigInteger> spi = PolyUtil.integerFromModularCoefficients(ifac, sp);
+            supi.add(spi);
+        }
+        //System.out.println("sup  = " + sup);
+        //System.out.println("supi = " + supi);
+        //List<GenPolynomial<BigInteger>> Ai = new ArrayList<GenPolynomial<BigInteger>>(A.size());
+        //for (GenPolynomial<MOD> a : A) {
+        //    GenPolynomial<BigInteger> ai = PolyUtil.integerFromModularCoefficients(ifac, a);
+        //    Ai.add(ai);
+        //}
+        List<GenPolynomial<BigInteger>> Bi = new ArrayList<GenPolynomial<BigInteger>>(A.size());
+        for (GenPolynomial<MOD> b : Bp) {
+            GenPolynomial<BigInteger> bi = PolyUtil.integerFromModularCoefficients(ifac, b);
+            Bi.add(bi);
+        }
+        GenPolynomial<BigInteger> Ci = PolyUtil.integerFromModularCoefficients(ifac, C);
+        //System.out.println("Ai = " + Ai);
+        //System.out.println("Ci = " + Ci);
+
+        //List<GenPolynomial<MOD>> Aq = new ArrayList<GenPolynomial<MOD>>(A.size());
+        //for (GenPolynomial<BigInteger> ai : Ai) {
+        //    GenPolynomial<MOD> aq = PolyUtil.<MOD> fromIntegerCoefficients(pkfac, ai);
+        //    Aq.add(aq);
+        //}
+        //System.out.println("Aq = " + Aq);
+
+        // compute error:
+        GenPolynomial<BigInteger> E = Ci; // - sum_i s_i b_i
+        int i = 0;
+        for (GenPolynomial<BigInteger> bi : Bi) {
+            E = E.subtract(bi.multiply(supi.get(i++)));
+        }
+        //System.out.println("E     = " + E);
+        if (E.isZERO()) {
+            logger.info("liftDiophant leaving on zero E");
+            return sup;
+        }
+        GenPolynomial<MOD> Ep = PolyUtil.<MOD> fromIntegerCoefficients(pkfac, E);
+        //System.out.println("Ep(0," + pkfac.nvar + ") = " + Ep);
+        logger.info("Ep(0," + pkfac.nvar + ") = " + Ep);
+        if (Ep.isZERO()) {
+            logger.info("liftDiophant leaving on zero Ep mod p^k");
+            return sup;
+        }
+        for (int e = 1; e <= d; e++) {
+            //System.out.println("\ne = " + e + " -------------------------------------- " + pkfac.nvar);
+            GenPolynomial<GenPolynomial<MOD>> Epr = PolyUtil.<MOD> recursive(qrfac, Ep);
+            //System.out.println("Epr   = " + Epr);
+            UnivPowerSeriesRing<GenPolynomial<MOD>> psfac = new UnivPowerSeriesRing<GenPolynomial<MOD>>(
+                            qrfac);
+            //System.out.println("psfac = " + psfac);
+            TaylorFunction<GenPolynomial<MOD>> F = new PolynomialTaylorFunction<GenPolynomial<MOD>>(Epr);
+            //System.out.println("F     = " + F);
+            //List<GenPolynomial<MOD>> Vs = new ArrayList<GenPolynomial<MOD>>(1);
+            GenPolynomial<MOD> vq = ckfac.fromInteger(v.getSymmetricInteger().getVal());
+            //Vs.add(vq);
+            //System.out.println("Vs    = " + Vs);
+            UnivPowerSeries<GenPolynomial<MOD>> Epst = psfac.seriesOfTaylor(F, vq);
+            //System.out.println("Epst  = " + Epst);
+            GenPolynomial<MOD> cm = Epst.coefficient(e);
+            //System.out.println("cm   = " + cm + ", cm.ring   = " + cm.ring.toScript());
+            if (cm.isZERO()) {
+                continue;
+            }
+            // recursion:
+            List<GenPolynomial<MOD>> S = HenselMultUtil.<MOD> liftDiophant(Ap, cm, Vp, d, k);
+            //System.out.println("S    = " + S);
+            if (!ckfac.coFac.equals(S.get(0).ring.coFac)) {
+                throw new IllegalArgumentException(
+                                "ckfac != pkfac: " + ckfac.coFac + " != " + S.get(0).ring.coFac);
+            }
+            if (pkfac.nvar == 2 && !HenselUtil.<MOD> isDiophantLift(Ap, S, cm)) {
+                //System.out.println("isDiophantLift: false");
+                throw new NoLiftingException("isDiophantLift: false");
+            }
+            mon = mon.multiply(xv); // Power.<GenPolynomial<MOD>> power(pkfac,xv,e);
+            //System.out.println("mon  = " + mon);
+            //List<GenPolynomial<MOD>> Sp = new ArrayList<GenPolynomial<MOD>>(S.size());
+            i = 0;
+            supi = new ArrayList<GenPolynomial<BigInteger>>(su.size());
+            for (GenPolynomial<MOD> dd : S) {
+                //System.out.println("dd = " + dd);
+                GenPolynomial<MOD> de = dd.extend(pkfac, 0, 0L);
+                GenPolynomial<MOD> dm = de.multiply(mon);
+                //Sp.add(dm);
+                de = sup.get(i).sum(dm);
+                //System.out.println("dd = " + dd);
+                sup.set(i++, de);
+                GenPolynomial<BigInteger> spi = PolyUtil.integerFromModularCoefficients(ifac, dm);
+                supi.add(spi);
+            }
+            //System.out.println("Sp   = " + Sp);
+            //System.out.println("sup  = " + sup);
+            //System.out.println("supi = " + supi);
+            // compute new error
+            //E = E; // - sum_i s_i b_i
+            i = 0;
+            for (GenPolynomial<BigInteger> bi : Bi) {
+                E = E.subtract(bi.multiply(supi.get(i++)));
+            }
+            //System.out.println("E     = " + E);
+            if (E.isZERO()) {
+                logger.info("liftDiophant leaving on zero E");
+                return sup;
+            }
+            Ep = PolyUtil.<MOD> fromIntegerCoefficients(pkfac, E);
+            //System.out.println("Ep(" + e + "," + pkfac.nvar + ") = " + Ep); 
+            logger.info("Ep(" + e + "," + pkfac.nvar + ") = " + Ep);
+            if (Ep.isZERO()) {
+                logger.info("liftDiophant leaving on zero Ep mod p^k");
+                return sup;
+            }
+        }
+        //System.out.println("*** done: " + pkfac.nvar);
+        return sup;
+    }
+
+
+    /**
+     * Modular Hensel lifting algorithm on coefficients test. Let p =
+     * f_i.ring.coFac.modul() and assume C == prod_{0,...,n-1} f_i mod p with
+     * gcd(f_i,f_j) == 1 mod p for i != j
+     * @param C integer polynomial
+     * @param Cp GenPolynomial mod p^k
+     * @param F = [f_0,...,f_{n-1}] list of monic modular polynomials.
+     * @param L = [g_0,...,g_{n-1}] list of lifted modular polynomials.
+     * @return true if C = prod_{0,...,n-1} g_i mod p^k, else false.
+     */
+    @SuppressWarnings("unused")
+    public static <MOD extends GcdRingElem<MOD> & Modular> boolean isHenselLift(GenPolynomial<BigInteger> C,
+                    GenPolynomial<MOD> Cp, List<GenPolynomial<MOD>> F, List<GenPolynomial<MOD>> L) {
+        boolean t = true;
+        GenPolynomialRing<MOD> qfac = L.get(0).ring;
+        GenPolynomial<MOD> q = qfac.getONE();
+        for (GenPolynomial<MOD> fi : L) {
+            q = q.multiply(fi);
+        }
+        t = Cp.equals(q);
+        if (!t) {
+            System.out.println("Cp     = " + Cp);
+            System.out.println("q      = " + q);
+            System.out.println("Cp != q: " + Cp.subtract(q));
+            return t;
+        }
+        GenPolynomialRing<BigInteger> dfac = C.ring;
+        GenPolynomial<BigInteger> Ci = PolyUtil.integerFromModularCoefficients(dfac, q);
+        t = C.equals(Ci);
+        if (!t) {
+            System.out.println("C      = " + C);
+            System.out.println("Ci     = " + Ci);
+            System.out.println("C != Ci: " + C.subtract(Ci));
+            return t;
+        }
+        // test L mod id(V) == F
+        return t;
+    }
+
+
+    /**
+     * Modular Hensel lifting algorithm, monic case. Let p =
+     * A_i.ring.coFac.modul() and assume ggt(a,b) == 1 mod p, for a, b in A.
+     * @param C monic GenPolynomial with integer coefficients
+     * @param Cp GenPolynomial mod p^k
+     * @param F list of modular GenPolynomials, mod (I_v, p^k )
+     * @param V list of integer substitution values
+     * @param k desired approximation exponent p^k.
+     * @return [g'_1,..., g'_n] with prod_i g'_i = Cp mod p^k.
+     */
+    public static <MOD extends GcdRingElem<MOD> & Modular> List<GenPolynomial<MOD>> liftHenselMonic(
+                    GenPolynomial<BigInteger> C, GenPolynomial<MOD> Cp, List<GenPolynomial<MOD>> F,
+                    List<BigInteger> V, long k) throws NoLiftingException {
+        GenPolynomialRing<MOD> pkfac = Cp.ring;
+        //if (pkfac.nvar == 1) { // V ignored
+        //    return HenselUtil.<MOD> liftHenselMonic(C,F,k);
+        //}
+        long d = C.degree();
+        //System.out.println("d = " + d);
+        // prepare stack of polynomial rings and polynomials
+        List<GenPolynomialRing<MOD>> Pfac = new ArrayList<GenPolynomialRing<MOD>>();
+        List<GenPolynomial<MOD>> Ap = new ArrayList<GenPolynomial<MOD>>();
+        List<MOD> Vb = new ArrayList<MOD>();
+        MOD v = pkfac.coFac.fromInteger(V.get(0).getVal());
+        Pfac.add(pkfac);
+        Ap.add(Cp);
+        Vb.add(v);
+        GenPolynomialRing<MOD> pf = pkfac;
+        GenPolynomial<MOD> ap = Cp;
+        for (int j = pkfac.nvar; j > 2; j--) {
+            pf = pf.contract(1);
+            Pfac.add(0, pf);
+            //MOD vp = pkfac.coFac.fromInteger(V.get(j - 2).getSymmetricInteger().getVal());
+            MOD vp = pkfac.coFac.fromInteger(V.get(j - 2).getVal());
+            //System.out.println("vp     = " + vp);
+            Vb.add(1, vp);
+            ap = PolyUtil.<MOD> evaluateMain(pf, ap, vp);
+            Ap.add(0, ap);
+        }
+        //System.out.println("Pfac   = " + Pfac);
+        if (debug) {
+            logger.debug("Pfac   = " + Pfac);
+        }
+        //System.out.println("Ap     = " + Ap);
+        //System.out.println("V      = " + V);
+        //System.out.println("Vb     = " + Vb);
+        // setup bi-variate base case
+        GenPolynomialRing<MOD> pk1fac = F.get(0).ring;
+        if (!pkfac.coFac.equals(pk1fac.coFac)) {
+            throw new IllegalArgumentException("F.ring != pkfac: " + pk1fac + " != " + pkfac);
+        }
+        // TODO: adjust leading coefficients
+        pkfac = Pfac.get(0);
+        //Cp = Ap.get(0);
+        //System.out.println("pkfac  = " + pkfac.toScript());
+        //System.out.println("pk1fac = " + pk1fac.toScript());
+        GenPolynomialRing<BigInteger> i1fac = new GenPolynomialRing<BigInteger>(new BigInteger(), pk1fac);
+        //System.out.println("i1fac = " + i1fac.toScript());
+        List<GenPolynomial<BigInteger>> Bi = new ArrayList<GenPolynomial<BigInteger>>(F.size());
+        for (GenPolynomial<MOD> b : F) {
+            GenPolynomial<BigInteger> bi = PolyUtil.integerFromModularCoefficients(i1fac, b);
+            Bi.add(bi);
+        }
+        //System.out.println("Bi = " + Bi);
+        // evaluate Cp at v_n:
+        //ModularRingFactory<MOD> cf = (ModularRingFactory<MOD>) pkfac.coFac;
+        //MOD vp = cf.fromInteger(v.getSymmetricInteger().getVal());
+        //System.out.println("v = " + v + ", vp = " + vp);
+        GenPolynomialRing<MOD> ckfac; // = pkfac.contract(1);
+        //GenPolynomial<MOD> Cs = PolyUtil.<MOD> evaluateMain(ckfac, Cp, vp);
+        //System.out.println("Cp = " + Cp);
+        //System.out.println("Cs = " + Cs);
+
+        List<GenPolynomial<MOD>> U = new ArrayList<GenPolynomial<MOD>>(F.size());
+        for (GenPolynomial<MOD> b : F) {
+            GenPolynomial<MOD> bi = b.extend(pkfac, 0, 0L);
+            U.add(bi);
+        }
+        //System.out.println("U  = " + U);
+        List<GenPolynomial<MOD>> U1 = F;
+        //System.out.println("U1 = " + U1);
+
+        GenPolynomial<BigInteger> E = C.ring.getZERO();
+        List<MOD> Vh = new ArrayList<MOD>();
+
+        while (Pfac.size() > 0) { // loop through stack of polynomial rings
+            pkfac = Pfac.remove(0);
+            Cp = Ap.remove(0);
+            v = Vb.remove(0);
+            //Vh.add(0,v);
+            //System.out.println("\npkfac = " + pkfac.toScript() + " ================================== " + Vh);
+
+            // (x_n - v)
+            GenPolynomial<MOD> mon = pkfac.getONE();
+            GenPolynomial<MOD> xv = pkfac.univariate(0, 1);
+            xv = xv.subtract(pkfac.fromInteger(v.getSymmetricInteger().getVal()));
+            //System.out.println("xv = " + xv);
+
+            long deg = Cp.degree(pkfac.nvar - 1);
+            //System.out.println("deg = " + deg);
+
+            GenPolynomialRing<BigInteger> ifac = new GenPolynomialRing<BigInteger>(new BigInteger(), pkfac);
+            //System.out.println("ifac = " + ifac.toScript());
+            List<GenPolynomial<BigInteger>> Bip = new ArrayList<GenPolynomial<BigInteger>>(F.size());
+            for (GenPolynomial<BigInteger> b : Bi) {
+                GenPolynomial<BigInteger> bi = b.extend(ifac, 0, 0L);
+                Bip.add(bi);
+            }
+            Bi = Bip;
+            //System.out.println("Bi = " + Bi);
+            GenPolynomial<BigInteger> Ci = PolyUtil.integerFromModularCoefficients(ifac, Cp);
+            //System.out.println("Ci = " + Ci);
+
+            // compute error:
+            E = ifac.getONE();
+            for (GenPolynomial<BigInteger> bi : Bi) {
+                E = E.multiply(bi);
+            }
+            E = Ci.subtract(E);
+            //System.out.println("E     = " + E);
+            GenPolynomial<MOD> Ep = PolyUtil.<MOD> fromIntegerCoefficients(pkfac, E);
+            //System.out.println("Ep(0," + pkfac.nvar + ") = " + Ep);
+            logger.info("Ep(0," + deg + "," + pkfac.nvar + ") = " + Ep);
+
+            String[] mn = new String[] { pkfac.getVars()[pkfac.nvar - 1] };
+            ckfac = pkfac.contract(1);
+            GenPolynomialRing<GenPolynomial<MOD>> pkrfac = new GenPolynomialRing<GenPolynomial<MOD>>(ckfac, 1,
+                            mn);
+            //System.out.println("pkrfac = " + pkrfac.toScript());
+
+            for (int e = 1; e <= deg && !Ep.isZERO(); e++) {
+                //System.out.println("\ne = " + e + " -------------------------------------- " + pkfac.nvar);
+                GenPolynomial<GenPolynomial<MOD>> Epr = PolyUtil.<MOD> recursive(pkrfac, Ep);
+                //System.out.println("Epr   = " + Epr);
+                UnivPowerSeriesRing<GenPolynomial<MOD>> psfac = new UnivPowerSeriesRing<GenPolynomial<MOD>>(
+                                pkrfac);
+                //System.out.println("psfac = " + psfac);
+                TaylorFunction<GenPolynomial<MOD>> T = new PolynomialTaylorFunction<GenPolynomial<MOD>>(Epr);
+                //System.out.println("T     = " + T);
+                //List<GenPolynomial<MOD>> Vs = new ArrayList<GenPolynomial<MOD>>(1);
+                GenPolynomial<MOD> vq = ckfac.fromInteger(v.getSymmetricInteger().getVal());
+                //Vs.add(vq);
+                //System.out.println("Vs    = " + Vs + ", Vh = " + Vh);
+                UnivPowerSeries<GenPolynomial<MOD>> Epst = psfac.seriesOfTaylor(T, vq);
+                //System.out.println("Epst  = " + Epst);
+                logger.info("Epst(" + e + "," + deg + ", " + pkfac.nvar + ") = " + Epst);
+                GenPolynomial<MOD> cm = Epst.coefficient(e);
+                //System.out.println("cm   = " + cm);
+                if (cm.isZERO()) {
+                    continue;
+                }
+                List<GenPolynomial<MOD>> Ud = HenselMultUtil.<MOD> liftDiophant(U1, cm, Vh, d, k);
+                //System.out.println("Ud = " + Ud);
+
+                mon = mon.multiply(xv);
+                //System.out.println("mon  = " + mon);
+                //List<GenPolynomial<MOD>> Sd = new ArrayList<GenPolynomial<MOD>>(Ud.size());
+                int i = 0;
+                List<GenPolynomial<BigInteger>> Si = new ArrayList<GenPolynomial<BigInteger>>(Ud.size());
+                for (GenPolynomial<MOD> dd : Ud) {
+                    //System.out.println("dd = " + dd);
+                    GenPolynomial<MOD> de = dd.extend(pkfac, 0, 0L);
+                    GenPolynomial<MOD> dm = de.multiply(mon);
+                    //Sd.add(dm);
+                    de = U.get(i).sum(dm);
+                    //System.out.println("de = " + de);
+                    U.set(i++, de);
+                    GenPolynomial<BigInteger> si = PolyUtil.integerFromModularCoefficients(ifac, de);
+                    Si.add(si);
+                }
+                //System.out.println("Sd   = " + Sd);
+                //System.out.println("U    = " + U);
+                //System.out.println("Si   = " + Si);
+
+                // compute new error:
+                E = ifac.getONE();
+                for (GenPolynomial<BigInteger> bi : Si) {
+                    E = E.multiply(bi);
+                }
+                E = Ci.subtract(E);
+                //System.out.println("E     = " + E);
+                Ep = PolyUtil.<MOD> fromIntegerCoefficients(pkfac, E);
+                //System.out.println("Ep(0," + pkfac.nvar + ") = " + Ep);
+                logger.info("Ep(" + e + "," + deg + "," + pkfac.nvar + ") = " + Ep);
+            }
+            Vh.add(v);
+            U1 = U;
+            if (Pfac.size() > 0) {
+                List<GenPolynomial<MOD>> U2 = new ArrayList<GenPolynomial<MOD>>(U.size());
+                pkfac = Pfac.get(0);
+                for (GenPolynomial<MOD> b : U) {
+                    GenPolynomial<MOD> bi = b.extend(pkfac, 0, 0L);
+                    U2.add(bi);
+                }
+                U = U2;
+                //System.out.println("U  = " + U);
+            }
+        }
+        if (E.isZERO()) {
+            logger.info("liftHensel leaving with zero E");
+        }
+        return U;
+    }
+
+
+    /**
+     * Modular Hensel lifting algorithm. Let p = A_i.ring.coFac.modul() and
+     * assume ggt(a,b) == 1 mod p, for a, b in A.
+     * @param C GenPolynomial with integer coefficients
+     * @param Cp GenPolynomial C mod p^k
+     * @param F list of modular GenPolynomials, mod (I_v, p^k )
+     * @param V list of integral substitution values
+     * @param k desired approximation exponent p^k.
+     * @param G list of leading coefficients of the factors of C.
+     * @return [g'_1,..., g'_n] with prod_i g'_i = Cp mod p^k.
+     */
+    public static <MOD extends GcdRingElem<MOD> & Modular> List<GenPolynomial<MOD>> liftHensel(
+                    GenPolynomial<BigInteger> C, GenPolynomial<MOD> Cp, List<GenPolynomial<MOD>> F,
+                    List<BigInteger> V, long k, List<GenPolynomial<BigInteger>> G) throws NoLiftingException {
+        GenPolynomialRing<MOD> pkfac = Cp.ring;
+        long d = C.degree();
+        //System.out.println("C = " + C);
+        //System.out.println("Cp = " + Cp);
+        //System.out.println("G = " + G);
+
+        //GenPolynomial<BigInteger> cd = G.get(0); // 1
+        //System.out.println("cd = " + cd + ", ring = " + C.ring);
+        //if ( cd.equals(C.ring.univariate(0)) ) {
+        //    System.out.println("cd == G[1]");
+        //}
+        // G mod p^k, in all variables
+        GenPolynomialRing<MOD> pkfac1 = new GenPolynomialRing<MOD>(pkfac.coFac, G.get(0).ring);
+        List<GenPolynomial<MOD>> Lp = new ArrayList<GenPolynomial<MOD>>(G.size());
+        for (GenPolynomial<BigInteger> cd1 : G) {
+            GenPolynomial<MOD> cdq = PolyUtil.<MOD> fromIntegerCoefficients(pkfac1, cd1);
+            cdq = cdq.extendLower(pkfac, 0, 0L); // reintroduce lower variable
+            Lp.add(cdq);
+        }
+        logger.info("G modulo p^k: " + Lp); // + ", ring = " + pkfac1);
+
+        // prepare stack of polynomial rings, polynomials and evaluated leading coefficients
+        List<GenPolynomialRing<MOD>> Pfac = new ArrayList<GenPolynomialRing<MOD>>();
+        List<GenPolynomial<MOD>> Ap = new ArrayList<GenPolynomial<MOD>>();
+        List<List<GenPolynomial<MOD>>> Gp = new ArrayList<List<GenPolynomial<MOD>>>();
+        List<MOD> Vb = new ArrayList<MOD>();
+        //MOD v = V.get(0); // fromInteger
+        Pfac.add(pkfac);
+        Ap.add(Cp);
+        Gp.add(Lp);
+        GenPolynomialRing<MOD> pf = pkfac;
+        //GenPolynomialRing<MOD> pf1 = pkfac1;
+        GenPolynomial<MOD> ap = Cp;
+        List<GenPolynomial<MOD>> Lpp = Lp;
+        for (int j = pkfac.nvar; j > 2; j--) {
+            pf = pf.contract(1);
+            Pfac.add(0, pf);
+            //MOD vp = pkfac.coFac.fromInteger(V.get(pkfac.nvar - j).getSymmetricInteger().getVal());
+            MOD vp = pkfac.coFac.fromInteger(V.get(pkfac.nvar - j).getVal());
+            //System.out.println("vp     = " + vp);
+            Vb.add(vp);
+            ap = PolyUtil.<MOD> evaluateMain(pf, ap, vp);
+            Ap.add(0, ap);
+            List<GenPolynomial<MOD>> Lps = new ArrayList<GenPolynomial<MOD>>(Lpp.size());
+            for (GenPolynomial<MOD> qp : Lpp) {
+                GenPolynomial<MOD> qpe = PolyUtil.<MOD> evaluateMain(pf, qp, vp);
+                Lps.add(qpe);
+            }
+            //System.out.println("Lps = " + Lps);
+            Lpp = Lps;
+            Gp.add(0, Lpp);
+        }
+        Vb.add(pkfac.coFac.fromInteger(V.get(pkfac.nvar - 2).getVal()));
+        //System.out.println("Pfac   = " + Pfac);
+        if (debug) {
+            logger.debug("Pfac   = " + Pfac);
+        }
+        //System.out.println("Ap     = " + Ap);
+        //System.out.println("Gp     = " + Gp);
+        //System.out.println("Gp[0]  = " + Gp.get(0) + ", Gp[0].ring = " + Gp.get(0).get(0).ring);
+        //System.out.println("V      = " + V);
+        //System.out.println("Vb     = " + Vb + ", V == Vb: " + V.equals(Vb));
+
+        // check bi-variate base case
+        GenPolynomialRing<MOD> pk1fac = F.get(0).ring;
+        if (!pkfac.coFac.equals(pk1fac.coFac)) {
+            throw new IllegalArgumentException("F.ring != pkfac: " + pk1fac + " != " + pkfac);
+        }
+
+        // init recursion
+        List<GenPolynomial<MOD>> U = F;
+        //logger.info("to lift U = " + U); // + ", U1.ring = " + U1.get(0).ring);
+        GenPolynomial<BigInteger> E = C.ring.getZERO();
+        List<MOD> Vh = new ArrayList<MOD>();
+        List<GenPolynomial<BigInteger>> Si; // = new ArrayList<GenPolynomial<BigInteger>>(F.size());
+        MOD v = null;
+
+        while (Pfac.size() > 0) { // loop through stack of polynomial rings
+            pkfac = Pfac.remove(0);
+            Cp = Ap.remove(0);
+            Lpp = Gp.remove(0);
+            v = Vb.remove(Vb.size() - 1); // last in stack
+            //System.out.println("\npkfac = " + pkfac.toScript() + " ================================== " + v);
+            logger.info("stack loop: pkfac = " + pkfac.toScript() + " v = " + v);
+
+            List<GenPolynomial<MOD>> U1 = U;
+            logger.info("to lift U1 = " + U1); // + ", U1.ring = " + U1.get(0).ring);
+            U = new ArrayList<GenPolynomial<MOD>>(U1.size());
+
+            // update U, replace leading coefficient if required
+            int j = 0;
+            for (GenPolynomial<MOD> b : U1) {
+                //System.out.println("b = " + b + ", b.ring = " + b.ring);
+                GenPolynomial<MOD> bi = b.extend(pkfac, 0, 0L);
+                GenPolynomial<MOD> li = Lpp.get(j);
+                if (!li.isONE()) {
+                    //System.out.println("li = " + li + ", li.ring = " + li.ring);
+                    //System.out.println("bi = " + bi);
+                    GenPolynomialRing<GenPolynomial<MOD>> pkrfac = pkfac.recursive(pkfac.nvar - 1);
+                    //System.out.println("pkrfac = " + pkrfac);
+                    GenPolynomial<GenPolynomial<MOD>> br = PolyUtil.<MOD> recursive(pkrfac, bi);
+                    //System.out.println("br = " + br);
+                    GenPolynomial<GenPolynomial<MOD>> bs = PolyUtil.<MOD> switchVariables(br);
+                    //System.out.println("bs = " + bs + ", bs.ring = " + bs.ring);
+
+                    GenPolynomial<GenPolynomial<MOD>> lr = PolyUtil.<MOD> recursive(pkrfac, li);
+                    //System.out.println("lr = " + lr);
+                    GenPolynomial<GenPolynomial<MOD>> ls = PolyUtil.<MOD> switchVariables(lr);
+                    //System.out.println("ls = " + ls + ", ls.ring = " + ls.ring);
+                    if (!ls.isConstant() && !ls.isZERO()) {
+                        throw new RuntimeException("ls not constant " + ls + ", li = " + li);
+                    }
+                    bs.doPutToMap(bs.leadingExpVector(), ls.leadingBaseCoefficient());
+                    //System.out.println("bs = " + bs + ", bs.ring = " + bs.ring);
+                    br = PolyUtil.<MOD> switchVariables(bs);
+                    //System.out.println("br = " + br);
+                    bi = PolyUtil.<MOD> distribute(pkfac, br);
+                    //System.out.println("bi = " + bi);
+                }
+                U.add(bi);
+                j++;
+            }
+            logger.info("U with leading coefficient replaced = " + U); // + ", U.ring = " + U.get(0).ring);
+
+            // (x_n - v)
+            GenPolynomial<MOD> mon = pkfac.getONE();
+            GenPolynomial<MOD> xv = pkfac.univariate(0, 1);
+            xv = xv.subtract(pkfac.fromInteger(v.getSymmetricInteger().getVal()));
+            //System.out.println("xv = " + xv);
+
+            long deg = Cp.degree(pkfac.nvar - 1);
+            //System.out.println("deg = " + deg + ", degv = " + Cp.degreeVector());
+
+            // convert to integer polynomials
+            GenPolynomialRing<BigInteger> ifac = new GenPolynomialRing<BigInteger>(new BigInteger(), pkfac);
+            //System.out.println("ifac = " + ifac.toScript());
+            List<GenPolynomial<BigInteger>> Bi = PolyUtil.integerFromModularCoefficients(ifac, U);
+            //System.out.println("Bi = " + Bi);
+            GenPolynomial<BigInteger> Ci = PolyUtil.integerFromModularCoefficients(ifac, Cp);
+            //System.out.println("Ci = " + Ci);
+
+            // compute error:
+            E = ifac.getONE();
+            for (GenPolynomial<BigInteger> bi : Bi) {
+                E = E.multiply(bi);
+            }
+            //System.out.println("E  = " + E);
+            E = Ci.subtract(E);
+            //System.out.println("E  = " + E);
+            GenPolynomial<MOD> Ep = PolyUtil.<MOD> fromIntegerCoefficients(pkfac, E);
+            logger.info("Ep(0," + deg + "," + pkfac.nvar + ") = " + Ep);
+
+            GenPolynomialRing<GenPolynomial<MOD>> pkrfac = pkfac.recursive(1);
+            GenPolynomialRing<MOD> ckfac = (GenPolynomialRing<MOD>) pkrfac.coFac;
+            //System.out.println("pkrfac = " + pkrfac.toScript());
+
+            for (int e = 1; e <= deg && !Ep.isZERO(); e++) {
+                //System.out.println("\ne = " + e + " -------------------------------------- " + deg);
+                logger.info("approximation loop: e = " + e + " of deg = " + deg);
+                GenPolynomial<GenPolynomial<MOD>> Epr = PolyUtil.<MOD> recursive(pkrfac, Ep);
+                //System.out.println("Epr   = " + Epr);
+                UnivPowerSeriesRing<GenPolynomial<MOD>> psfac = new UnivPowerSeriesRing<GenPolynomial<MOD>>(
+                                pkrfac);
+                //System.out.println("psfac = " + psfac);
+                TaylorFunction<GenPolynomial<MOD>> T = new PolynomialTaylorFunction<GenPolynomial<MOD>>(Epr);
+                //System.out.println("T     = " + T);
+                GenPolynomial<MOD> vq = ckfac.fromInteger(v.getSymmetricInteger().getVal());
+                //System.out.println("vq    = " + vq + ", Vh = " + Vh);
+                UnivPowerSeries<GenPolynomial<MOD>> Epst = psfac.seriesOfTaylor(T, vq);
+                //System.out.println("Epst  = " + Epst);
+                logger.info("Epst(" + e + "," + deg + "," + pkfac.nvar + ") = " + Epst);
+                GenPolynomial<MOD> cm = Epst.coefficient(e);
+                if (cm.isZERO()) {
+                    //System.out.println("cm   = " + cm);
+                    continue;
+                }
+                List<GenPolynomial<MOD>> Ud = HenselMultUtil.<MOD> liftDiophant(U1, cm, Vh, d, k);
+                //System.out.println("Ud = " + Ud);
+
+                mon = mon.multiply(xv);
+                //System.out.println("mon  = " + mon);
+                //List<GenPolynomial<MOD>> Sd = new ArrayList<GenPolynomial<MOD>>(Ud.size());
+                int i = 0;
+                Si = new ArrayList<GenPolynomial<BigInteger>>(Ud.size());
+                for (GenPolynomial<MOD> dd : Ud) {
+                    //System.out.println("dd = " + dd);
+                    GenPolynomial<MOD> de = dd.extend(pkfac, 0, 0L);
+                    GenPolynomial<MOD> dm = de.multiply(mon);
+                    //Sd.add(dm);
+                    de = U.get(i).sum(dm);
+                    //System.out.println("de = " + de);
+                    U.set(i++, de);
+                    GenPolynomial<BigInteger> si = PolyUtil.integerFromModularCoefficients(ifac, de);
+                    Si.add(si);
+                }
+                //System.out.println("Sd   = " + Sd);
+                //System.out.println("U    = " + U + ", U.ring = " + U.get(0).ring);
+                //System.out.println("Si   = " + Si);
+
+                // compute new error:
+                E = ifac.getONE();
+                for (GenPolynomial<BigInteger> bi : Si) {
+                    E = E.multiply(bi);
+                }
+                E = Ci.subtract(E);
+                //System.out.println("E = " + E);
+                Ep = PolyUtil.<MOD> fromIntegerCoefficients(pkfac, E);
+                //System.out.println("Ep(0," + pkfac.nvar + ") = " + Ep);
+                logger.info("Ep(" + e + "," + deg + "," + pkfac.nvar + ") = " + Ep);
+            }
+            Vh.add(v);
+            GenPolynomial<MOD> Uf = U.get(0).ring.getONE();
+            for (GenPolynomial<MOD> Upp : U) {
+                Uf = Uf.multiply(Upp);
+            }
+            if (false && !Cp.leadingExpVector().equals(Uf.leadingExpVector())) { // not meanigfull test
+                System.out.println("\nU    = " + U);
+                System.out.println("Cp   = " + Cp);
+                System.out.println("Uf   = " + Uf);
+                //System.out.println("Cp.ring = " + Cp.ring.toScript() + ", Uf.ring = " + Uf.ring.toScript() + "\n");
+                System.out.println("");
+                //throw new NoLiftingException("no factorization, Cp != Uf");
+            }
+        }
+        if (E.isZERO()) {
+            logger.info("liftHensel leaving with zero E, Ep");
+        }
+        if (false && debug) {
+            // remove normalization required ??
+            GreatestCommonDivisorAbstract<BigInteger> ufd = GCDFactory.getImplementation(new BigInteger());
+            List<GenPolynomial<BigInteger>> Fii = new ArrayList<GenPolynomial<BigInteger>>(U.size());
+            for (GenPolynomial<BigInteger> bi : Si) {
+                GenPolynomial<BigInteger> ci = ufd.content(bi); //ufd.primitivePart(bi); // ??
+                if (!ci.isONE()) {
+                    System.out.println("bi = " + bi + ", cont(bi) = " + ci);
+                }
+                //Fii.add(ci);
+            }
+            //Si = Fii;
+            //System.out.println("Si  = " + Si);
+        }
+        logger.info("multivariate lift: U = " + U + ", of " + F);
+        return U;
+    }
+
+
+    /**
+     * Modular Hensel full lifting algorithm. Let p = A_i.ring.coFac.modul() and
+     * assume ggt(a,b) == 1 mod p, for a, b in A.
+     * @param C GenPolynomial with integer coefficients
+     * @param F list of modular GenPolynomials, mod (I_v, p )
+     * @param V list of integer substitution values
+     * @param k desired approximation exponent p^k.
+     * @param G = [g_1,...,g_n] list of factors of leading coefficients.
+     * @return [c_1,..., c_n] with prod_i c_i = C mod p^k.
+     */
+    @SuppressWarnings("unchecked")
+    public static <MOD extends GcdRingElem<MOD> & Modular> List<GenPolynomial<MOD>> liftHenselFull(
+                    GenPolynomial<BigInteger> C, List<GenPolynomial<MOD>> F, List<BigInteger> V, long k,
+                    List<GenPolynomial<BigInteger>> G) throws NoLiftingException {
+        if (F == null || F.size() == 0) {
+            return new ArrayList<GenPolynomial<MOD>>();
+        }
+        GenPolynomialRing<MOD> pkfac = F.get(0).ring;
+        //long d = C.degree();
+        // setup q = p^k
+        RingFactory<MOD> cfac = pkfac.coFac;
+        ModularRingFactory<MOD> pcfac = (ModularRingFactory<MOD>) cfac;
+        //System.out.println("pcfac = " + pcfac);
+        BigInteger p = pcfac.getIntegerModul();
+        BigInteger q = p.power(k);
+        ModularRingFactory<MOD> mcfac;
+        if (ModLongRing.MAX_LONG.compareTo(q.getVal()) > 0) {
+            mcfac = (ModularRingFactory) new ModLongRing(q.getVal());
+        } else {
+            mcfac = (ModularRingFactory) new ModIntegerRing(q.getVal());
+        }
+        //System.out.println("mcfac = " + mcfac);
+
+        // convert C from Z[...] to Z_q[...]
+        GenPolynomialRing<MOD> qcfac = new GenPolynomialRing<MOD>(mcfac, C.ring);
+        GenPolynomial<MOD> Cq = PolyUtil.<MOD> fromIntegerCoefficients(qcfac, C);
+        //System.out.println("C  = " + C);
+        //System.out.println("Cq = " + Cq);
+
+        // convert g_i from Z[...] to Z_q[...]
+        GenPolynomialRing<MOD> gcfac = new GenPolynomialRing<MOD>(mcfac, G.get(0).ring);
+        List<GenPolynomial<MOD>> GQ = new ArrayList<GenPolynomial<MOD>>();
+        boolean allOnes = true;
+        for (GenPolynomial<BigInteger> g : G) {
+            if (!g.isONE()) {
+                allOnes = false;
+            }
+            GenPolynomial<MOD> gq = PolyUtil.<MOD> fromIntegerCoefficients(gcfac, g);
+            GQ.add(gq);
+        }
+        //System.out.println("G  = " + G);
+        //System.out.println("GQ = " + GQ);
+
+        // evaluate C to Z_q[x]
+        GenPolynomialRing<MOD> pf = qcfac;
+        GenPolynomial<MOD> ap = Cq;
+        for (int j = C.ring.nvar; j > 1; j--) {
+            pf = pf.contract(1);
+            //MOD vp = mcfac.fromInteger(V.get(C.ring.nvar - j).getSymmetricInteger().getVal());
+            MOD vp = mcfac.fromInteger(V.get(C.ring.nvar - j).getVal());
+            //System.out.println("vp     = " + vp);
+            ap = PolyUtil.<MOD> evaluateMain(pf, ap, vp);
+            //System.out.println("ap     = " + ap);
+        }
+        GenPolynomial<MOD> Cq1 = ap;
+        //System.out.println("Cq1 = " + Cq1);
+        if (Cq1.isZERO()) {
+            throw new NoLiftingException("C mod (I, p^k) == 0: " + C);
+        }
+        GenPolynomialRing<BigInteger> ifac = new GenPolynomialRing<BigInteger>(new BigInteger(), pf);
+        GenPolynomial<BigInteger> Ci = PolyUtil.integerFromModularCoefficients(ifac, Cq1);
+        //System.out.println("Ci  = " + Ci);
+        GreatestCommonDivisorAbstract<BigInteger> ufd = GCDFactory.getImplementation(new BigInteger());
+        Ci = Ci.abs();
+        BigInteger cCi = ufd.baseContent(Ci);
+        Ci = Ci.divide(cCi);
+        //System.out.println("cCi = " + cCi);
+        //System.out.println("Ci  = " + Ci);
+        ////System.out.println("F.fac = " + F.get(0).ring);
+
+        // evaluate G to Z_q
+        //List<GenPolynomial<MOD>> GP = new ArrayList<GenPolynomial<MOD>>();
+        for (GenPolynomial<MOD> gq : GQ) {
+            GenPolynomialRing<MOD> gf = gcfac;
+            GenPolynomial<MOD> gp = gq;
+            for (int j = gcfac.nvar; j > 1; j--) {
+                gf = gf.contract(1);
+                //MOD vp = mcfac.fromInteger(V.get(gcfac.nvar - j).getSymmetricInteger().getVal());
+                MOD vp = mcfac.fromInteger(V.get(gcfac.nvar - j).getVal());
+                //System.out.println("vp     = " + vp);
+                gp = PolyUtil.<MOD> evaluateMain(gf, gp, vp);
+                //System.out.println("gp     = " + gp);
+            }
+            //GP.add(gp);
+        }
+        //System.out.println("GP = " + GP); // + ", GP.ring = " + GP.get(0).ring);
+
+        // leading coefficient for recursion base, for Cq1 and list GP 
+        BigInteger gi0 = Ci.leadingBaseCoefficient(); // gq0.getSymmetricInteger();
+        //System.out.println("gi0 = " + gi0);
+
+        // lift F to Z_{p^k}[x]
+        //System.out.println("Ci = " + Ci + ", F = " + F + ", k = " + k + ", p = " + F.get(0).ring + ", gi0 = " + gi0);
+        List<GenPolynomial<MOD>> U1 = null;
+        if (gi0.isONE()) {
+            U1 = HenselUtil.<MOD> liftHenselMonic(Ci, F, k);
+        } else {
+            U1 = HenselUtil.<MOD> liftHensel(Ci, F, k, gi0); // gi0 TODO ??
+        }
+        logger.info("univariate lift: Ci = " + Ci + ", F = " + F + ", U1 = " + U1);
+        //System.out.println("U1.fac = " + U1.get(0).ring);
+
+        // adjust leading coefficients of U1 with F
+        List<GenPolynomial<BigInteger>> U1i = PolyUtil.<MOD> integerFromModularCoefficients(Ci.ring, U1);
+        //System.out.println("U1i = " + U1i);
+        boolean t = HenselUtil.isHenselLift(Ci, q, p, U1i);
+        //System.out.println("isLift(U1) = " + t);
+        if (!t) {
+            //System.out.println("NoLiftingException, Ci = " + Ci + ", U1i = " + U1i);
+            throw new NoLiftingException("Ci = " + Ci + ", U1i = " + U1i);
+        }
+        MOD cC = mcfac.fromInteger(cCi.getVal());
+        List<GenPolynomial<MOD>> U1f = PolyUtil.<MOD> fromIntegerCoefficients(F.get(0).ring, U1i);
+        //System.out.println("U1f = " + U1f);
+        List<GenPolynomial<MOD>> U1s = new ArrayList<GenPolynomial<MOD>>(U1.size());
+        int j = 0;
+        int s = 0;
+        for (GenPolynomial<MOD> u : U1) {
+            GenPolynomial<MOD> uf = U1f.get(j);
+            GenPolynomial<MOD> f = F.get(j);
+            GenPolynomial<BigInteger> ui = U1i.get(j);
+            GenPolynomial<BigInteger> gi = G.get(j);
+            if (ui.signum() != gi.signum()) {
+                //System.out.println("ui = " + ui + ", gi = " + gi);
+                u = u.negate();
+                uf = uf.negate();
+                s++;
+            }
+            j++;
+            if (uf.isConstant()) {
+                //System.out.println("u   = " + u);
+                u = u.monic();
+                //System.out.println("u  = " + u);
+                u = u.multiply(cC);
+                cC = cC.divide(cC);
+                //System.out.println("u   = " + u);
+            } else {
+                MOD x = f.leadingBaseCoefficient().divide(uf.leadingBaseCoefficient());
+                //System.out.println("x   = " + x + ", xi = " + x.getSymmetricInteger());
+                if (!x.isONE()) {
+                    MOD xq = mcfac.fromInteger(x.getSymmetricInteger().getVal());
+                    //System.out.println("xq  = " + xq);
+                    u = u.multiply(xq);
+                    cC = cC.divide(xq);
+                    //System.out.println("cC  = " + cC);
+                }
+            }
+            U1s.add(u);
+        }
+        //if ( s % 2 != 0 || !cC.isONE()) {
+        if (!cC.isONE()) {
+            throw new NoLiftingException("s = " + s + ", Ci = " + Ci + ", U1i = " + U1i + ", cC = " + cC);
+        }
+        U1 = U1s;
+        U1i = PolyUtil.<MOD> integerFromModularCoefficients(Ci.ring, U1);
+        //System.out.println("U1i = " + U1i);
+        U1f = PolyUtil.<MOD> fromIntegerCoefficients(F.get(0).ring, U1i);
+        if (!F.equals(U1f)) { // evtl loop until reached
+            System.out.println("F   = " + F);
+            System.out.println("U1f = " + U1f);
+            throw new NoLiftingException("F = " + F + ", U1f = " + U1f);
+        }
+        logger.info("multivariate lift: U1 = " + U1);
+
+        // lift U to Z_{p^k}[x,...]
+        //System.out.println("C = " + C + ", U1 = " + U1 + ", V = " + V + ", k = " + k + ", q = " + U1.get(0).ring + ", G = " + G);
+        List<GenPolynomial<MOD>> U = null;
+        if (allOnes) {
+            U = HenselMultUtil.<MOD> liftHenselMonic(C, Cq, U1, V, k);
+        } else {
+            U = HenselMultUtil.<MOD> liftHensel(C, Cq, U1, V, k, G);
+        }
+        logger.info("multivariate lift: C = " + C + ", U1 = " + U1 + ", U = " + U);
+        //System.out.println("U  = " + U);
+        //System.out.println("U.fac = " + U.get(0).ring);
+        return U;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/HenselUtil.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/HenselUtil.java
@@ -1,0 +1,1871 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.arith.BigInteger;
+import edu.jas.arith.ModInteger;
+import edu.jas.arith.ModIntegerRing;
+import edu.jas.arith.ModLongRing;
+import edu.jas.arith.Modular;
+import edu.jas.arith.ModularRingFactory;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.Monomial;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Hensel utilities for ufd.
+ * @author Heinz Kredel
+ */
+
+public class HenselUtil {
+
+
+    private static final Logger logger = LogManager.getLogger(HenselUtil.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Modular Hensel lifting algorithm on coefficients. Let p =
+     * A.ring.coFac.modul() = B.ring.coFac.modul() and assume C == A*B mod p
+     * with gcd(A,B) == 1 mod p and S A + T B == 1 mod p. See Algorithm 6.1. in
+     * Geddes et.al.. Linear version, as it does not lift S A + T B == 1 mod
+     * p^{e+1}.
+     * @param C GenPolynomial
+     * @param A GenPolynomial
+     * @param B other GenPolynomial
+     * @param S GenPolynomial
+     * @param T GenPolynomial
+     * @param M bound on the coefficients of A1 and B1 as factors of C.
+     * @return [A1,B1,Am,Bm] = lift(C,A,B), with C = A1 * B1 mod p^e, Am = A1
+     *         mod p^e, Bm = B1 mod p^e .
+     */
+    @SuppressWarnings("unchecked")
+    public static <MOD extends GcdRingElem<MOD> & Modular> HenselApprox<MOD> liftHensel(
+                    GenPolynomial<BigInteger> C, BigInteger M, GenPolynomial<MOD> A, GenPolynomial<MOD> B,
+                    GenPolynomial<MOD> S, GenPolynomial<MOD> T) throws NoLiftingException {
+        if (C == null || C.isZERO()) {
+            return new HenselApprox<MOD>(C, C, A, B);
+        }
+        if (A == null || A.isZERO() || B == null || B.isZERO()) {
+            throw new IllegalArgumentException("A and B must be nonzero");
+        }
+        GenPolynomialRing<BigInteger> fac = C.ring;
+        if (fac.nvar != 1) { // assert ?
+            throw new IllegalArgumentException("polynomial ring not univariate");
+        }
+        // setup factories
+        GenPolynomialRing<MOD> pfac = A.ring;
+        RingFactory<MOD> p = pfac.coFac;
+        RingFactory<MOD> q = p;
+        ModularRingFactory<MOD> P = (ModularRingFactory<MOD>) p;
+        ModularRingFactory<MOD> Q = (ModularRingFactory<MOD>) q;
+        BigInteger Qi = Q.getIntegerModul();
+        BigInteger M2 = M.multiply(M.fromInteger(2));
+        BigInteger Mq = Qi;
+
+        // normalize c and a, b factors, assert p is prime
+        GenPolynomial<BigInteger> Ai;
+        GenPolynomial<BigInteger> Bi;
+        BigInteger c = C.leadingBaseCoefficient();
+        C = C.multiply(c); // sic
+        MOD a = A.leadingBaseCoefficient();
+        if (!a.isONE()) { // A = A.monic();
+            A = A.divide(a);
+            S = S.multiply(a);
+        }
+        MOD b = B.leadingBaseCoefficient();
+        if (!b.isONE()) { // B = B.monic();
+            B = B.divide(b);
+            T = T.multiply(b);
+        }
+        MOD cm = P.fromInteger(c.getVal());
+        A = A.multiply(cm);
+        B = B.multiply(cm);
+        T = T.divide(cm);
+        S = S.divide(cm);
+        Ai = PolyUtil.integerFromModularCoefficients(fac, A);
+        Bi = PolyUtil.integerFromModularCoefficients(fac, B);
+        // replace leading base coefficients
+        ExpVector ea = Ai.leadingExpVector();
+        ExpVector eb = Bi.leadingExpVector();
+        Ai.doPutToMap(ea, c);
+        Bi.doPutToMap(eb, c);
+
+        // polynomials mod p
+        GenPolynomial<MOD> Ap;
+        GenPolynomial<MOD> Bp;
+        GenPolynomial<MOD> A1p = A;
+        GenPolynomial<MOD> B1p = B;
+        GenPolynomial<MOD> Ep;
+
+        // polynomials over the integers
+        GenPolynomial<BigInteger> E;
+        GenPolynomial<BigInteger> Ea;
+        GenPolynomial<BigInteger> Eb;
+        GenPolynomial<BigInteger> Ea1;
+        GenPolynomial<BigInteger> Eb1;
+
+        while (Mq.compareTo(M2) < 0) {
+            // compute E=(C-AB)/q over the integers
+            E = C.subtract(Ai.multiply(Bi));
+            if (E.isZERO()) {
+                logger.info("leaving on zero E");
+                break;
+            }
+            try {
+                E = E.divide(Qi);
+            } catch (RuntimeException e) {
+                // useful in debuging
+                //System.out.println("C  = " + C );
+                //System.out.println("Ai = " + Ai );
+                //System.out.println("Bi = " + Bi );
+                //System.out.println("E  = " + E );
+                //System.out.println("Qi = " + Qi );
+                throw e;
+            }
+            // E mod p
+            Ep = PolyUtil.<MOD> fromIntegerCoefficients(pfac, E);
+            //logger.info("Ep = " + Ep);
+
+            // construct approximation mod p
+            Ap = S.multiply(Ep); // S,T ++ T,S
+            Bp = T.multiply(Ep);
+            GenPolynomial<MOD>[] QR;
+            QR = Ap.quotientRemainder(B);
+            GenPolynomial<MOD> Qp;
+            GenPolynomial<MOD> Rp;
+            Qp = QR[0];
+            Rp = QR[1];
+            A1p = Rp;
+            B1p = Bp.sum(A.multiply(Qp));
+
+            // construct q-adic approximation, convert to integer
+            Ea = PolyUtil.integerFromModularCoefficients(fac, A1p);
+            Eb = PolyUtil.integerFromModularCoefficients(fac, B1p);
+            Ea1 = Ea.multiply(Qi);
+            Eb1 = Eb.multiply(Qi);
+
+            Ea = Ai.sum(Eb1); // Eb1 and Ea1 are required
+            Eb = Bi.sum(Ea1); //--------------------------
+            assert (Ea.degree(0) + Eb.degree(0) <= C.degree(0));
+            //if ( Ea.degree(0)+Eb.degree(0) > C.degree(0) ) { // debug
+            //   throw new RuntimeException("deg(A)+deg(B) > deg(C)");
+            //}
+
+            // prepare for next iteration
+            Mq = Qi;
+            Qi = Q.getIntegerModul().multiply(P.getIntegerModul());
+            // Q = new ModIntegerRing(Qi.getVal());
+            if (ModLongRing.MAX_LONG.compareTo(Qi.getVal()) > 0) {
+                Q = (ModularRingFactory) new ModLongRing(Qi.getVal());
+            } else {
+                Q = (ModularRingFactory) new ModIntegerRing(Qi.getVal());
+            }
+            Ai = Ea;
+            Bi = Eb;
+        }
+        GreatestCommonDivisorAbstract<BigInteger> ufd = new GreatestCommonDivisorPrimitive<BigInteger>();
+
+        // remove normalization
+        BigInteger ai = ufd.baseContent(Ai);
+        Ai = Ai.divide(ai);
+        BigInteger bi = null;
+        try {
+            bi = c.divide(ai);
+            Bi = Bi.divide(bi); // divide( c/a )
+        } catch (RuntimeException e) {
+            //System.out.println("C  = " + C );
+            //System.out.println("Ai = " + Ai );
+            //System.out.println("Bi = " + Bi );
+            //System.out.println("c  = " + c );
+            //System.out.println("ai = " + ai );
+            //System.out.println("bi = " + bi );
+            //System.out.println("no exact lifting possible " + e);
+            throw new NoLiftingException("no exact lifting possible " + e);
+        }
+        return new HenselApprox<MOD>(Ai, Bi, A1p, B1p);
+    }
+
+
+    /**
+     * Modular Hensel lifting algorithm on coefficients. Let p =
+     * A.ring.coFac.modul() = B.ring.coFac.modul() and assume C == A*B mod p
+     * with gcd(A,B) == 1 mod p. See algorithm 6.1. in Geddes et.al. and
+     * algorithms 3.5.{5,6} in Cohen.
+     * @param C GenPolynomial
+     * @param A GenPolynomial
+     * @param B other GenPolynomial
+     * @param M bound on the coefficients of A1 and B1 as factors of C.
+     * @return [A1,B1] = lift(C,A,B), with C = A1 * B1.
+     */
+    @SuppressWarnings("unchecked")
+    public static <MOD extends GcdRingElem<MOD> & Modular> HenselApprox<MOD> liftHensel(
+                    GenPolynomial<BigInteger> C, BigInteger M, GenPolynomial<MOD> A, GenPolynomial<MOD> B)
+                    throws NoLiftingException {
+        if (C == null || C.isZERO()) {
+            return new HenselApprox<MOD>(C, C, A, B);
+        }
+        if (A == null || A.isZERO() || B == null || B.isZERO()) {
+            throw new IllegalArgumentException("A and B must be nonzero");
+        }
+        GenPolynomialRing<BigInteger> fac = C.ring;
+        if (fac.nvar != 1) { // assert ?
+            throw new IllegalArgumentException("polynomial ring not univariate");
+        }
+        // one Hensel step on part polynomials
+        try {
+            GenPolynomial<MOD>[] gst = A.egcd(B);
+            if (!gst[0].isONE()) {
+                throw new NoLiftingException(
+                                "A and B not coprime, gcd = " + gst[0] + ", A = " + A + ", B = " + B);
+            }
+            GenPolynomial<MOD> s = gst[1];
+            GenPolynomial<MOD> t = gst[2];
+            HenselApprox<MOD> ab = HenselUtil.<MOD> liftHensel(C, M, A, B, s, t);
+            return ab;
+        } catch (ArithmeticException e) {
+            throw new NoLiftingException("coefficient error " + e);
+        }
+    }
+
+
+    /**
+     * Modular quadratic Hensel lifting algorithm on coefficients. Let p =
+     * A.ring.coFac.modul() = B.ring.coFac.modul() and assume C == A*B mod p
+     * with gcd(A,B) == 1 mod p and S A + T B == 1 mod p. See algorithm 6.1. in
+     * Geddes et.al. and algorithms 3.5.{5,6} in Cohen. Quadratic version, as it
+     * also lifts S A + T B == 1 mod p^{e+1}.
+     * @param C GenPolynomial
+     * @param A GenPolynomial
+     * @param B other GenPolynomial
+     * @param S GenPolynomial
+     * @param T GenPolynomial
+     * @param M bound on the coefficients of A1 and B1 as factors of C.
+     * @return [A1,B1] = lift(C,A,B), with C = A1 * B1.
+     */
+    @SuppressWarnings("unchecked")
+    public static <MOD extends GcdRingElem<MOD> & Modular> HenselApprox<MOD> liftHenselQuadratic(
+                    GenPolynomial<BigInteger> C, BigInteger M, GenPolynomial<MOD> A, GenPolynomial<MOD> B,
+                    GenPolynomial<MOD> S, GenPolynomial<MOD> T) throws NoLiftingException {
+        if (C == null || C.isZERO()) {
+            return new HenselApprox<MOD>(C, C, A, B);
+        }
+        if (A == null || A.isZERO() || B == null || B.isZERO()) {
+            throw new IllegalArgumentException("A and B must be nonzero");
+        }
+        GenPolynomialRing<BigInteger> fac = C.ring;
+        if (fac.nvar != 1) { // assert ?
+            throw new IllegalArgumentException("polynomial ring not univariate");
+        }
+        // setup factories
+        GenPolynomialRing<MOD> pfac = A.ring;
+        RingFactory<MOD> p = pfac.coFac;
+        RingFactory<MOD> q = p;
+        ModularRingFactory<MOD> P = (ModularRingFactory<MOD>) p;
+        ModularRingFactory<MOD> Q = (ModularRingFactory<MOD>) q;
+        BigInteger Qi = Q.getIntegerModul();
+        BigInteger M2 = M.multiply(M.fromInteger(2));
+        BigInteger Mq = Qi;
+        GenPolynomialRing<MOD> qfac;
+        qfac = new GenPolynomialRing<MOD>(Q, pfac);
+
+        // normalize c and a, b factors, assert p is prime
+        GenPolynomial<BigInteger> Ai;
+        GenPolynomial<BigInteger> Bi;
+        BigInteger c = C.leadingBaseCoefficient();
+        C = C.multiply(c); // sic
+        MOD a = A.leadingBaseCoefficient();
+        if (!a.isONE()) { // A = A.monic();
+            A = A.divide(a);
+            S = S.multiply(a);
+        }
+        MOD b = B.leadingBaseCoefficient();
+        if (!b.isONE()) { // B = B.monic();
+            B = B.divide(b);
+            T = T.multiply(b);
+        }
+        MOD cm = P.fromInteger(c.getVal());
+        A = A.multiply(cm);
+        B = B.multiply(cm);
+        T = T.divide(cm);
+        S = S.divide(cm);
+        Ai = PolyUtil.integerFromModularCoefficients(fac, A);
+        Bi = PolyUtil.integerFromModularCoefficients(fac, B);
+        // replace leading base coefficients
+        ExpVector ea = Ai.leadingExpVector();
+        ExpVector eb = Bi.leadingExpVector();
+        Ai.doPutToMap(ea, c);
+        Bi.doPutToMap(eb, c);
+
+        // polynomials mod p
+        GenPolynomial<MOD> Ap;
+        GenPolynomial<MOD> Bp;
+        GenPolynomial<MOD> A1p = A;
+        GenPolynomial<MOD> B1p = B;
+        GenPolynomial<MOD> Ep;
+        GenPolynomial<MOD> Sp = S;
+        GenPolynomial<MOD> Tp = T;
+
+        // polynomials mod q
+        GenPolynomial<MOD> Aq;
+        GenPolynomial<MOD> Bq;
+        //GenPolynomial<MOD> Eq;
+
+        // polynomials over the integers
+        GenPolynomial<BigInteger> E;
+        GenPolynomial<BigInteger> Ea;
+        GenPolynomial<BigInteger> Eb;
+        GenPolynomial<BigInteger> Ea1;
+        GenPolynomial<BigInteger> Eb1;
+        GenPolynomial<BigInteger> Si;
+        GenPolynomial<BigInteger> Ti;
+
+        Si = PolyUtil.integerFromModularCoefficients(fac, S);
+        Ti = PolyUtil.integerFromModularCoefficients(fac, T);
+
+        Aq = PolyUtil.<MOD> fromIntegerCoefficients(qfac, Ai);
+        Bq = PolyUtil.<MOD> fromIntegerCoefficients(qfac, Bi);
+
+        while (Mq.compareTo(M2) < 0) {
+            // compute E=(C-AB)/q over the integers
+            E = C.subtract(Ai.multiply(Bi));
+            if (E.isZERO()) {
+                logger.info("leaving on zero E");
+                break;
+            }
+            E = E.divide(Qi);
+            // E mod p
+            Ep = PolyUtil.<MOD> fromIntegerCoefficients(qfac, E);
+            //logger.info("Ep = " + Ep + ", qfac = " + qfac);
+            //if (Ep.isZERO()) {
+            //System.out.println("leaving on zero error");
+            //??logger.info("leaving on zero Ep");
+            //??break;
+            //}
+
+            // construct approximation mod p
+            Ap = Sp.multiply(Ep); // S,T ++ T,S
+            Bp = Tp.multiply(Ep);
+            GenPolynomial<MOD>[] QR;
+            //logger.info("Ap = " + Ap + ", Bp = " + Bp + ", fac(Ap) = " + Ap.ring);
+            QR = Ap.quotientRemainder(Bq);
+            GenPolynomial<MOD> Qp;
+            GenPolynomial<MOD> Rp;
+            Qp = QR[0];
+            Rp = QR[1];
+            //logger.info("Qp = " + Qp + ", Rp = " + Rp);
+            A1p = Rp;
+            B1p = Bp.sum(Aq.multiply(Qp));
+
+            // construct q-adic approximation, convert to integer
+            Ea = PolyUtil.integerFromModularCoefficients(fac, A1p);
+            Eb = PolyUtil.integerFromModularCoefficients(fac, B1p);
+            Ea1 = Ea.multiply(Qi);
+            Eb1 = Eb.multiply(Qi);
+            Ea = Ai.sum(Eb1); // Eb1 and Ea1 are required
+            Eb = Bi.sum(Ea1); //--------------------------
+            assert (Ea.degree(0) + Eb.degree(0) <= C.degree(0));
+            //if ( Ea.degree(0)+Eb.degree(0) > C.degree(0) ) { // debug
+            //   throw new RuntimeException("deg(A)+deg(B) > deg(C)");
+            //}
+            Ai = Ea;
+            Bi = Eb;
+
+            // gcd representation factors error --------------------------------
+            // compute E=(1-SA-TB)/q over the integers
+            E = fac.getONE();
+            E = E.subtract(Si.multiply(Ai)).subtract(Ti.multiply(Bi));
+            E = E.divide(Qi);
+            // E mod q
+            Ep = PolyUtil.<MOD> fromIntegerCoefficients(qfac, E);
+            //logger.info("Ep2 = " + Ep);
+
+            // construct approximation mod q
+            Ap = Sp.multiply(Ep); // S,T ++ T,S
+            Bp = Tp.multiply(Ep);
+            QR = Bp.quotientRemainder(Aq); // Ai == A mod p ?
+            Qp = QR[0];
+            Rp = QR[1];
+            B1p = Rp;
+            A1p = Ap.sum(Bq.multiply(Qp));
+
+            //if (debug) {
+            //    Eq = A1p.multiply(Aq).sum(B1p.multiply(Bq)).subtract(Ep);
+            //    if (!Eq.isZERO()) {
+            //        System.out.println("A*A1p+B*B1p-Ep2 != 0 " + Eq);
+            //        throw new RuntimeException("A*A1p+B*B1p-Ep2 != 0 mod " + Q.getIntegerModul());
+            //    }
+            //}
+
+            // construct q-adic approximation, convert to integer
+            Ea = PolyUtil.integerFromModularCoefficients(fac, A1p);
+            Eb = PolyUtil.integerFromModularCoefficients(fac, B1p);
+            Ea1 = Ea.multiply(Qi);
+            Eb1 = Eb.multiply(Qi);
+            Ea = Si.sum(Ea1); // Eb1 and Ea1 are required
+            Eb = Ti.sum(Eb1); //--------------------------
+            Si = Ea;
+            Ti = Eb;
+
+            // prepare for next iteration
+            Mq = Qi;
+            Qi = Q.getIntegerModul().multiply(Q.getIntegerModul());
+            if (ModLongRing.MAX_LONG.compareTo(Qi.getVal()) > 0) {
+                Q = (ModularRingFactory) new ModLongRing(Qi.getVal());
+            } else {
+                Q = (ModularRingFactory) new ModIntegerRing(Qi.getVal());
+            }
+            //Q = new ModIntegerRing(Qi.getVal());
+            //System.out.println("Q = " + Q + ", from Q = " + Mq);
+
+            qfac = new GenPolynomialRing<MOD>(Q, pfac);
+
+            Aq = PolyUtil.<MOD> fromIntegerCoefficients(qfac, Ai);
+            Bq = PolyUtil.<MOD> fromIntegerCoefficients(qfac, Bi);
+            Sp = PolyUtil.<MOD> fromIntegerCoefficients(qfac, Si);
+            Tp = PolyUtil.<MOD> fromIntegerCoefficients(qfac, Ti);
+            //if (debug) {
+            //    E = Ai.multiply(Si).sum(Bi.multiply(Ti));
+            //    Eq = PolyUtil.<MOD> fromIntegerCoefficients(qfac, E);
+            //    if (!Eq.isONE()) {
+            //        System.out.println("Ai*Si+Bi*Ti=1 " + Eq);
+            //        throw new RuntimeException("Ai*Si+Bi*Ti != 1 mod " + Q.getIntegerModul());
+            //    }
+            //}
+        }
+        GreatestCommonDivisorAbstract<BigInteger> ufd = new GreatestCommonDivisorPrimitive<BigInteger>();
+
+        // remove normalization if possible
+        BigInteger ai = ufd.baseContent(Ai);
+        Ai = Ai.divide(ai);
+        BigInteger bi = null;
+        try {
+            bi = c.divide(ai);
+            Bi = Bi.divide(bi); // divide( c/a )
+        } catch (RuntimeException e) {
+            //System.out.println("C  = " + C );
+            //System.out.println("Ai = " + Ai );
+            //System.out.println("Bi = " + Bi );
+            //System.out.println("c  = " + c );
+            //System.out.println("ai = " + ai );
+            //System.out.println("bi = " + bi );
+            //System.out.println("no exact lifting possible " + e);
+            throw new NoLiftingException("no exact lifting possible " + e);
+        }
+        return new HenselApprox<MOD>(Ai, Bi, A1p, B1p);
+    }
+
+
+    /**
+     * Modular quadratic Hensel lifting algorithm on coefficients. Let p =
+     * A.ring.coFac.modul() = B.ring.coFac.modul() and assume C == A*B mod p
+     * with gcd(A,B) == 1 mod p. See algorithm 6.1. in Geddes et.al. and
+     * algorithms 3.5.{5,6} in Cohen. Quadratic version.
+     * @param C GenPolynomial
+     * @param A GenPolynomial
+     * @param B other GenPolynomial
+     * @param M bound on the coefficients of A1 and B1 as factors of C.
+     * @return [A1,B1] = lift(C,A,B), with C = A1 * B1.
+     */
+    @SuppressWarnings("unchecked")
+    public static <MOD extends GcdRingElem<MOD> & Modular> HenselApprox<MOD> liftHenselQuadratic(
+                    GenPolynomial<BigInteger> C, BigInteger M, GenPolynomial<MOD> A, GenPolynomial<MOD> B)
+                    throws NoLiftingException {
+        if (C == null || C.isZERO()) {
+            return new HenselApprox<MOD>(C, C, A, B);
+        }
+        if (A == null || A.isZERO() || B == null || B.isZERO()) {
+            throw new IllegalArgumentException("A and B must be nonzero");
+        }
+        GenPolynomialRing<BigInteger> fac = C.ring;
+        if (fac.nvar != 1) { // assert ?
+            throw new IllegalArgumentException("polynomial ring not univariate");
+        }
+        // one Hensel step on part polynomials
+        try {
+            GenPolynomial<MOD>[] gst = A.egcd(B);
+            if (!gst[0].isONE()) {
+                throw new NoLiftingException(
+                                "A and B not coprime, gcd = " + gst[0] + ", A = " + A + ", B = " + B);
+            }
+            GenPolynomial<MOD> s = gst[1];
+            GenPolynomial<MOD> t = gst[2];
+            HenselApprox<MOD> ab = HenselUtil.<MOD> liftHenselQuadratic(C, M, A, B, s, t);
+            return ab;
+        } catch (ArithmeticException e) {
+            throw new NoLiftingException("coefficient error " + e);
+        }
+    }
+
+
+    /**
+     * Modular Hensel lifting algorithm on coefficients. Let p =
+     * A.ring.coFac.modul() = B.ring.coFac.modul() and assume C == A*B mod p
+     * with gcd(A,B) == 1 mod p. See algorithm 6.1. in Geddes et.al. and
+     * algorithms 3.5.{5,6} in Cohen. Quadratic version.
+     * @param C GenPolynomial
+     * @param A GenPolynomial
+     * @param B other GenPolynomial
+     * @param M bound on the coefficients of A1 and B1 as factors of C.
+     * @return [A1,B1] = lift(C,A,B), with C = A1 * B1.
+     */
+    @SuppressWarnings("unchecked")
+    public static <MOD extends GcdRingElem<MOD> & Modular> HenselApprox<MOD> liftHenselQuadraticFac(
+                    GenPolynomial<BigInteger> C, BigInteger M, GenPolynomial<MOD> A, GenPolynomial<MOD> B)
+                    throws NoLiftingException {
+        if (C == null || C.isZERO()) {
+            throw new IllegalArgumentException("C must be nonzero");
+        }
+        if (A == null || A.isZERO() || B == null || B.isZERO()) {
+            throw new IllegalArgumentException("A and B must be nonzero");
+        }
+        GenPolynomialRing<BigInteger> fac = C.ring;
+        if (fac.nvar != 1) { // assert ?
+            throw new IllegalArgumentException("polynomial ring not univariate");
+        }
+        // one Hensel step on part polynomials
+        try {
+            GenPolynomial<MOD>[] gst = A.egcd(B);
+            if (!gst[0].isONE()) {
+                throw new NoLiftingException(
+                                "A and B not coprime, gcd = " + gst[0] + ", A = " + A + ", B = " + B);
+            }
+            GenPolynomial<MOD> s = gst[1];
+            GenPolynomial<MOD> t = gst[2];
+            HenselApprox<MOD> ab = HenselUtil.<MOD> liftHenselQuadraticFac(C, M, A, B, s, t);
+            return ab;
+        } catch (ArithmeticException e) {
+            throw new NoLiftingException("coefficient error " + e);
+        }
+    }
+
+
+    /**
+     * Modular Hensel lifting algorithm on coefficients. Let p =
+     * A.ring.coFac.modul() = B.ring.coFac.modul() and assume C == A*B mod p
+     * with gcd(A,B) == 1 mod p and S A + T B == 1 mod p. See algorithm 6.1. in
+     * Geddes et.al. and algorithms 3.5.{5,6} in Cohen. Quadratic version, as it
+     * also lifts S A + T B == 1 mod p^{e+1}.
+     * @param C primitive GenPolynomial
+     * @param A GenPolynomial
+     * @param B other GenPolynomial
+     * @param S GenPolynomial
+     * @param T GenPolynomial
+     * @param M bound on the coefficients of A1 and B1 as factors of C.
+     * @return [A1,B1] = lift(C,A,B), with C = A1 * B1.
+     */
+    @SuppressWarnings("unchecked")
+    public static <MOD extends GcdRingElem<MOD> & Modular> HenselApprox<MOD> liftHenselQuadraticFac(
+                    GenPolynomial<BigInteger> C, BigInteger M, GenPolynomial<MOD> A, GenPolynomial<MOD> B,
+                    GenPolynomial<MOD> S, GenPolynomial<MOD> T) throws NoLiftingException {
+        //System.out.println("*** version for factorization *** ");
+        //GenPolynomial<BigInteger>[] AB = new GenPolynomial[2];
+        if (C == null || C.isZERO()) {
+            throw new IllegalArgumentException("C must be nonzero");
+        }
+        if (A == null || A.isZERO() || B == null || B.isZERO()) {
+            throw new IllegalArgumentException("A and B must be nonzero");
+        }
+        GenPolynomialRing<BigInteger> fac = C.ring;
+        if (fac.nvar != 1) { // assert ?
+            throw new IllegalArgumentException("polynomial ring not univariate");
+        }
+        // setup factories
+        GenPolynomialRing<MOD> pfac = A.ring;
+        RingFactory<MOD> p = pfac.coFac;
+        RingFactory<MOD> q = p;
+        ModularRingFactory<MOD> P = (ModularRingFactory<MOD>) p;
+        ModularRingFactory<MOD> Q = (ModularRingFactory<MOD>) q;
+        BigInteger PP = Q.getIntegerModul();
+        BigInteger Qi = PP;
+        BigInteger M2 = M.multiply(M.fromInteger(2));
+        if (debug) {
+            //System.out.println("M2 =  " + M2);
+            logger.debug("M2 =  " + M2);
+        }
+        BigInteger Mq = Qi;
+        GenPolynomialRing<MOD> qfac;
+        qfac = new GenPolynomialRing<MOD>(Q, pfac); // mod p
+        GenPolynomialRing<MOD> mfac;
+        BigInteger Mi = Q.getIntegerModul().multiply(Q.getIntegerModul());
+        ModularRingFactory<MOD> Qmm;
+        // = new ModIntegerRing(Mi.getVal());
+        if (ModLongRing.MAX_LONG.compareTo(Mi.getVal()) > 0) {
+            Qmm = (ModularRingFactory) new ModLongRing(Mi.getVal());
+        } else {
+            Qmm = (ModularRingFactory) new ModIntegerRing(Mi.getVal());
+        }
+        mfac = new GenPolynomialRing<MOD>(Qmm, qfac); // mod p^e
+        MOD Qm = Qmm.fromInteger(Qi.getVal());
+
+        // partly normalize c and a, b factors, assert p is prime
+        GenPolynomial<BigInteger> Ai;
+        GenPolynomial<BigInteger> Bi;
+        BigInteger c = C.leadingBaseCoefficient();
+        C = C.multiply(c); // sic
+        MOD a = A.leadingBaseCoefficient();
+        if (!a.isONE()) { // A = A.monic();
+            A = A.divide(a);
+            S = S.multiply(a);
+        }
+        MOD b = B.leadingBaseCoefficient();
+        if (!b.isONE()) { // B = B.monic();
+            B = B.divide(b);
+            T = T.multiply(b);
+        }
+        MOD cm = P.fromInteger(c.getVal());
+        if (cm.isZERO()) {
+            System.out.println("c =  " + c);
+            System.out.println("P =  " + P);
+            throw new ArithmeticException("c mod p == 0 not meaningful");
+        }
+        // mod p
+        A = A.multiply(cm);
+        S = S.divide(cm);
+        B = B.multiply(cm);
+        T = T.divide(cm);
+        Ai = PolyUtil.integerFromModularCoefficients(fac, A);
+        Bi = PolyUtil.integerFromModularCoefficients(fac, B);
+        // replace leading base coefficients
+        ExpVector ea = Ai.leadingExpVector();
+        ExpVector eb = Bi.leadingExpVector();
+        Ai.doPutToMap(ea, c);
+        Bi.doPutToMap(eb, c);
+
+        // polynomials mod p
+        GenPolynomial<MOD> Ap;
+        GenPolynomial<MOD> Bp;
+        GenPolynomial<MOD> A1p = A;
+        GenPolynomial<MOD> B1p = B;
+        GenPolynomial<MOD> Sp = S;
+        GenPolynomial<MOD> Tp = T;
+
+        // polynomials mod q
+        GenPolynomial<MOD> Aq;
+        GenPolynomial<MOD> Bq;
+
+        // polynomials mod p^e
+        GenPolynomial<MOD> Cm;
+        GenPolynomial<MOD> Am;
+        GenPolynomial<MOD> Bm;
+        GenPolynomial<MOD> Em;
+        GenPolynomial<MOD> Emp;
+        GenPolynomial<MOD> Sm;
+        GenPolynomial<MOD> Tm;
+        GenPolynomial<MOD> Ema;
+        GenPolynomial<MOD> Emb;
+        GenPolynomial<MOD> Ema1;
+        GenPolynomial<MOD> Emb1;
+
+        // polynomials over the integers
+        GenPolynomial<BigInteger> Ei;
+        GenPolynomial<BigInteger> Si;
+        GenPolynomial<BigInteger> Ti;
+
+        Si = PolyUtil.integerFromModularCoefficients(fac, S);
+        Ti = PolyUtil.integerFromModularCoefficients(fac, T);
+
+        Aq = PolyUtil.<MOD> fromIntegerCoefficients(qfac, Ai);
+        Bq = PolyUtil.<MOD> fromIntegerCoefficients(qfac, Bi);
+
+        // polynomials mod p^e
+        Cm = PolyUtil.<MOD> fromIntegerCoefficients(mfac, C);
+        Am = PolyUtil.<MOD> fromIntegerCoefficients(mfac, Ai);
+        Bm = PolyUtil.<MOD> fromIntegerCoefficients(mfac, Bi);
+        Sm = PolyUtil.<MOD> fromIntegerCoefficients(mfac, Si);
+        Tm = PolyUtil.<MOD> fromIntegerCoefficients(mfac, Ti);
+        //System.out.println("Cm =  " + Cm);
+        //System.out.println("Am =  " + Am);
+        //System.out.println("Bm =  " + Bm);
+        //System.out.println("Ai =  " + Ai);
+        //System.out.println("Bi =  " + Bi);
+        //System.out.println("mfac =  " + mfac);
+
+        while (Mq.compareTo(M2) < 0) {
+            // compute E=(C-AB)/p mod p^e
+            if (debug) {
+                //System.out.println("mfac =  " + Cm.ring);
+                logger.debug("mfac =  " + Cm.ring);
+            }
+            Em = Cm.subtract(Am.multiply(Bm));
+            //System.out.println("Em =  " + Em);
+            if (Em.isZERO()) {
+                if (C.subtract(Ai.multiply(Bi)).isZERO()) {
+                    logger.info("leaving on zero E");
+                    break;
+                }
+            }
+            // Em = Em.divide( Qm );
+            Ei = PolyUtil.integerFromModularCoefficients(fac, Em);
+            Ei = Ei.divide(Qi);
+            //System.out.println("Ei =  " + Ei);
+
+            // Ei mod p
+            Emp = PolyUtil.<MOD> fromIntegerCoefficients(qfac, Ei);
+            //            Emp = PolyUtil.<MOD>fromIntegerCoefficients(qfac,
+            //               PolyUtil.integerFromModularCoefficients(fac,Em) ); 
+            //System.out.println("Emp =  " + Emp);
+            //logger.info("Emp = " + Emp);
+            if (Emp.isZERO()) {
+                if (C.subtract(Ai.multiply(Bi)).isZERO()) {
+                    logger.info("leaving on zero Emp");
+                    break;
+                }
+            }
+
+            // construct approximation mod p
+            Ap = Sp.multiply(Emp); // S,T ++ T,S 
+            Bp = Tp.multiply(Emp);
+            GenPolynomial<MOD>[] QR = null;
+            QR = Ap.quotientRemainder(Bq); // Bq !
+            GenPolynomial<MOD> Qp = QR[0];
+            GenPolynomial<MOD> Rp = QR[1];
+            A1p = Rp;
+            B1p = Bp.sum(Aq.multiply(Qp)); // Aq !
+            //System.out.println("A1p =  " + A1p);
+            //System.out.println("B1p =  " + B1p);
+
+            // construct q-adic approximation
+            Ema = PolyUtil.<MOD> fromIntegerCoefficients(mfac,
+                            PolyUtil.integerFromModularCoefficients(fac, A1p));
+            Emb = PolyUtil.<MOD> fromIntegerCoefficients(mfac,
+                            PolyUtil.integerFromModularCoefficients(fac, B1p));
+            //System.out.println("Ema =  " + Ema);
+            //System.out.println("Emb =  " + Emb);
+            Ema1 = Ema.multiply(Qm);
+            Emb1 = Emb.multiply(Qm);
+            Ema = Am.sum(Emb1); // Eb1 and Ea1 are required
+            Emb = Bm.sum(Ema1); //--------------------------
+            assert (Ema.degree(0) + Emb.degree(0) <= Cm.degree(0));
+            //if ( Ema.degree(0)+Emb.degree(0) > Cm.degree(0) ) { // debug
+            //   throw new RuntimeException("deg(A)+deg(B) > deg(C)");
+            //}
+            Am = Ema;
+            Bm = Emb;
+            Ai = PolyUtil.integerFromModularCoefficients(fac, Am);
+            Bi = PolyUtil.integerFromModularCoefficients(fac, Bm);
+            //System.out.println("Am =  " + Am);
+            //System.out.println("Bm =  " + Bm);
+            //System.out.println("Ai =  " + Ai);
+            //System.out.println("Bi =  " + Bi + "\n");
+
+            // gcd representation factors error --------------------------------
+            // compute E=(1-SA-TB)/p mod p^e
+            Em = mfac.getONE();
+            Em = Em.subtract(Sm.multiply(Am)).subtract(Tm.multiply(Bm));
+            //System.out.println("Em  =  " + Em);
+            // Em = Em.divide( Pm );
+
+            Ei = PolyUtil.integerFromModularCoefficients(fac, Em);
+            Ei = Ei.divide(Qi);
+            //System.out.println("Ei =  " + Ei);
+            // Ei mod p
+            Emp = PolyUtil.<MOD> fromIntegerCoefficients(qfac, Ei);
+            //Emp = PolyUtil.<MOD>fromIntegerCoefficients(qfac,
+            //               PolyUtil.integerFromModularCoefficients(fac,Em) );
+            //System.out.println("Emp =  " + Emp);
+
+            // construct approximation mod p
+            Ap = Sp.multiply(Emp); // S,T ++ T,S // Ep Eqp
+            Bp = Tp.multiply(Emp); // Ep Eqp
+            QR = Bp.quotientRemainder(Aq); // Ap Aq ! // Ai == A mod p ?
+            Qp = QR[0];
+            Rp = QR[1];
+            B1p = Rp;
+            A1p = Ap.sum(Bq.multiply(Qp));
+            //System.out.println("A1p =  " + A1p);
+            //System.out.println("B1p =  " + B1p);
+
+            // construct p^e-adic approximation
+            Ema = PolyUtil.<MOD> fromIntegerCoefficients(mfac,
+                            PolyUtil.integerFromModularCoefficients(fac, A1p));
+            Emb = PolyUtil.<MOD> fromIntegerCoefficients(mfac,
+                            PolyUtil.integerFromModularCoefficients(fac, B1p));
+            Ema1 = Ema.multiply(Qm);
+            Emb1 = Emb.multiply(Qm);
+            Ema = Sm.sum(Ema1); // Emb1 and Ema1 are required
+            Emb = Tm.sum(Emb1); //--------------------------
+            Sm = Ema;
+            Tm = Emb;
+            Si = PolyUtil.integerFromModularCoefficients(fac, Sm);
+            Ti = PolyUtil.integerFromModularCoefficients(fac, Tm);
+            //System.out.println("Sm =  " + Sm);
+            //System.out.println("Tm =  " + Tm);
+            //System.out.println("Si =  " + Si);
+            //System.out.println("Ti =  " + Ti + "\n");
+
+            // prepare for next iteration
+            Qi = Q.getIntegerModul().multiply(Q.getIntegerModul());
+            Mq = Qi;
+            //lmfac = mfac;
+            // Q = new ModIntegerRing(Qi.getVal());
+            if (ModLongRing.MAX_LONG.compareTo(Qi.getVal()) > 0) {
+                Q = (ModularRingFactory) new ModLongRing(Qi.getVal());
+            } else {
+                Q = (ModularRingFactory) new ModIntegerRing(Qi.getVal());
+            }
+            qfac = new GenPolynomialRing<MOD>(Q, pfac);
+            BigInteger Qmmi = Qmm.getIntegerModul().multiply(Qmm.getIntegerModul());
+            //Qmm = new ModIntegerRing(Qmmi.getVal());
+            if (ModLongRing.MAX_LONG.compareTo(Qmmi.getVal()) > 0) {
+                Qmm = (ModularRingFactory) new ModLongRing(Qmmi.getVal());
+            } else {
+                Qmm = (ModularRingFactory) new ModIntegerRing(Qmmi.getVal());
+            }
+            mfac = new GenPolynomialRing<MOD>(Qmm, qfac);
+            Qm = Qmm.fromInteger(Qi.getVal());
+
+            Cm = PolyUtil.<MOD> fromIntegerCoefficients(mfac, C);
+            Am = PolyUtil.<MOD> fromIntegerCoefficients(mfac, Ai);
+            Bm = PolyUtil.<MOD> fromIntegerCoefficients(mfac, Bi);
+            Sm = PolyUtil.<MOD> fromIntegerCoefficients(mfac, Si);
+            Tm = PolyUtil.<MOD> fromIntegerCoefficients(mfac, Ti);
+
+            assert (isHenselLift(C, Mi, PP, Ai, Bi));
+            Mi = Mi.fromInteger(Qmm.getIntegerModul().getVal());
+
+            Aq = PolyUtil.<MOD> fromIntegerCoefficients(qfac, Ai);
+            Bq = PolyUtil.<MOD> fromIntegerCoefficients(qfac, Bi);
+            Sp = PolyUtil.<MOD> fromIntegerCoefficients(qfac, Si);
+            Tp = PolyUtil.<MOD> fromIntegerCoefficients(qfac, Ti);
+
+            //System.out.println("Am =  " + Am);
+            //System.out.println("Bm =  " + Bm);
+            //System.out.println("Sm =  " + Sm);
+            //System.out.println("Tm =  " + Tm);
+            //System.out.println("mfac =  " + mfac);
+            //System.out.println("Qmm = " + Qmm + ", M2   =  " + M2 + ", Mq   =  " + Mq + "\n");
+        }
+        //System.out.println("*Ai =  " + Ai);
+        //System.out.println("*Bi =  " + Bi);
+
+        Em = Cm.subtract(Am.multiply(Bm));
+        if (!Em.isZERO()) {
+            System.out.println("Em =  " + Em);
+            //throw new NoLiftingException("no exact lifting possible");
+        }
+        // remove normalization not possible when not exact factorization
+        GreatestCommonDivisorAbstract<BigInteger> ufd = new GreatestCommonDivisorPrimitive<BigInteger>();
+        // remove normalization if possible
+        BigInteger ai = ufd.baseContent(Ai);
+        Ai = Ai.divide(ai); // Ai=pp(Ai)
+        BigInteger[] qr = c.quotientRemainder(ai);
+        BigInteger bi = null;
+        boolean exact = true;
+        if (qr[1].isZERO()) {
+            bi = qr[0];
+            try {
+                Bi = Bi.divide(bi); // divide( c/a )
+            } catch (RuntimeException e) {
+                System.out.println("*catch: no exact factorization: " + bi + ", e = " + e);
+                exact = false;
+            }
+        } else {
+            System.out.println("*remainder: no exact factorization: q = " + qr[0] + ", r = " + qr[1]);
+            exact = false;
+        }
+        if (!exact) {
+            System.out.println("*Ai =  " + Ai);
+            System.out.println("*ai =  " + ai);
+            System.out.println("*Bi =  " + Bi);
+            System.out.println("*bi =  " + bi);
+            System.out.println("*c  =  " + c);
+            throw new NoLiftingException("no exact lifting possible");
+        }
+        return new HenselApprox<MOD>(Ai, Bi, Aq, Bq);
+    }
+
+
+    /**
+     * Modular Hensel lifting test. Let p be a prime number and assume C ==
+     * prod_{0,...,n-1} g_i mod p with gcd(g_i,g_j) == 1 mod p for i != j.
+     * @param C GenPolynomial
+     * @param G = [g_0,...,g_{n-1}] list of GenPolynomial
+     * @param M bound on the coefficients of g_i as factors of C.
+     * @param p prime number.
+     * @return true if C = prod_{0,...,n-1} g_i mod p^e, else false.
+     */
+    public static//<MOD extends GcdRingElem<MOD> & Modular> 
+    boolean isHenselLift(GenPolynomial<BigInteger> C, BigInteger M, BigInteger p,
+                    List<GenPolynomial<BigInteger>> G) {
+        if (C == null || C.isZERO()) {
+            return false;
+        }
+        GenPolynomialRing<BigInteger> pfac = C.ring;
+        ModIntegerRing pm = new ModIntegerRing(p.getVal(), true);
+        GenPolynomialRing<ModInteger> mfac = new GenPolynomialRing<ModInteger>(pm, pfac);
+
+        // check mod p
+        GenPolynomial<ModInteger> cl = mfac.getONE();
+        GenPolynomial<ModInteger> hlp;
+        for (GenPolynomial<BigInteger> hl : G) {
+            //System.out.println("hl       = " + hl);
+            hlp = PolyUtil.<ModInteger> fromIntegerCoefficients(mfac, hl);
+            //System.out.println("hl mod p = " + hlp);
+            cl = cl.multiply(hlp);
+        }
+        GenPolynomial<ModInteger> cp = PolyUtil.<ModInteger> fromIntegerCoefficients(mfac, C);
+        if (!cp.equals(cl)) {
+            System.out.println("Hensel precondition wrong!");
+            if (debug) {
+                System.out.println("cl      = " + cl);
+                System.out.println("cp      = " + cp);
+                System.out.println("mon(cl) = " + cl.monic());
+                System.out.println("mon(cp) = " + cp.monic());
+                System.out.println("cp-cl   = " + cp.subtract(cl));
+                System.out.println("M       = " + M + ", p = " + p);
+            }
+            return false;
+        }
+
+        // check mod p^e 
+        BigInteger mip = p;
+        while (mip.compareTo(M) < 0) {
+            mip = mip.multiply(mip); // p
+        }
+        // mip = mip.multiply(p);
+        pm = new ModIntegerRing(mip.getVal(), false);
+        mfac = new GenPolynomialRing<ModInteger>(pm, pfac);
+        cl = mfac.getONE();
+        for (GenPolynomial<BigInteger> hl : G) {
+            //System.out.println("hl         = " + hl);
+            hlp = PolyUtil.<ModInteger> fromIntegerCoefficients(mfac, hl);
+            //System.out.println("hl mod p^e = " + hlp);
+            cl = cl.multiply(hlp);
+        }
+        cp = PolyUtil.<ModInteger> fromIntegerCoefficients(mfac, C);
+        if (!cp.equals(cl)) {
+            System.out.println("Hensel post condition wrong!");
+            System.out.println("cl    = " + cl);
+            System.out.println("cp    = " + cp);
+            System.out.println("cp-cl = " + cp.subtract(cl));
+            System.out.println("M = " + M + ", p = " + p + ", p^e = " + mip);
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Modular Hensel lifting test. Let p be a prime number and assume C == A *
+     * B mod p with gcd(A,B) == 1 mod p.
+     * @param C GenPolynomial
+     * @param A GenPolynomial
+     * @param B GenPolynomial
+     * @param M bound on the coefficients of A and B as factors of C.
+     * @param p prime number.
+     * @return true if C = A * B mod p**e, else false.
+     */
+    public static//<MOD extends GcdRingElem<MOD> & Modular>
+    boolean isHenselLift(GenPolynomial<BigInteger> C, BigInteger M, BigInteger p, GenPolynomial<BigInteger> A,
+                    GenPolynomial<BigInteger> B) {
+        List<GenPolynomial<BigInteger>> G = new ArrayList<GenPolynomial<BigInteger>>(2);
+        G.add(A);
+        G.add(B);
+        return isHenselLift(C, M, p, G);
+    }
+
+
+    /**
+     * Modular Hensel lifting test. Let p be a prime number and assume C == A *
+     * B mod p with gcd(A,B) == 1 mod p.
+     * @param C GenPolynomial
+     * @param Ha Hensel approximation.
+     * @param M bound on the coefficients of A and B as factors of C.
+     * @param p prime number.
+     * @return true if C = A * B mod p^e, else false.
+     */
+    public static <MOD extends GcdRingElem<MOD> & Modular> boolean isHenselLift(GenPolynomial<BigInteger> C,
+                    BigInteger M, BigInteger p, HenselApprox<MOD> Ha) {
+        List<GenPolynomial<BigInteger>> G = new ArrayList<GenPolynomial<BigInteger>>(2);
+        G.add(Ha.A);
+        G.add(Ha.B);
+        return isHenselLift(C, M, p, G);
+    }
+
+
+    /**
+     * Constructing and lifting algorithm for extended Euclidean relation. Let p
+     * = A.ring.coFac.modul() and assume gcd(A,B) == 1 mod p.
+     * @param A modular GenPolynomial
+     * @param B modular GenPolynomial
+     * @param k desired approximation exponent p^k.
+     * @return [s,t] with s A + t B = 1 mod p^k.
+     */
+    @SuppressWarnings("unchecked")
+    public static <MOD extends GcdRingElem<MOD> & Modular> GenPolynomial<MOD>[] liftExtendedEuclidean(
+                    GenPolynomial<MOD> A, GenPolynomial<MOD> B, long k) throws NoLiftingException {
+        if (A == null || A.isZERO() || B == null || B.isZERO()) {
+            throw new IllegalArgumentException("A and B must be nonzero, A = " + A + ", B = " + B);
+        }
+        GenPolynomialRing<MOD> fac = A.ring;
+        if (fac.nvar != 1) { // assert ?
+            throw new IllegalArgumentException("polynomial ring not univariate");
+        }
+        // start with extended Euclidean relation mod p
+        GenPolynomial<MOD>[] gst = null;
+        try {
+            gst = A.egcd(B);
+            if (!gst[0].isONE()) {
+                throw new NoLiftingException(
+                                "A and B not coprime, gcd = " + gst[0] + ", A = " + A + ", B = " + B);
+            }
+        } catch (ArithmeticException e) {
+            throw new NoLiftingException("coefficient error " + e);
+        }
+        GenPolynomial<MOD> S = gst[1];
+        GenPolynomial<MOD> T = gst[2];
+        //System.out.println("eeS = " + S + ": " + S.ring.coFac);
+        //System.out.println("eeT = " + T + ": " + T.ring.coFac);
+
+        // setup integer polynomial ring
+        GenPolynomialRing<BigInteger> ifac = new GenPolynomialRing<BigInteger>(new BigInteger(), fac);
+        GenPolynomial<BigInteger> one = ifac.getONE();
+        GenPolynomial<BigInteger> Ai = PolyUtil.integerFromModularCoefficients(ifac, A);
+        GenPolynomial<BigInteger> Bi = PolyUtil.integerFromModularCoefficients(ifac, B);
+        GenPolynomial<BigInteger> Si = PolyUtil.integerFromModularCoefficients(ifac, S);
+        GenPolynomial<BigInteger> Ti = PolyUtil.integerFromModularCoefficients(ifac, T);
+        //System.out.println("Ai = " + Ai);
+        //System.out.println("Bi = " + Bi);
+        //System.out.println("Si = " + Si);
+        //System.out.println("Ti = " + Ti);
+
+        // approximate mod p^i
+        ModularRingFactory<MOD> mcfac = (ModularRingFactory<MOD>) fac.coFac;
+        BigInteger p = mcfac.getIntegerModul();
+        BigInteger modul = p;
+        GenPolynomialRing<MOD> mfac; // = new GenPolynomialRing<MOD>(mcfac, fac);
+        for (int i = 1; i < k; i++) {
+            // e = 1 - s a - t b in Z[x]
+            GenPolynomial<BigInteger> e = one.subtract(Si.multiply(Ai)).subtract(Ti.multiply(Bi));
+            //System.out.println("\ne = " + e);
+            if (e.isZERO()) {
+                logger.info("leaving on zero e in liftExtendedEuclidean");
+                break;
+            }
+            e = e.divide(modul);
+            // move to Z_p[x] and compute next approximation 
+            GenPolynomial<MOD> c = PolyUtil.<MOD> fromIntegerCoefficients(fac, e);
+            //System.out.println("c = " + c + ": " + c.ring.coFac);
+            GenPolynomial<MOD> s = S.multiply(c);
+            GenPolynomial<MOD> t = T.multiply(c);
+            //System.out.println("s = " + s + ": " + s.ring.coFac);
+            //System.out.println("t = " + t + ": " + t.ring.coFac);
+
+            GenPolynomial<MOD>[] QR = s.quotientRemainder(B); // watch for ordering 
+            GenPolynomial<MOD> q = QR[0];
+            s = QR[1];
+            t = t.sum(q.multiply(A));
+            //System.out.println("s = " + s + ": " + s.ring.coFac);
+            //System.out.println("t = " + t + ": " + t.ring.coFac);
+
+            GenPolynomial<BigInteger> si = PolyUtil.integerFromModularCoefficients(ifac, s);
+            GenPolynomial<BigInteger> ti = PolyUtil.integerFromModularCoefficients(ifac, t);
+            //System.out.println("si = " + si);
+            //System.out.println("ti = " + si);
+            // add approximation to solution
+            Si = Si.sum(si.multiply(modul));
+            Ti = Ti.sum(ti.multiply(modul));
+            //System.out.println("Si = " + Si);
+            //System.out.println("Ti = " + Ti);
+            modul = modul.multiply(p);
+            //System.out.println("modul = " + modul + ", " + p + "^" + i + ", p^i = " + p.power(i));
+        }
+        //System.out.println("Si = " + Si + ", Ti = " + Ti);
+        // setup ring mod p^i
+        if (ModLongRing.MAX_LONG.compareTo(modul.getVal()) > 0) {
+            mcfac = (ModularRingFactory) new ModLongRing(modul.getVal());
+        } else {
+            mcfac = (ModularRingFactory) new ModIntegerRing(modul.getVal());
+        }
+        //System.out.println("mcfac = " + mcfac);
+        mfac = new GenPolynomialRing<MOD>(mcfac, fac);
+        S = PolyUtil.<MOD> fromIntegerCoefficients(mfac, Si);
+        T = PolyUtil.<MOD> fromIntegerCoefficients(mfac, Ti);
+        //System.out.println("S = " + S + ": " + S.ring.coFac);
+        //System.out.println("T = " + T + ": " + T.ring.coFac);
+        if (debug) {
+            List<GenPolynomial<MOD>> AP = new ArrayList<GenPolynomial<MOD>>();
+            AP.add(B);
+            AP.add(A);
+            List<GenPolynomial<MOD>> SP = new ArrayList<GenPolynomial<MOD>>();
+            SP.add(S);
+            SP.add(T);
+            if (!HenselUtil.<MOD> isExtendedEuclideanLift(AP, SP)) {
+                System.out.println("isExtendedEuclideanLift: false");
+            }
+        }
+        @SuppressWarnings("cast")
+        GenPolynomial<MOD>[] rel = (GenPolynomial<MOD>[]) new GenPolynomial[2];
+        rel[0] = S;
+        rel[1] = T;
+        return rel;
+    }
+
+
+    /**
+     * Constructing and lifting algorithm for extended Euclidean relation. Let p
+     * = A_i.ring.coFac.modul() and assume gcd(A_i,A_j) == 1 mod p, i != j.
+     * @param A list of modular GenPolynomials
+     * @param k desired approximation exponent p^k.
+     * @return [s_0,...,s_n-1] with sum_i s_i * B_i = 1 mod p^k, with B_i =
+     *         prod_{i!=j} A_j.
+     */
+    public static <MOD extends GcdRingElem<MOD> & Modular> List<GenPolynomial<MOD>> liftExtendedEuclidean(
+                    List<GenPolynomial<MOD>> A, long k) throws NoLiftingException {
+        if (A == null || A.size() <= 1) {
+            throw new IllegalArgumentException("A must be non null and non empty");
+        }
+        GenPolynomialRing<MOD> fac = A.get(0).ring;
+        if (fac.nvar != 1) { // assert ?
+            throw new IllegalArgumentException("polynomial ring not univariate");
+        }
+        GenPolynomial<MOD> zero = fac.getZERO();
+        int r = A.size();
+        List<GenPolynomial<MOD>> Q = new ArrayList<GenPolynomial<MOD>>(r);
+        for (int i = 0; i < r; i++) {
+            Q.add(zero);
+        }
+        //System.out.println("A = " + A);
+        Q.set(r - 2, A.get(r - 1));
+        for (int j = r - 3; j >= 0; j--) {
+            GenPolynomial<MOD> q = A.get(j + 1).multiply(Q.get(j + 1));
+            Q.set(j, q);
+        }
+        //System.out.println("Q = " + Q);
+        List<GenPolynomial<MOD>> B = new ArrayList<GenPolynomial<MOD>>(r + 1);
+        List<GenPolynomial<MOD>> lift = new ArrayList<GenPolynomial<MOD>>(r);
+        for (int i = 0; i < r; i++) {
+            B.add(zero);
+            lift.add(zero);
+        }
+        GenPolynomial<MOD> one = fac.getONE();
+        GenPolynomialRing<BigInteger> ifac = new GenPolynomialRing<BigInteger>(new BigInteger(), fac);
+        B.add(0, one);
+        //System.out.println("B(0) = " + B.get(0));
+        GenPolynomial<MOD> b = one;
+        for (int j = 0; j < r - 1; j++) {
+            //System.out.println("Q("+(j)+") = " + Q.get(j));
+            //System.out.println("A("+(j)+") = " + A.get(j));
+            //System.out.println("B("+(j)+") = " + B.get(j));
+            List<GenPolynomial<MOD>> S = liftDiophant(Q.get(j), A.get(j), B.get(j), k);
+            //System.out.println("\nSb = " + S);
+            b = S.get(0);
+            GenPolynomial<MOD> bb = PolyUtil.<MOD> fromIntegerCoefficients(fac,
+                            PolyUtil.integerFromModularCoefficients(ifac, b));
+            B.set(j + 1, bb);
+            lift.set(j, S.get(1));
+            //System.out.println("B("+(j+1)+") = " + B.get(j+1));
+            if (debug) {
+                logger.info("lift(" + j + ") = " + lift.get(j));
+            }
+        }
+        //System.out.println("liftb = " + lift);
+        lift.set(r - 1, b);
+        if (debug) {
+            logger.info("lift(" + (r - 1) + ") = " + b);
+        }
+        //System.out.println("B("+(r-1)+") = " + B.get(r-1) + " : " +  B.get(r-1).ring.coFac + ", b = " +  b + " : " +  b.ring.coFac);
+        //System.out.println("B = " + B);
+        //System.out.println("liftb = " + lift);
+        return lift;
+    }
+
+
+    /**
+     * Modular diophantine equation solution and lifting algorithm. Let p =
+     * A_i.ring.coFac.modul() and assume gcd(A,B) == 1 mod p.
+     * @param A modular GenPolynomial, mod p^k
+     * @param B modular GenPolynomial, mod p^k
+     * @param C modular GenPolynomial, mod p^k
+     * @param k desired approximation exponent p^k.
+     * @return [s, t] with s A' + t B' = C mod p^k, with A' = B, B' = A.
+     */
+    public static <MOD extends GcdRingElem<MOD> & Modular> List<GenPolynomial<MOD>> liftDiophant(
+                    GenPolynomial<MOD> A, GenPolynomial<MOD> B, GenPolynomial<MOD> C, long k)
+                    throws NoLiftingException {
+        if (A == null || A.isZERO() || B == null || B.isZERO()) {
+            throw new IllegalArgumentException(
+                            "A and B must be nonzero, A = " + A + ", B = " + B + ", C = " + C);
+        }
+        List<GenPolynomial<MOD>> sol = new ArrayList<GenPolynomial<MOD>>();
+        GenPolynomialRing<MOD> fac = C.ring;
+        if (fac.nvar != 1) { // assert ?
+            throw new IllegalArgumentException("polynomial ring not univariate");
+        }
+        //System.out.println("C = " + C);
+        GenPolynomial<MOD> zero = fac.getZERO();
+        for (int i = 0; i < 2; i++) {
+            sol.add(zero);
+        }
+        GenPolynomialRing<BigInteger> ifac = new GenPolynomialRing<BigInteger>(new BigInteger(), fac);
+        for (Monomial<MOD> m : C) {
+            //System.out.println("monomial = " + m);
+            long e = m.e.getVal(0);
+            List<GenPolynomial<MOD>> S = liftDiophant(A, B, e, k);
+            //System.out.println("Se = " + S);
+            MOD a = m.c;
+            //System.out.println("C.fac = " + fac.toScript());
+            a = fac.coFac.fromInteger(a.getSymmetricInteger().getVal());
+            int i = 0;
+            for (GenPolynomial<MOD> d : S) {
+                //System.out.println("d = " + d);
+                d = PolyUtil.<MOD> fromIntegerCoefficients(fac,
+                                PolyUtil.integerFromModularCoefficients(ifac, d));
+                d = d.multiply(a);
+                d = sol.get(i).sum(d);
+                //System.out.println("d = " + d);
+                sol.set(i++, d);
+            }
+            //System.out.println("sol = " + sol + ", for " + m);
+        }
+        if (debug) {
+            //GenPolynomialRing<BigInteger> ifac = new GenPolynomialRing<BigInteger>(new BigInteger(), fac);
+            A = PolyUtil.<MOD> fromIntegerCoefficients(fac, PolyUtil.integerFromModularCoefficients(ifac, A));
+            B = PolyUtil.<MOD> fromIntegerCoefficients(fac, PolyUtil.integerFromModularCoefficients(ifac, B));
+            C = PolyUtil.<MOD> fromIntegerCoefficients(fac, PolyUtil.integerFromModularCoefficients(ifac, C));
+            GenPolynomial<MOD> y = B.multiply(sol.get(0)).sum(A.multiply(sol.get(1)));
+            if (!y.equals(C)) {
+                System.out.println("A = " + A + ", B = " + B);
+                System.out.println("s1 = " + sol.get(0) + ", s2 = " + sol.get(1));
+                System.out.println("Error: A*r1 + B*r2 = " + y + " : " + fac.coFac);
+            }
+        }
+        return sol;
+    }
+
+
+    /**
+     * Modular diophantine equation solution and lifting algorithm. Let p =
+     * A_i.ring.coFac.modul() and assume gcd(a,b) == 1 mod p, for a, b in A.
+     * @param A list of modular GenPolynomials, mod p^k
+     * @param C modular GenPolynomial, mod p^k
+     * @param k desired approximation exponent p^k.
+     * @return [s_1,..., s_n] with sum_i s_i A_i' = C mod p^k, with Ai' =
+     *         prod_{j!=i} A_j.
+     */
+    public static <MOD extends GcdRingElem<MOD> & Modular> List<GenPolynomial<MOD>> liftDiophant(
+                    List<GenPolynomial<MOD>> A, GenPolynomial<MOD> C, long k) throws NoLiftingException {
+        if (false && A.size() <= 2) {
+            return HenselUtil.<MOD> liftDiophant(A.get(0), A.get(1), C, k);
+        }
+        List<GenPolynomial<MOD>> sol = new ArrayList<GenPolynomial<MOD>>();
+        GenPolynomialRing<MOD> fac = C.ring;
+        if (fac.nvar != 1) { // assert ?
+            throw new IllegalArgumentException("polynomial ring not univariate");
+        }
+        //System.out.println("C = " + C);
+        GenPolynomial<MOD> zero = fac.getZERO();
+        for (int i = 0; i < A.size(); i++) {
+            sol.add(zero);
+        }
+        GenPolynomialRing<BigInteger> ifac = new GenPolynomialRing<BigInteger>(new BigInteger(), fac);
+        for (Monomial<MOD> m : C) {
+            //System.out.println("monomial = " + m);
+            long e = m.e.getVal(0);
+            List<GenPolynomial<MOD>> S = liftDiophant(A, e, k);
+            //System.out.println("Se = " + S);
+            MOD a = m.c;
+            //System.out.println("C.fac = " + fac.toScript());
+            a = fac.coFac.fromInteger(a.getSymmetricInteger().getVal());
+            int i = 0;
+            for (GenPolynomial<MOD> d : S) {
+                //System.out.println("d = " + d);
+                d = PolyUtil.<MOD> fromIntegerCoefficients(fac,
+                                PolyUtil.integerFromModularCoefficients(ifac, d));
+                d = d.multiply(a);
+                d = sol.get(i).sum(d);
+                //System.out.println("d = " + d);
+                sol.set(i++, d);
+            }
+            //System.out.println("sol = " + sol + ", for " + m);
+        }
+        /*
+        if (true || debug) {
+            //GenPolynomialRing<BigInteger> ifac = new GenPolynomialRing<BigInteger>(new BigInteger(), fac);
+            A = PolyUtil.<MOD> fromIntegerCoefficients(fac, PolyUtil.integerFromModularCoefficients(ifac, A));
+            B = PolyUtil.<MOD> fromIntegerCoefficients(fac, PolyUtil.integerFromModularCoefficients(ifac, B));
+            C = PolyUtil.<MOD> fromIntegerCoefficients(fac, PolyUtil.integerFromModularCoefficients(ifac, C));
+            GenPolynomial<MOD> y = B.multiply(sol.get(0)).sum(A.multiply(sol.get(1)));
+            if (!y.equals(C)) {
+                System.out.println("A = " + A + ", B = " + B);
+                System.out.println("s1 = " + sol.get(0) + ", s2 = " + sol.get(1));
+                System.out.println("Error: A*r1 + B*r2 = " + y + " : " + fac.coFac);
+            }
+        }
+        */
+        return sol;
+    }
+
+
+    /**
+     * Modular diophantine equation solution and lifting algorithm. Let p =
+     * A_i.ring.coFac.modul() and assume gcd(A,B) == 1 mod p.
+     * @param A modular GenPolynomial
+     * @param B modular GenPolynomial
+     * @param e exponent for x^e
+     * @param k desired approximation exponent p^k.
+     * @return [s, t] with s A' + t B' = x^e mod p^k, with A' = B, B' = A.
+     */
+    public static <MOD extends GcdRingElem<MOD> & Modular> List<GenPolynomial<MOD>> liftDiophant(
+                    GenPolynomial<MOD> A, GenPolynomial<MOD> B, long e, long k) throws NoLiftingException {
+        if (A == null || A.isZERO() || B == null || B.isZERO()) {
+            throw new IllegalArgumentException("A and B must be nonzero, A = " + A + ", B = " + B);
+        }
+        List<GenPolynomial<MOD>> sol = new ArrayList<GenPolynomial<MOD>>();
+        GenPolynomialRing<MOD> fac = A.ring;
+        if (fac.nvar != 1) { // assert ?
+            throw new IllegalArgumentException("polynomial ring not univariate");
+        }
+        // lift EE relation to p^k
+        GenPolynomial<MOD>[] lee = liftExtendedEuclidean(B, A, k);
+        GenPolynomial<MOD> s1 = lee[0];
+        GenPolynomial<MOD> s2 = lee[1];
+        if (e == 0L) {
+            sol.add(s1);
+            sol.add(s2);
+            //System.out.println("sol@0 = " + sol); 
+            return sol;
+        }
+        fac = s1.ring;
+        GenPolynomialRing<BigInteger> ifac = new GenPolynomialRing<BigInteger>(new BigInteger(), fac);
+        A = PolyUtil.<MOD> fromIntegerCoefficients(fac, PolyUtil.integerFromModularCoefficients(ifac, A));
+        B = PolyUtil.<MOD> fromIntegerCoefficients(fac, PolyUtil.integerFromModularCoefficients(ifac, B));
+
+        //      this is the wrong sequence:
+        //         GenPolynomial<MOD> xe = fac.univariate(0,e);
+        //         GenPolynomial<MOD> q = s1.multiply(xe);
+        //         GenPolynomial<MOD>[] QR = q.quotientRemainder(B);
+        //         q = QR[0];
+        //         GenPolynomial<MOD> r1 = QR[1];
+        //         GenPolynomial<MOD> r2 = s2.multiply(xe).sum( q.multiply(A) );
+
+        GenPolynomial<MOD> xe = fac.univariate(0, e);
+        GenPolynomial<MOD> q = s1.multiply(xe);
+        GenPolynomial<MOD>[] QR = q.quotientRemainder(A);
+        q = QR[0];
+        //System.out.println("ee coeff qr = " + Arrays.toString(QR));
+        GenPolynomial<MOD> r1 = QR[1];
+        GenPolynomial<MOD> r2 = s2.multiply(xe).sum(q.multiply(B));
+        //System.out.println("r1 = " + r1 + ", r2 = " + r2);
+        sol.add(r1);
+        sol.add(r2);
+        //System.out.println("sol@"+ e + " = " + sol); 
+        if (debug) {
+            GenPolynomial<MOD> y = B.multiply(r1).sum(A.multiply(r2));
+            if (!y.equals(xe)) {
+                System.out.println("A = " + A + ", B = " + B);
+                System.out.println("r1 = " + r1 + ", r2 = " + r2);
+                System.out.println("Error: A*r1 + B*r2 = " + y);
+            }
+        }
+        return sol;
+    }
+
+
+    /**
+     * Modular diophantine equation solution and lifting algorithm. Let p =
+     * A_i.ring.coFac.modul() and assume gcd(a,b) == 1 mod p, for a, b in A.
+     * @param A list of modular GenPolynomials
+     * @param e exponent for x^e
+     * @param k desired approximation exponent p^k.
+     * @return [s_1,..., s_n] with sum_i s_i A_i' = x^e mod p^k, with Ai' =
+     *         prod_{j!=i} A_j.
+     */
+    public static <MOD extends GcdRingElem<MOD> & Modular> List<GenPolynomial<MOD>> liftDiophant(
+                    List<GenPolynomial<MOD>> A, long e, long k) throws NoLiftingException {
+        if (false && A.size() <= 2) {
+            return HenselUtil.<MOD> liftDiophant(A.get(0), A.get(1), e, k);
+        }
+        List<GenPolynomial<MOD>> sol = new ArrayList<GenPolynomial<MOD>>();
+        GenPolynomialRing<MOD> fac = A.get(0).ring;
+        if (fac.nvar != 1) { // assert ?
+            throw new IllegalArgumentException("polynomial ring not univariate");
+        }
+        // lift EE relation to p^k
+        List<GenPolynomial<MOD>> lee = liftExtendedEuclidean(A, k);
+        if (e == 0L) {
+            //System.out.println("sol@0 = " + sol); 
+            return lee;
+        }
+        fac = lee.get(0).ring;
+        GenPolynomialRing<BigInteger> ifac = new GenPolynomialRing<BigInteger>(new BigInteger(), fac);
+        List<GenPolynomial<MOD>> S = new ArrayList<GenPolynomial<MOD>>(lee.size());
+        for (GenPolynomial<MOD> a : lee) {
+            a = PolyUtil.<MOD> fromIntegerCoefficients(fac, PolyUtil.integerFromModularCoefficients(ifac, a));
+            S.add(a);
+        }
+        GenPolynomial<MOD> xe = fac.univariate(0, e);
+        //List<GenPolynomial<MOD>> Sr = new ArrayList<GenPolynomial<MOD>>(lee.size());
+        int i = 0;
+        for (GenPolynomial<MOD> s : S) {
+            GenPolynomial<MOD> q = s.multiply(xe);
+            GenPolynomial<MOD> r = q.remainder(A.get(i++));
+            //System.out.println("r = " + r);
+            sol.add(r);
+        }
+        //System.out.println("sol@"+ e + " = " + sol); 
+        /*
+        if (true || debug) {
+            GenPolynomial<MOD> y = B.multiply(r1).sum(A.multiply(r2));
+            if (!y.equals(xe)) {
+                System.out.println("A = " + A + ", B = " + B);
+                System.out.println("r1 = " + r1 + ", r2 = " + r2);
+                System.out.println("Error: A*r1 + B*r2 = " + y);
+            }
+        }
+        */
+        return sol;
+    }
+
+
+    /**
+     * Modular Diophant relation lifting test.
+     * @param A modular GenPolynomial
+     * @param B modular GenPolynomial
+     * @param C modular GenPolynomial
+     * @param S1 modular GenPolynomial
+     * @param S2 modular GenPolynomial
+     * @return true if A*S1 + B*S2 = C, else false.
+     */
+    public static <MOD extends GcdRingElem<MOD> & Modular> boolean isDiophantLift(GenPolynomial<MOD> A,
+                    GenPolynomial<MOD> B, GenPolynomial<MOD> S1, GenPolynomial<MOD> S2,
+                    GenPolynomial<MOD> C) {
+        GenPolynomialRing<MOD> fac = C.ring;
+        GenPolynomialRing<BigInteger> ifac = new GenPolynomialRing<BigInteger>(new BigInteger(), fac);
+        GenPolynomial<MOD> a = PolyUtil.<MOD> fromIntegerCoefficients(fac,
+                        PolyUtil.integerFromModularCoefficients(ifac, A));
+        GenPolynomial<MOD> b = PolyUtil.<MOD> fromIntegerCoefficients(fac,
+                        PolyUtil.integerFromModularCoefficients(ifac, B));
+        GenPolynomial<MOD> s1 = PolyUtil.<MOD> fromIntegerCoefficients(fac,
+                        PolyUtil.integerFromModularCoefficients(ifac, S1));
+        GenPolynomial<MOD> s2 = PolyUtil.<MOD> fromIntegerCoefficients(fac,
+                        PolyUtil.integerFromModularCoefficients(ifac, S2));
+        GenPolynomial<MOD> t = a.multiply(s1).sum(b.multiply(s2));
+        if (t.equals(C)) {
+            return true;
+        }
+        if (debug) {
+            System.out.println("a  = " + a);
+            System.out.println("b  = " + b);
+            System.out.println("s1 = " + s1);
+            System.out.println("s2 = " + s2);
+            System.out.println("t  = " + t);
+            System.out.println("C  = " + C);
+        }
+        return false;
+    }
+
+
+    /**
+     * Modular extended Euclidean relation lifting test.
+     * @param A list of GenPolynomials
+     * @param S = [s_0,...,s_{n-1}] list of GenPolynomial
+     * @return true if prod_{0,...,n-1} s_i * B_i = 1 mod p^e, with B_i =
+     *         prod_{i!=j} A_j, else false.
+     */
+    public static <MOD extends GcdRingElem<MOD> & Modular> boolean isExtendedEuclideanLift(
+                    List<GenPolynomial<MOD>> A, List<GenPolynomial<MOD>> S) {
+        GenPolynomialRing<MOD> fac = A.get(0).ring;
+        GenPolynomial<MOD> C = fac.getONE();
+        return isDiophantLift(A, S, C);
+    }
+
+
+    /**
+     * Modular Diophant relation lifting test.
+     * @param A list of GenPolynomials
+     * @param S = [s_0,...,s_{n-1}] list of GenPolynomials
+     * @param C = GenPolynomial
+     * @return true if prod_{0,...,n-1} s_i * B_i = C mod p^k, with B_i =
+     *         prod_{i!=j} A_j, else false.
+     */
+    public static <MOD extends GcdRingElem<MOD> & Modular> boolean isDiophantLift(List<GenPolynomial<MOD>> A,
+                    List<GenPolynomial<MOD>> S, GenPolynomial<MOD> C) {
+        GenPolynomialRing<MOD> fac = A.get(0).ring;
+        GenPolynomialRing<BigInteger> ifac = new GenPolynomialRing<BigInteger>(new BigInteger(), fac);
+        List<GenPolynomial<MOD>> B = new ArrayList<GenPolynomial<MOD>>(A.size());
+        int i = 0;
+        for (GenPolynomial<MOD> ai : A) {
+            GenPolynomial<MOD> b = fac.getONE();
+            int j = 0;
+            for (GenPolynomial<MOD> aj : A) {
+                if (i != j /*!ai.equals(aj)*/) {
+                    b = b.multiply(aj);
+                }
+                j++;
+            }
+            //System.out.println("b = " + b);
+            b = PolyUtil.<MOD> fromIntegerCoefficients(fac, PolyUtil.integerFromModularCoefficients(ifac, b));
+            B.add(b);
+            i++;
+        }
+        //System.out.println("B = " + B);
+        // check mod p^e 
+        GenPolynomial<MOD> t = fac.getZERO();
+        i = 0;
+        for (GenPolynomial<MOD> a : B) {
+            GenPolynomial<MOD> b = S.get(i++);
+            b = PolyUtil.<MOD> fromIntegerCoefficients(fac, PolyUtil.integerFromModularCoefficients(ifac, b));
+            GenPolynomial<MOD> s = a.multiply(b);
+            t = t.sum(s);
+        }
+        if (!t.equals(C)) {
+            if (debug) {
+                System.out.println("no diophant lift!");
+                System.out.println("A = " + A);
+                System.out.println("B = " + B);
+                System.out.println("S = " + S);
+                System.out.println("C = " + C);
+                System.out.println("t = " + t);
+            }
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Modular Hensel lifting algorithm on coefficients. Let p =
+     * f_i.ring.coFac.modul() and assume C == prod_{0,...,n-1} f_i mod p with
+     * gcd(f_i,f_j) == 1 mod p for i != j
+     * @param C monic integer polynomial
+     * @param F = [f_0,...,f_{n-1}] list of monic modular polynomials.
+     * @param k approximation exponent.
+     * @return [g_0,...,g_{n-1}] with C = prod_{0,...,n-1} g_i mod p^k.
+     */
+    @SuppressWarnings("unchecked")
+    public static <MOD extends GcdRingElem<MOD> & Modular> List<GenPolynomial<MOD>> liftHenselMonic(
+                    GenPolynomial<BigInteger> C, List<GenPolynomial<MOD>> F, long k)
+                    throws NoLiftingException {
+        if (C == null || C.isZERO() || F == null || F.size() == 0) {
+            throw new IllegalArgumentException("C must be nonzero and F must be nonempty");
+        }
+        GenPolynomialRing<BigInteger> fac = C.ring;
+        if (fac.nvar != 1) { // assert ?
+            throw new IllegalArgumentException("polynomial ring not univariate");
+        }
+        List<GenPolynomial<MOD>> lift = new ArrayList<GenPolynomial<MOD>>(F.size());
+        GenPolynomialRing<MOD> pfac = F.get(0).ring;
+        RingFactory<MOD> pcfac = pfac.coFac;
+        ModularRingFactory<MOD> PF = (ModularRingFactory<MOD>) pcfac;
+        BigInteger P = PF.getIntegerModul();
+        int n = F.size();
+        if (n == 1) { // lift F_0, this case will probably never be used
+            GenPolynomial<MOD> f = F.get(0);
+            ModularRingFactory<MOD> mcfac;
+            if (ModLongRing.MAX_LONG.compareTo(P.getVal()) > 0) {
+                mcfac = (ModularRingFactory) new ModLongRing(P.getVal());
+            } else {
+                mcfac = (ModularRingFactory) new ModIntegerRing(P.getVal());
+            }
+            GenPolynomialRing<MOD> mfac = new GenPolynomialRing<MOD>(mcfac, fac);
+            f = PolyUtil.fromIntegerCoefficients(mfac, PolyUtil.integerFromModularCoefficients(fac, f));
+            lift.add(f);
+            return lift;
+        }
+        //         if (n == 2) { // only one step
+        //             HenselApprox<MOD> ab = HenselUtil.<MOD> liftHenselQuadratic(C, M, F.get(0), F.get(1));
+        //             lift.add(ab.Am);
+        //             lift.add(ab.Bm);
+        //             return lift;
+        //         }
+
+        // setup integer polynomial ring
+        GenPolynomialRing<BigInteger> ifac = new GenPolynomialRing<BigInteger>(new BigInteger(), fac);
+        List<GenPolynomial<BigInteger>> Fi = PolyUtil.integerFromModularCoefficients(ifac, F);
+        //System.out.println("Fi = " + Fi);
+
+        List<GenPolynomial<MOD>> S = liftExtendedEuclidean(F, k + 1); // lift works for any k, use this
+        //System.out.println("Sext = " + S);
+        if (debug) {
+            logger.info("EE lift = " + S);
+            // adjust coefficients
+            List<GenPolynomial<MOD>> Sx = PolyUtil.fromIntegerCoefficients(pfac,
+                            PolyUtil.integerFromModularCoefficients(ifac, S));
+            try {
+                boolean il = HenselUtil.<MOD> isExtendedEuclideanLift(F, Sx);
+                //System.out.println("islift = " + il);
+            } catch (RuntimeException e) {
+                e.printStackTrace();
+            }
+        }
+        List<GenPolynomial<BigInteger>> Si = PolyUtil.integerFromModularCoefficients(ifac, S);
+        //System.out.println("Si = " + Si);
+        //System.out.println("C = " + C);
+
+        // approximate mod p^i
+        ModularRingFactory<MOD> mcfac = PF;
+        BigInteger p = mcfac.getIntegerModul();
+        BigInteger modul = p;
+        GenPolynomialRing<MOD> mfac = new GenPolynomialRing<MOD>(mcfac, fac);
+        List<GenPolynomial<MOD>> Sp = PolyUtil.fromIntegerCoefficients(mfac, Si);
+        //System.out.println("Sp = " + Sp);
+        for (int i = 1; i < k; i++) {
+            //System.out.println("i = " + i);
+            GenPolynomial<BigInteger> e = fac.getONE();
+            for (GenPolynomial<BigInteger> fi : Fi) {
+                e = e.multiply(fi);
+            }
+            e = C.subtract(e);
+            //System.out.println("\ne = " + e);
+            if (e.isZERO()) {
+                logger.info("leaving on zero e");
+                break;
+            }
+            try {
+                e = e.divide(modul);
+            } catch (RuntimeException ex) {
+                ex.printStackTrace();
+                throw ex;
+            }
+            //System.out.println("e = " + e);
+            // move to in Z_p[x]
+            GenPolynomial<MOD> c = PolyUtil.<MOD> fromIntegerCoefficients(mfac, e);
+            //System.out.println("c = " + c + ": " + c.ring.coFac);
+
+            List<GenPolynomial<MOD>> s = new ArrayList<GenPolynomial<MOD>>(S.size());
+            int j = 0;
+            for (GenPolynomial<MOD> f : Sp) {
+                f = f.multiply(c);
+                //System.out.println("f = " + f + " : " + f.ring.coFac);
+                //System.out.println("F,i = " + F.get(j) + " : " + F.get(j).ring.coFac);
+                f = f.remainder(F.get(j++));
+                //System.out.println("f = " + f + " : " + f.ring.coFac);
+                s.add(f);
+            }
+            //System.out.println("s = " + s);
+            List<GenPolynomial<BigInteger>> si = PolyUtil.integerFromModularCoefficients(ifac, s);
+            //System.out.println("si = " + si);
+
+            List<GenPolynomial<BigInteger>> Fii = new ArrayList<GenPolynomial<BigInteger>>(F.size());
+            j = 0;
+            for (GenPolynomial<BigInteger> f : Fi) {
+                f = f.sum(si.get(j++).multiply(modul));
+                Fii.add(f);
+            }
+            //System.out.println("Fii = " + Fii);
+            Fi = Fii;
+            modul = modul.multiply(p);
+            if (i >= k - 1) {
+                logger.info("e != 0 for k = " + k);
+            }
+        }
+        // setup ring mod p^k
+        modul = p.power(k);
+        if (ModLongRing.MAX_LONG.compareTo(modul.getVal()) > 0) {
+            mcfac = (ModularRingFactory) new ModLongRing(modul.getVal());
+        } else {
+            mcfac = (ModularRingFactory) new ModIntegerRing(modul.getVal());
+        }
+        //System.out.println("mcfac = " + mcfac);
+        mfac = new GenPolynomialRing<MOD>(mcfac, fac);
+        lift = PolyUtil.<MOD> fromIntegerCoefficients(mfac, Fi);
+        //System.out.println("lift = " + lift + ": " + lift.get(0).ring.coFac);
+        return lift;
+    }
+
+
+    /**
+     * Modular Hensel lifting algorithm on coefficients. Let p =
+     * f_i.ring.coFac.modul() and assume C == prod_{0,...,n-1} f_i mod p with
+     * gcd(f_i,f_j) == 1 mod p for i != j
+     * @param C integer polynomial
+     * @param F = [f_0,...,f_{n-1}] list of monic modular polynomials.
+     * @param k approximation exponent.
+     * @param g leading coefficient.
+     * @return [g_0,...,g_{n-1}] with C = prod_{0,...,n-1} g_i mod p^k.
+     */
+    @SuppressWarnings("unchecked")
+    public static <MOD extends GcdRingElem<MOD> & Modular> List<GenPolynomial<MOD>> liftHensel(
+                    GenPolynomial<BigInteger> C, List<GenPolynomial<MOD>> F, long k, BigInteger g)
+                    throws NoLiftingException {
+        if (C == null || C.isZERO() || F == null || F.size() == 0) {
+            throw new IllegalArgumentException("C must be nonzero and F must be nonempty");
+        }
+        GenPolynomialRing<BigInteger> fac = C.ring;
+        if (fac.nvar != 1) { // assert ?
+            throw new IllegalArgumentException("polynomial ring not univariate");
+        }
+        List<GenPolynomial<MOD>> lift = new ArrayList<GenPolynomial<MOD>>(F.size());
+        GenPolynomialRing<MOD> pfac = F.get(0).ring;
+        RingFactory<MOD> pcfac = pfac.coFac;
+        ModularRingFactory<MOD> PF = (ModularRingFactory<MOD>) pcfac;
+        BigInteger P = PF.getIntegerModul();
+        int n = F.size();
+        if (n == 1) { // lift F_0, this case will probably never be used
+            GenPolynomial<MOD> f = F.get(0);
+            ModularRingFactory<MOD> mcfac;
+            if (ModLongRing.MAX_LONG.compareTo(P.getVal()) > 0) {
+                mcfac = (ModularRingFactory) new ModLongRing(P.getVal());
+            } else {
+                mcfac = (ModularRingFactory) new ModIntegerRing(P.getVal());
+            }
+            GenPolynomialRing<MOD> mfac = new GenPolynomialRing<MOD>(mcfac, fac);
+            f = PolyUtil.fromIntegerCoefficients(mfac, PolyUtil.integerFromModularCoefficients(fac, f));
+            lift.add(f);
+            return lift;
+        }
+        // if (n == 2) { // only one step
+        //     HenselApprox<MOD> ab = HenselUtil.<MOD> liftHenselQuadratic(C, M, F.get(0), F.get(1));
+        //     lift.add(ab.Am);
+        //     lift.add(ab.Bm);
+        //     return lift;
+        // }
+
+        // normalize C and F_i factors
+        BigInteger cc = g; //C.leadingBaseCoefficient(); // == g ??
+        for (int i = 1; i < F.size(); i++) { // #F-1
+            C = C.multiply(cc); // sic
+        }
+        MOD cm = PF.fromInteger(cc.getVal());
+        List<GenPolynomial<MOD>> Fp = new ArrayList<GenPolynomial<MOD>>(F.size());
+        for (GenPolynomial<MOD> fm : F) {
+            GenPolynomial<MOD> am = fm.monic();
+            am = am.multiply(cm);
+            Fp.add(am);
+        }
+        F = Fp;
+
+        // setup integer polynomial ring
+        GenPolynomialRing<BigInteger> ifac = new GenPolynomialRing<BigInteger>(new BigInteger(), fac);
+        List<GenPolynomial<BigInteger>> Fi = PolyUtil.integerFromModularCoefficients(ifac, F);
+        //System.out.println("Fi = " + Fi);
+
+        // inplace modify polynomials, replace leading coefficient
+        for (GenPolynomial<BigInteger> ai : Fi) {
+            if (ai.isZERO()) {
+                continue;
+            }
+            ExpVector ea = ai.leadingExpVector();
+            ai.doPutToMap(ea, cc);
+        }
+        //System.out.println("Fi = " + Fi);
+
+        List<GenPolynomial<MOD>> S = liftExtendedEuclidean(F, k + 1); // lift works for any k, use this
+        //System.out.println("Sext = " + S);
+        if (debug) {
+            logger.info("EE lift = " + S);
+            // adjust coefficients
+            List<GenPolynomial<MOD>> Sx = PolyUtil.fromIntegerCoefficients(pfac,
+                            PolyUtil.integerFromModularCoefficients(ifac, S));
+            try {
+                boolean il = HenselUtil.<MOD> isExtendedEuclideanLift(F, Sx);
+                //System.out.println("islift = " + il);
+            } catch (RuntimeException e) {
+                e.printStackTrace();
+            }
+        }
+        List<GenPolynomial<BigInteger>> Si = PolyUtil.integerFromModularCoefficients(ifac, S);
+        //System.out.println("Si = " + Si);
+        //System.out.println("C = " + C);
+
+        // approximate mod p^i
+        ModularRingFactory<MOD> mcfac = PF;
+        BigInteger p = mcfac.getIntegerModul();
+        BigInteger modul = p;
+        GenPolynomialRing<MOD> mfac = new GenPolynomialRing<MOD>(mcfac, fac);
+        List<GenPolynomial<MOD>> Sp = PolyUtil.fromIntegerCoefficients(mfac, Si);
+        //System.out.println("Sp = " + Sp);
+        for (int i = 1; i < k; i++) {
+            //System.out.println("i = " + i);
+            GenPolynomial<BigInteger> e = fac.getONE();
+            for (GenPolynomial<BigInteger> fi : Fi) {
+                e = e.multiply(fi);
+            }
+            e = C.subtract(e);
+            //System.out.println("\ne = " + e);
+            if (e.isZERO()) {
+                logger.info("leaving on zero e");
+                break;
+            }
+            try {
+                e = e.divide(modul);
+            } catch (RuntimeException ex) {
+                ex.printStackTrace();
+                throw ex;
+            }
+            //System.out.println("e = " + e);
+            // move to in Z_p[x]
+            GenPolynomial<MOD> c = PolyUtil.<MOD> fromIntegerCoefficients(mfac, e);
+            //System.out.println("c = " + c + ": " + c.ring.coFac);
+
+            List<GenPolynomial<MOD>> s = new ArrayList<GenPolynomial<MOD>>(S.size());
+            int j = 0;
+            for (GenPolynomial<MOD> f : Sp) {
+                f = f.multiply(c);
+                //System.out.println("f = " + f + " : " + f.ring.coFac);
+                //System.out.println("F,i = " + F.get(j) + " : " + F.get(j).ring.coFac);
+                f = f.remainder(F.get(j++));
+                //System.out.println("f = " + f + " : " + f.ring.coFac);
+                s.add(f);
+            }
+            //System.out.println("s = " + s);
+            List<GenPolynomial<BigInteger>> si = PolyUtil.integerFromModularCoefficients(ifac, s);
+            //System.out.println("si = " + si);
+
+            List<GenPolynomial<BigInteger>> Fii = new ArrayList<GenPolynomial<BigInteger>>(F.size());
+            j = 0;
+            for (GenPolynomial<BigInteger> f : Fi) {
+                f = f.sum(si.get(j++).multiply(modul));
+                Fii.add(f);
+            }
+            //System.out.println("Fii = " + Fii);
+            Fi = Fii;
+            modul = modul.multiply(p);
+            if (i >= k - 1) {
+                logger.info("e != 0 for k = " + k);
+            }
+        }
+        //System.out.println("Fi = " + Fi);
+        // remove normalization
+        GreatestCommonDivisorAbstract<BigInteger> ufd = GCDFactory.getImplementation(cc);
+        //BigInteger ai = ufd.baseContent(Fi.get(0));
+        //System.out.println("ai = " + ai + ", cc = " + cc);
+        List<GenPolynomial<BigInteger>> Fii = new ArrayList<GenPolynomial<BigInteger>>(F.size());
+        //int j = 0;
+        for (GenPolynomial<BigInteger> bi : Fi) {
+            GenPolynomial<BigInteger> ci = null;
+            //if ( j++ == 0 ) {
+            //    ci = bi.divide(ai);
+            //} else {
+            //    BigInteger i = cc.divide(ai);
+            //    ci = bi.divide(i);
+            //}
+            ci = ufd.basePrimitivePart(bi); // ??
+            //System.out.println("bi = " + bi + ", ci = " + ci);
+            Fii.add(ci);
+        }
+        Fi = Fii;
+
+        // setup ring mod p^k
+        modul = p.power(k);
+        if (ModLongRing.MAX_LONG.compareTo(modul.getVal()) > 0) {
+            mcfac = (ModularRingFactory) new ModLongRing(modul.getVal());
+        } else {
+            mcfac = (ModularRingFactory) new ModIntegerRing(modul.getVal());
+        }
+        //System.out.println("mcfac = " + mcfac);
+        mfac = new GenPolynomialRing<MOD>(mcfac, fac);
+        lift = PolyUtil.<MOD> fromIntegerCoefficients(mfac, Fi);
+        //System.out.println("lift = " + lift + ": " + lift.get(0).ring.coFac);
+        return lift;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/NoLiftingException.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/NoLiftingException.java
@@ -1,0 +1,36 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+/**
+ * Non existing Hensel lifting. Exception to be thrown when a valid
+ * Hensel lifting cannot be constructed.
+ * @author Heinz Kredel
+ */
+
+public class NoLiftingException extends Exception {
+
+
+    public NoLiftingException() {
+        super("NoLiftingException");
+    }
+
+
+    public NoLiftingException(String c) {
+        super(c);
+    }
+
+
+    public NoLiftingException(String c, Throwable t) {
+        super(c, t);
+    }
+
+
+    public NoLiftingException(Throwable t) {
+        super("NoLiftingException", t);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/PartialFraction.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/PartialFraction.java
@@ -1,0 +1,375 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.AlgebraicNumberRing;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Container for the partial fraction decomposition of a squarefree denominator.
+ * num/den = sum( a_i / d_i )
+ * @author Heinz Kredel
+ * @param <C> coefficient type
+ */
+
+public class PartialFraction<C extends GcdRingElem<C>> implements Serializable {
+
+
+    private static final Logger logger = LogManager.getLogger(PartialFraction.class);
+
+
+    /**
+     * Original numerator polynomial coefficients from C and deg(num) &lt;
+     * deg(den).
+     */
+    public final GenPolynomial<C> num;
+
+
+    /**
+     * Original (irreducible) denominator polynomial coefficients from C.
+     */
+    public final GenPolynomial<C> den;
+
+
+    /**
+     * List of numbers from C.
+     */
+    public final List<C> cfactors;
+
+
+    /**
+     * List of linear factors of the denominator with coefficients from C.
+     */
+    public final List<GenPolynomial<C>> cdenom;
+
+
+    /**
+     * List of algebraic numbers of an algebraic field extension over C.
+     */
+    public final List<AlgebraicNumber<C>> afactors;
+
+
+    /**
+     * List of factors of the denominator with coefficients from an
+     * AlgebraicNumberRing&lt;C&gt;.
+     */
+    public final List<GenPolynomial<AlgebraicNumber<C>>> adenom;
+
+
+    /**
+     * Constructor.
+     * @param n numerator GenPolynomial over C.
+     * @param d irreducible denominator GenPolynomial over C.
+     * @param cf list of elements a_i.
+     * @param cd list of linear factors d_i of d.
+     * @param af list of algebraic elements a_i.
+     * @param ad list of linear (irreducible) factors d_i of d with algebraic
+     *            coefficients. n/d = sum( a_i / d_i )
+     */
+    public PartialFraction(GenPolynomial<C> n, GenPolynomial<C> d, List<C> cf, List<GenPolynomial<C>> cd,
+                    List<AlgebraicNumber<C>> af, List<GenPolynomial<AlgebraicNumber<C>>> ad) {
+        num = n;
+        den = d;
+        cfactors = cf;
+        cdenom = cd;
+        afactors = af;
+        adenom = ad;
+        for (GenPolynomial<C> p : cdenom) {
+            if (p.degree(0) > 1) {
+                throw new IllegalArgumentException("polynomial not linear, p = " + p);
+            }
+        }
+        for (GenPolynomial<AlgebraicNumber<C>> a : adenom) {
+            if (a.degree(0) > 1) {
+                throw new IllegalArgumentException("polynomial not linear, a = " + a);
+            }
+        }
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        sb.append("(" + num.toString() + ")");
+        sb.append(" / ");
+        sb.append("(" + den.toString() + ")");
+        sb.append(" =\n");
+        boolean first = true;
+        for (int i = 0; i < cfactors.size(); i++) {
+            C cp = cfactors.get(i);
+            if (first) {
+                first = false;
+            } else {
+                sb.append(" + ");
+            }
+            sb.append("(" + cp.toString() + ")");
+            GenPolynomial<C> p = cdenom.get(i);
+            sb.append(" / (" + p.toString() + ")");
+        }
+        if (!first && afactors.size() > 0) {
+            sb.append(" + ");
+        }
+        first = true;
+        for (int i = 0; i < afactors.size(); i++) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append(" + ");
+            }
+            AlgebraicNumber<C> ap = afactors.get(i);
+            AlgebraicNumberRing<C> ar = ap.factory();
+            GenPolynomial<AlgebraicNumber<C>> p = adenom.get(i);
+            if (p.degree(0) < ar.modul.degree(0) && ar.modul.degree(0) > 2) {
+                sb.append("sum_(" + ar.getGenerator() + " in ");
+                sb.append("rootOf(" + ar.modul + ") ) ");
+            } else {
+                //sb.append("sum_("+ar+") ");
+            }
+            sb.append("(" + ap.toString() + ")");
+            sb.append(" / (" + p.toString() + ")");
+            //sb.append(" ## over " + ap.factory() + "\n");
+        }
+        return sb.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this container.
+     * @see edu.jas.structure.ElemFactory#toScript()
+     */
+    public String toScript() {
+        // Python case
+        StringBuffer sb = new StringBuffer();
+        sb.append(num.toScript());
+        sb.append(" / ");
+        sb.append(den.toScript());
+        sb.append(" = ");
+        boolean first = true;
+        int i = 0;
+        for (C cp : cfactors) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append(" + ");
+            }
+            sb.append(cp.toScript());
+            GenPolynomial<C> p = cdenom.get(i);
+            sb.append(" / " + p.toScript());
+        }
+        if (!first) {
+            sb.append(" + ");
+        }
+        first = true;
+        i = 0;
+        for (AlgebraicNumber<C> ap : afactors) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append(" + ");
+            }
+            AlgebraicNumberRing<C> ar = ap.factory();
+            GenPolynomial<AlgebraicNumber<C>> p = adenom.get(i);
+            if (p.degree(0) < ar.modul.degree(0) && ar.modul.degree(0) > 2) {
+                sb.append("sum_(" + ar.getGenerator().toScript() + " in ");
+                sb.append("rootOf(" + ar.modul.toScript() + ") ) ");
+            } else {
+                //sb.append("sum_("+ar+") ");
+            }
+            sb.append(ap.toScript());
+            sb.append(" / " + p.toScript());
+            //sb.append(" ## over " + ap.toScriptFactory() + "\n");
+        }
+        return sb.toString();
+    }
+
+
+    /**
+     * Hash code for this Factors.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h = num.hashCode();
+        h = h * 37 + den.hashCode();
+        h = h * 37 + cfactors.hashCode();
+        h = h * 37 + cdenom.hashCode();
+        h = h * 37 + afactors.hashCode();
+        h = h * 37 + adenom.hashCode();
+        return h;
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object B) {
+        if (B == null) {
+            return false;
+        }
+        if (!(B instanceof PartialFraction)) {
+            return false;
+        }
+        PartialFraction<C> a = (PartialFraction<C>) B;
+        boolean t = num.equals(a.num) && den.equals(a.den);
+        if (!t) {
+            return t;
+        }
+        t = cfactors.equals(a.cfactors);
+        if (!t) {
+            return t;
+        }
+        t = cdenom.equals(a.cdenom);
+        if (!t) {
+            return t;
+        }
+        t = afactors.equals(a.afactors);
+        if (!t) {
+            return t;
+        }
+        t = adenom.equals(a.adenom);
+        return t;
+    }
+
+
+    /**
+     * Test if correct partial fraction. num/den = sum( a_i / d_i )
+     */
+    @SuppressWarnings("unchecked")
+    public boolean isPartialFraction() {
+        QuotientRing<C> qfac = new QuotientRing<C>(num.ring);
+        // num / den
+        Quotient<C> q = new Quotient<C>(qfac, num, den);
+        //System.out.println("q = " + q);
+        Quotient<C> qs = qfac.getZERO();
+        int i = 0;
+        for (C c : cfactors) {
+            GenPolynomial<C> cp = cdenom.get(i++);
+            // plus c / cp
+            GenPolynomial<C> cd = num.ring.getONE().multiply(c);
+            Quotient<C> qq = new Quotient<C>(qfac, cd, cp);
+            qs = qs.sum(qq);
+        }
+        //System.out.println("qs = " + qs);
+        if (afactors.isEmpty()) {
+            return q.compareTo(qs) == 0;
+        }
+
+        // sort by extension field
+        Set<AlgebraicNumberRing<C>> fields = new HashSet<AlgebraicNumberRing<C>>();
+        for (AlgebraicNumber<C> ap : afactors) {
+            if (ap.ring.depth() > 1) {
+                logger.warn("extension field depth to high"); // todo
+            }
+            fields.add(ap.ring);
+        }
+        //System.out.println("fields = " + fields);
+        Map<AlgebraicNumberRing<C>, List<AlgebraicNumber<C>>> facs = new HashMap<AlgebraicNumberRing<C>, List<AlgebraicNumber<C>>>();
+        for (AlgebraicNumber<C> ap : afactors) {
+            List<AlgebraicNumber<C>> cf = facs.get(ap.ring);
+            if (cf == null) {
+                cf = new ArrayList<AlgebraicNumber<C>>();
+            }
+            cf.add(ap);
+            facs.put(ap.ring, cf);
+        }
+        //System.out.println("facs = " + facs);
+        Map<AlgebraicNumberRing<C>, List<GenPolynomial<AlgebraicNumber<C>>>> pfacs = new HashMap<AlgebraicNumberRing<C>, List<GenPolynomial<AlgebraicNumber<C>>>>();
+        for (GenPolynomial<AlgebraicNumber<C>> ap : adenom) {
+            AlgebraicNumberRing<C> ar = (AlgebraicNumberRing<C>) ap.ring.coFac;
+            List<GenPolynomial<AlgebraicNumber<C>>> cf = pfacs.get(ar);
+            if (cf == null) {
+                cf = new ArrayList<GenPolynomial<AlgebraicNumber<C>>>();
+            }
+            cf.add(ap);
+            pfacs.put(ar, cf);
+        }
+        //System.out.println("pfacs = " + pfacs);
+
+        // check algebraic parts 
+        boolean sumMissing = false;
+        for (AlgebraicNumberRing<C> ar : fields) {
+            if (ar.modul.degree(0) > 2) { //&& p.degree(0) < ar.modul.degree(0) ?
+                sumMissing = true;
+            }
+            List<AlgebraicNumber<C>> cf = facs.get(ar);
+            List<GenPolynomial<AlgebraicNumber<C>>> cfp = pfacs.get(ar);
+            GenPolynomialRing<AlgebraicNumber<C>> apfac = cfp.get(0).ring;
+            QuotientRing<AlgebraicNumber<C>> aqfac = new QuotientRing<AlgebraicNumber<C>>(apfac);
+            Quotient<AlgebraicNumber<C>> aq = aqfac.getZERO();
+            i = 0;
+            for (AlgebraicNumber<C> c : cf) {
+                GenPolynomial<AlgebraicNumber<C>> cp = cfp.get(i++);
+                // plus c / cp
+                GenPolynomial<AlgebraicNumber<C>> cd = apfac.getONE().multiply(c);
+                Quotient<AlgebraicNumber<C>> qq = new Quotient<AlgebraicNumber<C>>(aqfac, cd, cp);
+                //System.out.println("qq = " + qq);
+                aq = aq.sum(qq);
+            }
+            //System.out.println("aq = " + aq);
+            GenPolynomialRing<C> cfac = ar.ring;
+            GenPolynomialRing<GenPolynomial<C>> prfac = new GenPolynomialRing<GenPolynomial<C>>(cfac, apfac);
+            GenPolynomial<GenPolynomial<C>> pqnum = PolyUtil.<C> fromAlgebraicCoefficients(prfac, aq.num);
+            GenPolynomial<GenPolynomial<C>> pqden = PolyUtil.<C> fromAlgebraicCoefficients(prfac, aq.den);
+            //System.out.println("pq = (" + pqnum + ") / (" + pqden + ")");
+
+            C one = cfac.coFac.getONE(); // varaible should no more occur in coefficient
+            GenPolynomialRing<C> pfac = new GenPolynomialRing<C>(cfac.coFac, prfac);
+            GenPolynomial<C> pnum = PolyUtil.<C> evaluateFirstRec(cfac, pfac, pqnum, one);
+            GenPolynomial<C> pden = PolyUtil.<C> evaluateFirstRec(cfac, pfac, pqden, one);
+            //System.out.println("p = (" + pnum + ") / (" + pden + ")");
+
+            // iterate if multiple field extensions
+            while (cfac.coFac instanceof AlgebraicNumberRing) {
+                //System.out.println("cfac.coFac = " + cfac.coFac.toScript());
+                AlgebraicNumberRing<C> ar2 = (AlgebraicNumberRing<C>) cfac.coFac;
+                cfac = ar2.ring;
+                prfac = new GenPolynomialRing<GenPolynomial<C>>(cfac, apfac);
+                GenPolynomial<AlgebraicNumber<C>> prnum = (GenPolynomial<AlgebraicNumber<C>>) pnum;
+                GenPolynomial<AlgebraicNumber<C>> prden = (GenPolynomial<AlgebraicNumber<C>>) pden;
+                pqnum = PolyUtil.<C> fromAlgebraicCoefficients(prfac, prnum);
+                pqden = PolyUtil.<C> fromAlgebraicCoefficients(prfac, prden);
+                one = cfac.coFac.getONE(); // varaible should no more occur in coefficient
+                pfac = new GenPolynomialRing<C>(cfac.coFac, prfac);
+                pnum = PolyUtil.<C> evaluateFirstRec(cfac, pfac, pqnum, one);
+                pden = PolyUtil.<C> evaluateFirstRec(cfac, pfac, pqden, one);
+            }
+
+            Quotient<C> qq = new Quotient<C>(qfac, pnum, pden);
+            //System.out.println("qq = " + qq);
+            qs = qs.sum(qq);
+        }
+        boolean cmp = q.compareTo(qs) == 0;
+        if (!cmp) {
+            System.out.println("q != qs: " + q + " != " + qs);
+        }
+        return cmp || sumMissing;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/PolyUfdUtil.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/PolyUfdUtil.java
@@ -1,0 +1,886 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.arith.BigInteger;
+import edu.jas.arith.BigRational;
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.AlgebraicNumberRing;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.poly.TermOrderByName;
+import edu.jas.ps.UnivPowerSeries;
+import edu.jas.ps.UnivPowerSeriesRing;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.Power;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+import edu.jas.structure.UnaryFunctor;
+import edu.jas.util.ListUtil;
+
+
+/**
+ * Polynomial ufd utilities. For example conversion between different
+ * representations and Kronecker substitution.
+ * @author Heinz Kredel
+ */
+
+public class PolyUfdUtil {
+
+
+    private static final Logger logger = LogManager.getLogger(PolyUfdUtil.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Factors of Quotient rational function.
+     * @param A rational function to be factored.
+     * @return list of irreducible rational function parts.
+     */
+    public static <C extends GcdRingElem<C>> SortedMap<Quotient<C>, Long> factors(Quotient<C> A) {
+        SortedMap<Quotient<C>, Long> factors = new TreeMap<Quotient<C>, Long>();
+        if (A == null || A.isZERO()) {
+            return factors;
+        }
+        if (A.abs().isONE()) {
+            factors.put(A, 1L);
+            return factors;
+        }
+        QuotientRing<C> qfac = A.ring;
+        GenPolynomialRing<C> fac = qfac.ring;
+        FactorAbstract<C> eng = FactorFactory.<C> getImplementation(fac.coFac);
+        GenPolynomial<C> n = A.num;
+        SortedMap<GenPolynomial<C>, Long> numfactors = eng.factors(n);
+        for (Map.Entry<GenPolynomial<C>, Long> me : numfactors.entrySet()) {
+            GenPolynomial<C> f = me.getKey();
+            Long e = me.getValue();
+            Quotient<C> q = new Quotient<C>(qfac, f);
+            factors.put(q, e);
+        }
+        GenPolynomial<C> d = A.den;
+        if (d.isONE()) {
+            return factors;
+        }
+        GenPolynomial<C> one = fac.getONE();
+        SortedMap<GenPolynomial<C>, Long> denfactors = eng.factors(d);
+        for (Map.Entry<GenPolynomial<C>, Long> me : denfactors.entrySet()) {
+            GenPolynomial<C> f = me.getKey();
+            Long e = me.getValue();
+            Quotient<C> q = new Quotient<C>(qfac, one, f);
+            factors.put(q, e);
+        }
+        return factors;
+    }
+
+
+    /**
+     * Quotient is (squarefree) factorization.
+     * @param P Quotient.
+     * @param F = [p_1 -&gt; e_1, ..., p_k -&gt; e_k].
+     * @return true if P = prod_{i=1,...,k} p_i**e_i, else false.
+     */
+    public static <C extends GcdRingElem<C>> boolean isFactorization(Quotient<C> P,
+                    SortedMap<Quotient<C>, Long> F) {
+        if (P == null || F == null) {
+            throw new IllegalArgumentException("P and F may not be null");
+        }
+        if (P.isZERO() && F.size() == 0) {
+            return true;
+        }
+        Quotient<C> t = P.ring.getONE();
+        for (Map.Entry<Quotient<C>, Long> me : F.entrySet()) {
+            Quotient<C> f = me.getKey();
+            Long E = me.getValue();
+            long e = E.longValue();
+            Quotient<C> g = f.power(e);
+            t = t.multiply(g);
+        }
+        boolean f = P.equals(t) || P.equals(t.negate());
+        if (!f) {
+            P = P.monic();
+            t = t.monic();
+            f = P.equals(t) || P.equals(t.negate());
+            if (f) {
+                return f;
+            }
+            logger.info("no factorization(map): F = " + F + ", P = " + P + ", t = " + t);
+        }
+        return f;
+    }
+
+
+    /**
+     * Integral polynomial from rational function coefficients. Represent as
+     * polynomial with integral polynomial coefficients by multiplication with
+     * the lcm of the numerators of the rational function coefficients.
+     * @param fac result polynomial factory.
+     * @param A polynomial with rational function coefficients to be converted.
+     * @return polynomial with integral polynomial coefficients.
+     */
+    public static <C extends GcdRingElem<C>> GenPolynomial<GenPolynomial<C>> integralFromQuotientCoefficients(
+                    GenPolynomialRing<GenPolynomial<C>> fac, GenPolynomial<Quotient<C>> A) {
+        GenPolynomial<GenPolynomial<C>> B = fac.getZERO().copy();
+        if (A == null || A.isZERO()) {
+            return B;
+        }
+        GenPolynomial<C> c = null;
+        GenPolynomial<C> d;
+        GenPolynomial<C> x;
+        GreatestCommonDivisor<C> ufd = new GreatestCommonDivisorSubres<C>();
+        int s = 0;
+        // lcm of denominators
+        for (Quotient<C> y : A.getMap().values()) {
+            x = y.den;
+            // c = lcm(c,x)
+            if (c == null) {
+                c = x;
+                s = x.signum();
+            } else {
+                d = ufd.gcd(c, x);
+                c = c.multiply(x.divide(d));
+            }
+        }
+        if (s < 0) {
+            c = c.negate();
+        }
+        for (Map.Entry<ExpVector, Quotient<C>> y : A.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            Quotient<C> a = y.getValue();
+            // p = n*(c/d)
+            GenPolynomial<C> b = c.divide(a.den);
+            GenPolynomial<C> p = a.num.multiply(b);
+            //B = B.sum( p, e ); // inefficient
+            B.doPutToMap(e, p);
+        }
+        return B;
+    }
+
+
+    /**
+     * Integral polynomial from rational function coefficients. Represent as
+     * polynomial with integral polynomial coefficients by multiplication with
+     * the lcm of the numerators of the rational function coefficients.
+     * @param fac result polynomial factory.
+     * @param L list of polynomial with rational function coefficients to be
+     *            converted.
+     * @return list of polynomials with integral polynomial coefficients.
+     */
+    public static <C extends GcdRingElem<C>> List<GenPolynomial<GenPolynomial<C>>> integralFromQuotientCoefficients(
+                    GenPolynomialRing<GenPolynomial<C>> fac, Collection<GenPolynomial<Quotient<C>>> L) {
+        if (L == null) {
+            return null;
+        }
+        List<GenPolynomial<GenPolynomial<C>>> list = new ArrayList<GenPolynomial<GenPolynomial<C>>>(L.size());
+        for (GenPolynomial<Quotient<C>> p : L) {
+            list.add(integralFromQuotientCoefficients(fac, p));
+        }
+        return list;
+    }
+
+
+    /**
+     * Rational function from integral polynomial coefficients. Represent as
+     * polynomial with type Quotient<C> coefficients.
+     * @param fac result polynomial factory.
+     * @param A polynomial with integral polynomial coefficients to be
+     *            converted.
+     * @return polynomial with type Quotient<C> coefficients.
+     */
+    public static <C extends GcdRingElem<C>> GenPolynomial<Quotient<C>> quotientFromIntegralCoefficients(
+                    GenPolynomialRing<Quotient<C>> fac, GenPolynomial<GenPolynomial<C>> A) {
+        GenPolynomial<Quotient<C>> B = fac.getZERO().copy();
+        if (A == null || A.isZERO()) {
+            return B;
+        }
+        RingFactory<Quotient<C>> cfac = fac.coFac;
+        QuotientRing<C> qfac = (QuotientRing<C>) cfac;
+        for (Map.Entry<ExpVector, GenPolynomial<C>> y : A.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            GenPolynomial<C> a = y.getValue();
+            Quotient<C> p = new Quotient<C>(qfac, a); // can not be zero
+            if (!p.isZERO()) {
+                //B = B.sum( p, e ); // inefficient
+                B.doPutToMap(e, p);
+            }
+        }
+        return B;
+    }
+
+
+    /**
+     * Rational function from integral polynomial coefficients. Represent as
+     * polynomial with type Quotient<C> coefficients.
+     * @param fac result polynomial factory.
+     * @param L list of polynomials with integral polynomial coefficients to be
+     *            converted.
+     * @return list of polynomials with type Quotient<C> coefficients.
+     */
+    public static <C extends GcdRingElem<C>> List<GenPolynomial<Quotient<C>>> quotientFromIntegralCoefficients(
+                    GenPolynomialRing<Quotient<C>> fac, Collection<GenPolynomial<GenPolynomial<C>>> L) {
+        if (L == null) {
+            return null;
+        }
+        List<GenPolynomial<Quotient<C>>> list = new ArrayList<GenPolynomial<Quotient<C>>>(L.size());
+        for (GenPolynomial<GenPolynomial<C>> p : L) {
+            list.add(quotientFromIntegralCoefficients(fac, p));
+        }
+        return list;
+    }
+
+
+    /**
+     * From BigInteger coefficients. Represent as polynomial with type
+     * GenPolynomial&lt;C&gt; coefficients, e.g. ModInteger or BigRational.
+     * @param fac result polynomial factory.
+     * @param A polynomial with GenPolynomial&lt;BigInteger&gt; coefficients to
+     *            be converted.
+     * @return polynomial with type GenPolynomial&lt;C&gt; coefficients.
+     */
+    public static <C extends RingElem<C>> GenPolynomial<GenPolynomial<C>> fromIntegerCoefficients(
+                    GenPolynomialRing<GenPolynomial<C>> fac, GenPolynomial<GenPolynomial<BigInteger>> A) {
+        GenPolynomial<GenPolynomial<C>> B = fac.getZERO().copy();
+        if (A == null || A.isZERO()) {
+            return B;
+        }
+        RingFactory<GenPolynomial<C>> cfac = fac.coFac;
+        GenPolynomialRing<C> rfac = (GenPolynomialRing<C>) cfac;
+        for (Map.Entry<ExpVector, GenPolynomial<BigInteger>> y : A.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            GenPolynomial<BigInteger> a = y.getValue();
+            GenPolynomial<C> p = PolyUtil.<C> fromIntegerCoefficients(rfac, a);
+            if (!p.isZERO()) {
+                //B = B.sum( p, e ); // inefficient
+                B.doPutToMap(e, p);
+            }
+        }
+        return B;
+    }
+
+
+    /**
+     * From BigInteger coefficients. Represent as polynomial with type
+     * GenPolynomial&lt;C&gt; coefficients, e.g. ModInteger or BigRational.
+     * @param fac result polynomial factory.
+     * @param L polynomial list with GenPolynomial&lt;BigInteger&gt;
+     *            coefficients to be converted.
+     * @return polynomial list with polynomials with type GenPolynomial&lt;C&gt;
+     *         coefficients.
+     */
+    public static <C extends RingElem<C>> List<GenPolynomial<GenPolynomial<C>>> fromIntegerCoefficients(
+                    GenPolynomialRing<GenPolynomial<C>> fac,
+                    List<GenPolynomial<GenPolynomial<BigInteger>>> L) {
+        List<GenPolynomial<GenPolynomial<C>>> K = null;
+        if (L == null) {
+            return K;
+        }
+        K = new ArrayList<GenPolynomial<GenPolynomial<C>>>(L.size());
+        if (L.size() == 0) {
+            return K;
+        }
+        for (GenPolynomial<GenPolynomial<BigInteger>> a : L) {
+            GenPolynomial<GenPolynomial<C>> b = fromIntegerCoefficients(fac, a);
+            K.add(b);
+        }
+        return K;
+    }
+
+
+    //------------------------------
+
+
+    /**
+     * BigInteger from BigRational coefficients. Represent as polynomial with
+     * type GenPolynomial&lt;BigInteger&gt; coefficients.
+     * @param fac result polynomial factory.
+     * @param A polynomial with GenPolynomial&lt;BigRational&gt; coefficients to
+     *            be converted.
+     * @return polynomial with type GenPolynomial&lt;BigInteger&gt;
+     *         coefficients.
+     */
+    public static GenPolynomial<GenPolynomial<BigInteger>> integerFromRationalCoefficients(
+                    GenPolynomialRing<GenPolynomial<BigInteger>> fac,
+                    GenPolynomial<GenPolynomial<BigRational>> A) {
+        GenPolynomial<GenPolynomial<BigInteger>> B = fac.getZERO().copy();
+        if (A == null || A.isZERO()) {
+            return B;
+        }
+        java.math.BigInteger gcd = null;
+        java.math.BigInteger lcm = null;
+        int sLCM = 0;
+        int sGCD = 0;
+        // lcm of all denominators
+        for (GenPolynomial<BigRational> av : A.getMap().values()) {
+            for (BigRational y : av.getMap().values()) {
+                java.math.BigInteger numerator = y.numerator();
+                java.math.BigInteger denominator = y.denominator();
+                // lcm = lcm(lcm,x)
+                if (lcm == null) {
+                    lcm = denominator;
+                    sLCM = denominator.signum();
+                } else {
+                    java.math.BigInteger d = lcm.gcd(denominator);
+                    lcm = lcm.multiply(denominator.divide(d));
+                }
+                // gcd = gcd(gcd,x)
+                if (gcd == null) {
+                    gcd = numerator;
+                    sGCD = numerator.signum();
+                } else {
+                    gcd = gcd.gcd(numerator);
+                }
+            }
+            //System.out.println("gcd = " + gcd + ", lcm = " + lcm);
+        }
+        if (sLCM < 0) {
+            lcm = lcm.negate();
+        }
+        if (sGCD < 0) {
+            gcd = gcd.negate();
+        }
+        //System.out.println("gcd** = " + gcd + ", lcm = " + lcm);
+        RingFactory<GenPolynomial<BigInteger>> cfac = fac.coFac;
+        GenPolynomialRing<BigInteger> rfac = (GenPolynomialRing<BigInteger>) cfac;
+        for (Map.Entry<ExpVector, GenPolynomial<BigRational>> y : A.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            GenPolynomial<BigRational> a = y.getValue();
+            // common denominator over all coefficients
+            GenPolynomial<BigInteger> p = PolyUtil.integerFromRationalCoefficients(rfac, gcd, lcm, a);
+            if (!p.isZERO()) {
+                //B = B.sum( p, e ); // inefficient
+                B.doPutToMap(e, p);
+            }
+        }
+        return B;
+    }
+
+
+    /**
+     * BigInteger from BigRational coefficients. Represent as polynomial with
+     * type GenPolynomial&lt;BigInteger&gt; coefficients.
+     * @param fac result polynomial factory.
+     * @param L polynomial list with GenPolynomial&lt;BigRational&gt;
+     *            coefficients to be converted.
+     * @return polynomial list with polynomials with type
+     *         GenPolynomial&lt;BigInteger&gt; coefficients.
+     */
+    public static List<GenPolynomial<GenPolynomial<BigInteger>>> integerFromRationalCoefficients(
+                    GenPolynomialRing<GenPolynomial<BigInteger>> fac,
+                    List<GenPolynomial<GenPolynomial<BigRational>>> L) {
+        List<GenPolynomial<GenPolynomial<BigInteger>>> K = null;
+        if (L == null) {
+            return K;
+        }
+        K = new ArrayList<GenPolynomial<GenPolynomial<BigInteger>>>(L.size());
+        if (L.isEmpty()) {
+            return K;
+        }
+        for (GenPolynomial<GenPolynomial<BigRational>> a : L) {
+            GenPolynomial<GenPolynomial<BigInteger>> b = integerFromRationalCoefficients(fac, a);
+            K.add(b);
+        }
+        return K;
+    }
+
+
+    /**
+     * Introduce lower variable. Represent as polynomial with type
+     * GenPolynomial&lt;C&gt; coefficients.
+     * @param rfac result polynomial factory.
+     * @param A polynomial to be extended.
+     * @return polynomial with type GenPolynomial&lt;C&gt; coefficients.
+     */
+    public static <C extends GcdRingElem<C>> GenPolynomial<GenPolynomial<C>> introduceLowerVariable(
+                    GenPolynomialRing<GenPolynomial<C>> rfac, GenPolynomial<C> A) {
+        if (A == null || rfac == null) {
+            return null;
+        }
+        GenPolynomial<GenPolynomial<C>> Pc = rfac.getONE().multiply(A);
+        if (Pc.isZERO()) {
+            return Pc;
+        }
+        Pc = PolyUtil.<C> switchVariables(Pc);
+        return Pc;
+    }
+
+
+    /**
+     * From AlgebraicNumber coefficients. Represent as polynomial with type
+     * GenPolynomial&lt;C&gt; coefficients, e.g. ModInteger or BigRational.
+     * @param rfac result polynomial factory.
+     * @param A polynomial with AlgebraicNumber coefficients to be converted.
+     * @param k for (y-k x) substitution.
+     * @return polynomial with type GenPolynomial&lt;C&gt; coefficients.
+     */
+    public static <C extends GcdRingElem<C>> GenPolynomial<GenPolynomial<C>> substituteFromAlgebraicCoefficients(
+                    GenPolynomialRing<GenPolynomial<C>> rfac, GenPolynomial<AlgebraicNumber<C>> A, long k) {
+        if (A == null || rfac == null) {
+            return null;
+        }
+        if (A.isZERO()) {
+            return rfac.getZERO();
+        }
+        // setup x - k alpha
+        GenPolynomialRing<AlgebraicNumber<C>> apfac = A.ring;
+        GenPolynomial<AlgebraicNumber<C>> x = apfac.univariate(0);
+        AlgebraicNumberRing<C> afac = (AlgebraicNumberRing<C>) A.ring.coFac;
+        AlgebraicNumber<C> alpha = afac.getGenerator();
+        AlgebraicNumber<C> ka = afac.fromInteger(k);
+        GenPolynomial<AlgebraicNumber<C>> s = x.subtract(ka.multiply(alpha)); // x - k alpha
+        //System.out.println("x - k alpha = " + s);
+        //System.out.println("s.ring = " + s.ring.toScript());
+        if (debug) {
+            logger.info("x - k alpha: " + s);
+        }
+        // substitute, convert and switch
+        //System.out.println("Asubs = " + A);
+        GenPolynomial<AlgebraicNumber<C>> B;
+        if (s.ring.nvar <= 1) {
+            B = PolyUtil.<AlgebraicNumber<C>> substituteMain(A, s);
+        } else {
+            B = PolyUtil.<AlgebraicNumber<C>> substituteUnivariateMult(A, s);
+        }
+        //System.out.println("Bsubs = " + B);
+        GenPolynomial<GenPolynomial<C>> Pc = PolyUtil.<C> fromAlgebraicCoefficients(rfac, B); // Q[alpha][x]
+        //System.out.println("Pc[a,x] = " + Pc);
+        Pc = PolyUtil.<C> switchVariables(Pc); // Q[x][alpha]
+        //System.out.println("Pc[x,a] = " + Pc);
+        return Pc;
+    }
+
+
+    /**
+     * Convert to AlgebraicNumber coefficients. Represent as polynomial with
+     * AlgebraicNumber<C> coefficients, C is e.g. ModInteger or BigRational.
+     * @param pfac result polynomial factory.
+     * @param A polynomial with GenPolynomial&lt;BigInteger&gt; coefficients to
+     *            be converted.
+     * @param k for (y-k x) substitution.
+     * @return polynomial with AlgebraicNumber&lt;C&gt; coefficients.
+     */
+    public static <C extends GcdRingElem<C>> GenPolynomial<AlgebraicNumber<C>> substituteConvertToAlgebraicCoefficients(
+                    GenPolynomialRing<AlgebraicNumber<C>> pfac, GenPolynomial<C> A, long k) {
+        if (A == null || pfac == null) {
+            return null;
+        }
+        if (A.isZERO()) {
+            return pfac.getZERO();
+        }
+        // convert to Q(alpha)[x]
+        GenPolynomial<AlgebraicNumber<C>> B = PolyUtil.<C> convertToAlgebraicCoefficients(pfac, A);
+        // setup x .+. k alpha for back substitution
+        GenPolynomial<AlgebraicNumber<C>> x = pfac.univariate(0);
+        AlgebraicNumberRing<C> afac = (AlgebraicNumberRing<C>) pfac.coFac;
+        AlgebraicNumber<C> alpha = afac.getGenerator();
+        AlgebraicNumber<C> ka = afac.fromInteger(k);
+        GenPolynomial<AlgebraicNumber<C>> s = x.sum(ka.multiply(alpha)); // x + k alpha
+        // substitute
+        //System.out.println("s.ring = " + s.ring.toScript());
+        GenPolynomial<AlgebraicNumber<C>> N;
+        if (s.ring.nvar <= 1) {
+            N = PolyUtil.<AlgebraicNumber<C>> substituteMain(B, s);
+        } else {
+            N = PolyUtil.<AlgebraicNumber<C>> substituteUnivariateMult(B, s);
+        }
+        return N;
+    }
+
+
+    /**
+     * Norm of a polynomial with AlgebraicNumber coefficients.
+     * @param A uni or multivariate polynomial from
+     *            GenPolynomial&lt;AlgebraicNumber&lt;C&gt;&gt;.
+     * @param k for (y - k x) substitution.
+     * @return norm(A) = res_x(A(x,y),m(x)) in GenPolynomialRing&lt;C&gt;.
+     */
+    public static <C extends GcdRingElem<C>> GenPolynomial<C> norm(GenPolynomial<AlgebraicNumber<C>> A,
+                    long k) {
+        if (A == null) {
+            return null;
+        }
+        GenPolynomialRing<AlgebraicNumber<C>> pfac = A.ring; // Q(alpha)[x]
+        //if (pfac.nvar > 1) {
+        //    throw new IllegalArgumentException("only for univariate polynomials");
+        //}
+        AlgebraicNumberRing<C> afac = (AlgebraicNumberRing<C>) pfac.coFac;
+        GenPolynomial<C> agen = afac.modul;
+        GenPolynomialRing<C> cfac = afac.ring;
+        if (A.isZERO()) {
+            return cfac.getZERO();
+        }
+        AlgebraicNumber<C> ldcf = A.leadingBaseCoefficient();
+        if (!ldcf.isONE()) {
+            A = A.monic();
+        }
+        GenPolynomialRing<GenPolynomial<C>> rfac = new GenPolynomialRing<GenPolynomial<C>>(cfac, pfac);
+        //System.out.println("rfac = " + rfac.toScript());
+
+        // transform minimal polynomial to bi-variate polynomial
+        GenPolynomial<GenPolynomial<C>> Ac = PolyUfdUtil.<C> introduceLowerVariable(rfac, agen);
+
+        // transform to bi-variate polynomial, 
+        // switching varaible sequence from Q[alpha][x] to Q[X][alpha]
+        GenPolynomial<GenPolynomial<C>> Pc = PolyUfdUtil.<C> substituteFromAlgebraicCoefficients(rfac, A, k);
+        Pc = PolyUtil.<C> monic(Pc);
+        //System.out.println("Pc = " + Pc.toScript() + " :: " + Pc.ring.toScript());
+
+        GreatestCommonDivisorSubres<C> engine = new GreatestCommonDivisorSubres<C>( /*cfac.coFac*/);
+        // = (GreatestCommonDivisorAbstract<C>)GCDFactory.<C>getImplementation( cfac.coFac );
+
+        GenPolynomial<GenPolynomial<C>> Rc = engine.recursiveUnivariateResultant(Pc, Ac);
+        //System.out.println("Rc = " + Rc.toScript());
+        GenPolynomial<C> res = Rc.leadingBaseCoefficient();
+        res = res.monic();
+        return res;
+    }
+
+
+    /**
+     * Norm of a polynomial with AlgebraicNumber coefficients.
+     * @param A polynomial from GenPolynomial&lt;AlgebraicNumber&lt;C&gt;&gt;.
+     * @return norm(A) = resultant_x( A(x,y), m(x) ) in K[y].
+     */
+    public static <C extends GcdRingElem<C>> GenPolynomial<C> norm(GenPolynomial<AlgebraicNumber<C>> A) {
+        return norm(A, 0L);
+    }
+
+
+    /**
+     * Ensure that the field property is determined. Checks if modul is
+     * irreducible and modifies the algebraic number ring.
+     * @param afac algebraic number ring.
+     */
+    public static <C extends GcdRingElem<C>> void ensureFieldProperty(AlgebraicNumberRing<C> afac) {
+        if (afac.getField() != -1) {
+            return;
+        }
+        if (!afac.ring.coFac.isField()) {
+            afac.setField(false);
+            return;
+        }
+        Factorization<C> mf = FactorFactory.<C> getImplementation(afac.ring);
+        if (mf.isIrreducible(afac.modul)) {
+            afac.setField(true);
+        } else {
+            afac.setField(false);
+        }
+    }
+
+
+    /**
+     * Construct a random irreducible univariate polynomial of degree d.
+     * @param cfac coefficient polynomial ring.
+     * @param degree of random polynomial.
+     * @return irreducible univariate polynomial.
+     */
+    public static <C extends GcdRingElem<C>> GenPolynomial<C> randomIrreduciblePolynomial(RingFactory<C> cfac,
+                    int degree) {
+        if (!cfac.isField()) {
+            throw new IllegalArgumentException("coefficient ring must be a field " + cfac);
+        }
+        GenPolynomialRing<C> ring = new GenPolynomialRing<C>(cfac, 1, TermOrderByName.INVLEX);
+        return randomIrreduciblePolynomial(ring, degree);
+    }
+
+
+    /**
+     * Construct a random irreducible univariate polynomial of degree d.
+     * @param ring coefficient ring.
+     * @param degree of random polynomial.
+     * @return irreducible univariate polynomial.
+     */
+    public static <C extends GcdRingElem<C>> GenPolynomial<C> randomIrreduciblePolynomial(
+                    GenPolynomialRing<C> ring, int degree) {
+        if (!ring.coFac.isField()) {
+            throw new IllegalArgumentException("coefficient ring must be a field " + ring.coFac);
+        }
+        Factorization<C> eng = FactorFactory.<C> getImplementation(ring);
+        GenPolynomial<C> mod = ring.getZERO();
+        int k = ring.coFac.characteristic().bitLength(); // log
+        if (k < 3) {
+            k = 7;
+        }
+        int l = degree / 2 + 2;
+        int d = degree + 1;
+        float q = 0.55f;
+        for (;;) {
+            mod = ring.random(k, l, d, q).monic();
+            if (mod.degree() != degree) {
+                mod = mod.sum(ring.univariate(0, degree));
+            }
+            if (mod.trailingBaseCoefficient().isZERO()) {
+                mod = mod.sum(ring.getONE());
+            }
+            //System.out.println("algebriacNumberField: mod = " + mod + ", k = " + k);
+            if (eng.isIrreducible(mod)) {
+                break;
+            }
+        }
+        return mod;
+    }
+
+
+    /**
+     * Construct an algebraic number field of degree d. Uses a random
+     * irreducible polynomial of degree d as modulus of the algebraic number
+     * ring.
+     * @param cfac coefficient ring.
+     * @param degree of random polynomial.
+     * @return algebraic number field.
+     */
+    public static <C extends GcdRingElem<C>> AlgebraicNumberRing<C> algebraicNumberField(RingFactory<C> cfac,
+                    int degree) {
+        GenPolynomial<C> mod = randomIrreduciblePolynomial(cfac, degree);
+        AlgebraicNumberRing<C> afac = new AlgebraicNumberRing<C>(mod, true);
+        return afac;
+    }
+
+
+    /**
+     * Construct an algebraic number field of degree d. Uses a random
+     * irreducible polynomial of degree d as modulus of the algebraic number
+     * ring.
+     * @param ring coefficient polynomial ring.
+     * @param degree of random polynomial.
+     * @return algebraic number field.
+     */
+    public static <C extends GcdRingElem<C>> AlgebraicNumberRing<C> algebraicNumberField(
+                    GenPolynomialRing<C> ring, int degree) {
+        GenPolynomial<C> mod = randomIrreduciblePolynomial(ring, degree);
+        AlgebraicNumberRing<C> afac = new AlgebraicNumberRing<C>(mod, true);
+        return afac;
+    }
+
+
+    /**
+     * Construct Berlekamp Q matrix.
+     * @param A univariate modular polynomial.
+     * @return Q matrix.
+     */
+    public static <C extends GcdRingElem<C>> ArrayList<ArrayList<C>> constructQmatrix(GenPolynomial<C> A) {
+        ArrayList<ArrayList<C>> Q = new ArrayList<ArrayList<C>>();
+        if (A == null || A.isZERO()) {
+            return Q;
+        }
+        GenPolynomialRing<C> pfac = A.ring;
+        //System.out.println("pfac = " + pfac.toScript());
+        java.math.BigInteger q = pfac.coFac.characteristic(); //.longValueExact();
+        int lq = q.bitLength(); //Power.logarithm(2, q);
+        if (pfac.coFac instanceof AlgebraicNumberRing) {
+            lq = (int) ((AlgebraicNumberRing) pfac.coFac).extensionDegree();
+            q = q.pow(lq); //Power.power(q, lq);
+        }
+        logger.info("Q matrix for cfac = " + q);
+        long d = A.degree(0);
+        GenPolynomial<C> x = pfac.univariate(0);
+        //System.out.println("x = " + x.toScript());
+        GenPolynomial<C> r = pfac.getONE();
+        //System.out.println("r = " + r.toScript());
+        List<GenPolynomial<C>> Qp = new ArrayList<GenPolynomial<C>>();
+        Qp.add(r);
+        GenPolynomial<C> pow = Power.<GenPolynomial<C>> modPositivePower(x, q, A);
+        //System.out.println("pow = " + pow.toScript());
+        Qp.add(pow);
+        r = pow;
+        for (int i = 2; i < d; i++) {
+            r = r.multiply(pow).remainder(A);
+            Qp.add(r);
+        }
+        //System.out.println("Qp = " + Qp);
+        UnivPowerSeriesRing<C> psfac = new UnivPowerSeriesRing<C>(pfac);
+        //System.out.println("psfac = " + psfac.toScript());
+        for (GenPolynomial<C> p : Qp) {
+            UnivPowerSeries<C> ps = psfac.fromPolynomial(p);
+            //System.out.println("ps = " + ps.toScript());
+            ArrayList<C> pr = new ArrayList<C>();
+            for (int i = 0; i < d; i++) {
+                C c = ps.coefficient(i);
+                pr.add(c);
+            }
+            Q.add(pr);
+        }
+        //System.out.println("Q = " + Q);
+        return Q;
+    }
+
+
+    /**
+     * Kronecker substitution. Substitute x_i by x**d**(i-1) to construct a
+     * univariate polynomial.
+     * @param A polynomial to be converted.
+     * @return a univariate polynomial.
+     */
+    public static <C extends GcdRingElem<C>> GenPolynomial<C> substituteKronecker(GenPolynomial<C> A) {
+        if (A == null) {
+            return A;
+        }
+        long d = A.degree() + 1L;
+        return substituteKronecker(A, d);
+    }
+
+
+    /**
+     * Kronecker substitution. Substitute x_i by x**d**(i-1) to construct a
+     * univariate polynomial.
+     * @param A polynomial to be converted.
+     * @return a univariate polynomial.
+     */
+    public static <C extends GcdRingElem<C>> GenPolynomial<C> substituteKronecker(GenPolynomial<C> A,
+                    long d) {
+        if (A == null) {
+            return A;
+        }
+        RingFactory<C> cfac = A.ring.coFac;
+        GenPolynomialRing<C> ufac = new GenPolynomialRing<C>(cfac, 1);
+        GenPolynomial<C> B = ufac.getZERO().copy();
+        if (A.isZERO()) {
+            return B;
+        }
+        for (Map.Entry<ExpVector, C> y : A.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            C a = y.getValue();
+            long f = 0L;
+            long h = 1L;
+            for (int i = 0; i < e.length(); i++) {
+                long j = e.getVal(i) * h;
+                f += j;
+                h *= d;
+            }
+            ExpVector g = ExpVector.create(1, 0, f);
+            B.doPutToMap(g, a);
+        }
+        return B;
+    }
+
+
+    /**
+     * Kronecker substitution. Substitute x_i by x**d**(i-1) to construct
+     * univariate polynomials.
+     * @param A list of polynomials to be converted.
+     * @return a list of univariate polynomials.
+     */
+    public static <C extends GcdRingElem<C>> List<GenPolynomial<C>> substituteKronecker(
+                    List<GenPolynomial<C>> A, int d) {
+        if (A == null || A.get(0) == null) {
+            return null;
+        }
+        return ListUtil.<GenPolynomial<C>, GenPolynomial<C>> map(A, new SubstKronecker<C>(d));
+    }
+
+
+    /**
+     * Kronecker back substitution. Substitute x**d**(i-1) to x_i to construct a
+     * multivariate polynomial.
+     * @param A polynomial to be converted.
+     * @param fac result polynomial factory.
+     * @return a multivariate polynomial.
+     */
+    public static <C extends GcdRingElem<C>> GenPolynomial<C> backSubstituteKronecker(
+                    GenPolynomialRing<C> fac, GenPolynomial<C> A, long d) {
+        if (A == null) {
+            return A;
+        }
+        if (fac == null) {
+            throw new IllegalArgumentException("null factory not allowed ");
+        }
+        int n = fac.nvar;
+        GenPolynomial<C> B = fac.getZERO().copy();
+        if (A.isZERO()) {
+            return B;
+        }
+        for (Map.Entry<ExpVector, C> y : A.getMap().entrySet()) {
+            ExpVector e = y.getKey();
+            C a = y.getValue();
+            long f = e.getVal(0);
+            ExpVector g = ExpVector.create(n);
+            for (int i = 0; i < n; i++) {
+                long j = f % d;
+                f /= d;
+                g = g.subst(i, j);
+            }
+            B.doPutToMap(g, a);
+        }
+        return B;
+    }
+
+
+    /**
+     * Kronecker back substitution. Substitute x**d**(i-1) to x_i to construct
+     * multivariate polynomials.
+     * @param A list of polynomials to be converted.
+     * @param fac result polynomial factory.
+     * @return a list of multivariate polynomials.
+     */
+    public static <C extends GcdRingElem<C>> List<GenPolynomial<C>> backSubstituteKronecker(
+                    GenPolynomialRing<C> fac, List<GenPolynomial<C>> A, long d) {
+        return ListUtil.<GenPolynomial<C>, GenPolynomial<C>> map(A, new BackSubstKronecker<C>(fac, d));
+    }
+
+}
+
+
+/**
+ * Kronecker substitutuion functor.
+ */
+class SubstKronecker<C extends GcdRingElem<C>> implements UnaryFunctor<GenPolynomial<C>, GenPolynomial<C>> {
+
+
+    final long d;
+
+
+    public SubstKronecker(long d) {
+        this.d = d;
+    }
+
+
+    public GenPolynomial<C> eval(GenPolynomial<C> c) {
+        if (c == null) {
+            return null;
+        }
+        return PolyUfdUtil.<C> substituteKronecker(c, d);
+    }
+}
+
+
+/**
+ * Kronecker back substitutuion functor.
+ */
+class BackSubstKronecker<C extends GcdRingElem<C>>
+                implements UnaryFunctor<GenPolynomial<C>, GenPolynomial<C>> {
+
+
+    final long d;
+
+
+    final GenPolynomialRing<C> fac;
+
+
+    public BackSubstKronecker(GenPolynomialRing<C> fac, long d) {
+        this.d = d;
+        this.fac = fac;
+    }
+
+
+    public GenPolynomial<C> eval(GenPolynomial<C> c) {
+        if (c == null) {
+            return null;
+        }
+        return PolyUfdUtil.<C> backSubstituteKronecker(fac, c, d);
+    }
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/Quotient.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/Quotient.java
@@ -1,0 +1,634 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.kern.PrettyPrint;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.QuotPair;
+
+
+/**
+ * Quotient, that is a rational function, based on GenPolynomial with RingElem
+ * interface. Objects of this class are immutable.
+ * @author Heinz Kredel
+ */
+public class Quotient<C extends GcdRingElem<C>>
+                implements GcdRingElem<Quotient<C>>, QuotPair<GenPolynomial<C>> {
+
+
+    private static final Logger logger = LogManager.getLogger(Quotient.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Quotient class factory data structure.
+     */
+    public final QuotientRing<C> ring;
+
+
+    /**
+     * Numerator part of the element data structure.
+     */
+    public final GenPolynomial<C> num;
+
+
+    /**
+     * Denominator part of the element data structure.
+     */
+    public final GenPolynomial<C> den;
+
+
+    /**
+     * The constructor creates a Quotient object from a ring factory.
+     * @param r ring factory.
+     */
+    public Quotient(QuotientRing<C> r) {
+        this(r, r.ring.getZERO());
+    }
+
+
+    /**
+     * The constructor creates a Quotient object from a ring factory and a
+     * numerator polynomial. The denominator is assumed to be 1.
+     * @param r ring factory.
+     * @param n numerator polynomial.
+     */
+    public Quotient(QuotientRing<C> r, GenPolynomial<C> n) {
+        this(r, n, r.ring.getONE(), true);
+    }
+
+
+    /**
+     * The constructor creates a Quotient object from a ring factory and a
+     * numerator and denominator polynomial.
+     * @param r ring factory.
+     * @param n numerator polynomial.
+     * @param d denominator polynomial.
+     */
+    public Quotient(QuotientRing<C> r, GenPolynomial<C> n, GenPolynomial<C> d) {
+        this(r, n, d, false);
+    }
+
+
+    /**
+     * The constructor creates a Quotient object from a ring factory and a
+     * numerator and denominator polynomial.
+     * @param r ring factory.
+     * @param n numerator polynomial.
+     * @param d denominator polynomial.
+     * @param isred true if gcd(n,d) == 1, else false.
+     */
+    protected Quotient(QuotientRing<C> r, GenPolynomial<C> n, GenPolynomial<C> d, boolean isred) {
+        if (d == null || d.isZERO()) {
+            throw new IllegalArgumentException("denominator may not be zero");
+        }
+        ring = r;
+        if (d.signum() < 0) {
+            n = n.negate();
+            d = d.negate();
+        }
+        if (!isred) {
+            // must reduce to lowest terms
+            GenPolynomial<C> gcd = ring.gcd(n, d);
+            if (false || debug) {
+                logger.info("gcd = " + gcd);
+            }
+            //GenPolynomial<C> gcd = ring.ring.getONE();
+            if (!gcd.isONE()) {
+                //logger.info("gcd = " + gcd);
+                n = ring.divide(n, gcd);
+                d = ring.divide(d, gcd);
+            }
+        }
+        C lc = d.leadingBaseCoefficient();
+        if (!lc.isONE() && lc.isUnit()) {
+            lc = lc.inverse();
+            n = n.multiply(lc);
+            d = d.multiply(lc);
+        }
+        num = n;
+        den = d;
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public QuotientRing<C> factory() {
+        return ring;
+    }
+
+
+    /**
+     * Numerator.
+     * @see edu.jas.structure.QuotPair#numerator()
+     */
+    public GenPolynomial<C> numerator() {
+        return num;
+    }
+
+
+    /**
+     * Denominator.
+     * @see edu.jas.structure.QuotPair#denominator()
+     */
+    public GenPolynomial<C> denominator() {
+        return den;
+    }
+
+
+    /**
+     * Clone this.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    public Quotient<C> copy() {
+        return new Quotient<C>(ring, num, den, true);
+    }
+
+
+    /**
+     * Is Quotient zero.
+     * @return If this is 0 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isZERO()
+     */
+    public boolean isZERO() {
+        return num.isZERO();
+    }
+
+
+    /**
+     * Is Quotient one.
+     * @return If this is 1 then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isONE()
+     */
+    public boolean isONE() {
+        return num.equals(den);
+    }
+
+
+    /**
+     * Is Quotient a unit.
+     * @return If this is a unit then true is returned, else false.
+     * @see edu.jas.structure.RingElem#isUnit()
+     */
+    public boolean isUnit() {
+        if (num.isZERO()) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Is Qoutient a constant.
+     * @return true, if this has constant numerator and denominator, else false.
+     */
+    public boolean isConstant() {
+        return num.isConstant() && den.isConstant();
+    }
+
+
+    /**
+     * Get the String representation as RingElem.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        if (PrettyPrint.isTrue()) {
+            String s = "{ " + num.toString(ring.ring.getVars());
+            if (!den.isONE()) {
+                s += " | " + den.toString(ring.ring.getVars());
+            }
+            return s + " }";
+        }
+        return "Quotient[ " + num.toString() + " | " + den.toString() + " ]";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        if (den.isONE()) {
+            return num.toScript();
+        }
+        if (den.length() == 1 && den.totalDegree() > 1) {
+            return num.toScript() + " / (" + den.toScript() + " )";
+        }
+        return num.toScript() + " / " + den.toScript();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python case
+        return factory().toScript();
+    }
+
+
+    /**
+     * Quotient comparison.
+     * @param b Quotient.
+     * @return sign(this-b).
+     */
+    @Override
+    public int compareTo(Quotient<C> b) {
+        if (b == null || b.isZERO()) {
+            return this.signum();
+        }
+        if (this.isZERO()) {
+            return -b.signum();
+        }
+        // assume sign(den,b.den) > 0
+        int s1 = num.signum();
+        int s2 = b.num.signum();
+        int t = (s1 - s2) / 2;
+        if (t != 0) {
+            return t;
+        }
+        if (den.compareTo(b.den) == 0) {
+            return num.compareTo(b.num);
+        }
+        GenPolynomial<C> r = num.multiply(b.den);
+        GenPolynomial<C> s = den.multiply(b.num);
+        return r.compareTo(s);
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean equals(Object b) {
+        if (b == null) {
+            return false;
+        }
+        if (!(b instanceof Quotient)) {
+            return false;
+        }
+        Quotient<C> a = (Quotient<C>) b;
+        return compareTo(a) == 0;
+        //return num.equals(a.num) && den.equals(a.den);
+    }
+
+
+    /**
+     * Hash code for this quotient.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = ring.hashCode();
+        h = 37 * h + num.hashCode();
+        h = 37 * h + den.hashCode();
+        return h;
+    }
+
+
+    /**
+     * Quotient absolute value.
+     * @return the absolute value of this.
+     * @see edu.jas.structure.RingElem#abs()
+     */
+    public Quotient<C> abs() {
+        return new Quotient<C>(ring, num.abs(), den, true);
+    }
+
+
+    /**
+     * Quotient summation.
+     * @param S Quotient.
+     * @return this+S.
+     */
+    public Quotient<C> sum(Quotient<C> S) {
+        if (S == null || S.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return S;
+        }
+        GenPolynomial<C> n;
+        if (den.isONE() && S.den.isONE()) {
+            n = num.sum(S.num);
+            return new Quotient<C>(ring, n);
+        }
+        if (den.isONE()) {
+            n = num.multiply(S.den);
+            n = n.sum(S.num);
+            return new Quotient<C>(ring, n, S.den, false);
+        }
+        if (S.den.isONE()) {
+            n = S.num.multiply(den);
+            n = n.sum(num);
+            return new Quotient<C>(ring, n, den, false);
+        }
+        if (den.compareTo(S.den) == 0) {
+            n = num.sum(S.num);
+            return new Quotient<C>(ring, n, den, false);
+        }
+        GenPolynomial<C> d;
+        GenPolynomial<C> sd;
+        GenPolynomial<C> g;
+        g = ring.gcd(den, S.den);
+        if (g.isONE()) {
+            d = den;
+            sd = S.den;
+        } else {
+            d = ring.divide(den, g);
+            sd = ring.divide(S.den, g);
+        }
+        n = num.multiply(sd);
+        n = n.sum(d.multiply(S.num));
+        if (n.isZERO()) {
+            return ring.getZERO();
+        }
+        GenPolynomial<C> f;
+        GenPolynomial<C> dd;
+        dd = den;
+        if (!g.isONE()) {
+            f = ring.gcd(n, g);
+            if (!f.isONE()) {
+                n = ring.divide(n, f);
+                dd = ring.divide(den, f);
+            }
+        }
+        d = dd.multiply(sd);
+        return new Quotient<C>(ring, n, d, true);
+    }
+
+
+    /**
+     * Quotient negate.
+     * @return -this.
+     * @see edu.jas.structure.RingElem#negate()
+     */
+    public Quotient<C> negate() {
+        return new Quotient<C>(ring, num.negate(), den, true);
+    }
+
+
+    /**
+     * Quotient signum.
+     * @see edu.jas.structure.RingElem#signum()
+     * @return signum(this).
+     */
+    public int signum() {
+        // assume sign(den) > 0
+        return num.signum();
+    }
+
+
+    /**
+     * Quotient subtraction.
+     * @param S Quotient.
+     * @return this-S.
+     */
+    public Quotient<C> subtract(Quotient<C> S) {
+        return sum(S.negate());
+    }
+
+
+    /**
+     * Quotient division.
+     * @param S Quotient.
+     * @return this/S.
+     */
+    public Quotient<C> divide(Quotient<C> S) {
+        return multiply(S.inverse());
+    }
+
+
+    /**
+     * Quotient inverse.
+     * @see edu.jas.structure.RingElem#inverse()
+     * @return S with S = 1/this.
+     */
+    public Quotient<C> inverse() {
+        if (num.isZERO()) {
+            throw new ArithmeticException("element not invertible " + this);
+        }
+        return new Quotient<C>(ring, den, num, true);
+    }
+
+
+    /**
+     * Quotient remainder.
+     * @param S Quotient.
+     * @return this - (this/S)*S.
+     */
+    public Quotient<C> remainder(Quotient<C> S) {
+        if (S.isZERO()) {
+            throw new ArithmeticException("element not invertible " + S);
+        }
+        return ring.getZERO();
+    }
+
+
+    /**
+     * Quotient and remainder by division of this by S.
+     * @param S a Quotient
+     * @return [this/S, this - (this/S)*S].
+     */
+    @SuppressWarnings("unchecked")
+    public Quotient<C>[] quotientRemainder(Quotient<C> S) {
+        return new Quotient[] { divide(S), remainder(S) };
+    }
+
+
+    /**
+     * Quotient multiplication.
+     * @param S Quotient.
+     * @return this*S.
+     */
+    public Quotient<C> multiply(Quotient<C> S) {
+        if (S == null || S.isZERO()) {
+            return S;
+        }
+        if (num.isZERO()) {
+            return this;
+        }
+        if (S.isONE()) {
+            return this;
+        }
+        if (this.isONE()) {
+            return S;
+        }
+        GenPolynomial<C> n;
+        if (den.isONE() && S.den.isONE()) {
+            n = num.multiply(S.num);
+            return new Quotient<C>(ring, n, den, true);
+        }
+        GenPolynomial<C> g;
+        GenPolynomial<C> d;
+        if (den.isONE()) {
+            g = ring.gcd(num, S.den);
+            n = ring.divide(num, g);
+            d = ring.divide(S.den, g);
+            n = n.multiply(S.num);
+            return new Quotient<C>(ring, n, d, true);
+        }
+        if (S.den.isONE()) {
+            g = ring.gcd(S.num, den);
+            n = ring.divide(S.num, g);
+            d = ring.divide(den, g);
+            n = n.multiply(num);
+            return new Quotient<C>(ring, n, d, true);
+        }
+        if (den.compareTo(S.den) == 0) { // correct ?
+            d = den.multiply(den);
+            n = num.multiply(S.num);
+            return new Quotient<C>(ring, n, d, true);
+        }
+        GenPolynomial<C> f;
+        GenPolynomial<C> sd;
+        GenPolynomial<C> sn;
+        g = ring.gcd(num, S.den);
+        n = ring.divide(num, g);
+        sd = ring.divide(S.den, g);
+        f = ring.gcd(den, S.num);
+        d = ring.divide(den, f);
+        sn = ring.divide(S.num, f);
+        n = n.multiply(sn);
+        d = d.multiply(sd);
+        return new Quotient<C>(ring, n, d, true);
+    }
+
+
+    /**
+     * Quotient multiplication by GenPolynomial.
+     * @param b GenPolynomial<C>.
+     * @return this*b.
+     */
+    public Quotient<C> multiply(GenPolynomial<C> b) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        if (num.isZERO()) {
+            return this;
+        }
+        if (b.isONE()) {
+            return this;
+        }
+        GenPolynomial<C> gcd = ring.gcd(b, den);
+        GenPolynomial<C> d = den;
+        if (!gcd.isONE()) {
+            b = ring.divide(b, gcd);
+            d = ring.divide(d, gcd);
+        }
+        if (this.isONE()) {
+            return new Quotient<C>(ring, b, d, true);
+        }
+        GenPolynomial<C> n = num.multiply(b);
+        return new Quotient<C>(ring, n, d, true);
+    }
+
+
+    /**
+     * Quotient multiplication by coefficient.
+     * @param b coefficient.
+     * @return this*b.
+     */
+    public Quotient<C> multiply(C b) {
+        if (b == null || b.isZERO()) {
+            return ring.getZERO();
+        }
+        if (num.isZERO()) {
+            return this;
+        }
+        if (b.isONE()) {
+            return this;
+        }
+        GenPolynomial<C> n = num.multiply(b);
+        return new Quotient<C>(ring, n, den, true);
+    }
+
+
+    /**
+     * Quotient monic.
+     * @return this with monic value part.
+     */
+    public Quotient<C> monic() {
+        if (num.isZERO()) {
+            return this;
+        }
+        C lbc = num.leadingBaseCoefficient();
+        if (!lbc.isUnit()) {
+            return this;
+        }
+        lbc = lbc.inverse();
+        //lbc = lbc.abs();
+        GenPolynomial<C> n = num.multiply(lbc);
+        //GenPolynomial<C> d = den.multiply(lbc);
+        return new Quotient<C>(ring, n, den, true);
+    }
+
+
+    /**
+     * Greatest common divisor.
+     * @param b other element.
+     * @return gcd(this,b).
+     */
+    public Quotient<C> gcd(Quotient<C> b) {
+        if (b == null || b.isZERO()) {
+            return this;
+        }
+        if (this.isZERO()) {
+            return b;
+        }
+        if (this.equals(b)) {
+            return this;
+        }
+        return ring.getONE();
+    }
+
+
+    /**
+     * Extended greatest common divisor.
+     * @param b other element.
+     * @return [ gcd(this,b), c1, c2 ] with c1*this + c2*b = gcd(this,b).
+     */
+    @SuppressWarnings("unchecked")
+    public Quotient<C>[] egcd(Quotient<C> b) {
+        Quotient<C>[] ret = (Quotient<C>[]) new Quotient[3];
+        ret[0] = null;
+        ret[1] = null;
+        ret[2] = null;
+        if (b == null || b.isZERO()) {
+            ret[0] = this;
+            return ret;
+        }
+        if (this.isZERO()) {
+            ret[0] = b;
+            return ret;
+        }
+        GenPolynomial<C> two = ring.ring.fromInteger(2);
+        ret[0] = ring.getONE();
+        ret[1] = (this.multiply(two)).inverse();
+        ret[2] = (b.multiply(two)).inverse();
+        return ret;
+    }
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/QuotientRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/QuotientRing.java
@@ -1,0 +1,403 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.kern.StringUtil;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+// import edu.jas.gbufd.PolyGBUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.QuotPairFactory;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Quotient ring factory based on GenPolynomial with RingElem interface. Objects
+ * of this class are immutable.
+ * @author Heinz Kredel
+ */
+public class QuotientRing<C extends GcdRingElem<C>> implements RingFactory<Quotient<C>>,
+                QuotPairFactory<GenPolynomial<C>, Quotient<C>> {
+
+
+    private static final Logger logger = LogManager.getLogger(QuotientRing.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Polynomial ring of the factory.
+     */
+    public final GenPolynomialRing<C> ring;
+
+
+    /**
+     * GCD engine of the factory.
+     */
+    public final GreatestCommonDivisor<C> engine;
+
+
+    /**
+     * Use GCD of package edu.jas.ufd.
+     */
+    public final boolean ufdGCD;
+
+
+    /**
+     * The constructor creates a QuotientRing object from a GenPolynomialRing.
+     * @param r polynomial ring.
+     */
+    public QuotientRing(GenPolynomialRing<C> r) {
+        this(r, true);
+    }
+
+
+    /**
+     * The constructor creates a QuotientRing object from a GenPolynomialRing.
+     * @param r polynomial ring.
+     * @param ufdGCD flag, if syzygy or gcd based algorithm used for engine.
+     */
+    public QuotientRing(GenPolynomialRing<C> r, boolean ufdGCD) {
+        ring = r;
+        this.ufdGCD = ufdGCD;
+        //         if (!ufdGCD) {
+        //             engine = null;
+        //             return;
+        //         }
+        engine = GCDFactory.<C> getProxy(ring.coFac);
+        logger.debug("quotient ring constructed");
+    }
+
+
+    /**
+     * Factory for base elements.
+     */
+    public GenPolynomialRing<C> pairFactory() {
+        return ring;
+    }
+
+
+    /**
+     * Create from numerator.
+     */
+    public Quotient<C> create(GenPolynomial<C> n) {
+        return new Quotient<C>(this, n);
+    }
+
+
+    /**
+     * Create from numerator, denominator pair.
+     */
+    public Quotient<C> create(GenPolynomial<C> n, GenPolynomial<C> d) {
+        return new Quotient<C>(this, n, d);
+    }
+
+
+    /**
+     * Divide.
+     * @param n first polynomial.
+     * @param d second polynomial.
+     * @return divide(n,d)
+     */
+    protected GenPolynomial<C> divide(GenPolynomial<C> n, GenPolynomial<C> d) {
+        return PolyUtil.<C> basePseudoDivide(n, d);
+    }
+
+
+    /**
+     * Greatest common divisor.
+     * @param n first polynomial.
+     * @param d second polynomial.
+     * @return gcd(n,d)
+     */
+    protected GenPolynomial<C> gcd(GenPolynomial<C> n, GenPolynomial<C> d) {
+        if (ufdGCD) {
+            return engine.gcd(n, d);
+        }
+        return engine.gcd(n, d);
+        //return PolyGBUtil.<C> syzGcd(ring, n, d);
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite()
+     */
+    public boolean isFinite() {
+        return false;
+    }
+
+
+    /**
+     * Copy Quotient element c.
+     * @param c
+     * @return a copy of c.
+     */
+    public Quotient<C> copy(Quotient<C> c) {
+        return new Quotient<C>(c.ring, c.num, c.den, true);
+    }
+
+
+    /**
+     * Get the zero element.
+     * @return 0 as Quotient.
+     */
+    public Quotient<C> getZERO() {
+        return new Quotient<C>(this, ring.getZERO());
+    }
+
+
+    /**
+     * Get the one element.
+     * @return 1 as Quotient.
+     */
+    public Quotient<C> getONE() {
+        return new Quotient<C>(this, ring.getONE());
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     * @see edu.jas.structure.ElemFactory#generators()
+     */
+    public List<Quotient<C>> generators() {
+        List<GenPolynomial<C>> pgens = ring.generators();
+        List<Quotient<C>> gens = new ArrayList<Quotient<C>>(pgens.size());
+        for (GenPolynomial<C> p : pgens) {
+            Quotient<C> q = new Quotient<C>(this, p);
+            gens.add(q);
+        }
+        return gens;
+    }
+
+
+    /**
+     * Query if this ring is commutative.
+     * @return true if this ring is commutative, else false.
+     */
+    public boolean isCommutative() {
+        return ring.isCommutative();
+    }
+
+
+    /**
+     * Query if this ring is associative.
+     * @return true if this ring is associative, else false.
+     */
+    public boolean isAssociative() {
+        return ring.isAssociative();
+    }
+
+
+    /**
+     * Query if this ring is a field.
+     * @return true.
+     */
+    public boolean isField() {
+        return true;
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic() {
+        return ring.characteristic();
+    }
+
+
+    /**
+     * Get a Quotient element from a BigInteger value.
+     * @param a BigInteger.
+     * @return a Quotient.
+     */
+    public Quotient<C> fromInteger(java.math.BigInteger a) {
+        return new Quotient<C>(this, ring.fromInteger(a));
+    }
+
+
+    /**
+     * Get a Quotient element from a long value.
+     * @param a long.
+     * @return a Quotient.
+     */
+    public Quotient<C> fromInteger(long a) {
+        return new Quotient<C>(this, ring.fromInteger(a));
+    }
+
+
+    /**
+     * Get the String representation as RingFactory.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        String s = null;
+        if (ring.coFac.characteristic().signum() == 0) {
+            s = "RatFunc";
+        } else {
+            s = "ModFunc";
+        }
+        return s + "( " + ring.toString() + " )";
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.ElemFactory#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        return "RF(" + ring.toScript() + ")";
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (b == null) {
+            return false;
+        }
+        if (!(b instanceof QuotientRing)) {
+            return false;
+        }
+        QuotientRing<C> a = (QuotientRing<C>) b;
+        return ring.equals(a.ring);
+    }
+
+
+    /**
+     * Hash code for this quotient ring.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = ring.hashCode();
+        return h;
+    }
+
+
+    /**
+     * Quotient random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @return a random residue element.
+     */
+    public Quotient<C> random(int n) {
+        GenPolynomial<C> r = ring.random(n).monic();
+        GenPolynomial<C> s = ring.random(n).monic();
+        while (s.isZERO()) {
+            s = ring.random(n).monic();
+        }
+        return new Quotient<C>(this, r, s, false);
+    }
+
+
+    /**
+     * Generate a random quotient polynomial.
+     * @param k bitsize of random coefficients.
+     * @param l number of terms.
+     * @param d maximal degree in each variable.
+     * @param q density of nozero exponents.
+     * @return a random quotient polynomial.
+     */
+    public Quotient<C> random(int k, int l, int d, float q) {
+        GenPolynomial<C> r = ring.random(k, l, d, q).monic();
+        GenPolynomial<C> s = ring.random(k, l, d, q).monic();
+        while (s.isZERO()) {
+            s = ring.random(k, l, d, q).monic();
+        }
+        return new Quotient<C>(this, r, s, false);
+    }
+
+
+    /**
+     * Quotient random.
+     * @param n such that 0 &le; v &le; (2<sup>n</sup>-1).
+     * @param rnd is a source for random bits.
+     * @return a random quotient element.
+     */
+    public Quotient<C> random(int n, Random rnd) {
+        GenPolynomial<C> r = ring.random(n, rnd).monic();
+        GenPolynomial<C> s = ring.random(n, rnd).monic();
+        while (s.isZERO()) {
+            s = ring.random(n, rnd).monic();
+        }
+        return new Quotient<C>(this, r, s, false);
+    }
+
+
+    /**
+     * Parse Quotient from String. Syntax: "{ polynomial | polynomial }" or
+     * "{ polynomial }" or " polynomial | polynomial " or " polynomial "
+     * @param s String.
+     * @return Quotient from s.
+     */
+    public Quotient<C> parse(String s) {
+        int i = s.indexOf("{");
+        if (i >= 0) {
+            s = s.substring(i + 1);
+        }
+        i = s.lastIndexOf("}");
+        if (i >= 0) {
+            s = s.substring(0, i);
+        }
+        i = s.indexOf("|");
+        if (i < 0) {
+            GenPolynomial<C> n = ring.parse(s);
+            return new Quotient<C>(this, n);
+        }
+        String s1 = s.substring(0, i);
+        String s2 = s.substring(i + 1);
+        GenPolynomial<C> n = ring.parse(s1);
+        GenPolynomial<C> d = ring.parse(s2);
+        return new Quotient<C>(this, n, d);
+    }
+
+
+    /**
+     * Parse Quotient from Reader.
+     * @param r Reader.
+     * @return next Quotient from r.
+     */
+    public Quotient<C> parse(Reader r) {
+        String s = StringUtil.nextPairedString(r, '{', '}');
+        return parse(s);
+    }
+
+
+    /**
+     * Degree of extension field.
+     * @return degree of this extension field, -1 for transcendental extension.
+     */
+    public long extensionDegree() {
+        long degree = -1L;
+        if (ring.nvar <= 0) {
+            degree = 0L;
+        }
+        return degree;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/Squarefree.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/Squarefree.java
@@ -1,0 +1,132 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.SortedMap;
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.structure.GcdRingElem;
+
+
+/**
+ * Squarefree decomposition interface.
+ * <p>
+ * <b>Usage:</b> To create objects that implement the <code>Squarefree</code>
+ * interface use the <code>SquarefreeFactory</code>. It will select an
+ * appropriate implementation based on the types of polynomial coefficients C.
+ * To obtain an implementation use <code>getImplementation()</code>, it returns
+ * an object of a class which extends the <code>SquarefreeAbstract</code> class
+ * which implements the <code>Squarefree</code> interface.
+ * <p>
+ * 
+ * <pre>
+ * Squarefree&lt;CT&gt; engine;
+ * engine = SquarefreeFactory.&lt;CT&gt; getImplementation(cofac);
+ * c = engine.squarefreeFactors(a);
+ * </pre>
+ * 
+ * <p>
+ * For example, if the coefficient type is BigInteger, the usage looks like
+ * 
+ * <p>
+ * 
+ * <pre>
+ * BigInteger cofac = new BigInteger();
+ * Squarefree&lt;BigInteger&gt; engine;
+ * engine = SquarefreeFactory.getImplementation(cofac);
+ * Sm = engine.sqaurefreeFactors(poly);
+ * </pre>
+ * 
+ * @author Heinz Kredel
+ * @see edu.jas.ufd.SquarefreeFactory#getImplementation
+ */
+
+public interface Squarefree<C extends GcdRingElem<C>> extends Serializable {
+
+
+    /**
+     * GenPolynomial greatest squarefree divisor.
+     * @param P GenPolynomial.
+     * @return squarefree(pp(P)).
+     */
+    public GenPolynomial<C> squarefreePart(GenPolynomial<C> P);
+
+
+    /**
+     * GenPolynomial test if is squarefree.
+     * @param P GenPolynomial.
+     * @return true if P is squarefree, else false.
+     */
+    public boolean isSquarefree(GenPolynomial<C> P);
+
+
+    /**
+     * GenPolynomial list test if squarefree.
+     * @param L list of GenPolynomial.
+     * @return true if each P in L is squarefree, else false.
+     */
+    public boolean isSquarefree(List<GenPolynomial<C>> L);
+
+
+    /**
+     * GenPolynomial squarefree factorization.
+     * @param P GenPolynomial.
+     * @return [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with P = prod_{i=1,...,k}
+     *         p_i^{e_i} and p_i squarefree.
+     */
+    public SortedMap<GenPolynomial<C>, Long> squarefreeFactors(GenPolynomial<C> P);
+
+
+    /**
+     * GenPolynomial is (squarefree) factorization.
+     * @param P GenPolynomial.
+     * @param F = [p_1,...,p_k].
+     * @return true if P = prod_{i=1,...,r} p_i, else false.
+     */
+    public boolean isFactorization(GenPolynomial<C> P, List<GenPolynomial<C>> F);
+
+
+    /**
+     * GenPolynomial is (squarefree) factorization.
+     * @param P GenPolynomial.
+     * @param F = [p_1 -&gt; e_1, ..., p_k -&gt; e_k].
+     * @return true if P = prod_{i=1,...,k} p_i**e_i, else false.
+     */
+    public boolean isFactorization(GenPolynomial<C> P, SortedMap<GenPolynomial<C>, Long> F);
+
+
+    /**
+     * GenPolynomial squarefree and co-prime list.
+     * @param A list of GenPolynomials.
+     * @return B with gcd(b,c) = 1 for all b != c in B and for all non-constant
+     *         a in A there exists b in B with b|a and each b in B is
+     *         squarefree. B does not contain zero or constant polynomials.
+     */
+    public List<GenPolynomial<C>> coPrimeSquarefree(List<GenPolynomial<C>> A);
+
+
+    /**
+     * GenPolynomial squarefree and co-prime list.
+     * @param a polynomial.
+     * @param P squarefree co-prime list of GenPolynomials.
+     * @return B with gcd(b,c) = 1 for all b != c in B and for non-constant a
+     *         there exists b in P with b|a. B does not contain zero or constant
+     *         polynomials.
+     */
+    public List<GenPolynomial<C>> coPrimeSquarefree(GenPolynomial<C> a, List<GenPolynomial<C>> P);
+
+
+    /**
+     * Test if list of GenPolynomials is squarefree and co-prime.
+     * @param B list of GenPolynomials.
+     * @return true, if for all b != c in B gcd(b,c) = 1 and each b in B is
+     *         squarefree, else false.
+     */
+    public boolean isCoPrimeSquarefree(List<GenPolynomial<C>> B);
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/SquarefreeAbstract.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/SquarefreeAbstract.java
@@ -1,0 +1,630 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Abstract squarefree decomposition class.
+ * @author Heinz Kredel
+ */
+
+public abstract class SquarefreeAbstract<C extends GcdRingElem<C>> implements Squarefree<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(SquarefreeAbstract.class);
+
+
+    /**
+     * GCD engine for respective base coefficients.
+     */
+    protected final GreatestCommonDivisorAbstract<C> engine;
+
+
+    /**
+     * Constructor.
+     */
+    public SquarefreeAbstract(GreatestCommonDivisorAbstract<C> engine) {
+        this.engine = engine;
+    }
+
+
+    /**
+     * GenPolynomial polynomial greatest squarefree divisor.
+     * @param P GenPolynomial.
+     * @return squarefree(pp(P)).
+     */
+    public abstract GenPolynomial<C> baseSquarefreePart(GenPolynomial<C> P);
+
+
+    /**
+     * GenPolynomial polynomial squarefree factorization.
+     * @param A GenPolynomial.
+     * @return [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with A = prod_{i=1,...,k}
+     *         p_i^{e_i} and p_i squarefree and gcd(p_i, p_j) = 1, for i != j.
+     */
+    public abstract SortedMap<GenPolynomial<C>, Long> baseSquarefreeFactors(GenPolynomial<C> A);
+
+
+    /**
+     * GenPolynomial recursive polynomial greatest squarefree divisor.
+     * @param P recursive univariate GenPolynomial.
+     * @return squarefree(pp(P)).
+     */
+    public abstract GenPolynomial<GenPolynomial<C>> recursiveUnivariateSquarefreePart(
+                    GenPolynomial<GenPolynomial<C>> P);
+
+
+    /**
+     * GenPolynomial recursive univariate polynomial squarefree factorization.
+     * @param P recursive univariate GenPolynomial.
+     * @return [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with P = prod_{i=1,...,k}
+     *         p_i^{e_i} and p_i squarefree and gcd(p_i, p_j) = 1, for i != j.
+     */
+    public abstract SortedMap<GenPolynomial<GenPolynomial<C>>, Long> recursiveUnivariateSquarefreeFactors(
+                    GenPolynomial<GenPolynomial<C>> P);
+
+
+    /**
+     * GenPolynomial greatest squarefree divisor.
+     * @param P GenPolynomial.
+     * @return squarefree(P) a primitive respectively monic polynomial.
+     */
+    public abstract GenPolynomial<C> squarefreePart(GenPolynomial<C> P);
+
+
+    /**
+     * GenPolynomial test if is squarefree.
+     * @param P GenPolynomial.
+     * @return true if P is squarefree, else false.
+     */
+    public boolean isSquarefree(GenPolynomial<C> P) {
+        GenPolynomial<C> S = squarefreePart(P);
+        GenPolynomial<C> Ps = P;
+        if (P.ring.coFac.isField()) {
+            Ps = Ps.monic();
+        } else {
+            Ps = engine.basePrimitivePart(Ps);
+        }
+        boolean f = Ps.equals(S);
+        return f;
+    }
+
+
+    /**
+     * GenPolynomial list test if squarefree.
+     * @param L list of GenPolynomial.
+     * @return true if each P in L is squarefree, else false.
+     */
+    public boolean isSquarefree(List<GenPolynomial<C>> L) {
+        if (L == null || L.isEmpty()) {
+            return true;
+        }
+        for (GenPolynomial<C> P : L) {
+            if (!isSquarefree(P)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Recursive GenPolynomial test if is squarefree.
+     * @param P recursive univariate GenPolynomial.
+     * @return true if P is squarefree, else false.
+     */
+    public boolean isRecursiveSquarefree(GenPolynomial<GenPolynomial<C>> P) {
+        GenPolynomial<GenPolynomial<C>> S = recursiveUnivariateSquarefreePart(P);
+        boolean f = P.equals(S);
+        if (!f) {
+            logger.info("not Squarefree, S != P: " + P + " != " + S);
+        }
+        return f;
+    }
+
+
+    /**
+     * GenPolynomial squarefree factorization.
+     * @param P GenPolynomial.
+     * @return [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with P = prod_{i=1,...,k}
+     *         p_i^{e_i} and p_i squarefree and gcd(p_i, p_j) = 1, for i != j.
+     */
+    public abstract SortedMap<GenPolynomial<C>, Long> squarefreeFactors(GenPolynomial<C> P);
+
+
+    /**
+     * GenPolynomial squarefree and co-prime list.
+     * @param A list of GenPolynomials.
+     * @return B with gcd(b,c) = 1 for all b != c in B and for all non-constant
+     *         a in A there exists b in B with b|a and each b in B is
+     *         squarefree. B does not contain zero or constant polynomials.
+     */
+    public List<GenPolynomial<C>> coPrimeSquarefree(List<GenPolynomial<C>> A) {
+        if (A == null || A.isEmpty()) {
+            return A;
+        }
+        List<GenPolynomial<C>> S = new ArrayList<GenPolynomial<C>>();
+        for (GenPolynomial<C> g : A) {
+            SortedMap<GenPolynomial<C>, Long> sm = squarefreeFactors(g);
+            S.addAll(sm.keySet());
+        }
+        List<GenPolynomial<C>> B = engine.coPrime(S);
+        return B;
+    }
+
+
+    /**
+     * GenPolynomial squarefree and co-prime list.
+     * @param a polynomial.
+     * @param P squarefree co-prime list of GenPolynomials.
+     * @return B with gcd(b,c) = 1 for all b != c in B and for non-constant a
+     *         there exists b in P with b|a. B does not contain zero or constant
+     *         polynomials.
+     */
+    public List<GenPolynomial<C>> coPrimeSquarefree(GenPolynomial<C> a, List<GenPolynomial<C>> P) {
+        if (a == null || a.isZERO() || a.isConstant()) {
+            return P;
+        }
+        SortedMap<GenPolynomial<C>, Long> sm = squarefreeFactors(a);
+        List<GenPolynomial<C>> B = P;
+        for (GenPolynomial<C> f : sm.keySet()) {
+            B = engine.coPrime(f, B);
+        }
+        return B;
+    }
+
+
+    /**
+     * Test if list of GenPolynomials is squarefree and co-prime.
+     * @param B list of GenPolynomials.
+     * @return true, if for all b != c in B gcd(b,c) = 1 and each b in B is
+     *         squarefree, else false.
+     */
+    public boolean isCoPrimeSquarefree(List<GenPolynomial<C>> B) {
+        if (B == null || B.isEmpty()) {
+            return true;
+        }
+        if (!engine.isCoPrime(B)) {
+            return false;
+        }
+        return isSquarefree(B);
+    }
+
+
+    /**
+     * Normalize factorization. p'_i &gt; 0 for i &gt; 1 and p'_1 != 1 if k &gt;
+     * 1.
+     * @param F = [p_1-&gt;e_1;, ..., p_k-&gt;e_k].
+     * @return F' = [p'_1-&gt;e_1, ..., p'_k-&gt;e_k].
+     */
+    public SortedMap<GenPolynomial<C>, Long> normalizeFactorization(SortedMap<GenPolynomial<C>, Long> F) {
+        if (F == null || F.size() <= 1) {
+            return F;
+        }
+        List<GenPolynomial<C>> Fp = new ArrayList<GenPolynomial<C>>(F.keySet());
+        GenPolynomial<C> f0 = Fp.get(0);
+        if (f0.ring.characteristic().signum() != 0) { // only ordered coefficients
+            return F;
+        }
+        long e0 = F.get(f0);
+        SortedMap<GenPolynomial<C>, Long> Sp = new TreeMap<GenPolynomial<C>, Long>();
+        for (int i = 1; i < Fp.size(); i++) {
+            GenPolynomial<C> fi = Fp.get(i);
+            long ei = F.get(fi);
+            if (fi.signum() < 0) {
+                //System.out.println("e0 = " + e0 + ", f0 = " + f0);
+                //System.out.println("ei = " + ei + ", fi = " + fi);
+                if (ei % 2 != 0 && e0 % 2 != 0) { // bug
+                    fi = fi.negate();
+                    f0 = f0.negate();
+                }
+            }
+            Sp.put(fi, ei);
+        }
+        if (!f0.isONE()) {
+            Sp.put(f0, e0);
+        }
+        return Sp;
+    }
+
+
+    /**
+     * GenPolynomial is (squarefree) factorization.
+     * @param P GenPolynomial.
+     * @param F = [p_1, ..., p_k].
+     * @return true if P = prod_{i=1,...,r} p_i, else false.
+     */
+    public boolean isFactorization(GenPolynomial<C> P, List<GenPolynomial<C>> F) {
+        if (P == null || F == null) {
+            throw new IllegalArgumentException("P and F may not be null");
+        }
+        if (P.isZERO() && F.size() == 0) {
+            return true;
+        }
+        GenPolynomial<C> t = P.ring.getONE();
+        for (GenPolynomial<C> f : F) {
+            t = t.multiply(f);
+        }
+        boolean f = P.equals(t) || P.equals(t.negate());
+        if (!f) {
+            logger.info("no factorization(list): F = " + F + ", P = " + P + ", t = " + t);
+        }
+        return f;
+    }
+
+
+    /**
+     * Count number of factors in a (squarefree) factorization.
+     * @param F = [p_1 -&gt; e_1, ..., p_k -&gt; e_k].
+     * @return sum_{i=1,...,k} e_i.
+     */
+    public long factorCount(SortedMap<GenPolynomial<C>, Long> F) {
+        if (F == null || F.isEmpty()) {
+            return 0L;
+        }
+        long f = 0L;
+        for (Long e : F.values()) {
+            f += e;
+        }
+        return f;
+    }
+
+
+    /**
+     * GenPolynomial is (squarefree) factorization.
+     * @param P GenPolynomial.
+     * @param F = [p_1 -&gt; e_1, ..., p_k -&gt; e_k].
+     * @return true if P = prod_{i=1,...,k} p_i**e_i, else false.
+     */
+    public boolean isFactorization(GenPolynomial<C> P, SortedMap<GenPolynomial<C>, Long> F) {
+        if (P == null || F == null) {
+            throw new IllegalArgumentException("P and F may not be null");
+        }
+        if (P.isZERO() && F.size() == 0) {
+            return true;
+        }
+        GenPolynomial<C> t = P.ring.getONE();
+        for (Map.Entry<GenPolynomial<C>, Long> me : F.entrySet()) {
+            GenPolynomial<C> f = me.getKey();
+            Long E = me.getValue();
+            long e = E.longValue();
+            GenPolynomial<C> g = f.power(e);
+            t = t.multiply(g);
+        }
+        boolean f = P.equals(t) || P.equals(t.negate());
+        if (!f) {
+            P = P.monic();
+            t = t.monic();
+            f = P.equals(t) || P.equals(t.negate());
+            if (f) {
+                return f;
+            }
+            logger.info("no factorization(map): F = " + F + ", P = " + P + ", t = " + t);
+            //RuntimeException e = new RuntimeException("fac-map");
+            //e.printStackTrace();
+            //throw e;
+        }
+        return f;
+    }
+
+
+    /**
+     * GenPolynomial is (squarefree) factorization.
+     * @param P GenPolynomial.
+     * @param F = [p_1 -&gt; e_1, ..., p_k -&gt; e_k].
+     * @return true if P = prod_{i=1,...,k} p_i**e_i, else false.
+     */
+    public boolean isRecursiveFactorization(GenPolynomial<GenPolynomial<C>> P,
+                    SortedMap<GenPolynomial<GenPolynomial<C>>, Long> F) {
+        if (P == null || F == null) {
+            throw new IllegalArgumentException("P and F may not be null");
+        }
+        if (P.isZERO() && F.size() == 0) {
+            return true;
+        }
+        GenPolynomial<GenPolynomial<C>> t = P.ring.getONE();
+        for (Map.Entry<GenPolynomial<GenPolynomial<C>>, Long> me : F.entrySet()) {
+            GenPolynomial<GenPolynomial<C>> f = me.getKey();
+            Long E = me.getValue(); // F.get(f);
+            long e = E.longValue();
+            GenPolynomial<GenPolynomial<C>> g = f.power(e);
+            t = t.multiply(g);
+        }
+        boolean f = P.equals(t) || P.equals(t.negate());
+        if (!f) {
+            GenPolynomialRing<C> cf = (GenPolynomialRing<C>) P.ring.coFac;
+            GreatestCommonDivisorAbstract<C> engine = GCDFactory.getProxy(cf.coFac);
+            GenPolynomial<GenPolynomial<C>> Pp = engine.recursivePrimitivePart(P);
+            Pp = PolyUtil.<C> monic(Pp);
+            GenPolynomial<GenPolynomial<C>> tp = engine.recursivePrimitivePart(t);
+            tp = PolyUtil.<C> monic(tp);
+            f = Pp.equals(tp) || Pp.equals(tp.negate());
+            if (f) {
+                return f;
+            }
+            logger.info("no factorization(map): F  = " + F + ", P  = " + P + ", t  = " + t + ", Pp = " + Pp
+                            + ", tp = " + tp);
+            //RuntimeException e = new RuntimeException("fac-map");
+            //e.printStackTrace();
+            //throw e;
+        }
+        return f;
+    }
+
+
+    /**
+     * GenPolynomial recursive polynomial greatest squarefree divisor.
+     * @param P recursive GenPolynomial.
+     * @return squarefree(pp(P)).
+     */
+    public GenPolynomial<GenPolynomial<C>> recursiveSquarefreePart(GenPolynomial<GenPolynomial<C>> P) {
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        if (P.ring.nvar <= 1) {
+            return recursiveUnivariateSquarefreePart(P);
+        }
+        // distributed polynomials squarefree part
+        GenPolynomialRing<GenPolynomial<C>> rfac = P.ring;
+        RingFactory<GenPolynomial<C>> rrfac = rfac.coFac;
+        GenPolynomialRing<C> cfac = (GenPolynomialRing<C>) rrfac;
+        GenPolynomialRing<C> dfac = cfac.extend(rfac.nvar);
+        GenPolynomial<C> Pd = PolyUtil.<C> distribute(dfac, P);
+        GenPolynomial<C> Dd = squarefreePart(Pd);
+        // convert to recursive
+        GenPolynomial<GenPolynomial<C>> C = PolyUtil.<C> recursive(rfac, Dd);
+        return C;
+    }
+
+
+    /**
+     * GenPolynomial recursive polynomial squarefree factorization.
+     * @param P recursive GenPolynomial.
+     * @return [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with P = prod_{i=1,...,k}
+     *         p_i^{e_i} and p_i squarefree and gcd(p_i, p_j) = 1, for i != j.
+     */
+    public SortedMap<GenPolynomial<GenPolynomial<C>>, Long> recursiveSquarefreeFactors(
+                    GenPolynomial<GenPolynomial<C>> P) {
+        SortedMap<GenPolynomial<GenPolynomial<C>>, Long> factors;
+        factors = new TreeMap<GenPolynomial<GenPolynomial<C>>, Long>();
+        if (P == null || P.isZERO()) {
+            return factors;
+        }
+        if (P.ring.nvar <= 1) {
+            return recursiveUnivariateSquarefreeFactors(P);
+        }
+        // distributed polynomials squarefree part
+        GenPolynomialRing<GenPolynomial<C>> rfac = P.ring;
+        RingFactory<GenPolynomial<C>> rrfac = rfac.coFac;
+        GenPolynomialRing<C> cfac = (GenPolynomialRing<C>) rrfac;
+        GenPolynomialRing<C> dfac = cfac.extend(rfac.nvar);
+        GenPolynomial<C> Pd = PolyUtil.<C> distribute(dfac, P);
+        SortedMap<GenPolynomial<C>, Long> dfacs = squarefreeFactors(Pd);
+        // convert to recursive
+        for (Map.Entry<GenPolynomial<C>, Long> Dm : dfacs.entrySet()) {
+            GenPolynomial<C> Dd = Dm.getKey();
+            Long e = Dm.getValue();
+            GenPolynomial<GenPolynomial<C>> C = PolyUtil.<C> recursive(rfac, Dd);
+            factors.put(C, e);
+        }
+        return factors;
+    }
+
+
+    /**
+     * Univariate GenPolynomial partial fraction decomposition.
+     * @param A univariate GenPolynomial.
+     * @param D sorted map [d_1 -&gt; e_1, ..., d_k -&gt; e_k] with d_i
+     *            squarefree.
+     * @return [ [Ai0, Ai1,..., Aie_i], i=0,...,k ] with A/prod(D) = A0 + sum(
+     *         sum ( Aij/di^j ) ) with deg(Aij) &lt; deg(di).
+     */
+    public List<List<GenPolynomial<C>>> basePartialFraction(GenPolynomial<C> A,
+                    SortedMap<GenPolynomial<C>, Long> D) {
+        if (D == null || A == null) {
+            throw new IllegalArgumentException("null A or D not allowed");
+        }
+        List<List<GenPolynomial<C>>> pf = new ArrayList<List<GenPolynomial<C>>>(D.size() + 1);
+        if (D.size() == 0) {
+            return pf;
+        }
+        //List<GenPolynomial<C>> fi;
+        if (A.isZERO()) {
+            for (Map.Entry<GenPolynomial<C>, Long> me : D.entrySet()) {
+                long e = me.getValue();
+                int e1 = (int) e + 1;
+                List<GenPolynomial<C>> fi = new ArrayList<GenPolynomial<C>>(e1);
+                for (int i = 0; i < e1; i++) {
+                    fi.add(A);
+                }
+                pf.add(fi);
+            }
+            List<GenPolynomial<C>> fi = new ArrayList<GenPolynomial<C>>(1);
+            fi.add(A);
+            pf.add(0, fi);
+            return pf;
+        }
+        // A != 0, D != empty
+        List<GenPolynomial<C>> Dp = new ArrayList<GenPolynomial<C>>(D.size());
+        for (Map.Entry<GenPolynomial<C>, Long> me : D.entrySet()) {
+            GenPolynomial<C> d = me.getKey();
+            long e = me.getValue(); //D.get(d);
+            GenPolynomial<C> f = d.power(e);
+            Dp.add(f);
+        }
+        List<GenPolynomial<C>> F = engine.basePartialFraction(A, Dp);
+        //System.out.println("fraction list = " + F.size());
+        GenPolynomial<C> A0 = F.remove(0);
+        List<GenPolynomial<C>> fi = new ArrayList<GenPolynomial<C>>(1);
+        fi.add(A0);
+        pf.add(fi);
+        int i = 0;
+        for (Map.Entry<GenPolynomial<C>, Long> me : D.entrySet()) { // assume fixed sequence order
+            GenPolynomial<C> d = me.getKey();
+            long e = me.getValue();
+            int ei = (int) e;
+            GenPolynomial<C> gi = F.get(i); // assume fixed sequence order
+            List<GenPolynomial<C>> Fi = engine.basePartialFraction(gi, d, ei);
+            pf.add(Fi);
+            i++;
+        }
+        return pf;
+    }
+
+
+    /**
+     * Test for Univariate GenPolynomial partial fraction decomposition.
+     * @param A univariate GenPolynomial.
+     * @param D sorted map [d_1 -&gt; e_1, ..., d_k -&gt; e_k] with d_i
+     *            squarefree.
+     * @param F a list of lists [ [Ai0, Ai1,..., Aie_i], i=0,...,k ]
+     * @return true, if A/prod(D) = A0 + sum( sum ( Aij/di^j ) ), else false.
+     */
+    public boolean isBasePartialFraction(GenPolynomial<C> A, SortedMap<GenPolynomial<C>, Long> D,
+                    List<List<GenPolynomial<C>>> F) {
+        if (D == null || A == null || F == null) {
+            throw new IllegalArgumentException("null A, D or F not allowed");
+        }
+        if (D.isEmpty() && F.isEmpty()) {
+            return true;
+        }
+        if (D.isEmpty() || F.isEmpty()) {
+            return false;
+        }
+        List<GenPolynomial<C>> Dp = new ArrayList<GenPolynomial<C>>(D.size());
+        for (Map.Entry<GenPolynomial<C>, Long> me : D.entrySet()) {
+            GenPolynomial<C> d = me.getKey();
+            long e = me.getValue(); // D.get(d);
+            GenPolynomial<C> f = d.power(e);
+            Dp.add(f);
+        }
+        List<GenPolynomial<C>> fi = F.get(0);
+        if (fi.size() != 1) {
+            logger.info("size(fi) != 1 " + fi);
+            return false;
+        }
+        boolean t;
+        GenPolynomial<C> A0 = fi.get(0);
+        //System.out.println("A0 = " + A0);
+        List<GenPolynomial<C>> Qp = new ArrayList<GenPolynomial<C>>(D.size() + 1);
+        Qp.add(A0);
+
+        //         List<GenPolynomial<C>> Fp = engine.basePartialFraction(A,Dp);
+        //         System.out.println("fraction list = " + F.size());
+        //         t = engine.isBasePartialFraction(A,Dp,Fp);
+        //         if ( ! t ) {
+        //             System.out.println("not recursion isPartFrac = " + Fp);
+        //             return false;
+        //         }
+        //         GenPolynomial<C> A0p = Fp.remove(0);
+        //         if ( ! A0.equals(A0p) ) {
+        //             System.out.println("A0 != A0p " + A0p);
+        //             return false;
+        //         }
+
+        int i = 0;
+        for (Map.Entry<GenPolynomial<C>, Long> me : D.entrySet()) { // assume fixed sequence order
+            GenPolynomial<C> d = me.getKey();
+            long e = me.getValue();
+            int ei = (int) e;
+            List<GenPolynomial<C>> Fi = F.get(i + 1); // assume fixed sequence order
+
+            //            GenPolynomial<C> pi = Fp.get(i);        // assume fixed sequence order
+            //             t = engine.isBasePartialFraction(pi,d,ei,Fi);
+            //             if ( ! t ) {
+            //                 System.out.println("not isPartFrac exp = " + pi + ", d = " + d + ", e = " + ei);
+            //                 System.out.println("not isPartFrac exp = " + Fi);
+            //                 return false;
+            //             }
+
+            GenPolynomial<C> qi = engine.basePartialFractionValue(d, ei, Fi);
+            Qp.add(qi);
+
+            //             t = qi.equals(pi);
+            //             if ( ! t ) {
+            //                 System.out.println("not isPartFrac exp = " + pi + ", d = " + d + ", e = " + ei + ", qi = " + qi);
+            //             }
+
+            i++;
+        }
+
+        t = engine.isBasePartialFraction(A, Dp, Qp);
+        if (!t) {
+            System.out.println("not final isPartFrac " + Qp);
+        }
+        return t;
+    }
+
+
+    /**
+     * Coefficients greatest squarefree divisor.
+     * @param P coefficient.
+     * @return squarefree part of P.
+     */
+    public C squarefreePart(C P) {
+        if (P == null) {
+            return null;
+        }
+        C s = null;
+        SortedMap<C, Long> factors = squarefreeFactors(P);
+        //if (logger.isWarnEnabled()) {
+        //    logger.warn("sqfPart, better use sqfFactors, factors = " + factors);
+        //}
+        for (C sp : factors.keySet()) {
+            if (s == null) {
+                s = sp;
+            } else {
+                s = s.multiply(sp);
+            }
+        }
+        return s;
+    }
+
+
+    /**
+     * Coefficients squarefree factorization.
+     * @param P coefficient.
+     * @return [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with P = prod_{i=1,...,k}
+     *         p_i^{e_i} and p_i squarefree and gcd(p_i, p_j) = 1, for i != j.
+     */
+    public abstract SortedMap<C, Long> squarefreeFactors(C P);
+    /* not possible:
+    {
+        if (P == null) {
+            return null;
+        }
+        SortedMap<C, Long> factors = new TreeMap<C, Long>();
+        SquarefreeAbstract<C> reng = SquarefreeFactory.getImplementation((RingFactory<C>) P.factory());
+            System.out.println("fcp,reng = " + reng);
+            SortedMap<C, Long> rfactors = reng.squarefreeFactors(P);
+            for (C c : rfactors.keySet()) {
+                if (!c.isONE()) {
+                    C cr = (C) (Object) c;
+                    Long rk = rfactors.get(c);
+                    factors.put(cr, rk);
+                }
+            }
+    
+        return factors;
+    }
+    */
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/SquarefreeFactory.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/SquarefreeFactory.java
@@ -1,0 +1,273 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.arith.BigInteger;
+import edu.jas.arith.BigRational;
+import edu.jas.arith.ModInt;
+import edu.jas.arith.ModIntRing;
+import edu.jas.arith.ModInteger;
+import edu.jas.arith.ModIntegerRing;
+import edu.jas.arith.ModLong;
+import edu.jas.arith.ModLongRing;
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.AlgebraicNumberRing;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Squarefree factorization algorithms factory. Select appropriate squarefree
+ * factorization engine based on the coefficient types.
+ * <p>
+ * <b>Usage:</b> To create objects that implement the <code>Squarefree</code>
+ * interface use the <code>SquarefreeFactory</code>. It will select an
+ * appropriate implementation based on the types of polynomial coefficients C.
+ * To obtain an implementation use <code>getImplementation()</code>, it returns
+ * an object of a class which extends the <code>SquarefreeAbstract</code> class
+ * which implements the <code>Squarefree</code> interface.
+ * 
+ * <pre>
+ * Squarefree&lt;CT&gt; engine;
+ * engine = SquarefreeFactory.&lt;CT&gt; getImplementation(cofac);
+ * c = engine.squarefreeFactors(a);
+ * </pre>
+ * 
+ * For example, if the coefficient type is BigInteger, the usage looks like
+ * 
+ * <pre>
+ * BigInteger cofac = new BigInteger();
+ * Squarefree&lt;BigInteger&gt; engine;
+ * engine = SquarefreeFactory.getImplementation(cofac);
+ * Sm = engine.sqaurefreeFactors(poly);
+ * </pre>
+ * 
+ * @author Heinz Kredel
+ * @see edu.jas.ufd.Squarefree#squarefreeFactors(edu.jas.poly.GenPolynomial P)
+ */
+
+public class SquarefreeFactory {
+
+
+    private static final Logger logger = LogManager.getLogger(SquarefreeFactory.class);
+
+
+    /**
+     * Protected factory constructor.
+     */
+    protected SquarefreeFactory() {
+    }
+
+
+    /**
+     * Determine suitable implementation of factorization algorithm, case
+     * ModInteger.
+     * @param fac ModIntegerRing.
+     * @return squarefree factorization algorithm implementation.
+     */
+    public static SquarefreeAbstract<ModInteger> getImplementation(ModIntegerRing fac) {
+        // fac.isField() checked in constructor
+        return new SquarefreeFiniteFieldCharP<ModInteger>(fac);
+    }
+
+
+    /**
+     * Determine suitable implementation of factorization algorithm, case
+     * ModLong.
+     * @param fac ModLongRing.
+     * @return squarefree factorization algorithm implementation.
+     */
+    public static SquarefreeAbstract<ModLong> getImplementation(ModLongRing fac) {
+        // fac.isField() checked in constructor
+        return new SquarefreeFiniteFieldCharP<ModLong>(fac);
+    }
+
+
+    /**
+     * Determine suitable implementation of factorization algorithm, case
+     * ModInt.
+     * @param fac ModIntRing.
+     * @return squarefree factorization algorithm implementation.
+     */
+    public static SquarefreeAbstract<ModInt> getImplementation(ModIntRing fac) {
+        // fac.isField() checked in constructor
+        return new SquarefreeFiniteFieldCharP<ModInt>(fac);
+    }
+
+
+    /**
+     * Determine suitable implementation of squarefree factorization algorithm,
+     * case BigInteger.
+     * @param fac BigInteger.
+     * @return squarefree factorization algorithm implementation.
+     */
+    public static SquarefreeAbstract<BigInteger> getImplementation(BigInteger fac) {
+        return new SquarefreeRingChar0<BigInteger>(fac);
+    }
+
+
+    /**
+     * Determine suitable implementation of squarefree factorization algorithms,
+     * case BigRational.
+     * @param fac BigRational.
+     * @return squarefree factorization algorithm implementation.
+     */
+    public static SquarefreeAbstract<BigRational> getImplementation(BigRational fac) {
+        return new SquarefreeFieldChar0Yun<BigRational>(fac);
+    }
+
+
+    /**
+     * Determine suitable implementation of squarefree factorization algorithms,
+     * case AlgebraicNumber&lt;C&gt;.
+     * @param fac AlgebraicNumberRing&lt;C&gt;.
+     * @param <C> coefficient type, e.g. BigRational, ModInteger.
+     * @return squarefree factorization algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C>> SquarefreeAbstract<AlgebraicNumber<C>> getImplementation(
+                    AlgebraicNumberRing<C> fac) {
+        PolyUfdUtil.<C> ensureFieldProperty(fac);
+        if (fac.isField()) {
+            if (fac.characteristic().signum() == 0) {
+                return new SquarefreeFieldChar0Yun<AlgebraicNumber<C>>(fac);
+            }
+            if (fac.isFinite()) {
+                return new SquarefreeFiniteFieldCharP<AlgebraicNumber<C>>(fac);
+            }
+            return new SquarefreeInfiniteAlgebraicFieldCharP<C>(fac);
+        }
+        throw new ArithmeticException("eventually no integral domain " + fac.getClass().getName());
+    }
+
+
+    /**
+     * Determine suitable implementation of squarefree factorization algorithms,
+     * case Quotient&lt;C&gt;.
+     * @param fac QuotientRing&lt;C&gt;.
+     * @param <C> coefficient type, e.g. BigRational, ModInteger.
+     * @return squarefree factorization algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C>> SquarefreeAbstract<Quotient<C>> getImplementation(
+                    QuotientRing<C> fac) {
+        if (fac.characteristic().signum() == 0) {
+            return new SquarefreeFieldChar0Yun<Quotient<C>>(fac);
+        }
+        return new SquarefreeInfiniteFieldCharP<C>(fac);
+    }
+
+
+    /**
+     * Determine suitable implementation of squarefree factorization algorithms,
+     * case GenPolynomial&lt;C&gt;.
+     * @param fac GenPolynomialRing&lt;C&gt;.
+     * @param <C> coefficient type, e.g. BigRational, ModInteger.
+     * @return squarefree factorization algorithm implementation.
+     */
+    public static <C extends GcdRingElem<C>> SquarefreeAbstract<C> getImplementation(
+                    GenPolynomialRing<C> fac) {
+        return getImplementationPoly(fac);
+    }
+
+
+    /*
+     * Determine suitable implementation of squarefree factorization algorithms,
+     * case GenPolynomial&lt;C&gt;.
+     * @param fac GenPolynomialRing&lt;C&gt;.
+     * @param <C> coefficient type, e.g. BigRational, ModInteger.
+     * @return squarefree factorization algorithm implementation.
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    protected static <C extends GcdRingElem<C>> SquarefreeAbstract<C> getImplementationPoly(
+                    GenPolynomialRing<C> fac) {
+        if (fac.characteristic().signum() == 0) {
+            if (fac.coFac.isField()) {
+                return new SquarefreeFieldChar0Yun<C>(fac.coFac);
+            }
+            return new SquarefreeRingChar0<C>(fac.coFac);
+        }
+        if (fac.coFac.isFinite()) {
+            return new SquarefreeFiniteFieldCharP<C>(fac.coFac);
+        }
+        Object ocfac = fac.coFac;
+        SquarefreeAbstract saq = null;
+        if (ocfac instanceof QuotientRing) {
+            QuotientRing<C> qf = (QuotientRing<C>) ocfac;
+            saq = new SquarefreeInfiniteFieldCharP<C>(qf);
+        } else if (ocfac instanceof AlgebraicNumberRing) {
+            AlgebraicNumberRing<C> af = (AlgebraicNumberRing<C>) ocfac;
+            saq = new SquarefreeInfiniteAlgebraicFieldCharP<C>(af);
+        }
+        if (saq == null) {
+            throw new IllegalArgumentException("no squarefree factorization " + fac.coFac);
+        }
+        SquarefreeAbstract<C> sa = (SquarefreeAbstract<C>) saq;
+        return sa;
+    }
+
+
+    /**
+     * Determine suitable implementation of squarefree factorization algorithms,
+     * other cases.
+     * @param <C> coefficient type
+     * @param fac RingFactory&lt;C&gt;.
+     * @return squarefree factorization algorithm implementation.
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    public static <C extends GcdRingElem<C>> SquarefreeAbstract<C> getImplementation(RingFactory<C> fac) {
+        //logger.info("fac = " + fac.getClass().getName());
+        //System.out.println("fac_o = " + fac.getClass().getName());
+        SquarefreeAbstract/*raw type<C>*/ ufd = null;
+        AlgebraicNumberRing afac = null;
+        QuotientRing qfac = null;
+        GenPolynomialRing pfac = null;
+        Object ofac = fac;
+        if (ofac instanceof BigInteger) {
+            ufd = new SquarefreeRingChar0<C>(fac);
+        } else if (ofac instanceof BigRational) {
+            ufd = new SquarefreeFieldChar0Yun<C>(fac);
+        } else if (ofac instanceof ModIntegerRing) {
+            ufd = new SquarefreeFiniteFieldCharP<C>(fac);
+        } else if (ofac instanceof ModLongRing) {
+            ufd = new SquarefreeFiniteFieldCharP<C>(fac);
+        } else if (ofac instanceof ModIntRing) {
+            ufd = new SquarefreeFiniteFieldCharP<C>(fac);
+        } else if (ofac instanceof AlgebraicNumberRing) {
+            afac = (AlgebraicNumberRing) ofac;
+            //ofac = afac.ring.coFac;
+            //System.out.println("o_afac = " + ofac);
+            ufd = getImplementation(afac);
+        } else if (ofac instanceof QuotientRing) {
+            qfac = (QuotientRing) ofac;
+            ufd = getImplementation(qfac);
+        } else if (ofac instanceof GenPolynomialRing) {
+            pfac = (GenPolynomialRing) ofac;
+            ufd = getImplementationPoly(pfac);
+        } else if (fac.isField()) {
+            //System.out.println("fac_field = " + fac);
+            if (fac.characteristic().signum() == 0) {
+                ufd = new SquarefreeFieldChar0Yun<C>(fac);
+            } else {
+                if (fac.isFinite()) {
+                    ufd = new SquarefreeFiniteFieldCharP<C>(fac);
+                } else {
+                    ufd = new SquarefreeInfiniteFieldCharP/*raw*/(fac);
+                }
+            }
+        } else if (fac.characteristic().signum() == 0) {
+            ufd = new SquarefreeRingChar0<C>(fac);
+        } else {
+            throw new IllegalArgumentException(
+                            "no squarefree factorization implementation for " + fac.getClass().getName());
+        }
+        logger.debug("ufd = " + ufd);
+        return (SquarefreeAbstract<C>) ufd;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/SquarefreeFieldChar0.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/SquarefreeFieldChar0.java
@@ -1,0 +1,520 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Squarefree decomposition for coefficient fields of characteristic 0.
+ * @author Heinz Kredel
+ */
+
+public class SquarefreeFieldChar0<C extends GcdRingElem<C>> extends SquarefreeAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(SquarefreeFieldChar0.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Factory for field of characteristic 0 coefficients.
+     */
+    protected final RingFactory<C> coFac;
+
+
+    /**
+     * Constructor.
+     */
+    public SquarefreeFieldChar0(RingFactory<C> fac) {
+        super(GCDFactory.<C> getProxy(fac));
+        if (!fac.isField()) {
+            throw new IllegalArgumentException("fac must be a field");
+        }
+        if (fac.characteristic().signum() != 0) {
+            throw new IllegalArgumentException("characterisic(fac) must be zero");
+        }
+        coFac = fac;
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return getClass().getName() + " with " + engine + " over " + coFac;
+    }
+
+
+    /**
+     * GenPolynomial polynomial greatest squarefree divisor.
+     * @param P GenPolynomial.
+     * @return squarefree(pp(P)).
+     */
+    @Override
+    public GenPolynomial<C> baseSquarefreePart(GenPolynomial<C> P) {
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        GenPolynomialRing<C> pfac = P.ring;
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException(
+                            this.getClass().getName() + " only for univariate polynomials");
+        }
+        GenPolynomial<C> pp = P.monic();
+        if (pp.isConstant()) {
+            return pp;
+        }
+        GenPolynomial<C> d = PolyUtil.<C> baseDeriviative(pp);
+        d = d.monic();
+        //System.out.println("d = " + d);
+        GenPolynomial<C> g = engine.baseGcd(pp, d);
+        g = g.monic();
+        GenPolynomial<C> q = PolyUtil.<C> basePseudoDivide(pp, g);
+        q = q.monic();
+        return q;
+    }
+
+
+    /**
+     * GenPolynomial test if is squarefree.
+     * @param P GenPolynomial.
+     * @return true if P is squarefree, else false.
+     */
+    public boolean isBaseSquarefree(GenPolynomial<C> P) {
+        if (P == null || P.isZERO()) {
+            return true;
+        }
+        GenPolynomialRing<C> pfac = P.ring;
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException(
+                            this.getClass().getName() + " only for univariate polynomials");
+        }
+        GenPolynomial<C> pp = P.monic();
+        if (pp.isConstant()) {
+            return true;
+        }
+        GenPolynomial<C> d = PolyUtil.<C> baseDeriviative(pp);
+        d = d.monic();
+        //System.out.println("d = " + d);
+        GenPolynomial<C> g = engine.baseGcd(pp, d);
+        //g = g.monic();
+        //return g.isONE();
+        return g.degree(0) == 0;
+    }
+
+
+    /**
+     * GenPolynomial polynomial squarefree factorization.
+     * @param A GenPolynomial.
+     * @return [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with A = prod_{i=1,...,k}
+     *         p_i^{e_i} and p_i squarefree and gcd(p_i, p_j) = 1, for i != j.
+     */
+    @Override
+    public SortedMap<GenPolynomial<C>, Long> baseSquarefreeFactors(GenPolynomial<C> A) {
+        SortedMap<GenPolynomial<C>, Long> sfactors = new TreeMap<GenPolynomial<C>, Long>();
+        if (A == null || A.isZERO()) {
+            return sfactors;
+        }
+        if (A.isConstant()) {
+            sfactors.put(A, 1L);
+            return sfactors;
+        }
+        GenPolynomialRing<C> pfac = A.ring;
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException(
+                            this.getClass().getName() + " only for univariate polynomials");
+        }
+        C ldbcf = A.leadingBaseCoefficient();
+        if (!ldbcf.isONE()) {
+            A = A.divide(ldbcf);
+            GenPolynomial<C> f1 = pfac.getONE().multiply(ldbcf);
+            //System.out.println("gcda sqf f1 = " + f1);
+            sfactors.put(f1, 1L);
+            ldbcf = pfac.coFac.getONE();
+        }
+        // divide by trailing term
+        ExpVector et = A.trailingExpVector();
+        if (!et.isZERO()) {
+            GenPolynomial<C> tr = pfac.valueOf(et);
+            if (logger.isInfoEnabled()) {
+                logger.info("trailing term = " + tr);
+            }
+            A = PolyUtil.<C> basePseudoDivide(A, tr);
+            long ep = et.getVal(0); // univariate
+            et = et.subst(0, 1);
+            tr = pfac.valueOf(et);
+            if (logger.isInfoEnabled()) {
+                logger.info("tr, ep = " + tr + ", " + ep);
+            }
+            sfactors.put(tr, ep);
+            if (A.length() == 1) {
+                return sfactors;
+            }
+        }
+        GenPolynomial<C> T0 = A;
+        GenPolynomial<C> Tp;
+        GenPolynomial<C> T = null;
+        GenPolynomial<C> V = null;
+        long k = 0L;
+        boolean init = true;
+        while (true) {
+            if (init) {
+                if (T0.isConstant() || T0.isZERO()) {
+                    break;
+                }
+                Tp = PolyUtil.<C> baseDeriviative(T0);
+                T = engine.baseGcd(T0, Tp);
+                T = T.monic();
+                V = PolyUtil.<C> basePseudoDivide(T0, T);
+                //System.out.println("iT0 = " + T0);
+                //System.out.println("iTp = " + Tp);
+                //System.out.println("iT  = " + T);
+                //System.out.println("iV  = " + V);
+                k = 0L;
+                init = false;
+            }
+            if (V.isConstant()) {
+                break;
+            }
+            k++;
+            GenPolynomial<C> W = engine.baseGcd(T, V);
+            W = W.monic();
+            GenPolynomial<C> z = PolyUtil.<C> basePseudoDivide(V, W);
+            //System.out.println("W = " + W);
+            //System.out.println("z = " + z);
+            V = W;
+            T = PolyUtil.<C> basePseudoDivide(T, V);
+            //System.out.println("V = " + V);
+            //System.out.println("T = " + T);
+            if (z.degree(0) > 0) {
+                if (ldbcf.isONE() && !z.leadingBaseCoefficient().isONE()) {
+                    z = z.monic();
+                    //logger.info("z,monic = " + z);
+                }
+                logger.info("z, k = " + z + ", " + k);
+                sfactors.put(z, k);
+            }
+        }
+        return normalizeFactorization(sfactors);
+    }
+
+
+    /**
+     * GenPolynomial recursive univariate polynomial greatest squarefree
+     * divisor.
+     * @param P recursive univariate GenPolynomial.
+     * @return squarefree(pp(P)).
+     */
+    @Override
+    public GenPolynomial<GenPolynomial<C>> recursiveUnivariateSquarefreePart(
+                    GenPolynomial<GenPolynomial<C>> P) {
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        GenPolynomialRing<GenPolynomial<C>> pfac = P.ring;
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException(
+                            this.getClass().getName() + " only for univariate recursive polynomials");
+        }
+        // squarefree content
+        GenPolynomial<GenPolynomial<C>> pp = P;
+        GenPolynomial<C> Pc = engine.recursiveContent(P);
+        //?? Pc = Pc.monic();
+        if (!Pc.isONE()) {
+            pp = PolyUtil.<C> coefficientPseudoDivide(pp, Pc);
+            //System.out.println("pp,sqp = " + pp);
+            //GenPolynomial<C> Pr = squarefreePart(Pc);
+            //Pr = Pr.monic();
+            //System.out.println("Pr,sqp = " + Pr);
+        }
+        if (pp.leadingExpVector().getVal(0) < 1) {
+            //System.out.println("pp = " + pp);
+            //System.out.println("Pc = " + Pc);
+            return pp.multiply(Pc);
+        }
+        GenPolynomial<GenPolynomial<C>> d = PolyUtil.<C> recursiveDeriviative(pp);
+        //System.out.println("d = " + d);
+        GenPolynomial<GenPolynomial<C>> g = engine.recursiveUnivariateGcd(pp, d);
+        //System.out.println("g,rec = " + g);
+        //??g = PolyUtil.<C> monic(g);
+        GenPolynomial<GenPolynomial<C>> q = PolyUtil.<C> recursivePseudoDivide(pp, g);
+        //?? q = PolyUtil.<C> monic(q);
+        return q.multiply(Pc);
+    }
+
+
+    /**
+     * GenPolynomial test if is squarefree.
+     * @param P GenPolynomial.
+     * @return true if P is squarefree, else false.
+     */
+    public boolean isRecursiveUnivariateSquarefree(GenPolynomial<GenPolynomial<C>> P) {
+        if (P == null || P.isZERO()) {
+            return true;
+        }
+        GenPolynomialRing<GenPolynomial<C>> pfac = P.ring;
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException(
+                            this.getClass().getName() + " only for univariate recursive polynomials");
+        }
+        GenPolynomial<GenPolynomial<C>> pp = P;
+        GenPolynomial<GenPolynomial<C>> d = PolyUtil.<C> recursiveDeriviative(pp);
+        //System.out.println("d = " + d);
+        GenPolynomial<GenPolynomial<C>> g = engine.recursiveUnivariateGcd(pp, d);
+        if (logger.isInfoEnabled()) {
+            logger.info("gcd = " + g);
+        }
+        //System.out.println("g,rec = " + g);
+        //g = PolyUtil.<C> monic(g);
+        //return g.isONE();
+        return g.degree(0) == 0;
+    }
+
+
+    /**
+     * GenPolynomial recursive univariate polynomial squarefree factorization.
+     * @param P recursive univariate GenPolynomial.
+     * @return [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with P = prod_{i=1,...,k}
+     *         p_i^{e_i} and p_i squarefree and gcd(p_i, p_j) = 1, for i != j.
+     */
+    @Override
+    public SortedMap<GenPolynomial<GenPolynomial<C>>, Long> recursiveUnivariateSquarefreeFactors(
+                    GenPolynomial<GenPolynomial<C>> P) {
+        SortedMap<GenPolynomial<GenPolynomial<C>>, Long> sfactors = new TreeMap<GenPolynomial<GenPolynomial<C>>, Long>();
+        if (P == null || P.isZERO()) {
+            return sfactors;
+        }
+        GenPolynomialRing<GenPolynomial<C>> pfac = P.ring;
+        if (pfac.nvar > 1) {
+            // recursiveContent not possible by return type
+            throw new IllegalArgumentException(
+                            this.getClass().getName() + " only for univariate polynomials");
+        }
+        // if base coefficient ring is a field, make monic
+        GenPolynomialRing<C> cfac = (GenPolynomialRing<C>) pfac.coFac;
+        C ldbcf = P.leadingBaseCoefficient().leadingBaseCoefficient();
+        if (!ldbcf.isONE()) {
+            GenPolynomial<C> lc = cfac.getONE().multiply(ldbcf);
+            GenPolynomial<GenPolynomial<C>> pl = pfac.getONE().multiply(lc);
+            sfactors.put(pl, 1L);
+            C li = ldbcf.inverse();
+            //System.out.println("li = " + li);
+            P = P.multiply(cfac.getONE().multiply(li));
+            //System.out.println("P,monic = " + P);
+            ldbcf = P.leadingBaseCoefficient().leadingBaseCoefficient();
+        }
+        // factors of content
+        GenPolynomial<C> Pc = engine.recursiveContent(P);
+        if (logger.isInfoEnabled()) {
+            logger.info("recursiveContent = " + Pc);
+        }
+        Pc = Pc.monic();
+        if (!Pc.isONE()) {
+            P = PolyUtil.<C> coefficientPseudoDivide(P, Pc);
+        }
+        SortedMap<GenPolynomial<C>, Long> rsf = squarefreeFactors(Pc);
+        if (logger.isInfoEnabled()) {
+            logger.info("squarefreeFactors = " + rsf);
+        }
+        // add factors of content
+        for (Map.Entry<GenPolynomial<C>, Long> me : rsf.entrySet()) {
+            GenPolynomial<C> c = me.getKey();
+            if (!c.isONE()) {
+                GenPolynomial<GenPolynomial<C>> cr = pfac.getONE().multiply(c);
+                Long rk = me.getValue(); // rsf.get(c);
+                sfactors.put(cr, rk);
+            }
+        }
+        // divide by trailing term
+        ExpVector et = P.trailingExpVector();
+        if (!et.isZERO()) {
+            GenPolynomial<GenPolynomial<C>> tr = pfac.valueOf(et);
+            if (logger.isInfoEnabled()) {
+                logger.info("trailing term = " + tr);
+            }
+            P = PolyUtil.<C> recursivePseudoDivide(P, tr);
+            long ep = et.getVal(0); // univariate
+            et = et.subst(0, 1);
+            tr = pfac.valueOf(et);
+            sfactors.put(tr, ep);
+        }
+
+        // factors of recursive polynomial
+        GenPolynomial<GenPolynomial<C>> T0 = P;
+        GenPolynomial<GenPolynomial<C>> Tp;
+        GenPolynomial<GenPolynomial<C>> T = null;
+        GenPolynomial<GenPolynomial<C>> V = null;
+        long k = 0L;
+        boolean init = true;
+        while (true) {
+            if (init) {
+                if (T0.isConstant() || T0.isZERO()) {
+                    break;
+                }
+                Tp = PolyUtil.<C> recursiveDeriviative(T0);
+                T = engine.recursiveUnivariateGcd(T0, Tp);
+                T = PolyUtil.<C> monic(T);
+                V = PolyUtil.<C> recursivePseudoDivide(T0, T);
+                //System.out.println("iT0 = " + T0);
+                //System.out.println("iTp = " + Tp);
+                //System.out.println("iT = " + T);
+                //System.out.println("iV = " + V);
+                k = 0L;
+                init = false;
+            }
+            if (V.isConstant()) {
+                break;
+            }
+            k++;
+            GenPolynomial<GenPolynomial<C>> W = engine.recursiveUnivariateGcd(T, V);
+            W = PolyUtil.<C> monic(W);
+            GenPolynomial<GenPolynomial<C>> z = PolyUtil.<C> recursivePseudoDivide(V, W);
+            //System.out.println("W = " + W);
+            //System.out.println("z = " + z);
+            V = W;
+            T = PolyUtil.<C> recursivePseudoDivide(T, V);
+            //System.out.println("V = " + V);
+            //System.out.println("T = " + T);
+            //was: if ( z.degree(0) > 0 ) {
+            if (!z.isONE() && !z.isZERO()) {
+                if (ldbcf.isONE()) {
+                    z = PolyUtil.<C> monic(z);
+                    logger.info("z,monic = " + z);
+                }
+                sfactors.put(z, k);
+            }
+        }
+        return sfactors;
+    }
+
+
+    /**
+     * GenPolynomial greatest squarefree divisor.
+     * @param P GenPolynomial.
+     * @return squarefree(pp(P)).
+     */
+    @Override
+    public GenPolynomial<C> squarefreePart(GenPolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P != null");
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        GenPolynomialRing<C> pfac = P.ring;
+        if (pfac.nvar <= 1) {
+            return baseSquarefreePart(P);
+        }
+        GenPolynomialRing<GenPolynomial<C>> rfac = pfac.recursive(1);
+        GenPolynomial<GenPolynomial<C>> Pr = PolyUtil.<C> recursive(rfac, P);
+        GenPolynomial<C> Pc = engine.recursiveContent(Pr);
+        Pr = PolyUtil.<C> coefficientPseudoDivide(Pr, Pc);
+        GenPolynomial<C> Ps = squarefreePart(Pc);
+        if (logger.isInfoEnabled()) {
+            logger.info("content = " + Pc + ", squarefreePart = " + Ps);
+        }
+        GenPolynomial<GenPolynomial<C>> PP = recursiveUnivariateSquarefreePart(Pr);
+        GenPolynomial<GenPolynomial<C>> PS = PP.multiply(Ps);
+        GenPolynomial<C> D = PolyUtil.<C> distribute(pfac, PS);
+        if (logger.isInfoEnabled()) {
+            logger.info("univRec = " + Pr + ", squarefreePart = " + PP);
+        }
+        return D;
+    }
+
+
+    /**
+     * GenPolynomial test if is squarefree.
+     * @param P GenPolynomial.
+     * @return true if P is squarefree, else false.
+     */
+    @Override
+    public boolean isSquarefree(GenPolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P != null");
+        }
+        if (P.isZERO()) {
+            return true;
+        }
+        GenPolynomialRing<C> pfac = P.ring;
+        if (pfac.nvar <= 1) {
+            return isBaseSquarefree(P);
+        }
+        GenPolynomialRing<GenPolynomial<C>> rfac = pfac.recursive(1);
+        GenPolynomial<GenPolynomial<C>> Pr = PolyUtil.<C> recursive(rfac, P);
+        return isRecursiveUnivariateSquarefree(Pr);
+    }
+
+
+    /**
+     * GenPolynomial squarefree factorization.
+     * @param P GenPolynomial.
+     * @return [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with P = prod_{i=1,...,k}
+     *         p_i^{e_i} and p_i squarefree and gcd(p_i, p_j) = 1, for i != j.
+     */
+    @Override
+    public SortedMap<GenPolynomial<C>, Long> squarefreeFactors(GenPolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P != null");
+        }
+        GenPolynomialRing<C> pfac = P.ring;
+        if (pfac.nvar <= 1) {
+            return normalizeFactorization(baseSquarefreeFactors(P));
+        }
+        SortedMap<GenPolynomial<C>, Long> sfactors = new TreeMap<GenPolynomial<C>, Long>();
+        if (P.isZERO()) {
+            return normalizeFactorization(sfactors);
+        }
+        if (P.isONE()) {
+            sfactors.put(P, 1L);
+            return normalizeFactorization(sfactors);
+        }
+        GenPolynomialRing<GenPolynomial<C>> rfac = pfac.recursive(1);
+        GenPolynomial<GenPolynomial<C>> Pr = PolyUtil.<C> recursive(rfac, P);
+        SortedMap<GenPolynomial<GenPolynomial<C>>, Long> PP = recursiveUnivariateSquarefreeFactors(Pr);
+
+        for (Map.Entry<GenPolynomial<GenPolynomial<C>>, Long> m : PP.entrySet()) {
+            Long i = m.getValue();
+            GenPolynomial<GenPolynomial<C>> Dr = m.getKey();
+            GenPolynomial<C> D = PolyUtil.<C> distribute(pfac, Dr);
+            sfactors.put(D, i);
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("squarefreeFactors(" + P + ") = " + sfactors);
+        }
+        return normalizeFactorization(sfactors);
+    }
+
+
+    /**
+     * Coefficients squarefree factorization.
+     * @param P coefficient.
+     * @return [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with P = prod_{i=1,...,k}
+     *         p_i^{e_i} and p_i squarefree and gcd(p_i, p_j) = 1, for i != j.
+     */
+    @Override
+    public SortedMap<C, Long> squarefreeFactors(C P) {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/SquarefreeFieldChar0Yun.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/SquarefreeFieldChar0Yun.java
@@ -1,0 +1,249 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Squarefree decomposition for coefficient fields of characteristic 0,
+ * algorithm of Yun.
+ * @author Heinz Kredel
+ */
+
+public class SquarefreeFieldChar0Yun<C extends GcdRingElem<C>> extends SquarefreeFieldChar0<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(SquarefreeFieldChar0Yun.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     */
+    public SquarefreeFieldChar0Yun(RingFactory<C> fac) {
+        super(fac);
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return getClass().getName() + " with " + engine + " over " + coFac;
+    }
+
+
+    /**
+     * GenPolynomial polynomial squarefree factorization.
+     * @param A GenPolynomial.
+     * @return [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with A = prod_{i=1,...,k}
+     *         p_i^{e_i} and p_i squarefree and gcd(p_i, p_j) = 1, for i != j.
+     */
+    @Override
+    public SortedMap<GenPolynomial<C>, Long> baseSquarefreeFactors(GenPolynomial<C> A) {
+        SortedMap<GenPolynomial<C>, Long> sfactors = new TreeMap<GenPolynomial<C>, Long>();
+        if (A == null || A.isZERO()) {
+            return sfactors;
+        }
+        if (A.isConstant()) {
+            sfactors.put(A, 1L);
+            return sfactors;
+        }
+        GenPolynomialRing<C> pfac = A.ring;
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException(
+                            this.getClass().getName() + " only for univariate polynomials");
+        }
+        C ldbcf = A.leadingBaseCoefficient();
+        if (!ldbcf.isONE()) {
+            A = A.divide(ldbcf);
+            GenPolynomial<C> f1 = pfac.getONE().multiply(ldbcf);
+            //System.out.println("gcda sqf f1 = " + f1);
+            sfactors.put(f1, 1L);
+            ldbcf = pfac.coFac.getONE();
+        }
+        // divide by trailing term
+        ExpVector et = A.trailingExpVector();
+        if (!et.isZERO()) {
+            GenPolynomial<C> tr = pfac.valueOf(et);
+            if (logger.isInfoEnabled()) {
+                logger.info("trailing term = " + tr);
+            }
+            A = PolyUtil.<C> basePseudoDivide(A, tr);
+            long ep = et.getVal(0); // univariate
+            et = et.subst(0, 1);
+            tr = pfac.valueOf(et);
+            if (logger.isInfoEnabled()) {
+                logger.info("tr, ep = " + tr + ", " + ep);
+            }
+            sfactors.put(tr, ep);
+            if (A.length() == 1) {
+                return sfactors;
+            }
+        }
+        GenPolynomial<C> Tp, T, W, Y, Z;
+        long k = 1L; //0L
+        Tp = PolyUtil.<C> baseDeriviative(A);
+        T = engine.baseGcd(A, Tp);
+        T = T.monic();
+        if (T.isConstant()) {
+            sfactors.put(A, k);
+            return sfactors;
+        }
+        W = PolyUtil.<C> basePseudoDivide(A, T);
+        //if (W.isConstant()) {
+        //    return sfactors;
+        //}
+        Y = PolyUtil.<C> basePseudoDivide(Tp, T);
+        GenPolynomial<C> Wp = PolyUtil.<C> baseDeriviative(W);
+        Z = Y.subtract(Wp);
+        while (!Z.isZERO()) {
+            GenPolynomial<C> g = engine.baseGcd(W, Z);
+            g = g.monic();
+            if (!g.isONE()) {
+                sfactors.put(g, k);
+            }
+            W = PolyUtil.<C> basePseudoDivide(W, g);
+            //System.out.println("W = " + W);
+            //System.out.println("g = " + g);
+            Y = PolyUtil.<C> basePseudoDivide(Z, g);
+            Wp = PolyUtil.<C> baseDeriviative(W);
+            Z = Y.subtract(Wp);
+            k++;
+        }
+        logger.info("W, k = " + W + ", " + k);
+        if (!W.isONE()) {
+            sfactors.put(W, k);
+        }
+        return normalizeFactorization(sfactors);
+    }
+
+
+    /**
+     * GenPolynomial recursive univariate polynomial squarefree factorization.
+     * @param P recursive univariate GenPolynomial.
+     * @return [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with P = prod_{i=1,...,k}
+     *         p_i^{e_i} and p_i squarefree and gcd(p_i, p_j) = 1, for i != j.
+     */
+    @Override
+    public SortedMap<GenPolynomial<GenPolynomial<C>>, Long> recursiveUnivariateSquarefreeFactors(
+                    GenPolynomial<GenPolynomial<C>> P) {
+        SortedMap<GenPolynomial<GenPolynomial<C>>, Long> sfactors = new TreeMap<GenPolynomial<GenPolynomial<C>>, Long>();
+        if (P == null || P.isZERO()) {
+            return sfactors;
+        }
+        GenPolynomialRing<GenPolynomial<C>> pfac = P.ring;
+        if (pfac.nvar > 1) {
+            // recursiveContent not possible by return type
+            throw new IllegalArgumentException(
+                            this.getClass().getName() + " only for univariate polynomials");
+        }
+        // if base coefficient ring is a field, make monic
+        GenPolynomialRing<C> cfac = (GenPolynomialRing<C>) pfac.coFac;
+        C ldbcf = P.leadingBaseCoefficient().leadingBaseCoefficient();
+        if (!ldbcf.isONE()) {
+            GenPolynomial<C> lc = cfac.getONE().multiply(ldbcf);
+            GenPolynomial<GenPolynomial<C>> pl = pfac.getONE().multiply(lc);
+            sfactors.put(pl, 1L);
+            C li = ldbcf.inverse();
+            //System.out.println("li = " + li);
+            P = P.multiply(cfac.getONE().multiply(li));
+            //System.out.println("P,monic = " + P);
+            ldbcf = P.leadingBaseCoefficient().leadingBaseCoefficient();
+        }
+        // factors of content
+        GenPolynomial<C> Pc = engine.recursiveContent(P);
+        if (logger.isInfoEnabled()) {
+            logger.info("recursiveContent = " + Pc);
+        }
+        Pc = Pc.monic();
+        if (!Pc.isONE()) {
+            P = PolyUtil.<C> coefficientPseudoDivide(P, Pc);
+        }
+        SortedMap<GenPolynomial<C>, Long> rsf = squarefreeFactors(Pc);
+        if (logger.isInfoEnabled()) {
+            logger.info("squarefreeFactors = " + rsf);
+        }
+        // add factors of content
+        for (Map.Entry<GenPolynomial<C>, Long> me : rsf.entrySet()) {
+            GenPolynomial<C> c = me.getKey();
+            if (!c.isONE()) {
+                GenPolynomial<GenPolynomial<C>> cr = pfac.getONE().multiply(c);
+                Long rk = me.getValue();
+                sfactors.put(cr, rk);
+            }
+        }
+        // divide by trailing term
+        ExpVector et = P.trailingExpVector();
+        if (!et.isZERO()) {
+            GenPolynomial<GenPolynomial<C>> tr = pfac.valueOf(et);
+            if (logger.isInfoEnabled()) {
+                logger.info("trailing term = " + tr);
+            }
+            P = PolyUtil.<C> recursivePseudoDivide(P, tr);
+            long ep = et.getVal(0); // univariate
+            et = et.subst(0, 1);
+            tr = pfac.valueOf(et);
+            sfactors.put(tr, ep);
+            //P.length == 1 ??
+        }
+        // factors of recursive polynomial
+        GenPolynomial<GenPolynomial<C>> Tp, T, W, Y, Z;
+        long k = 1L; //0L
+        Tp = PolyUtil.<C> recursiveDeriviative(P);
+        T = engine.recursiveUnivariateGcd(P, Tp);
+        T = PolyUtil.<C> monic(T);
+        if (T.isConstant()) {
+            sfactors.put(P, k);
+            return sfactors;
+        }
+        W = PolyUtil.<C> recursivePseudoDivide(P, T);
+        //if (W.isConstant()) {
+        //    return sfactors;
+        //}
+        Y = PolyUtil.<C> recursivePseudoDivide(Tp, T);
+        GenPolynomial<GenPolynomial<C>> Wp = PolyUtil.<C> recursiveDeriviative(W);
+        Z = Y.subtract(Wp);
+
+        while (!Z.isZERO()) {
+            GenPolynomial<GenPolynomial<C>> g = engine.recursiveGcd(W, Z);
+            g = PolyUtil.<C> monic(g);
+            if (!g.isONE()) {
+                sfactors.put(g, k);
+            }
+            W = PolyUtil.<C> recursivePseudoDivide(W, g);
+            //System.out.println("W = " + W);
+            //System.out.println("g = " + g);
+            Y = PolyUtil.<C> recursivePseudoDivide(Z, g);
+            Wp = PolyUtil.<C> recursiveDeriviative(W);
+            Z = Y.subtract(Wp);
+            k++;
+        }
+        logger.info("W, k = " + W + ", " + k);
+        if (!W.isONE()) {
+            sfactors.put(W, k);
+        }
+        return sfactors; //normalizeFactorization(sfactors);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/SquarefreeFieldCharP.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/SquarefreeFieldCharP.java
@@ -1,0 +1,732 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.AlgebraicNumberRing;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Squarefree decomposition for coefficient fields of characteristic p.
+ * @author Heinz Kredel
+ */
+
+public abstract class SquarefreeFieldCharP<C extends GcdRingElem<C>> extends SquarefreeAbstract<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(SquarefreeFieldCharP.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /*
+     * Squarefree engine for characteristic p base coefficients.
+     */
+    //protected final SquarefreeAbstract<C> rengine;
+
+
+    /**
+     * Factory for finite field of characteristic p coefficients.
+     */
+    protected final RingFactory<C> coFac;
+
+
+    /**
+     * Factory for a algebraic extension of a finite field of characteristic p
+     * coefficients. If <code>coFac</code> is an algebraic extension, then
+     * <code>aCoFac</code> is equal to <code>coFac</code>, else
+     * <code>aCoFac</code> is <code>null</code>.
+     */
+    protected final AlgebraicNumberRing<C> aCoFac;
+
+
+    /**
+     * Factory for a transcendental extension of a finite field of
+     * characteristic p coefficients. If <code>coFac</code> is an transcendental
+     * extension, then <code>qCoFac</code> is equal to <code>coFac</code>, else
+     * <code>qCoFac</code> is <code>null</code>.
+     */
+    protected final QuotientRing<C> qCoFac;
+
+
+    /**
+     * Constructor.
+     */
+    @SuppressWarnings("unchecked")
+    public SquarefreeFieldCharP(RingFactory<C> fac) {
+        super(GCDFactory.<C> getProxy(fac));
+        if (!fac.isField()) {
+            //throw new IllegalArgumentException("fac must be a field: "  + fac.toScript());
+            logger.warn("fac should be a field: " + fac.toScript());
+        }
+        if (fac.characteristic().signum() == 0) {
+            throw new IllegalArgumentException("characterisic(fac) must be non-zero");
+        }
+        coFac = fac;
+        Object oFac = coFac;
+        if (oFac instanceof AlgebraicNumberRing) {
+            aCoFac = (AlgebraicNumberRing<C>) oFac; // <C> is not correct
+            //rengine = (SquarefreeAbstract) SquarefreeFactory.getImplementation(aCoFac.ring);
+            qCoFac = null;
+        } else {
+            aCoFac = null;
+            if (oFac instanceof QuotientRing) {
+                qCoFac = (QuotientRing<C>) oFac; // <C> is not correct
+                //rengine = (SquarefreeAbstract) SquarefreeFactory.getImplementation(qCoFac.ring);
+            } else {
+                qCoFac = null;
+            }
+        }
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return getClass().getName() + " with " + engine + " over " + coFac;
+    }
+
+
+    /**
+     * GenPolynomial polynomial greatest squarefree divisor.
+     * @param P GenPolynomial.
+     * @return squarefree(pp(P)).
+     */
+    @Override
+    public GenPolynomial<C> baseSquarefreePart(GenPolynomial<C> P) {
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        GenPolynomialRing<C> pfac = P.ring;
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException(
+                            this.getClass().getName() + " only for univariate polynomials");
+        }
+        GenPolynomial<C> s = pfac.getONE();
+        SortedMap<GenPolynomial<C>, Long> factors = baseSquarefreeFactors(P);
+        //if (logger.isWarnEnabled()) {
+        //   logger.warn("sqfPart, better use sqfFactors, factors = " + factors);
+        //}
+        for (GenPolynomial<C> sp : factors.keySet()) {
+            s = s.multiply(sp);
+        }
+        s = s.monic();
+        return s;
+    }
+
+
+    /**
+     * GenPolynomial polynomial squarefree factorization.
+     * @param A GenPolynomial.
+     * @return [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with A = prod_{i=1,...,k}
+     *         p_i^{e_i} and p_i squarefree and gcd(p_i, p_j) = 1, for i != j.
+     */
+    @Override
+    public SortedMap<GenPolynomial<C>, Long> baseSquarefreeFactors(GenPolynomial<C> A) {
+        SortedMap<GenPolynomial<C>, Long> sfactors = new TreeMap<GenPolynomial<C>, Long>();
+        if (A == null || A.isZERO()) {
+            return sfactors;
+        }
+        GenPolynomialRing<C> pfac = A.ring;
+        if (A.isConstant()) {
+            C coeff = A.leadingBaseCoefficient();
+            //System.out.println("coeff = " + coeff + " @ " + coeff.factory());
+            SortedMap<C, Long> rfactors = squarefreeFactors(coeff);
+            //System.out.println("rfactors,const = " + rfactors);
+            if (rfactors != null && rfactors.size() > 0) {
+                for (Map.Entry<C, Long> me : rfactors.entrySet()) {
+                    C c = me.getKey();
+                    if (!c.isONE()) {
+                        GenPolynomial<C> cr = pfac.getONE().multiply(c);
+                        Long rk = me.getValue(); // rfactors.get(c);
+                        sfactors.put(cr, rk);
+                    }
+                }
+            } else {
+                sfactors.put(A, 1L);
+            }
+            return sfactors;
+        }
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException(
+                            this.getClass().getName() + " only for univariate polynomials");
+        }
+        C ldbcf = A.leadingBaseCoefficient();
+        if (!ldbcf.isONE()) {
+            A = A.divide(ldbcf);
+            SortedMap<C, Long> rfactors = squarefreeFactors(ldbcf);
+            //System.out.println("rfactors,ldbcf = " + rfactors);
+            if (rfactors != null && rfactors.size() > 0) {
+                for (Map.Entry<C, Long> me : rfactors.entrySet()) {
+                    C c = me.getKey();
+                    if (!c.isONE()) {
+                        GenPolynomial<C> cr = pfac.getONE().multiply(c);
+                        Long rk = me.getValue(); //rfactors.get(c);
+                        sfactors.put(cr, rk);
+                    }
+                }
+            } else {
+                GenPolynomial<C> f1 = pfac.getONE().multiply(ldbcf);
+                //System.out.println("gcda sqf f1 = " + f1);
+                sfactors.put(f1, 1L);
+            }
+            ldbcf = pfac.coFac.getONE();
+        }
+        // divide by trailing term
+        ExpVector et = A.trailingExpVector();
+        if (!et.isZERO()) {
+            GenPolynomial<C> tr = pfac.valueOf(et);
+            if (logger.isInfoEnabled()) {
+                logger.info("trailing term = " + tr);
+            }
+            A = PolyUtil.<C> basePseudoDivide(A, tr);
+            long ep = et.getVal(0); // univariate
+            et = et.subst(0, 1);
+            tr = pfac.valueOf(et);
+            if (logger.isInfoEnabled()) {
+                logger.info("tr, ep = " + tr + ", " + ep);
+            }
+            sfactors.put(tr, ep);
+            if (A.length() == 1) {
+                return sfactors;
+            }
+        }
+        GenPolynomial<C> T0 = A;
+        long e = 1L;
+        GenPolynomial<C> Tp;
+        GenPolynomial<C> T = null;
+        GenPolynomial<C> V = null;
+        long k = 0L;
+        long mp = 0L;
+        boolean init = true;
+        while (true) {
+            //System.out.println("T0 = " + T0);
+            if (init) {
+                if (T0.isConstant() || T0.isZERO()) {
+                    break;
+                }
+                Tp = PolyUtil.<C> baseDeriviative(T0);
+                T = engine.baseGcd(T0, Tp);
+                T = T.monic();
+                V = PolyUtil.<C> basePseudoDivide(T0, T);
+                //System.out.println("iT0 = " + T0);
+                //System.out.println("iTp = " + Tp);
+                //System.out.println("iT  = " + T);
+                //System.out.println("iV  = " + V);
+                //System.out.println("const(iV)  = " + V.isConstant());
+                k = 0L;
+                mp = 0L;
+                init = false;
+            }
+            if (V.isConstant()) {
+                mp = pfac.characteristic().longValueExact(); // assert != 0
+                //T0 = PolyUtil.<C> baseModRoot(T,mp);
+                T0 = baseRootCharacteristic(T);
+                logger.info("char root: T0 = " + T0 + ", T = " + T);
+                if (T0 == null) {
+                    //break;
+                    T0 = pfac.getZERO();
+                }
+                e = e * mp;
+                init = true;
+                continue;
+            }
+            k++;
+            if (mp != 0L && k % mp == 0L) {
+                T = PolyUtil.<C> basePseudoDivide(T, V);
+                System.out.println("k = " + k);
+                //System.out.println("T = " + T);
+                k++;
+            }
+            GenPolynomial<C> W = engine.baseGcd(T, V);
+            W = W.monic();
+            GenPolynomial<C> z = PolyUtil.<C> basePseudoDivide(V, W);
+            //System.out.println("W = " + W);
+            //System.out.println("z = " + z);
+            V = W;
+            T = PolyUtil.<C> basePseudoDivide(T, V);
+            //System.out.println("V = " + V);
+            //System.out.println("T = " + T);
+            if (z.degree(0) > 0) {
+                if (ldbcf.isONE() && !z.leadingBaseCoefficient().isONE()) {
+                    z = z.monic();
+                    //logger.info("z,monic = " + z);
+                }
+                logger.info("z, k = " + z + ", " + k);
+                sfactors.put(z, (e * k));
+            }
+        }
+        logger.info("exit char root: T0 = " + T0 + ", T = " + T);
+        return sfactors;
+    }
+
+
+    /**
+     * GenPolynomial recursive univariate polynomial greatest squarefree
+     * divisor.
+     * @param P recursive univariate GenPolynomial.
+     * @return squarefree(pp(P)).
+     */
+    @Override
+    public GenPolynomial<GenPolynomial<C>> recursiveUnivariateSquarefreePart(
+                    GenPolynomial<GenPolynomial<C>> P) {
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        GenPolynomialRing<GenPolynomial<C>> pfac = P.ring;
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException(
+                            this.getClass().getName() + " only for univariate polynomials");
+        }
+        GenPolynomial<GenPolynomial<C>> s = pfac.getONE();
+        SortedMap<GenPolynomial<GenPolynomial<C>>, Long> factors = recursiveUnivariateSquarefreeFactors(P);
+        if (logger.isWarnEnabled()) {
+            logger.info("sqfPart, better use sqfFactors, factors = " + factors);
+        }
+        for (GenPolynomial<GenPolynomial<C>> sp : factors.keySet()) {
+            s = s.multiply(sp);
+        }
+        s = PolyUtil.<C> monic(s);
+        return s;
+    }
+
+
+    /**
+     * GenPolynomial recursive univariate polynomial squarefree factorization.
+     * @param P recursive univariate GenPolynomial.
+     * @return [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with P = prod_{i=1,...,k}
+     *         p_i^{e_i} and p_i squarefree and gcd(p_i, p_j) = 1, for i != j.
+     */
+    @Override
+    public SortedMap<GenPolynomial<GenPolynomial<C>>, Long> recursiveUnivariateSquarefreeFactors(
+                    GenPolynomial<GenPolynomial<C>> P) {
+        SortedMap<GenPolynomial<GenPolynomial<C>>, Long> sfactors = new TreeMap<GenPolynomial<GenPolynomial<C>>, Long>();
+        if (P == null || P.isZERO()) {
+            return sfactors;
+        }
+        GenPolynomialRing<GenPolynomial<C>> pfac = P.ring;
+        if (pfac.nvar > 1) {
+            // recursiveContent not possible by return type
+            throw new IllegalArgumentException(
+                            this.getClass().getName() + " only for univariate polynomials");
+        }
+        // if base coefficient ring is a field, make monic
+        GenPolynomialRing<C> cfac = (GenPolynomialRing<C>) pfac.coFac;
+        C ldbcf = P.leadingBaseCoefficient().leadingBaseCoefficient();
+        if (!ldbcf.isONE()) {
+            GenPolynomial<C> lc = cfac.getONE().multiply(ldbcf);
+            GenPolynomial<GenPolynomial<C>> pl = pfac.getONE().multiply(lc);
+            sfactors.put(pl, 1L);
+            C li = ldbcf.inverse();
+            //System.out.println("li = " + li);
+            P = P.multiply(cfac.getONE().multiply(li));
+            //System.out.println("P,monic = " + P);
+            ldbcf = P.leadingBaseCoefficient().leadingBaseCoefficient();
+            if (debug) {
+                logger.debug("new ldbcf: " + ldbcf);
+            }
+        }
+        // factors of content
+        GenPolynomial<C> Pc = engine.recursiveContent(P);
+        if (logger.isInfoEnabled()) {
+            logger.info("Pc = " + Pc);
+        }
+        Pc = Pc.monic();
+        if (!Pc.isONE()) {
+            P = PolyUtil.<C> coefficientPseudoDivide(P, Pc);
+        }
+        SortedMap<GenPolynomial<C>, Long> rsf = squarefreeFactors(Pc);
+        if (logger.isInfoEnabled()) {
+            logger.info("rsf = " + rsf);
+        }
+        // add factors of content
+        for (Map.Entry<GenPolynomial<C>, Long> me : rsf.entrySet()) {
+            GenPolynomial<C> c = me.getKey();
+            if (!c.isONE()) {
+                GenPolynomial<GenPolynomial<C>> cr = pfac.getONE().multiply(c);
+                Long rk = me.getValue(); //rsf.get(c);
+                sfactors.put(cr, rk);
+            }
+        }
+        // divide by trailing term
+        ExpVector et = P.trailingExpVector();
+        if (!et.isZERO()) {
+            GenPolynomial<GenPolynomial<C>> tr = pfac.valueOf(et);
+            if (logger.isInfoEnabled()) {
+                logger.info("trailing term = " + tr);
+            }
+            P = PolyUtil.<C> recursivePseudoDivide(P, tr);
+            long ep = et.getVal(0); // univariate
+            et = et.subst(0, 1);
+            tr = pfac.valueOf(et);
+            sfactors.put(tr, ep);
+        }
+
+        // factors of recursive polynomial
+        GenPolynomial<GenPolynomial<C>> T0 = P;
+        long e = 1L;
+        GenPolynomial<GenPolynomial<C>> Tp;
+        GenPolynomial<GenPolynomial<C>> T = null;
+        GenPolynomial<GenPolynomial<C>> V = null;
+        long k = 0L;
+        long mp = 0L;
+        boolean init = true;
+        while (true) {
+            if (init) {
+                if (T0.isConstant() || T0.isZERO()) {
+                    break;
+                }
+                Tp = PolyUtil.<C> recursiveDeriviative(T0);
+                //System.out.println("iT0 = " + T0);
+                //System.out.println("iTp = " + Tp);
+                T = engine.recursiveUnivariateGcd(T0, Tp);
+                T = PolyUtil.<C> monic(T);
+                V = PolyUtil.<C> recursivePseudoDivide(T0, T);
+                //System.out.println("iT = " + T);
+                //System.out.println("iV = " + V);
+                k = 0L;
+                mp = 0L;
+                init = false;
+            }
+            if (V.isConstant()) {
+                mp = pfac.characteristic().longValueExact(); // assert != 0
+                //T0 = PolyUtil.<C> recursiveModRoot(T,mp);
+                T0 = recursiveUnivariateRootCharacteristic(T);
+                logger.info("char root: T0r = " + T0 + ", Tr = " + T);
+                if (T0 == null) {
+                    //break;
+                    T0 = pfac.getZERO();
+                }
+                e = e * mp;
+                init = true;
+                //continue;
+            }
+            k++;
+            if (mp != 0L && k % mp == 0L) {
+                T = PolyUtil.<C> recursivePseudoDivide(T, V);
+                System.out.println("k = " + k);
+                //System.out.println("T = " + T);
+                k++;
+            }
+            GenPolynomial<GenPolynomial<C>> W = engine.recursiveUnivariateGcd(T, V);
+            W = PolyUtil.<C> monic(W);
+            GenPolynomial<GenPolynomial<C>> z = PolyUtil.<C> recursivePseudoDivide(V, W);
+            //System.out.println("W = " + W);
+            //System.out.println("z = " + z);
+            V = W;
+            T = PolyUtil.<C> recursivePseudoDivide(T, V);
+            //System.out.println("V = " + V);
+            //System.out.println("T = " + T);
+            //was: if ( z.degree(0) > 0 ) {
+            if (!z.isONE() && !z.isZERO()) {
+                z = PolyUtil.<C> monic(z);
+                logger.info("z,put = " + z);
+                sfactors.put(z, (e * k));
+            }
+        }
+        logger.info("exit char root: T0 = " + T0 + ", T = " + T);
+        if (sfactors.size() == 0) {
+            sfactors.put(pfac.getONE(), 1L);
+        }
+        return sfactors;
+    }
+
+
+    /**
+     * GenPolynomial greatest squarefree divisor.
+     * @param P GenPolynomial.
+     * @return squarefree(pp(P)).
+     */
+    @Override
+    public GenPolynomial<C> squarefreePart(GenPolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P != null");
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        GenPolynomialRing<C> pfac = P.ring;
+        if (pfac.nvar <= 1) {
+            return baseSquarefreePart(P);
+        }
+        GenPolynomial<C> s = pfac.getONE();
+        SortedMap<GenPolynomial<C>, Long> factors = squarefreeFactors(P);
+        if (logger.isWarnEnabled()) {
+            logger.info("sqfPart, better use sqfFactors, factors = " + factors);
+        }
+        for (GenPolynomial<C> sp : factors.keySet()) {
+            if (sp.isConstant()) {
+                continue;
+            }
+            s = s.multiply(sp);
+        }
+        return s.monic();
+    }
+
+
+    /**
+     * GenPolynomial squarefree factorization.
+     * @param P GenPolynomial.
+     * @return [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with P = prod_{i=1,...,k}
+     *         p_i^{e_i} and p_i squarefree and gcd(p_i, p_j) = 1, for i != j.
+     */
+    @Override
+    public SortedMap<GenPolynomial<C>, Long> squarefreeFactors(GenPolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P != null");
+        }
+        GenPolynomialRing<C> pfac = P.ring;
+        if (pfac.nvar <= 1) {
+            return baseSquarefreeFactors(P);
+        }
+        SortedMap<GenPolynomial<C>, Long> sfactors = new TreeMap<GenPolynomial<C>, Long>();
+        if (P.isZERO()) {
+            return sfactors;
+        }
+        if (P.isONE()) {
+            sfactors.put(P, 1L);
+            return sfactors;
+        }
+        GenPolynomialRing<GenPolynomial<C>> rfac = pfac.recursive(1);
+        GenPolynomial<GenPolynomial<C>> Pr = PolyUtil.<C> recursive(rfac, P);
+        SortedMap<GenPolynomial<GenPolynomial<C>>, Long> PP = recursiveUnivariateSquarefreeFactors(Pr);
+        for (Map.Entry<GenPolynomial<GenPolynomial<C>>, Long> m : PP.entrySet()) {
+            Long i = m.getValue();
+            GenPolynomial<GenPolynomial<C>> Dr = m.getKey();
+            GenPolynomial<C> D = PolyUtil.<C> distribute(pfac, Dr);
+            sfactors.put(D, i);
+        }
+        return sfactors;
+    }
+
+
+    /**
+     * Coefficient squarefree factorization.
+     * @param coeff coefficient.
+     * @return [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with coeff = prod_{i=1,...,k}
+     *         p_i^{e_i} and p_i squarefree and gcd(p_i, p_j) = 1, for i != j.
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public SortedMap<C, Long> squarefreeFactors(C coeff) {
+        if (coeff == null) {
+            return null;
+        }
+        SortedMap<C, Long> factors = new TreeMap<C, Long>();
+        RingFactory<C> cfac = (RingFactory<C>) coeff.factory();
+        if (aCoFac != null) {
+            AlgebraicNumber<C> an = (AlgebraicNumber<C>) (Object) coeff;
+            if (cfac.isFinite()) {
+                SquarefreeFiniteFieldCharP<C> reng = (SquarefreeFiniteFieldCharP) SquarefreeFactory
+                                .getImplementation(cfac);
+                SortedMap<C, Long> rfactors = reng.rootCharacteristic(coeff); // ??
+                logger.info("rfactors,finite = " + rfactors);
+                factors.putAll(rfactors);
+                //return factors;
+            } else {
+                SquarefreeInfiniteAlgebraicFieldCharP<C> reng = (SquarefreeInfiniteAlgebraicFieldCharP) SquarefreeFactory
+                                .getImplementation(cfac);
+                SortedMap<AlgebraicNumber<C>, Long> rfactors = reng.squarefreeFactors(an);
+                logger.info("rfactors,infinite,algeb = " + rfactors);
+                for (Map.Entry<AlgebraicNumber<C>, Long> me : rfactors.entrySet()) {
+                    AlgebraicNumber<C> c = me.getKey();
+                    if (!c.isONE()) {
+                        C cr = (C) (Object) c;
+                        Long rk = me.getValue();
+                        factors.put(cr, rk);
+                    }
+                }
+            }
+        } else if (qCoFac != null) {
+            Quotient<C> q = (Quotient<C>) (Object) coeff;
+            SquarefreeInfiniteFieldCharP<C> reng = (SquarefreeInfiniteFieldCharP) SquarefreeFactory
+                            .getImplementation(cfac);
+            SortedMap<Quotient<C>, Long> rfactors = reng.squarefreeFactors(q);
+            logger.info("rfactors,infinite = " + rfactors);
+            for (Map.Entry<Quotient<C>, Long> me : rfactors.entrySet()) {
+                Quotient<C> c = me.getKey();
+                if (!c.isONE()) {
+                    C cr = (C) (Object) c;
+                    Long rk = me.getValue();
+                    factors.put(cr, rk);
+                }
+            }
+        } else if (cfac.isFinite()) {
+            SquarefreeFiniteFieldCharP<C> reng = (SquarefreeFiniteFieldCharP) SquarefreeFactory
+                            .getImplementation(cfac);
+            SortedMap<C, Long> rfactors = reng.rootCharacteristic(coeff); // ??
+            logger.info("rfactors,finite = " + rfactors);
+            factors.putAll(rfactors);
+            //return factors;
+        } else {
+            logger.warn("case " + cfac + " not implemented");
+        }
+        return factors;
+    }
+
+
+    /* --------- char-th roots --------------------- */
+
+
+    /**
+     * GenPolynomial char-th root univariate polynomial.
+     * @param P GenPolynomial.
+     * @return char-th_rootOf(P), or null if no char-th root.
+     */
+    public abstract GenPolynomial<C> baseRootCharacteristic(GenPolynomial<C> P);
+
+
+    /**
+     * GenPolynomial char-th root univariate polynomial with polynomial
+     * coefficients.
+     * @param P recursive univariate GenPolynomial.
+     * @return char-th_rootOf(P), or null if P is no char-th root.
+     */
+    public abstract GenPolynomial<GenPolynomial<C>> recursiveUnivariateRootCharacteristic(
+                    GenPolynomial<GenPolynomial<C>> P);
+
+
+    /**
+     * Polynomial is char-th root.
+     * @param P polynomial.
+     * @param F = [p_1 -&gt; e_1, ..., p_k -&gt; e_k].
+     * @return true if P = prod_{i=1,...,k} p_i**(e_i*p), else false.
+     */
+    public boolean isCharRoot(GenPolynomial<C> P, SortedMap<GenPolynomial<C>, Long> F) {
+        if (P == null || F == null) {
+            throw new IllegalArgumentException("P and F may not be null");
+        }
+        if (P.isZERO() && F.size() == 0) {
+            return true;
+        }
+        GenPolynomial<C> t = P.ring.getONE();
+        long p = P.ring.characteristic().longValueExact();
+        for (Map.Entry<GenPolynomial<C>, Long> me : F.entrySet()) {
+            GenPolynomial<C> f = me.getKey();
+            Long E = me.getValue();
+            long e = E.longValue();
+            GenPolynomial<C> g = f.power(e);
+            if (!f.isConstant()) {
+                g = g.power(p);
+            }
+            t = t.multiply(g);
+        }
+        boolean f = P.equals(t) || P.equals(t.negate());
+        if (!f) {
+            System.out.println("\nfactorization(map): " + f);
+            System.out.println("P = " + P);
+            System.out.println("t = " + t);
+            P = P.monic();
+            t = t.monic();
+            f = P.equals(t) || P.equals(t.negate());
+            if (f) {
+                return f;
+            }
+            System.out.println("\nfactorization(map): " + f);
+            System.out.println("P = " + P);
+            System.out.println("t = " + t);
+        }
+        return f;
+    }
+
+
+    /**
+     * Recursive polynomial is char-th root.
+     * @param P recursive polynomial.
+     * @param F = [p_1 -&gt; e_1, ..., p_k -&gt; e_k].
+     * @return true if P = prod_{i=1,...,k} p_i**(e_i*p), else false.
+     */
+    public boolean isRecursiveCharRoot(GenPolynomial<GenPolynomial<C>> P,
+                    SortedMap<GenPolynomial<GenPolynomial<C>>, Long> F) {
+        if (P == null || F == null) {
+            throw new IllegalArgumentException("P and F may not be null");
+        }
+        if (P.isZERO() && F.size() == 0) {
+            return true;
+        }
+        GenPolynomial<GenPolynomial<C>> t = P.ring.getONE();
+        long p = P.ring.characteristic().longValueExact();
+        for (Map.Entry<GenPolynomial<GenPolynomial<C>>, Long> me : F.entrySet()) {
+            GenPolynomial<GenPolynomial<C>> f = me.getKey();
+            Long E = me.getValue();
+            long e = E.longValue();
+            GenPolynomial<GenPolynomial<C>> g = f.power(e);
+            if (!f.isConstant()) {
+                g = g.power(p);
+            }
+            t = t.multiply(g);
+        }
+        boolean f = P.equals(t) || P.equals(t.negate());
+        if (!f) {
+            System.out.println("\nfactorization(map): " + f);
+            System.out.println("P = " + P);
+            System.out.println("t = " + t);
+            P = P.monic();
+            t = t.monic();
+            f = P.equals(t) || P.equals(t.negate());
+            if (f) {
+                return f;
+            }
+            System.out.println("\nfactorization(map): " + f);
+            System.out.println("P = " + P);
+            System.out.println("t = " + t);
+        }
+        return f;
+    }
+
+
+    /**
+     * Recursive polynomial is char-th root.
+     * @param P recursive polynomial.
+     * @param r = recursive polynomial.
+     * @return true if P = r**p, else false.
+     */
+    public boolean isRecursiveCharRoot(GenPolynomial<GenPolynomial<C>> P, GenPolynomial<GenPolynomial<C>> r) {
+        if (P == null || r == null) {
+            throw new IllegalArgumentException("P and r may not be null");
+        }
+        if (P.isZERO() && r.isZERO()) {
+            return true;
+        }
+        long p = P.ring.characteristic().longValueExact();
+        GenPolynomial<GenPolynomial<C>> t = r.power(p);
+
+        boolean f = P.equals(t) || P.equals(t.negate());
+        if (!f) {
+            System.out.println("\nisCharRoot: " + f);
+            System.out.println("P = " + P);
+            System.out.println("t = " + t);
+            P = P.monic();
+            t = t.monic();
+            f = P.equals(t) || P.equals(t.negate());
+            if (f) {
+                return f;
+            }
+            System.out.println("\nisCharRoot: " + f);
+            System.out.println("P = " + P);
+            System.out.println("t = " + t);
+        }
+        return f;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/SquarefreeFiniteFieldCharP.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/SquarefreeFiniteFieldCharP.java
@@ -1,0 +1,290 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.arith.BigInteger;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.Monomial;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.Power;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Squarefree decomposition for finite coefficient fields of characteristic p.
+ * @author Heinz Kredel
+ */
+
+public class SquarefreeFiniteFieldCharP<C extends GcdRingElem<C>> extends SquarefreeFieldCharP<C> {
+
+
+    private static final Logger logger = LogManager.getLogger(SquarefreeFiniteFieldCharP.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     */
+    public SquarefreeFiniteFieldCharP(RingFactory<C> fac) {
+        super(fac);
+        // isFinite() predicate now present
+        if (!fac.isFinite()) {
+            throw new IllegalArgumentException("fac must be finite");
+        }
+    }
+
+
+    /* --------- char-th roots --------------------- */
+
+    /**
+     * Characteristics root of a coefficient. <b>Note:</b> not needed at the
+     * moment.
+     * @param p coefficient.
+     * @return [p -&gt; k] if exists k with e=k*charactristic(c) and c = p**e,
+     *         else null.
+     */
+    public SortedMap<C, Long> rootCharacteristic(C p) {
+        if (p == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " p == null");
+        }
+        // already checked in constructor:
+        //java.math.BigInteger c = p.factory().characteristic();
+        //if ( c.signum() == 0 ) {
+        //    return null;
+        //}
+        SortedMap<C, Long> root = new TreeMap<C, Long>();
+        if (p.isZERO()) {
+            return root;
+        }
+        // true for finite fields:
+        root.put(p, 1L);
+        return root;
+    }
+
+
+    /**
+     * Characteristics root of a coefficient.
+     * @param c coefficient.
+     * @return r with r**p == c, if such an r exists, else null.
+     */
+    public C coeffRootCharacteristic(C c) {
+        if (c == null || c.isZERO()) {
+            return c;
+        }
+        C r = c;
+        if (aCoFac == null && qCoFac == null) {
+            // case ModInteger: c**p == c
+            return r;
+        }
+        if (aCoFac != null) {
+            // case AlgebraicNumber<ModInteger>: r = c**(p**(d-1)), r**p == c
+            long d = aCoFac.totalExtensionDegree();
+            //System.out.println("d = " + d);
+            if (d <= 1) {
+                return r;
+            }
+            BigInteger p = new BigInteger(aCoFac.characteristic());
+            BigInteger q = p.power(d - 1);
+            //System.out.println("p**(d-1) = " + q);
+            r = Power.<C> positivePower(r, q.getVal()); // r = r.power(q.getVal());
+            //System.out.println("r**q = " + r);
+            return r;
+        }
+        if (qCoFac != null) {
+            throw new UnsupportedOperationException("case QuotientRing not yet implemented");
+        }
+        return r;
+    }
+
+
+    /**
+     * Characteristics root of a polynomial. <b>Note:</b> call only in
+     * recursion.
+     * @param P polynomial.
+     * @return [p -&gt; k] if exists k with e=k*charactristic(P) and P = p**e,
+     *         else null.
+     */
+    public SortedMap<GenPolynomial<C>, Long> rootCharacteristic(GenPolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P == null");
+        }
+        java.math.BigInteger c = P.ring.characteristic();
+        if (c.signum() == 0) {
+            return null;
+        }
+        SortedMap<GenPolynomial<C>, Long> root = new TreeMap<GenPolynomial<C>, Long>();
+        if (P.isZERO()) {
+            return root;
+        }
+        if (P.isONE()) {
+            root.put(P, 1L);
+            return root;
+        }
+        SortedMap<GenPolynomial<C>, Long> sf = squarefreeFactors(P);
+        if (logger.isInfoEnabled()) {
+            logger.info("sf = " + sf);
+        }
+        // better: test if sf.size() == 1 // not ok
+        Long k = null;
+        for (Map.Entry<GenPolynomial<C>, Long> me : sf.entrySet()) {
+            GenPolynomial<C> p = me.getKey();
+            if (p.isConstant()) {
+                //System.out.println("p,const = " + p);
+                continue;
+            }
+            Long e = me.getValue(); //sf.get(p);
+            java.math.BigInteger E = new java.math.BigInteger(e.toString());
+            java.math.BigInteger r = E.remainder(c);
+            if (!r.equals(java.math.BigInteger.ZERO)) {
+                //System.out.println("r = " + r);
+                return null;
+            }
+            if (k == null) {
+                k = e;
+            } else if (k.compareTo(e) >= 0) {
+                k = e;
+            }
+        }
+        // now c divides all exponents
+        long cl = c.longValueExact();
+        GenPolynomial<C> rp = P.ring.getONE();
+        for (Map.Entry<GenPolynomial<C>, Long> me : sf.entrySet()) {
+            GenPolynomial<C> q = me.getKey();
+            Long e = me.getValue(); // sf.get(q);
+            if (q.isConstant()) { // ensure p-th root
+                C qc = q.leadingBaseCoefficient();
+                //System.out.println("qc,const = " + qc + ", e = " + e);
+                if (e > 1L) {
+                    qc = qc.power(e); //Power.<C> positivePower(qc, e);
+                    //e = 1L;
+                }
+                C qr = coeffRootCharacteristic(qc);
+                //System.out.println("qr,const = " + qr);
+                q = P.ring.getONE().multiply(qr);
+                root.put(q, 1L);
+                continue;
+            }
+            if (e > k) {
+                long ep = e / cl;
+                q = q.power(ep); //Power.<GenPolynomial<C>> positivePower(q, ep);
+            }
+            rp = rp.multiply(q);
+        }
+        if (k != null) {
+            k = k / cl;
+            root.put(rp, k);
+        }
+        //System.out.println("sf,root = " + root);
+        return root;
+    }
+
+
+    /**
+     * GenPolynomial char-th root univariate polynomial. Base coefficient type
+     * must be finite field, that is ModInteger or
+     * AlgebraicNumber&lt;ModInteger&gt; etc.
+     * @param P GenPolynomial.
+     * @return char-th_rootOf(P), or null if no char-th root.
+     */
+    @Override
+    public GenPolynomial<C> baseRootCharacteristic(GenPolynomial<C> P) {
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        GenPolynomialRing<C> pfac = P.ring;
+        if (pfac.nvar > 1) {
+            // basePthRoot not possible by return type
+            throw new IllegalArgumentException(P.getClass().getName() + " only for univariate polynomials");
+        }
+        RingFactory<C> rf = pfac.coFac;
+        if (rf.characteristic().signum() != 1) {
+            // basePthRoot not possible
+            throw new IllegalArgumentException(P.getClass().getName() + " only for char p > 0 " + rf);
+        }
+        long mp = rf.characteristic().longValueExact();
+        GenPolynomial<C> d = pfac.getZERO().copy();
+        for (Monomial<C> m : P) {
+            ExpVector f = m.e;
+            long fl = f.getVal(0);
+            if (fl % mp != 0) {
+                return null;
+            }
+            fl = fl / mp;
+            ExpVector e = ExpVector.create(1, 0, fl);
+            // for m.c exists a char-th root, since finite field
+            C r = coeffRootCharacteristic(m.c);
+            d.doPutToMap(e, r);
+        }
+        return d;
+    }
+
+
+    /**
+     * GenPolynomial char-th root univariate polynomial with polynomial
+     * coefficients.
+     * @param P recursive univariate GenPolynomial.
+     * @return char-th_rootOf(P), or null if P is no char-th root.
+     */
+    @Override
+    public GenPolynomial<GenPolynomial<C>> recursiveUnivariateRootCharacteristic(
+                    GenPolynomial<GenPolynomial<C>> P) {
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        GenPolynomialRing<GenPolynomial<C>> pfac = P.ring;
+        if (pfac.nvar > 1) {
+            // basePthRoot not possible by return type
+            throw new IllegalArgumentException(P.getClass().getName() + " only for univariate polynomials");
+        }
+        RingFactory<GenPolynomial<C>> rf = pfac.coFac;
+        if (rf.characteristic().signum() != 1) {
+            // basePthRoot not possible
+            throw new IllegalArgumentException(P.getClass().getName() + " only for char p > 0 " + rf);
+        }
+        long mp = rf.characteristic().longValueExact();
+        GenPolynomial<GenPolynomial<C>> d = pfac.getZERO().copy();
+        for (Monomial<GenPolynomial<C>> m : P) {
+            ExpVector f = m.e;
+            long fl = f.getVal(0);
+            if (fl % mp != 0) {
+                return null;
+            }
+            fl = fl / mp;
+            SortedMap<GenPolynomial<C>, Long> sm = rootCharacteristic(m.c);
+            if (sm == null) {
+                return null;
+            }
+            if (logger.isInfoEnabled()) {
+                logger.info("sm,rec = " + sm);
+            }
+            GenPolynomial<C> r = rf.getONE();
+            for (Map.Entry<GenPolynomial<C>, Long> me : sm.entrySet()) {
+                GenPolynomial<C> rp = me.getKey();
+                long gl = me.getValue(); //sm.get(rp);
+                if (gl > 1) {
+                    rp = rp.power(gl); //Power.<GenPolynomial<C>> positivePower(rp, gl);
+                }
+                r = r.multiply(rp);
+            }
+            ExpVector e = ExpVector.create(1, 0, fl);
+            //System.out.println("put-root r = " + r + ", e = " + e);
+            d.doPutToMap(e, r);
+        }
+        return d;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/SquarefreeInfiniteAlgebraicFieldCharP.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/SquarefreeInfiniteAlgebraicFieldCharP.java
@@ -1,0 +1,450 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.gb.GroebnerBaseAbstract;
+import edu.jas.gb.GroebnerBaseSeq;
+import edu.jas.gb.Reduction;
+import edu.jas.gb.ReductionSeq;
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.AlgebraicNumberRing;
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.Monomial;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.Power;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Squarefree decomposition for algebraic extensions of infinite coefficient
+ * fields of characteristic p &gt; 0.
+ * @author Heinz Kredel
+ */
+
+public class SquarefreeInfiniteAlgebraicFieldCharP<C extends GcdRingElem<C>>
+                extends SquarefreeFieldCharP<AlgebraicNumber<C>> {
+
+
+    private static final Logger logger = LogManager.getLogger(SquarefreeInfiniteAlgebraicFieldCharP.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Squarefree engine for infinite ring of characteristic p base
+     * coefficients.
+     */
+    protected final SquarefreeAbstract<C> aengine;
+
+
+    /**
+     * Constructor.
+     */
+    public SquarefreeInfiniteAlgebraicFieldCharP(RingFactory<AlgebraicNumber<C>> fac) {
+        super(fac);
+        // isFinite() predicate now present
+        if (fac.isFinite()) {
+            throw new IllegalArgumentException("fac must be in-finite");
+        }
+        AlgebraicNumberRing<C> afac = (AlgebraicNumberRing<C>) fac;
+        GenPolynomialRing<C> rfac = afac.ring;
+        //System.out.println("rfac = " + rfac);
+        //System.out.println("rfac = " + rfac.coFac);
+        aengine = SquarefreeFactory.<C> getImplementation(rfac);
+        //System.out.println("aengine = " + aengine);
+    }
+
+
+    /* --------- algebraic number char-th roots --------------------- */
+
+    /**
+     * Squarefree factors of a AlgebraicNumber.
+     * @param P AlgebraicNumber.
+     * @return [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with P = prod_{i=1, ..., k}
+     *         p_i^{e_i} and p_i squarefree and gcd(p_i, p_j) = 1, for i != j.
+     */
+    @Override
+    public SortedMap<AlgebraicNumber<C>, Long> squarefreeFactors(AlgebraicNumber<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P == null");
+        }
+        SortedMap<AlgebraicNumber<C>, Long> factors = new TreeMap<AlgebraicNumber<C>, Long>();
+        if (P.isZERO()) {
+            return factors;
+        }
+        if (P.isONE()) {
+            factors.put(P, 1L);
+            return factors;
+        }
+        GenPolynomial<C> an = P.val;
+        AlgebraicNumberRing<C> pfac = P.ring;
+        if (!an.isONE()) {
+            //System.out.println("an = " + an);
+            //System.out.println("aengine = " + aengine);
+            SortedMap<GenPolynomial<C>, Long> nfac = aengine.squarefreeFactors(an);
+            //System.out.println("nfac = " + nfac);
+            for (Map.Entry<GenPolynomial<C>, Long> me : nfac.entrySet()) {
+                GenPolynomial<C> nfp = me.getKey();
+                AlgebraicNumber<C> nf = new AlgebraicNumber<C>(pfac, nfp);
+                factors.put(nf, me.getValue()); //nfac.get(nfp));
+            }
+        }
+        if (factors.size() == 0) {
+            factors.put(P, 1L);
+        }
+        return factors;
+    }
+
+
+    /**
+     * Characteristics root of a AlgebraicNumber.
+     * @param P AlgebraicNumber.
+     * @return [p -&gt; k] if exists k with e=charactristic(P)*k and P = p**e,
+     *         else null.
+     */
+    @SuppressWarnings("unchecked")
+    public SortedMap<AlgebraicNumber<C>, Long> rootCharacteristic(AlgebraicNumber<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P == null");
+        }
+        java.math.BigInteger c = P.ring.characteristic();
+        if (c.signum() == 0) {
+            return null;
+        }
+        SortedMap<AlgebraicNumber<C>, Long> root = new TreeMap<AlgebraicNumber<C>, Long>();
+        if (P.isZERO()) {
+            return root;
+        }
+        if (P.isONE()) {
+            root.put(P, 1L);
+            return root;
+        }
+        // generate system of equations
+        AlgebraicNumberRing<C> afac = P.ring;
+        long deg = afac.modul.degree(0);
+        int d = (int) deg;
+        String[] vn = GenPolynomialRing.newVars("c", d);
+        GenPolynomialRing<AlgebraicNumber<C>> pfac = new GenPolynomialRing<AlgebraicNumber<C>>(afac, d, vn);
+        List<GenPolynomial<AlgebraicNumber<C>>> uv = (List<GenPolynomial<AlgebraicNumber<C>>>) pfac
+                        .univariateList();
+        GenPolynomial<AlgebraicNumber<C>> cp = pfac.getZERO();
+        GenPolynomialRing<C> apfac = afac.ring;
+        long i = 0;
+        for (GenPolynomial<AlgebraicNumber<C>> pa : uv) {
+            GenPolynomial<C> ca = apfac.univariate(0, i++);
+            GenPolynomial<AlgebraicNumber<C>> pb = pa.multiply(new AlgebraicNumber<C>(afac, ca));
+            cp = cp.sum(pb);
+        }
+        GenPolynomial<AlgebraicNumber<C>> cpp = Power.<GenPolynomial<AlgebraicNumber<C>>> positivePower(cp,
+                        c);
+        if (logger.isInfoEnabled()) {
+            logger.info("cp   = " + cp);
+            logger.info("cp^p = " + cpp);
+            logger.info("P    = " + P);
+        }
+        GenPolynomialRing<C> ppfac = new GenPolynomialRing<C>(apfac.coFac, pfac);
+        List<GenPolynomial<C>> gl = new ArrayList<GenPolynomial<C>>();
+        if (deg == c.longValueExact() && afac.modul.length() == 2) {
+            logger.info("deg(" + deg + ") == char_p(" + c.longValueExact() + ")");
+            for (Monomial<AlgebraicNumber<C>> m : cpp) {
+                ExpVector f = m.e;
+                AlgebraicNumber<C> a = m.c;
+                //System.out.println("a  = " + a + " : " + a.toScriptFactory());
+                GenPolynomial<C> ap = a.val;
+                for (Monomial<C> ma : ap) {
+                    ExpVector e = ma.e;
+                    C cc = ma.c;
+                    C pc = P.val.coefficient(e);
+                    C cc1 = ((RingFactory<C>) pc.factory()).getONE();
+                    C pc1 = ((RingFactory<C>) pc.factory()).getZERO();
+                    //System.out.println("cc = " + cc + ", e = " + e);
+                    //System.out.println("pc = " + pc + " : " + cc.toScriptFactory());
+                    if (cc instanceof AlgebraicNumber && pc instanceof AlgebraicNumber) {
+                        throw new UnsupportedOperationException(
+                                        "case multiple algebraic extensions not implemented");
+                    } else if (cc instanceof Quotient && pc instanceof Quotient) {
+                        Quotient<C> ccp = (Quotient<C>) (Object) cc;
+                        Quotient<C> pcp = (Quotient<C>) (Object) pc;
+                        if (pcp.isConstant()) {
+                            //logger.error("finite field not allowed here " + afac.toScript());
+                            throw new ArithmeticException("finite field not allowed here " + afac.toScript());
+                        }
+                        //C dc = cc.divide(pc);
+                        Quotient<C> dcp = ccp.divide(pcp);
+                        if (dcp.isConstant()) { // not possible: dc.isConstant() 
+                            //System.out.println("dcp = " + dcp + " : " + cc.toScriptFactory()); //  + ", dc = " + dc);
+                            //if ( dcp.num.isConstant() ) 
+                            cc1 = cc;
+                            pc1 = pc;
+                        }
+                        GenPolynomial<C> r = new GenPolynomial<C>(ppfac, cc1, f);
+                        r = r.subtract(pc1);
+                        //System.out.println("r = " + r);
+                        gl.add(r);
+                    }
+                }
+            }
+        } else {
+            for (Monomial<AlgebraicNumber<C>> m : cpp) {
+                ExpVector f = m.e;
+                AlgebraicNumber<C> a = m.c;
+                //System.out.println("m = " + m);
+                GenPolynomial<C> ap = a.val;
+                for (Monomial<C> ma : ap) {
+                    ExpVector e = ma.e;
+                    C cc = ma.c;
+                    C pc = P.val.coefficient(e);
+                    GenPolynomial<C> r = new GenPolynomial<C>(ppfac, cc, f);
+                    r = r.subtract(pc);
+                    //System.out.println("r = " + r);
+                    gl.add(r);
+                }
+            }
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("equations = " + gl);
+        }
+        // solve system of equations and construct result
+        Reduction<C> red = new ReductionSeq<C>();
+        gl = red.irreducibleSet(gl);
+        GroebnerBaseAbstract<C> bb = new GroebnerBaseSeq<C>(); //GBFactory.<C>getImplementation();
+        int z = bb.commonZeroTest(gl);
+        if (z < 0) { // no solution
+            return null;
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("solution = " + gl);
+        }
+        GenPolynomial<C> car = apfac.getZERO();
+        for (GenPolynomial<C> pl : gl) {
+            if (pl.length() <= 1) {
+                continue;
+            }
+            if (pl.length() > 2) {
+                throw new IllegalArgumentException("dim > 0 not implemented " + pl);
+            }
+            //System.out.println("pl = " + pl);
+            ExpVector e = pl.leadingExpVector();
+            int[] v = e.dependencyOnVariables();
+            if (v == null || v.length == 0) {
+                continue;
+            }
+            int vi = v[0];
+            //System.out.println("vi = " + vi);
+            GenPolynomial<C> ca = apfac.univariate(0, deg - 1 - vi);
+            //System.out.println("ca = " + ca);
+            C tc = pl.trailingBaseCoefficient();
+            tc = tc.negate();
+            if (e.maxDeg() == c.longValueExact()) { // p-th root of tc ...
+                //SortedMap<C, Long> br = aengine.rootCharacteristic(tc);
+                SortedMap<C, Long> br = aengine.squarefreeFactors(tc);
+                //System.out.println("br = " + br);
+                if (br != null && br.size() > 0) {
+                    C cc = apfac.coFac.getONE();
+                    for (Map.Entry<C, Long> me : br.entrySet()) {
+                        C bc = me.getKey();
+                        long ll = me.getValue();
+                        if (ll % c.longValueExact() == 0L) {
+                            long fl = ll / c.longValueExact();
+                            cc = cc.multiply(bc.power(fl));
+                        } else { // fail ?
+                            cc = cc.multiply(bc);
+                        }
+                    }
+                    //System.out.println("cc = " + cc);
+                    tc = cc;
+                }
+            }
+            ca = ca.multiply(tc);
+            car = car.sum(ca);
+        }
+        AlgebraicNumber<C> rr = new AlgebraicNumber<C>(afac, car);
+        if (logger.isInfoEnabled()) {
+            logger.info("solution AN = " + rr);
+            //System.out.println("rr = " + rr);
+        }
+        root.put(rr, 1L);
+        return root;
+    }
+
+
+    /**
+     * GenPolynomial char-th root main variable.
+     * @param P univariate GenPolynomial with AlgebraicNumber coefficients.
+     * @return char-th_rootOf(P), or null, if P is no char-th root.
+     */
+    public GenPolynomial<AlgebraicNumber<C>> rootCharacteristic(GenPolynomial<AlgebraicNumber<C>> P) {
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        GenPolynomialRing<AlgebraicNumber<C>> pfac = P.ring;
+        if (pfac.nvar > 1) {
+            // go to recursion
+            GenPolynomialRing<GenPolynomial<AlgebraicNumber<C>>> rfac = pfac.recursive(1);
+            GenPolynomial<GenPolynomial<AlgebraicNumber<C>>> Pr = PolyUtil
+                            .<AlgebraicNumber<C>> recursive(rfac, P);
+            GenPolynomial<GenPolynomial<AlgebraicNumber<C>>> Prc = recursiveUnivariateRootCharacteristic(Pr);
+            if (Prc == null) {
+                return null;
+            }
+            GenPolynomial<AlgebraicNumber<C>> D = PolyUtil.<AlgebraicNumber<C>> distribute(pfac, Prc);
+            return D;
+        }
+        RingFactory<AlgebraicNumber<C>> rf = pfac.coFac;
+        if (rf.characteristic().signum() != 1) {
+            // basePthRoot not possible
+            throw new IllegalArgumentException(
+                            P.getClass().getName() + " only for ModInteger polynomials " + rf);
+        }
+        long mp = rf.characteristic().longValueExact();
+        GenPolynomial<AlgebraicNumber<C>> d = pfac.getZERO().copy();
+        for (Monomial<AlgebraicNumber<C>> m : P) {
+            ExpVector f = m.e;
+            long fl = f.getVal(0);
+            if (fl % mp != 0) {
+                return null;
+            }
+            fl = fl / mp;
+            SortedMap<AlgebraicNumber<C>, Long> sm = rootCharacteristic(m.c);
+            if (sm == null) {
+                return null;
+            }
+            if (logger.isInfoEnabled()) {
+                logger.info("sm_alg,root = " + sm);
+            }
+            AlgebraicNumber<C> r = rf.getONE();
+            for (Map.Entry<AlgebraicNumber<C>, Long> me : sm.entrySet()) {
+                AlgebraicNumber<C> rp = me.getKey();
+                long gl = me.getValue();
+                if (gl > 1) {
+                    rp = rp.power(gl);
+                }
+                r = r.multiply(rp);
+            }
+            ExpVector e = ExpVector.create(1, 0, fl);
+            d.doPutToMap(e, r);
+        }
+        logger.info("sm_alg,root,d = " + d);
+        return d;
+    }
+
+
+    /**
+     * GenPolynomial char-th root univariate polynomial.
+     * @param P GenPolynomial.
+     * @return char-th_rootOf(P).
+     */
+    @Override
+    public GenPolynomial<AlgebraicNumber<C>> baseRootCharacteristic(GenPolynomial<AlgebraicNumber<C>> P) {
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        GenPolynomialRing<AlgebraicNumber<C>> pfac = P.ring;
+        if (pfac.nvar > 1) {
+            // basePthRoot not possible by return type
+            throw new IllegalArgumentException(P.getClass().getName() + " only for univariate polynomials");
+        }
+        RingFactory<AlgebraicNumber<C>> rf = pfac.coFac;
+        if (rf.characteristic().signum() != 1) {
+            // basePthRoot not possible
+            throw new IllegalArgumentException(P.getClass().getName() + " only for char p > 0 " + rf);
+        }
+        long mp = rf.characteristic().longValueExact();
+        GenPolynomial<AlgebraicNumber<C>> d = pfac.getZERO().copy();
+        for (Monomial<AlgebraicNumber<C>> m : P) {
+            //System.out.println("m = " + m);
+            ExpVector f = m.e;
+            long fl = f.getVal(0);
+            if (fl % mp != 0) {
+                return null;
+            }
+            fl = fl / mp;
+            SortedMap<AlgebraicNumber<C>, Long> sm = rootCharacteristic(m.c);
+            if (sm == null) {
+                return null;
+            }
+            if (logger.isInfoEnabled()) {
+                logger.info("sm_alg,base,root = " + sm);
+            }
+            AlgebraicNumber<C> r = rf.getONE();
+            for (Map.Entry<AlgebraicNumber<C>, Long> me : sm.entrySet()) {
+                AlgebraicNumber<C> rp = me.getKey();
+                //System.out.println("rp = " + rp);
+                long gl = me.getValue();
+                //System.out.println("gl = " + gl);
+                AlgebraicNumber<C> re = rp;
+                if (gl > 1) {
+                    re = rp.power(gl);
+                }
+                //System.out.println("re = " + re);
+                r = r.multiply(re);
+            }
+            ExpVector e = ExpVector.create(1, 0, fl);
+            d.doPutToMap(e, r);
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("sm_alg,base,d = " + d);
+        }
+        return d;
+    }
+
+
+    /**
+     * GenPolynomial char-th root univariate polynomial with polynomial
+     * coefficients.
+     * @param P recursive univariate GenPolynomial.
+     * @return char-th_rootOf(P), or null if P is no char-th root.
+     */
+    @Override
+    public GenPolynomial<GenPolynomial<AlgebraicNumber<C>>> recursiveUnivariateRootCharacteristic(
+                    GenPolynomial<GenPolynomial<AlgebraicNumber<C>>> P) {
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        GenPolynomialRing<GenPolynomial<AlgebraicNumber<C>>> pfac = P.ring;
+        if (pfac.nvar > 1) {
+            // basePthRoot not possible by return type
+            throw new IllegalArgumentException(
+                            P.getClass().getName() + " only for univariate recursive polynomials");
+        }
+        RingFactory<GenPolynomial<AlgebraicNumber<C>>> rf = pfac.coFac;
+        if (rf.characteristic().signum() != 1) {
+            // basePthRoot not possible
+            throw new IllegalArgumentException(P.getClass().getName() + " only for char p > 0 " + rf);
+        }
+        long mp = rf.characteristic().longValueExact();
+        GenPolynomial<GenPolynomial<AlgebraicNumber<C>>> d = pfac.getZERO().copy();
+        for (Monomial<GenPolynomial<AlgebraicNumber<C>>> m : P) {
+            ExpVector f = m.e;
+            long fl = f.getVal(0);
+            if (fl % mp != 0) {
+                return null;
+            }
+            fl = fl / mp;
+            GenPolynomial<AlgebraicNumber<C>> r = rootCharacteristic(m.c);
+            if (r == null) {
+                return null;
+            }
+            ExpVector e = ExpVector.create(1, 0, fl);
+            d.doPutToMap(e, r);
+        }
+        return d;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/SquarefreeInfiniteFieldCharP.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/SquarefreeInfiniteFieldCharP.java
@@ -1,0 +1,353 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.Monomial;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Squarefree decomposition for infinite coefficient fields of characteristic p.
+ * @author Heinz Kredel
+ */
+
+public class SquarefreeInfiniteFieldCharP<C extends GcdRingElem<C>>
+                extends SquarefreeFieldCharP<Quotient<C>> {
+
+
+    private static final Logger logger = LogManager.getLogger(SquarefreeInfiniteFieldCharP.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Squarefree engine for infinite ring of characteristic p base
+     * coefficients.
+     */
+    protected final SquarefreeAbstract<C> qengine;
+
+
+    /**
+     * Constructor.
+     */
+    @SuppressWarnings("unchecked")
+    public SquarefreeInfiniteFieldCharP(RingFactory<Quotient<C>> fac) {
+        super(fac);
+        // isFinite() predicate now present
+        if (fac.isFinite()) {
+            throw new IllegalArgumentException("fac must be in-finite");
+        }
+        QuotientRing<C> qfac = (QuotientRing<C>) fac;
+        GenPolynomialRing<C> rfac = qfac.ring;
+        qengine = (SquarefreeAbstract) SquarefreeFactory.<C> getImplementation(rfac);
+        //qengine = new SquarefreeFiniteFieldCharP<C>(rfac.coFac);
+        //qengine = new SquarefreeInfiniteRingCharP<C>( rfac.coFac );
+    }
+
+
+    /* --------- quotient char-th roots --------------------- */
+
+
+    /**
+     * Squarefree factors of a Quotient.
+     * @param P Quotient.
+     * @return [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with P = prod_{i=1, ..., k}
+     *         p_i^{e_i} and p_i squarefree and gcd(p_i, p_j) = 1, for i != j.
+     */
+    @Override
+    public SortedMap<Quotient<C>, Long> squarefreeFactors(Quotient<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P == null");
+        }
+        SortedMap<Quotient<C>, Long> factors = new TreeMap<Quotient<C>, Long>();
+        if (P.isZERO()) {
+            return factors;
+        }
+        if (P.isONE()) {
+            factors.put(P, 1L);
+            return factors;
+        }
+        GenPolynomial<C> num = P.num;
+        GenPolynomial<C> den = P.den;
+        QuotientRing<C> pfac = P.ring;
+        GenPolynomial<C> one = pfac.ring.getONE();
+        if (!num.isONE()) {
+            SortedMap<GenPolynomial<C>, Long> nfac = qengine.squarefreeFactors(num);
+            //System.out.println("nfac = " + nfac);
+            for (Map.Entry<GenPolynomial<C>, Long> me : nfac.entrySet()) {
+                GenPolynomial<C> nfp = me.getKey();
+                Quotient<C> nf = new Quotient<C>(pfac, nfp);
+                factors.put(nf, me.getValue()); //nfac.get(nfp));
+            }
+        }
+        if (den.isONE()) {
+            if (factors.size() == 0) {
+                factors.put(P, 1L);
+            }
+            return factors;
+        }
+        SortedMap<GenPolynomial<C>, Long> dfac = qengine.squarefreeFactors(den);
+        //System.out.println("dfac = " + dfac);
+        for (Map.Entry<GenPolynomial<C>, Long> me : dfac.entrySet()) {
+            GenPolynomial<C> dfp = me.getKey();
+            Quotient<C> df = new Quotient<C>(pfac, one, dfp);
+            factors.put(df, me.getValue()); //dfac.get(dfp));
+        }
+        if (factors.size() == 0) {
+            factors.put(P, 1L);
+        }
+        return factors;
+    }
+
+
+    /**
+     * Characteristics root of a Quotient.
+     * @param P Quotient.
+     * @return [p -&gt; k] if exists k with e=charactristic(P)*k and P = p**e,
+     *         else null.
+     */
+    public SortedMap<Quotient<C>, Long> rootCharacteristic(Quotient<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P == null");
+        }
+        java.math.BigInteger c = P.ring.characteristic();
+        if (c.signum() == 0) {
+            return null;
+        }
+        SortedMap<Quotient<C>, Long> root = new TreeMap<Quotient<C>, Long>();
+        if (P.isZERO()) {
+            return root;
+        }
+        if (P.isONE()) {
+            root.put(P, 1L);
+            return root;
+        }
+        SortedMap<Quotient<C>, Long> sf = squarefreeFactors(P);
+        if (sf.size() == 0) {
+            return null;
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("sf,quot = " + sf);
+        }
+        // better: test if sf.size() == 2 // no, since num and den factors 
+        Long k = null;
+        long cl = c.longValueExact();
+        for (Map.Entry<Quotient<C>, Long> me : sf.entrySet()) {
+            Quotient<C> p = me.getKey();
+            //System.out.println("p = " + p);
+            if (p.isConstant()) { // todo: check for non-constants in coefficients
+                continue;
+            }
+            Long e = me.getValue(); //sf.get(p);
+            long E = e.longValue();
+            long r = E % cl;
+            if (r != 0) {
+                //System.out.println("r = " + r);
+                return null;
+            }
+            if (k == null) {
+                k = e;
+            } else if (k >= e) {
+                k = e;
+            }
+        }
+        if (k == null) {
+            k = 1L; //return null;
+        }
+        // now c divides all exponents of non constant elements
+        for (Map.Entry<Quotient<C>, Long> me : sf.entrySet()) {
+            Quotient<C> q = me.getKey();
+            Long e = me.getValue(); //sf.get(q);
+            //System.out.println("q = " + q + ", e = " + e);
+            if (e >= k) {
+                e = e / cl;
+                //q = q.power(e);
+                root.put(q, e);
+            } else { // constant case
+                root.put(q, e);
+            }
+        }
+        //System.out.println("root = " + root);
+        return root;
+    }
+
+
+    /**
+     * GenPolynomial char-th root main variable.
+     * @param P univariate GenPolynomial with Quotient coefficients.
+     * @return char-th_rootOf(P), or null, if P is no char-th root.
+     */
+    public GenPolynomial<Quotient<C>> rootCharacteristic(GenPolynomial<Quotient<C>> P) {
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        GenPolynomialRing<Quotient<C>> pfac = P.ring;
+        if (pfac.nvar > 1) {
+            // go to recursion
+            GenPolynomialRing<GenPolynomial<Quotient<C>>> rfac = pfac.recursive(1);
+            GenPolynomial<GenPolynomial<Quotient<C>>> Pr = PolyUtil.<Quotient<C>> recursive(rfac, P);
+            GenPolynomial<GenPolynomial<Quotient<C>>> Prc = recursiveUnivariateRootCharacteristic(Pr);
+            if (Prc == null) {
+                return null;
+            }
+            GenPolynomial<Quotient<C>> D = PolyUtil.<Quotient<C>> distribute(pfac, Prc);
+            return D;
+        }
+        RingFactory<Quotient<C>> rf = pfac.coFac;
+        if (rf.characteristic().signum() != 1) {
+            // basePthRoot not possible
+            throw new IllegalArgumentException(
+                            P.getClass().getName() + " only for ModInteger polynomials " + rf);
+        }
+        long mp = rf.characteristic().longValueExact();
+        GenPolynomial<Quotient<C>> d = pfac.getZERO().copy();
+        for (Monomial<Quotient<C>> m : P) {
+            ExpVector f = m.e;
+            long fl = f.getVal(0);
+            if (fl % mp != 0) {
+                return null;
+            }
+            fl = fl / mp;
+            SortedMap<Quotient<C>, Long> sm = rootCharacteristic(m.c);
+            if (sm == null) {
+                return null;
+            }
+            if (logger.isInfoEnabled()) {
+                logger.info("sm,root = " + sm);
+            }
+            Quotient<C> r = rf.getONE();
+            for (Map.Entry<Quotient<C>, Long> me : sm.entrySet()) {
+                Quotient<C> rp = me.getKey();
+                long gl = me.getValue(); // sm.get(rp);
+                if (gl > 1) {
+                    rp = rp.power(gl);
+                }
+                r = r.multiply(rp);
+            }
+            ExpVector e = ExpVector.create(1, 0, fl);
+            d.doPutToMap(e, r);
+        }
+        logger.info("sm,root,d = " + d);
+        return d;
+    }
+
+
+    /**
+     * GenPolynomial char-th root univariate polynomial.
+     * @param P GenPolynomial.
+     * @return char-th_rootOf(P).
+     */
+    @Override
+    public GenPolynomial<Quotient<C>> baseRootCharacteristic(GenPolynomial<Quotient<C>> P) {
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        GenPolynomialRing<Quotient<C>> pfac = P.ring;
+        if (pfac.nvar > 1) {
+            // basePthRoot not possible by return type
+            throw new IllegalArgumentException(P.getClass().getName() + " only for univariate polynomials");
+        }
+        RingFactory<Quotient<C>> rf = pfac.coFac;
+        if (rf.characteristic().signum() != 1) {
+            // basePthRoot not possible
+            throw new IllegalArgumentException(P.getClass().getName() + " only for char p > 0 " + rf);
+        }
+        long mp = rf.characteristic().longValueExact();
+        GenPolynomial<Quotient<C>> d = pfac.getZERO().copy();
+        for (Monomial<Quotient<C>> m : P) {
+            //System.out.println("m = " + m);
+            ExpVector f = m.e;
+            long fl = f.getVal(0);
+            if (fl % mp != 0) {
+                return null;
+            }
+            fl = fl / mp;
+            SortedMap<Quotient<C>, Long> sm = rootCharacteristic(m.c);
+            if (sm == null) {
+                return null;
+            }
+            if (logger.isInfoEnabled()) {
+                logger.info("sm,base,root = " + sm);
+            }
+            Quotient<C> r = rf.getONE();
+            for (Map.Entry<Quotient<C>, Long> me : sm.entrySet()) {
+                Quotient<C> rp = me.getKey();
+                //System.out.println("rp = " + rp);
+                long gl = me.getValue(); //sm.get(rp);
+                //System.out.println("gl = " + gl);
+                Quotient<C> re = rp;
+                if (gl > 1) {
+                    re = rp.power(gl);
+                }
+                //System.out.println("re = " + re);
+                r = r.multiply(re);
+            }
+            ExpVector e = ExpVector.create(1, 0, fl);
+            d.doPutToMap(e, r);
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("sm,base,d = " + d);
+        }
+        return d;
+    }
+
+
+    /**
+     * GenPolynomial char-th root univariate polynomial with polynomial
+     * coefficients.
+     * @param P recursive univariate GenPolynomial.
+     * @return char-th_rootOf(P), or null if P is no char-th root.
+     */
+    @Override
+    public GenPolynomial<GenPolynomial<Quotient<C>>> recursiveUnivariateRootCharacteristic(
+                    GenPolynomial<GenPolynomial<Quotient<C>>> P) {
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        GenPolynomialRing<GenPolynomial<Quotient<C>>> pfac = P.ring;
+        if (pfac.nvar > 1) {
+            // basePthRoot not possible by return type
+            throw new IllegalArgumentException(
+                            P.getClass().getName() + " only for univariate recursive polynomials");
+        }
+        RingFactory<GenPolynomial<Quotient<C>>> rf = pfac.coFac;
+        if (rf.characteristic().signum() != 1) {
+            // basePthRoot not possible
+            throw new IllegalArgumentException(P.getClass().getName() + " only for char p > 0 " + rf);
+        }
+        long mp = rf.characteristic().longValueExact();
+        GenPolynomial<GenPolynomial<Quotient<C>>> d = pfac.getZERO().copy();
+        for (Monomial<GenPolynomial<Quotient<C>>> m : P) {
+            ExpVector f = m.e;
+            long fl = f.getVal(0);
+            if (fl % mp != 0) {
+                return null;
+            }
+            fl = fl / mp;
+            GenPolynomial<Quotient<C>> r = rootCharacteristic(m.c);
+            if (r == null) {
+                return null;
+            }
+            ExpVector e = ExpVector.create(1, 0, fl);
+            d.doPutToMap(e, r);
+        }
+        return d;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/SquarefreeRingChar0.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/SquarefreeRingChar0.java
@@ -1,0 +1,440 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufd;
+
+
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.poly.ExpVector;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.poly.PolyUtil;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * Squarefree decomposition for coefficient rings of characteristic 0.
+ * @author Heinz Kredel
+ */
+
+public class SquarefreeRingChar0<C extends GcdRingElem<C>>
+                extends SquarefreeAbstract<C> /*implements Squarefree<C>*/ {
+
+
+    private static final Logger logger = LogManager.getLogger(SquarefreeRingChar0.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Factory for ring of characteristic 0 coefficients.
+     */
+    protected final RingFactory<C> coFac;
+
+
+    /**
+     * Constructor.
+     */
+    public SquarefreeRingChar0(RingFactory<C> fac) {
+        super(GCDFactory.<C> getProxy(fac));
+        if (fac.isField()) {
+            throw new IllegalArgumentException("fac is a field: use SquarefreeFieldChar0");
+        }
+        if (fac.characteristic().signum() != 0) {
+            throw new IllegalArgumentException("characterisic(fac) must be zero");
+        }
+        coFac = fac;
+    }
+
+
+    /**
+     * Get the String representation.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return getClass().getName() + " with " + engine + " over " + coFac;
+    }
+
+
+    /**
+     * GenPolynomial polynomial greatest squarefree divisor.
+     * @param P GenPolynomial.
+     * @return squarefree(pp(P)).
+     */
+    @Override
+    public GenPolynomial<C> baseSquarefreePart(GenPolynomial<C> P) {
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        GenPolynomialRing<C> pfac = P.ring;
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException(
+                            this.getClass().getName() + " only for univariate polynomials");
+        }
+        GenPolynomial<C> pp = engine.basePrimitivePart(P);
+        if (pp.isConstant()) {
+            return pp;
+        }
+        GenPolynomial<C> d = PolyUtil.<C> baseDeriviative(pp);
+        d = engine.basePrimitivePart(d);
+        GenPolynomial<C> g = engine.baseGcd(pp, d);
+        g = engine.basePrimitivePart(g);
+        GenPolynomial<C> q = PolyUtil.<C> basePseudoDivide(pp, g);
+        q = engine.basePrimitivePart(q);
+        return q;
+    }
+
+
+    /**
+     * GenPolynomial polynomial squarefree factorization.
+     * @param A GenPolynomial.
+     * @return [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with A = prod_{i=1,...,k}
+     *         p_i^{e_i} and p_i squarefree and gcd(p_i, p_j) = 1, for i != j.
+     */
+    @Override
+    public SortedMap<GenPolynomial<C>, Long> baseSquarefreeFactors(GenPolynomial<C> A) {
+        SortedMap<GenPolynomial<C>, Long> sfactors = new TreeMap<GenPolynomial<C>, Long>();
+        if (A == null || A.isZERO()) {
+            return sfactors;
+        }
+        if (A.isConstant()) {
+            sfactors.put(A, 1L);
+            return sfactors;
+        }
+        GenPolynomialRing<C> pfac = A.ring;
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException(
+                            this.getClass().getName() + " only for univariate polynomials");
+        }
+        C ldbcf = A.leadingBaseCoefficient();
+        if (!ldbcf.isONE()) {
+            C cc = engine.baseContent(A);
+            A = A.divide(cc);
+            GenPolynomial<C> f1 = pfac.getONE().multiply(cc);
+            //System.out.println("gcda sqf f1 = " + f1);
+            sfactors.put(f1, 1L);
+        }
+        // divide by trailing term
+        ExpVector et = A.trailingExpVector();
+        if (!et.isZERO()) {
+            GenPolynomial<C> tr = pfac.valueOf(et);
+            if (logger.isInfoEnabled()) {
+                logger.info("trailing term = " + tr);
+            }
+            A = PolyUtil.<C> basePseudoDivide(A, tr);
+            long ep = et.getVal(0); // univariate
+            et = et.subst(0, 1);
+            tr = pfac.valueOf(et);
+            if (logger.isInfoEnabled()) {
+                logger.info("tr, ep = " + tr + ", " + ep);
+            }
+            sfactors.put(tr, ep);
+            if (A.length() == 1) {
+                return sfactors;
+            }
+        }
+        GenPolynomial<C> T0 = A;
+        GenPolynomial<C> Tp;
+        GenPolynomial<C> T = null;
+        GenPolynomial<C> V = null;
+        long k = 0L;
+        boolean init = true;
+        while (true) {
+            if (init) {
+                if (T0.isConstant() || T0.isZERO()) {
+                    break;
+                }
+                Tp = PolyUtil.<C> baseDeriviative(T0);
+                T = engine.baseGcd(T0, Tp);
+                T = engine.basePrimitivePart(T);
+                V = PolyUtil.<C> basePseudoDivide(T0, T);
+                //System.out.println("iT0 = " + T0);
+                //System.out.println("iTp = " + Tp);
+                //System.out.println("iT  = " + T);
+                //System.out.println("iV  = " + V);
+                k = 0L;
+                init = false;
+            }
+            if (V.isConstant()) {
+                break;
+            }
+            k++;
+            GenPolynomial<C> W = engine.baseGcd(T, V);
+            W = engine.basePrimitivePart(W);
+            GenPolynomial<C> z = PolyUtil.<C> basePseudoDivide(V, W);
+            //System.out.println("W = " + W);
+            //System.out.println("z = " + z);
+            V = W;
+            T = PolyUtil.<C> basePseudoDivide(T, V);
+            //System.out.println("V = " + V);
+            //System.out.println("T = " + T);
+            if (z.degree(0) > 0) {
+                if (ldbcf.isONE() && !z.leadingBaseCoefficient().isONE()) {
+                    z = engine.basePrimitivePart(z);
+                    //logger.info("z,pp = " + z);
+                }
+                logger.info("z, k = " + z + ", " + k);
+                sfactors.put(z, k);
+            }
+        }
+        return normalizeFactorization(sfactors);
+    }
+
+
+    /**
+     * GenPolynomial recursive univariate polynomial greatest squarefree
+     * divisor.
+     * @param P recursive univariate GenPolynomial.
+     * @return squarefree(pp(P)).
+     */
+    @Override
+    public GenPolynomial<GenPolynomial<C>> recursiveUnivariateSquarefreePart(
+                    GenPolynomial<GenPolynomial<C>> P) {
+        if (P == null || P.isZERO()) {
+            return P;
+        }
+        GenPolynomialRing<GenPolynomial<C>> pfac = P.ring;
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException(
+                            this.getClass().getName() + " only for multivariate polynomials");
+        }
+        // squarefree content
+        GenPolynomial<GenPolynomial<C>> pp = P;
+        GenPolynomial<C> Pc = engine.recursiveContent(P);
+        Pc = engine.basePrimitivePart(Pc);
+        //System.out.println("Pc,bPP = " + Pc);
+        if (!Pc.isONE()) {
+            pp = PolyUtil.<C> coefficientPseudoDivide(pp, Pc);
+            //System.out.println("pp,sqp = " + pp);
+            //GenPolynomial<C> Pr = squarefreePart(Pc);
+            //Pr = engine.basePrimitivePart(Pr);
+            //System.out.println("Pr,bPP = " + Pr);
+        }
+        if (pp.leadingExpVector().getVal(0) < 1) {
+            //System.out.println("pp = " + pp);
+            //System.out.println("Pc = " + Pc);
+            return pp.multiply(Pc);
+        }
+        GenPolynomial<GenPolynomial<C>> d = PolyUtil.<C> recursiveDeriviative(pp);
+        //System.out.println("d = " + d);
+        GenPolynomial<GenPolynomial<C>> g = engine.recursiveUnivariateGcd(pp, d);
+        //System.out.println("g,rec = " + g);
+        g = engine.baseRecursivePrimitivePart(g);
+        //System.out.println("g,bPP = " + g);
+        GenPolynomial<GenPolynomial<C>> q = PolyUtil.<C> recursivePseudoDivide(pp, g);
+        q = engine.baseRecursivePrimitivePart(q);
+        //System.out.println("q,bPP = " + q);
+        return q.multiply(Pc);
+    }
+
+
+    /**
+     * GenPolynomial recursive univariate polynomial squarefree factorization.
+     * @param P recursive univariate GenPolynomial.
+     * @return [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with P = prod_{i=1,...,k}
+     *         p_i^{e_i} and p_i squarefree and gcd(p_i, p_j) = 1, for i != j.
+     */
+    @Override
+    public SortedMap<GenPolynomial<GenPolynomial<C>>, Long> recursiveUnivariateSquarefreeFactors(
+                    GenPolynomial<GenPolynomial<C>> P) {
+        SortedMap<GenPolynomial<GenPolynomial<C>>, Long> sfactors = new TreeMap<GenPolynomial<GenPolynomial<C>>, Long>();
+        if (P == null || P.isZERO()) {
+            return sfactors;
+        }
+        GenPolynomialRing<GenPolynomial<C>> pfac = P.ring;
+        if (pfac.nvar > 1) {
+            // recursiveContent not possible by return type
+            throw new IllegalArgumentException(
+                            this.getClass().getName() + " only for univariate polynomials");
+        }
+        // if base coefficient ring is a field, make monic
+        GenPolynomialRing<C> cfac = (GenPolynomialRing<C>) pfac.coFac;
+        C bcc = engine.baseRecursiveContent(P);
+        if (!bcc.isONE()) {
+            GenPolynomial<C> lc = cfac.getONE().multiply(bcc);
+            GenPolynomial<GenPolynomial<C>> pl = pfac.getONE().multiply(lc);
+            sfactors.put(pl, 1L);
+            P = PolyUtil.<C> baseRecursiveDivide(P, bcc);
+        }
+        // factors of content
+        GenPolynomial<C> Pc = engine.recursiveContent(P);
+        if (logger.isInfoEnabled()) {
+            logger.info("Pc = " + Pc);
+        }
+        Pc = engine.basePrimitivePart(Pc);
+        //System.out.println("Pc,PP = " + Pc);
+        if (!Pc.isONE()) {
+            P = PolyUtil.<C> coefficientPseudoDivide(P, Pc);
+        }
+        SortedMap<GenPolynomial<C>, Long> rsf = squarefreeFactors(Pc);
+        if (logger.isInfoEnabled()) {
+            logger.info("rsf = " + rsf);
+        }
+        // add factors of content
+        for (Map.Entry<GenPolynomial<C>, Long> me : rsf.entrySet()) {
+            GenPolynomial<C> c = me.getKey();
+            if (!c.isONE()) {
+                GenPolynomial<GenPolynomial<C>> cr = pfac.getONE().multiply(c);
+                Long rk = me.getValue(); //rsf.get(c);
+                sfactors.put(cr, rk);
+            }
+        }
+        // divide by trailing term
+        ExpVector et = P.trailingExpVector();
+        if (!et.isZERO()) {
+            GenPolynomial<GenPolynomial<C>> tr = pfac.valueOf(et);
+            if (logger.isInfoEnabled()) {
+                logger.info("trailing term = " + tr);
+            }
+            P = PolyUtil.<C> recursivePseudoDivide(P, tr);
+            long ep = et.getVal(0); // univariate
+            et = et.subst(0, 1);
+            tr = pfac.valueOf(et);
+            sfactors.put(tr, ep);
+        }
+
+        // factors of recursive polynomial
+        GenPolynomial<GenPolynomial<C>> T0 = P;
+        GenPolynomial<GenPolynomial<C>> Tp;
+        GenPolynomial<GenPolynomial<C>> T = null;
+        GenPolynomial<GenPolynomial<C>> V = null;
+        long k = 0L;
+        boolean init = true;
+        while (true) {
+            if (init) {
+                if (T0.isConstant() || T0.isZERO()) {
+                    break;
+                }
+                Tp = PolyUtil.<C> recursiveDeriviative(T0);
+                //System.out.println("iTp = " + Tp);
+                T = engine.recursiveUnivariateGcd(T0, Tp);
+                //System.out.println("iT = " + T);
+                if (debug) {
+                    logger.info("T0 = " + T0 + ", Tp = " + Tp + ", T = " + T);
+                }
+                T = engine.baseRecursivePrimitivePart(T);
+                //System.out.println("iT = " + T);
+                V = PolyUtil.<C> recursivePseudoDivide(T0, T);
+                //System.out.println("iT0 = " + T0);
+                //System.out.println("iV = " + V);
+                k = 0L;
+                init = false;
+            }
+            if (V.isConstant()) {
+                break;
+            }
+            k++;
+            GenPolynomial<GenPolynomial<C>> W = engine.recursiveUnivariateGcd(T, V);
+            if (debug) {
+                logger.info("T = " + T + ", V = " + V + ", W = " + W);
+            }
+            W = engine.baseRecursivePrimitivePart(W);
+            GenPolynomial<GenPolynomial<C>> z = PolyUtil.<C> recursivePseudoDivide(V, W);
+            //System.out.println("W = " + W);
+            //System.out.println("z = " + z);
+            V = W;
+            T = PolyUtil.<C> recursivePseudoDivide(T, V);
+            //System.out.println("V = " + V);
+            //System.out.println("T = " + T);
+            //was: if ( z.degree(0) > 0 ) {
+            if (!z.isONE() && !z.isZERO()) {
+                z = engine.baseRecursivePrimitivePart(z);
+                if (logger.isInfoEnabled()) {
+                    logger.info("z = " + z + ", k = " + k);
+                }
+                sfactors.put(z, k);
+            }
+        }
+        return sfactors;
+    }
+
+
+    /**
+     * GenPolynomial greatest squarefree divisor.
+     * @param P GenPolynomial.
+     * @return squarefree(pp(P)).
+     */
+    @Override
+    public GenPolynomial<C> squarefreePart(GenPolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P != null");
+        }
+        if (P.isZERO()) {
+            return P;
+        }
+        GenPolynomialRing<C> pfac = P.ring;
+        if (pfac.nvar <= 1) {
+            return baseSquarefreePart(P);
+        }
+        GenPolynomialRing<GenPolynomial<C>> rfac = pfac.recursive(1);
+        GenPolynomial<GenPolynomial<C>> Pr = PolyUtil.<C> recursive(rfac, P);
+        GenPolynomial<C> Pc = engine.recursiveContent(Pr);
+        Pr = PolyUtil.<C> coefficientPseudoDivide(Pr, Pc);
+        GenPolynomial<C> Ps = squarefreePart(Pc);
+        GenPolynomial<GenPolynomial<C>> PP = recursiveUnivariateSquarefreePart(Pr);
+        GenPolynomial<GenPolynomial<C>> PS = PP.multiply(Ps);
+        GenPolynomial<C> D = PolyUtil.<C> distribute(pfac, PS);
+        return D;
+    }
+
+
+    /**
+     * GenPolynomial squarefree factorization.
+     * @param P GenPolynomial.
+     * @return [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with P = prod_{i=1,...,k}
+     *         p_i^{e_i} and p_i squarefree and gcd(p_i, p_j) = 1, for i != j.
+     */
+    @Override
+    public SortedMap<GenPolynomial<C>, Long> squarefreeFactors(GenPolynomial<C> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P != null");
+        }
+        GenPolynomialRing<C> pfac = P.ring;
+        if (pfac.nvar <= 1) {
+            return baseSquarefreeFactors(P);
+        }
+        SortedMap<GenPolynomial<C>, Long> sfactors = new TreeMap<GenPolynomial<C>, Long>();
+        if (P.isZERO()) {
+            return sfactors;
+        }
+        if (P.isONE()) {
+            sfactors.put(P, 1L);
+            return sfactors;
+        }
+        GenPolynomialRing<GenPolynomial<C>> rfac = pfac.recursive(1);
+
+        GenPolynomial<GenPolynomial<C>> Pr = PolyUtil.<C> recursive(rfac, P);
+        SortedMap<GenPolynomial<GenPolynomial<C>>, Long> PP = recursiveUnivariateSquarefreeFactors(Pr);
+
+        for (Map.Entry<GenPolynomial<GenPolynomial<C>>, Long> m : PP.entrySet()) {
+            Long i = m.getValue();
+            GenPolynomial<GenPolynomial<C>> Dr = m.getKey();
+            GenPolynomial<C> D = PolyUtil.<C> distribute(pfac, Dr);
+            sfactors.put(D, i);
+        }
+        return normalizeFactorization(sfactors);
+    }
+
+
+    /**
+     * Coefficients squarefree factorization.
+     * @param P coefficient.
+     * @return [p_1 -&gt; e_1, ..., p_k -&gt; e_k] with P = prod_{i=1,...,k}
+     *         p_i^{e_i} and p_i squarefree and gcd(p_i, p_j) = 1, for i != j.
+     */
+    @Override
+    public SortedMap<C, Long> squarefreeFactors(C P) {
+        throw new UnsupportedOperationException("method not implemented");
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/package.html
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufd/package.html
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "../DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>Unique Factorization Domain package</title>
+  </head>
+
+  <body>
+    <h1>Unique factorization domain package.</h1>
+
+<p>
+  This package contains classes for polynomials rings as unique
+  factorization domains.  Provided methods with interface
+  <code>GreatestCommonDivisor</code> are e.g. greatest common divisors
+  <code>gcd()</code>, primitive part <code>primitivePart()</code> or
+  <code>coPrime()</code>.  The different classes implement variants of
+  polynomial remainder sequences (PRS) and modular methods.  Interface
+  <code>Squarefree</code> provides the greatest squarefree factor
+  <code>squarefreeFactor()</code> and a complete squarefree
+  decompostion can be obtained with method
+  <code>squarefreeFactors()</code>.  There is a
+  <code>Factorization</code> interface with an
+  <code>FactorAbstract</code> class with common codes.  Factorization
+  of univariate polynomials exists for several coefficient rings:
+  modulo primes in class <code>FactorModular</code>, over integers in
+  class <code>FactorInteger</code>, over rational numbers in class
+  <code>FactorRational</code>, over algebraic numbers in class
+  <code>FactorAlgebraic&lt;C&gt;</code> and over rational functions in
+  class <code>FactorQuotient&lt;C&gt;</code> (where for the last two
+  classes <code>C</code> can be any other ring for which the
+  <code>FactorFactory. getImplementation</code> returns an
+  implementation).  Multivatiate polynomials over the integers (and
+  rational numbers) are factored using the algorithm of P. Wang. For
+  other coeffcients the multivatiate polynomials are reduced to
+  univariate polynomials via Kronecker substitution.  <!-- and are
+  therefore not very efficient at the moment. The factorization of
+  polynomials is partly experimental.--> The rational function class
+  <code>Quotient</code> computes quotients of polynomials reduced to
+  lowest terms.
+</p>
+<p>
+  To choose the correct implementation always use the factory classes
+  <code>GCDFactory</code>, <code>SquarefreeFactory</code> and
+  <code>FactorFactory</code> with methods
+  <code>getImplementation()</code> or <code>getProxy()</code>.  These
+  methods will take care of all possible (implemented) coefficient
+  rings properties.  The polynomial coefficients must implement the
+  <code>GcdRingElem</code> interface and so must allow greatest common
+  divisor computations.  Greatest common divisor computation is
+  completely generic and works for any implemented integral domain.
+  If special, optimized implementations exist they will be used.
+  Squarefree decomposition is also completely generic and works for
+  any implemented integral domain. There are no special, optimized
+  implementations.  Factorization is generic relative to the
+  implemented ring constructions: algebraic field extensions and
+  transcendent field extensions. Implemented base cases are modular
+  coefficient, integer coefficients and rational number coefficients.
+</p>
+<p>
+  The implementation follows 
+  Geddes &amp; Czapor &amp; Labahn <em>Algorithms for Computer Algebra</em>
+  and Cohen <em>A Curse in Computational Algebraic Number Theory</em>.
+  See also Kaltofen <em>Factorization of Polynomials</em> in Computing Supplement, 
+  <em>Springer, 1982</em>,
+  Davenport &amp; Gianni &amp; Trager <em>Scratchpad's View of Algebra II: A Categorical View of Factorization</em>
+  in <em>ISSAC'91</em>
+  and the <a href="http://krum.rz.uni-mannheim.de/mas/src/" target="mas.src">ALDES/SAC2 code</a>
+  as contained in <a href="http://krum.rz.uni-mannheim.de/mas/" target="mas">MAS</a>.
+</p>
+
+    <hr />
+    <address><a href="mailto:kredel at rz.uni-mannheim.de">Heinz Kredel</a></address>
+<p>
+<!-- Created: Sun Mar  4 16:46:52 CET 2007 -->
+<!-- hhmts start -->
+Last modified: Fri Sep 21 21:56:48 CEST 2012
+<!-- hhmts end -->
+</p>
+<p>$Id$ 
+</p>
+  </body>
+</html>

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufdroot/FactorRealAlgebraic.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufdroot/FactorRealAlgebraic.java
@@ -1,0 +1,134 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.ufdroot;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.arith.Rational;
+import edu.jas.poly.AlgebraicNumber;
+import edu.jas.poly.GenPolynomial;
+import edu.jas.poly.GenPolynomialRing;
+import edu.jas.root.PolyUtilRoot;
+import edu.jas.root.RealAlgebraicNumber;
+import edu.jas.root.RealAlgebraicRing;
+import edu.jas.structure.GcdRingElem;
+import edu.jas.ufd.FactorAbstract;
+import edu.jas.ufd.FactorFactory;
+
+
+/**
+ * Real algebraic number coefficients factorization algorithms. This class
+ * implements factorization methods for polynomials over real algebraic numbers
+ * from package
+ * 
+ * <pre>
+ * edu.jas.root
+ * </pre>
+ * 
+ * .
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class FactorRealAlgebraic<C extends GcdRingElem<C> & Rational> extends
+                FactorAbstract<RealAlgebraicNumber<C>> {
+
+
+    // TODO: is absolute possible? and what does it mean?
+    //FactorAbsolute<AlgebraicNumber<C>>
+    //FactorAbstract<AlgebraicNumber<C>>
+
+
+    private static final Logger logger = LogManager.getLogger(FactorRealAlgebraic.class);
+
+
+    //private static final boolean debug = logger.isInfoEnabled();
+
+
+    /**
+     * Factorization engine for base coefficients.
+     */
+    public final FactorAbstract<AlgebraicNumber<C>> factorAlgebraic;
+
+
+    /**
+     * No argument constructor. <b>Note:</b> can't use this constructor.
+     */
+    protected FactorRealAlgebraic() {
+        throw new IllegalArgumentException("don't use this constructor");
+    }
+
+
+    /**
+     * Constructor.
+     * @param fac algebraic number factory.
+     */
+    public FactorRealAlgebraic(RealAlgebraicRing<C> fac) {
+        this(fac, FactorFactory.<AlgebraicNumber<C>> getImplementation(fac.algebraic));
+    }
+
+
+    /**
+     * Constructor.
+     * @param fac algebraic number factory.
+     * @param factorAlgebraic factorization engine for polynomials over base
+     *            coefficients.
+     */
+    public FactorRealAlgebraic(RealAlgebraicRing<C> fac, FactorAbstract<AlgebraicNumber<C>> factorAlgebraic) {
+        super(fac);
+        this.factorAlgebraic = factorAlgebraic;
+    }
+
+
+    /**
+     * GenPolynomial base factorization of a squarefree polynomial.
+     * @param P squarefree GenPolynomial&lt;RealAlgebraicNumber&lt;C&gt;&gt;.
+     * @return [p_1,...,p_k] with P = prod_{i=1, ..., k} p_i.
+     */
+    @Override
+    public List<GenPolynomial<RealAlgebraicNumber<C>>> baseFactorsSquarefree(
+                    GenPolynomial<RealAlgebraicNumber<C>> P) {
+        if (P == null) {
+            throw new IllegalArgumentException(this.getClass().getName() + " P == null");
+        }
+        List<GenPolynomial<RealAlgebraicNumber<C>>> factors = new ArrayList<GenPolynomial<RealAlgebraicNumber<C>>>();
+        if (P.isZERO()) {
+            return factors;
+        }
+        if (P.isONE()) {
+            factors.add(P);
+            return factors;
+        }
+        GenPolynomialRing<RealAlgebraicNumber<C>> pfac = P.ring; // Q(alpha)[x]
+        if (pfac.nvar > 1) {
+            throw new IllegalArgumentException("only for univariate polynomials");
+        }
+        RealAlgebraicRing<C> rfac = (RealAlgebraicRing<C>) pfac.coFac;
+
+        RealAlgebraicNumber<C> ldcf = P.leadingBaseCoefficient();
+        if (!ldcf.isONE()) {
+            P = P.monic();
+            factors.add(pfac.getONE().multiply(ldcf));
+        }
+        //System.out.println("\nP = " + P);
+        GenPolynomialRing<AlgebraicNumber<C>> afac = new GenPolynomialRing<AlgebraicNumber<C>>(
+                        rfac.algebraic, pfac);
+        GenPolynomial<AlgebraicNumber<C>> A = PolyUtilRoot.<C> algebraicFromRealCoefficients(afac, P);
+        // factor A:
+        List<GenPolynomial<AlgebraicNumber<C>>> afactors = factorAlgebraic.baseFactorsSquarefree(A);
+        for (GenPolynomial<AlgebraicNumber<C>> a : afactors) {
+            GenPolynomial<RealAlgebraicNumber<C>> p = PolyUtilRoot.<C> realFromAlgebraicCoefficients(pfac, a);
+            factors.add(p);
+        }
+        logger.info("real algebraic factors = " + factors);
+        return factors;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufdroot/package.html
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/ufdroot/package.html
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+          "../DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>Unique Factorization Domain and Roots package</title>
+  </head>
+
+  <body>
+    <h1>Unique Factorization Domain and Roots package.</h1>
+
+<p>
+  This package contains classes for factorization in structures 
+  used in roots computation, for example <code>FactorRealAlgebraic</code>.
+</p>
+
+
+    <hr />
+    <address><a href="mailto:kredel at rz.uni-mannheim.de">Heinz Kredel</a></address>
+<p>
+<!-- Created: Sat Feb  4 12:43:29 CET 2012 -->
+<!-- hhmts start -->
+Last modified: Sat Feb  4 12:45:33 CET 2012
+<!-- hhmts end -->
+</p>
+<p>$Id$ 
+</p>
+  </body>
+</html>

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/ArrayUtil.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/ArrayUtil.java
@@ -1,0 +1,47 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.util;
+
+
+// import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+
+/**
+ * Array utilities. For example copyOf from Java 6. <b>Note:</b> unused at the
+ * moment since it is not working in Java 5.
+ * @author Heinz Kredel
+ */
+public class ArrayUtil {
+
+
+    //private static final Logger logger = LogManager.getLogger(ArrayUtil.class);
+    // private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Copy the specified array.
+     * @param original array.
+     * @param newLength new array length.
+     * @return copy of original.
+     */
+    public static <T> T[] copyOf(T[] original, int newLength) {
+        @SuppressWarnings("unchecked")
+        T[] copy = (T[]) new Object[newLength];
+        System.arraycopy(original, 0, copy, 0, Math.min(original.length, newLength));
+        return copy;
+    }
+
+
+    /**
+     * Copy the specified array.
+     * @param original array.
+     * @return copy of original.
+     */
+    public static <T> T[] copyOf(T[] original) {
+        return copyOf(original, original.length);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/CartesianProduct.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/CartesianProduct.java
@@ -1,0 +1,174 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.util;
+
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+
+/**
+ * Cartesian product with iterator.
+ * @author Heinz Kredel
+ */
+public class CartesianProduct<E> implements Iterable<List<E>> {
+
+
+    /**
+     * data structure.
+     */
+    public final List<Iterable<E>> comps;
+
+
+    /**
+     * CartesianProduct constructor.
+     * @param comps components of the Cartesian product.
+     */
+    public CartesianProduct(List<Iterable<E>> comps) {
+        if (comps == null) {
+            throw new IllegalArgumentException("null components not allowed");
+        }
+        this.comps = comps;
+    }
+
+
+    //     /**
+    //      * CartesianProduct constructor.
+    //      * @param comps components of the Cartesian product.
+    //      */
+    //     public CartesianProduct(List<List<E>> comps) {
+    //         this( listToIterable(comps)  );
+    //     }
+
+
+    /**
+     * Get an iterator over subsets.
+     * @return an iterator.
+     */
+    public Iterator<List<E>> iterator() {
+        return new CartesianProductIterator<E>(comps);
+    }
+
+
+    /**
+     * Transform list to iterables.
+     * @param comp components of the Cartesian product.
+     * @return iterables taken from lists.
+     */
+    static <E> List<Iterable<E>> listToIterable(List<List<E>> comp) {
+        List<Iterable<E>> iter = new ArrayList<Iterable<E>>(comp.size());
+        for (List<E> list : comp) {
+            iter.add(list);
+        }
+        return iter;
+    }
+
+
+}
+
+
+/**
+ * Cartesian product iterator.
+ * @author Heinz Kredel
+ */
+class CartesianProductIterator<E> implements Iterator<List<E>> {
+
+
+    /**
+     * data structure.
+     */
+    final List<Iterable<E>> comps;
+
+
+    final List<Iterator<E>> compit;
+
+
+    List<E> current;
+
+
+    boolean empty;
+
+
+    /**
+     * CartesianProduct iterator constructor.
+     * @param comps components of the Cartesian product.
+     */
+    public CartesianProductIterator(List<Iterable<E>> comps) {
+        if (comps == null) {
+            throw new IllegalArgumentException("null comps not allowed");
+        }
+        this.comps = comps;
+        current = new ArrayList<E>(comps.size());
+        compit = new ArrayList<Iterator<E>>(comps.size());
+        empty = false;
+        for (Iterable<E> ci : comps) {
+            Iterator<E> it = ci.iterator();
+            if (!it.hasNext()) {
+                empty = true;
+                current.clear();
+                break;
+            }
+            current.add(it.next());
+            compit.add(it);
+        }
+        //System.out.println("current = " + current);
+    }
+
+
+    /**
+     * Test for availability of a next tuple.
+     * @return true if the iteration has more tuples, else false.
+     */
+    public synchronized boolean hasNext() {
+        return !empty;
+    }
+
+
+    /**
+     * Get next tuple.
+     * @return next tuple.
+     */
+    public synchronized List<E> next() {
+        if (empty) {
+            throw new NoSuchElementException("invalid call of next()");
+        }
+        List<E> res = new ArrayList<E>(current);
+        // search iterator which hasNext
+        int i = compit.size() - 1;
+        for (; i >= 0; i--) {
+            Iterator<E> iter = compit.get(i);
+            if (iter.hasNext()) {
+                break;
+            }
+        }
+        if (i < 0) {
+            empty = true;
+            return res;
+        }
+        // update iterators
+        for (int j = i + 1; j < compit.size(); j++) {
+            Iterator<E> iter = comps.get(j).iterator();
+            compit.set(j, iter);
+        }
+        // update current
+        for (int j = i; j < compit.size(); j++) {
+            Iterator<E> iter = compit.get(j);
+            E el = iter.next();
+            current.set(j, el);
+        }
+        return res;
+    }
+
+
+    /**
+     * Remove a tuple if allowed.
+     */
+    public void remove() {
+        throw new UnsupportedOperationException("cannnot remove tuples");
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/CartesianProductInfinite.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/CartesianProductInfinite.java
@@ -1,0 +1,392 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.util;
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+
+/**
+ * Cartesian product of infinite components with iterator. Works also for finite
+ * iterables.
+ * @author Heinz Kredel
+ */
+public class CartesianProductInfinite<E> implements Iterable<List<E>> {
+
+
+    /**
+     * data structure.
+     */
+    public final List<Iterable<E>> comps;
+
+
+    /**
+     * CartesianProduct constructor.
+     * @param comps components of the Cartesian product.
+     */
+    public CartesianProductInfinite(List<Iterable<E>> comps) {
+        if (comps == null || comps.size() == 0) {
+            throw new IllegalArgumentException("null components not allowed");
+        }
+        this.comps = comps;
+    }
+
+
+    /**
+     * Get an iterator over subsets.
+     * @return an iterator.
+     */
+    public Iterator<List<E>> iterator() {
+        if (comps.size() == 1) {
+            return new CartesianOneProductInfiniteIterator<E>(comps.get(0));
+        }
+        //         if ( comps.size() == 2 ) { // this part is not realy required
+        //             return new CartesianTwoProductInfiniteIterator<E>(comps.get(0),comps.get(1));
+        //         }
+        int n = comps.size();
+        int k = n / 2 + n % 2; // ceiling
+        Iterable<List<E>> c0 = new CartesianProductInfinite<E>(comps.subList(0, k));
+        Iterable<List<E>> c1 = new CartesianProductInfinite<E>(comps.subList(k, n));
+        return new CartesianTwoProductInfiniteIteratorList<E>(c0, c1);
+    }
+
+}
+
+
+/**
+ * Cartesian product infinite iterator, one factor.
+ * @author Heinz Kredel
+ */
+class CartesianOneProductInfiniteIterator<E> implements Iterator<List<E>> {
+
+
+    /**
+     * data structure.
+     */
+    final Iterator<E> compit;
+
+
+    /**
+     * CartesianProduct iterator constructor.
+     * @param comps components of the cartesian product.
+     */
+    public CartesianOneProductInfiniteIterator(Iterable<E> comps) {
+        if (comps == null) {
+            throw new IllegalArgumentException("null comps not allowed");
+        }
+        compit = comps.iterator();
+    }
+
+
+    /**
+     * Test for availability of a next tuple.
+     * @return true if the iteration has more tuples, else false.
+     */
+    public synchronized boolean hasNext() {
+        return compit.hasNext();
+    }
+
+
+    /**
+     * Get next tuple.
+     * @return next tuple.
+     */
+    public synchronized List<E> next() {
+        List<E> res = new ArrayList<E>(1);
+        res.add(compit.next());
+        return res;
+    }
+
+
+    /**
+     * Remove a tuple if allowed.
+     */
+    public void remove() {
+        throw new UnsupportedOperationException("cannnot remove tuples");
+    }
+
+}
+
+
+/**
+ * Cartesian product infinite iterator, two factors.
+ * @author Heinz Kredel
+ */
+class CartesianTwoProductInfiniteIterator<E> implements Iterator<List<E>> {
+
+
+    /**
+     * data structure.
+     */
+    final Iterator<E> compit0;
+
+
+    final Iterator<E> compit1;
+
+
+    final List<E> fincomps0;
+
+
+    final List<E> fincomps1;
+
+
+    Iterator<E> fincompit0;
+
+
+    Iterator<E> fincompit1;
+
+
+    List<E> current;
+
+
+    boolean empty;
+
+
+    long level;
+
+
+    /**
+     * CartesianProduct iterator constructor.
+     * @param comps0 first components of the Cartesian product.
+     * @param comps1 second components of the Cartesian product.
+     */
+    public CartesianTwoProductInfiniteIterator(Iterable<E> comps0, Iterable<E> comps1) {
+        if (comps0 == null || comps1 == null) {
+            throw new IllegalArgumentException("null comps not allowed");
+        }
+        empty = false;
+        level = 0;
+        current = new ArrayList<E>(2);
+
+        compit0 = comps0.iterator();
+        E e = compit0.next();
+        current.add(e);
+        fincomps0 = new ArrayList<E>();
+        fincomps0.add(e);
+        fincompit0 = fincomps0.iterator();
+        //E d = 
+        fincompit0.next(); // remove current
+
+        compit1 = comps1.iterator();
+        e = compit1.next();
+        current.add(e);
+        fincomps1 = new ArrayList<E>();
+        fincomps1.add(e);
+        fincompit1 = fincomps1.iterator();
+        //@SuppressWarnings("unused")
+        //d = 
+        fincompit1.next(); // remove current
+        //System.out.println("current   = " + current);
+    }
+
+
+    /**
+     * Test for availability of a next tuple.
+     * @return true if the iteration has more tuples, else false.
+     */
+    public synchronized boolean hasNext() {
+        return !empty;
+    }
+
+
+    /**
+     * Get next tuple.
+     * @return next tuple.
+     */
+    public synchronized List<E> next() {
+        if (empty) {
+            throw new NoSuchElementException("invalid call of next()");
+        }
+        List<E> res = current; // new ArrayList<E>(current); // copy
+        if (fincompit0.hasNext() && fincompit1.hasNext()) {
+            E e0 = fincompit0.next();
+            E e1 = fincompit1.next();
+            current = new ArrayList<E>();
+            current.add(e0);
+            current.add(e1);
+            return res;
+        }
+        level++;
+        if (level % 2 == 1) {
+            Collections.reverse(fincomps0);
+        } else {
+            Collections.reverse(fincomps1);
+        }
+        if (compit0.hasNext() && compit1.hasNext()) {
+            fincomps0.add(compit0.next());
+            fincomps1.add(compit1.next());
+        } else {
+            empty = true;
+            return res;
+        }
+        if (level % 2 == 0) {
+            Collections.reverse(fincomps0);
+        } else {
+            Collections.reverse(fincomps1);
+        }
+        //System.out.println("list(0) = " + fincomps0);
+        //System.out.println("list(1) = " + fincomps1);
+        fincompit0 = fincomps0.iterator();
+        fincompit1 = fincomps1.iterator();
+        E e0 = fincompit0.next();
+        E e1 = fincompit1.next();
+        current = new ArrayList<E>();
+        current.add(e0);
+        current.add(e1);
+        return res;
+    }
+
+
+    /**
+     * Remove a tuple if allowed.
+     */
+    public void remove() {
+        throw new UnsupportedOperationException("cannnot remove tuples");
+    }
+
+}
+
+
+/**
+ * Cartesian product infinite iterator, two factors list version.
+ * @author Heinz Kredel
+ */
+class CartesianTwoProductInfiniteIteratorList<E> implements Iterator<List<E>> {
+
+
+    /**
+     * data structure.
+     */
+    final Iterator<List<E>> compit0;
+
+
+    final Iterator<List<E>> compit1;
+
+
+    final List<List<E>> fincomps0;
+
+
+    final List<List<E>> fincomps1;
+
+
+    Iterator<List<E>> fincompit0;
+
+
+    Iterator<List<E>> fincompit1;
+
+
+    List<E> current;
+
+
+    boolean empty;
+
+
+    long level;
+
+
+    /**
+     * CartesianProduct iterator constructor.
+     * @param comps0 first components of the Cartesian product.
+     * @param comps1 second components of the Cartesian product.
+     */
+    public CartesianTwoProductInfiniteIteratorList(Iterable<List<E>> comps0, Iterable<List<E>> comps1) {
+        if (comps0 == null || comps1 == null) {
+            throw new IllegalArgumentException("null comps not allowed");
+        }
+        current = new ArrayList<E>();
+        empty = false;
+        level = 0;
+
+        compit0 = comps0.iterator();
+        List<E> e = compit0.next();
+        current.addAll(e);
+        fincomps0 = new ArrayList<List<E>>();
+        fincomps0.add(e);
+        fincompit0 = fincomps0.iterator();
+        //List<E> d = 
+        fincompit0.next(); // remove current
+
+        compit1 = comps1.iterator();
+        e = compit1.next();
+        current.addAll(e);
+        fincomps1 = new ArrayList<List<E>>();
+        fincomps1.add(e);
+        fincompit1 = fincomps1.iterator();
+        //@SuppressWarnings("unused")
+        //d = 
+        fincompit1.next(); // remove current
+        //System.out.println("current   = " + current);
+    }
+
+
+    /**
+     * Test for availability of a next tuple.
+     * @return true if the iteration has more tuples, else false.
+     */
+    public synchronized boolean hasNext() {
+        return !empty;
+    }
+
+
+    /**
+     * Get next tuple.
+     * @return next tuple.
+     */
+    public synchronized List<E> next() {
+        if (empty) {
+            throw new NoSuchElementException("invalid call of next()");
+        }
+        List<E> res = current; // new ArrayList<E>(current);
+        if (fincompit0.hasNext() && fincompit1.hasNext()) {
+            List<E> e0 = fincompit0.next();
+            List<E> e1 = fincompit1.next();
+            current = new ArrayList<E>();
+            current.addAll(e0);
+            current.addAll(e1);
+            return res;
+        }
+        level++;
+        if (level % 2 == 1) {
+            Collections.reverse(fincomps0);
+        } else {
+            Collections.reverse(fincomps1);
+        }
+        if (compit0.hasNext() && compit1.hasNext()) {
+            fincomps0.add(compit0.next());
+            fincomps1.add(compit1.next());
+        } else {
+            empty = true;
+            return res;
+        }
+        if (level % 2 == 0) {
+            Collections.reverse(fincomps0);
+        } else {
+            Collections.reverse(fincomps1);
+        }
+        //System.out.println("list(0) = " + fincomps0);
+        //System.out.println("list(1) = " + fincomps1);
+        fincompit0 = fincomps0.iterator();
+        fincompit1 = fincomps1.iterator();
+        List<E> e0 = fincompit0.next();
+        List<E> e1 = fincompit1.next();
+        current = new ArrayList<E>();
+        current.addAll(e0);
+        current.addAll(e1);
+        return res;
+    }
+
+
+    /**
+     * Remove a tuple if allowed.
+     */
+    public void remove() {
+        throw new UnsupportedOperationException("cannnot remove tuples");
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/CartesianProductLong.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/CartesianProductLong.java
@@ -1,0 +1,241 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.util;
+
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+
+/**
+ * Cartesian product for Long with iterator. Similar to CartesianProduct but
+ * returns only tuples of given total degree.
+ * @author Heinz Kredel
+ */
+public class CartesianProductLong implements Iterable<List<Long>> {
+
+
+    /**
+     * data structure.
+     */
+    public final List<LongIterable> comps;
+
+
+    public final long upperBound;
+
+
+    /**
+     * CartesianProduct constructor.
+     * @param comps components of the Cartesian product.
+     * @param ub an upper bound for the total degree of the elements.
+     */
+    public CartesianProductLong(List<LongIterable> comps, long ub) {
+        if (comps == null) {
+            throw new IllegalArgumentException("null components not allowed");
+        }
+        this.comps = comps;
+        this.upperBound = ub;
+    }
+
+
+    /**
+     * Get an iterator over subsets.
+     * @return an iterator.
+     */
+    public Iterator<List<Long>> iterator() {
+        return new CartesianProductLongIterator(comps, upperBound);
+    }
+
+}
+
+
+/**
+ * Cartesian product iterator for Longs. Similar to CartesianProductIterator but
+ * returns only tuples of given total degree.
+ * @author Heinz Kredel
+ */
+class CartesianProductLongIterator implements Iterator<List<Long>> {
+
+
+    /**
+     * data structure.
+     */
+    final List<LongIterable> comps;
+
+
+    final List<LongIterator> compit;
+
+
+    List<Long> current;
+
+
+    boolean empty;
+
+
+    public final long upperBound;
+
+
+    /**
+     * CartesianProduct iterator constructor.
+     * @param comps components of the Cartesian product.
+     * @param ub an upper bound for the total degree of the elements.
+     */
+    public CartesianProductLongIterator(List<LongIterable> comps, long ub) {
+        if (comps == null) {
+            throw new IllegalArgumentException("null comps not allowed");
+        }
+        this.comps = comps;
+        this.upperBound = ub;
+        current = new ArrayList<Long>(comps.size());
+        compit = new ArrayList<LongIterator>(comps.size());
+        empty = false;
+        for (LongIterable ci : comps) {
+            LongIterator it = (LongIterator) ci.iterator();
+            if (it.getUpperBound() < this.upperBound) {
+                throw new IllegalArgumentException("each iterator (" + it.getUpperBound()
+                                + ") must be able to reach total upper bound " + upperBound);
+            }
+            if (!it.hasNext()) {
+                empty = true;
+                current.clear();
+                return;
+            }
+            current.add(it.next());
+            compit.add(it);
+        }
+        // start with last component equal to upper bound
+        LongIterator it = compit.get(compit.size() - 1);
+        long d = -1L;
+        while (it.hasNext()) {
+            d = it.next();
+            if (d >= upperBound) {
+                break;
+            }
+        }
+        if (d >= 0L) {
+            current.set(current.size() - 1, d);
+        }
+        if (totalDegree(current) != upperBound) {
+            empty = true;
+            current.clear();
+        }
+        //System.out.println("current = " + current);
+    }
+
+
+    /**
+     * Test for availability of a next tuple.
+     * @return true if the iteration has more tuples, else false.
+     */
+    public synchronized boolean hasNext() {
+        return !empty;
+    }
+
+
+    /**
+     * Get next tuple.
+     * @return next tuple.
+     */
+    public synchronized List<Long> next() {
+        if (empty) {
+            throw new NoSuchElementException("invalid call of next()");
+        }
+        List<Long> res = new ArrayList<Long>(current);
+        //int waist = 0;
+        while (true) {
+            // search iterator which hasNext
+            int i = compit.size() - 1;
+            for (; i >= 0; i--) {
+                LongIterator iter = compit.get(i);
+                if (iter.hasNext()) {
+                    break;
+                }
+            }
+            if (i < 0) {
+                empty = true;
+                //System.out.println("inner waist = " + waist);
+                return res;
+            }
+            long pd = 0L;
+            for (int j = 0; j < i; j++) {
+                pd += current.get(j);
+            }
+            if (pd >= upperBound) {
+                if (current.get(0) == upperBound) {
+                    empty = true;
+                    //System.out.println("inner waist = " + waist);
+                    return res;
+                }
+                pd = upperBound;
+            }
+            long rd = upperBound - pd;
+            // update iterators
+            for (int j = i + 1; j < compit.size(); j++) {
+                LongIterator iter = (LongIterator) comps.get(j).iterator();
+                iter.setUpperBound(rd);
+                compit.set(j, iter);
+            }
+            // update current
+            for (int j = i; j < compit.size(); j++) {
+                LongIterator iter = compit.get(j);
+                Long el = iter.next();
+                current.set(j, el);
+            }
+            long td = totalDegree(current);
+            if (td == upperBound) {
+                //System.out.println("inner waist = " + waist);
+                return res;
+            }
+            //System.out.println("current = " + current + ", td = " + td);
+            if (td > upperBound) {
+                //waist++;
+                continue;
+            }
+            // adjust last component to total degree
+            LongIterator it = compit.get(compit.size() - 1);
+            long d = -1L;
+            while (td < upperBound && it.hasNext()) {
+                td++;
+                d = it.next();
+            }
+            //System.out.println("d = " + d);
+            if (d >= 0L) {
+                current.set(current.size() - 1, d);
+            }
+            if (td == upperBound) {
+                //System.out.println("inner waist = " + waist);
+                return res;
+            }
+            //waist++;
+            // continue search
+        }
+        //return res;
+    }
+
+
+    /**
+     * Total degree of a tuple.
+     * @param e list of Longs.
+     * @return sum of all elements in e.
+     */
+    public long totalDegree(List<Long> e) {
+        long d = 0L;
+        for (Long i : e) {
+            d += i;
+        }
+        return d;
+    }
+
+
+    /**
+     * Remove a tuple if allowed.
+     */
+    public void remove() {
+        throw new UnsupportedOperationException("cannnot remove tuples");
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/CatReader.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/CatReader.java
@@ -1,0 +1,86 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.util;
+
+
+import java.io.IOException;
+import java.io.Reader;
+
+
+// import org.apache.logging.log4j.Logger;
+// import org.apache.logging.log4j.LogManager; 
+
+
+/**
+ * Reader to conncat two readers. Read from first reader until it is empty, then
+ * read from second reader.
+ * @author Heinz Kredel
+ */
+
+public class CatReader extends Reader {
+
+
+    // private static final Logger logger = LogManager.getLogger(CatReader.class);
+    // private static final boolean debug = logger.isDebugEnabled();
+
+
+    private final Reader first;
+
+
+    private final Reader second;
+
+
+    private boolean doFirst;
+
+
+    /**
+     * Constructor.
+     * @param f first Reader.
+     * @param s second Reader.
+     */
+    public CatReader(Reader f, Reader s) {
+        first = f;
+        second = s;
+        doFirst = true;
+    }
+
+
+    /**
+     * Read char array.
+     * @param cbuf array.
+     * @param off start offset.
+     * @param len number of chars to read.
+     * @return number of chars read, or -1.
+     */
+    @Override
+    public int read(char[] cbuf, int off, int len) throws IOException {
+        int i = -1;
+        if (doFirst) {
+            i = first.read(cbuf, off, len);
+            if (i < 0) {
+                doFirst = false;
+                i = second.read(cbuf, off, len);
+            }
+        } else {
+            i = second.read(cbuf, off, len);
+        }
+        //System.out.println("i = " + i);
+        return i;
+    }
+
+
+    /**
+     * Close this Reader.
+     */
+    @Override
+    public void close() throws IOException {
+        try {
+            first.close();
+        } finally {
+            second.close();
+        }
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/ChannelFactory.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/ChannelFactory.java
@@ -1,0 +1,277 @@
+/*
+ * $Id$
+ */
+
+//package edu.unima.ky.parallel;
+package edu.jas.util;
+
+
+import java.io.IOException;
+
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.BindException;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue; //import java.util.concurrent.ArrayBlockingQueue;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+
+/**
+ * ChannelFactory implements a symmetric and non blocking way of setting up
+ * sockets on the client and server side. The constructor sets up a ServerSocket
+ * and accepts and stores any Socket creation requests from clients. The created
+ * Sockets can the be retrieved from the store without blocking. Refactored for
+ * java.util.concurrent.
+ * @author Akitoshi Yoshida
+ * @author Heinz Kredel
+ * @see SocketChannel
+ */
+public class ChannelFactory extends Thread {
+
+
+    private static final Logger logger = LogManager.getLogger(ChannelFactory.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * default port of socket.
+     */
+    public final static int DEFAULT_PORT = 4711;
+
+
+    /**
+     * port of socket.
+     */
+    private final int port;
+
+
+    /**
+     * BoundedBuffer for sockets.
+     */
+    private final BlockingQueue<SocketChannel> buf;
+
+
+    /**
+     * local server socket.
+     */
+    private volatile ServerSocket srv;
+
+
+    /**
+     * is local server up and running.
+     */
+    private volatile boolean srvrun = false;
+
+
+    /**
+     * is thread started.
+     */
+    private volatile boolean srvstart = false;
+
+
+    /**
+     * Constructs a ChannelFactory on the DEFAULT_PORT.
+     */
+    public ChannelFactory() {
+        this(DEFAULT_PORT);
+    }
+
+
+    /**
+     * Constructs a ChannelFactory.
+     * @param p port.
+     */
+    public ChannelFactory(int p) {
+        buf = new LinkedBlockingQueue<SocketChannel>(/*infinite*/);
+        if (p <= 0) {
+            port = DEFAULT_PORT;
+        } else {
+            port = p;
+        }
+        try {
+            srv = new ServerSocket(port);
+            //this.start(); moved to init and getChannel
+            logger.info("server bound to port " + port);
+        } catch (BindException e) {
+            srv = null;
+            logger.warn("server not started, port used " + port);
+            if (debug) {
+                e.printStackTrace();
+            }
+        } catch (IOException e) {
+            logger.debug("IOException " + e);
+            if (logger.isDebugEnabled()) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName() + "(" + srv + ", buf = " + buf.size() + ")";
+    }
+
+
+    /**
+     * thread initialization and start.
+     */
+    public void init() {
+        if (srv != null && ! srvstart  ) {
+            this.start();
+            srvstart = true;
+            logger.info("ChannelFactory at " + srv);
+        }
+    }
+
+
+    /**
+     * Get a new socket channel from a server socket.
+     */
+    public SocketChannel getChannel() throws InterruptedException {
+        // return (SocketChannel)buf.get();
+        if (srv == null) {
+            if (srvrun) {
+                throw new IllegalArgumentException("dont call when no server listens");
+            }
+        } else if ( ! srvstart  ) {
+            init();
+        }
+        return buf.take();
+    }
+
+
+    /**
+     * Get a new socket channel to a given host.
+     * @param h hostname
+     */
+    public SocketChannel getChannel(String h) throws IOException {
+        return getChannel(h,DEFAULT_PORT);
+    }
+
+
+    /**
+     * Get a new socket channel to a given host.
+     * @param h hostname
+     * @param p port
+     */
+    public SocketChannel getChannel(String h, int p) throws IOException {
+        if (p <= 0) {
+            p = port;
+        }
+        SocketChannel c = null;
+        int i = 0;
+        int delay = 5; // 50
+        logger.debug("connecting to " + h);
+        while (c == null) {
+            try {
+                c = new SocketChannel(new Socket(h, p));
+            } catch (IOException e) {
+                //System.out.println(e);
+                // wait server ready
+                i++;
+                if (i % 50 == 0) {
+                    delay += delay;
+                    logger.info("Server on " + h + ":" + p + " not ready in " + delay + "ms");
+                }
+                try {
+                    Thread.sleep(delay);
+                    if (i % 50 == 0 && debug) {
+                        throw new Exception("time wait, host = " + h + ", port = " + port);
+                    }
+                } catch (InterruptedException w) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("Interrupted during IO wait " + w);
+                } catch (Exception ee) { // debug only
+                    ee.printStackTrace();
+                }
+            }
+        }
+        logger.debug("connected, iter = " + i);
+        return c;
+    }
+
+
+    /**
+     * Run the servers accept() in an infinite loop.
+     */
+    @Override
+    public void run() {
+        if (srv == null) {
+            return; // nothing to do
+        }
+        srvrun = true;
+        while (true) {
+            try {
+                logger.info("waiting for connection on " + srv);
+                Socket s = srv.accept();
+                if (this.isInterrupted()) {
+                    //System.out.println("ChannelFactory interrupted");
+                    srvrun = false;
+                    if (s != null) { // by code-spotter
+                        s.close();
+                    }
+                    return;
+                }
+                //logger.debug("Socket = " +s);
+                logger.debug("connection accepted");
+                SocketChannel c = new SocketChannel(s);
+                buf.put(c);
+            } catch (IOException e) {
+                //logger.debug("ChannelFactory IO terminating");
+                srvrun = false;
+                return;
+            } catch (InterruptedException e) {
+                // unfug Thread.currentThread().interrupt();
+                //logger.debug("ChannelFactory IE terminating");
+                srvrun = false;
+                return;
+            }
+        }
+    }
+
+
+    /**
+     * Terminate the Channel Factory
+     */
+    public void terminate() {
+        if ( ! srvstart ) {
+            logger.debug("server not started");
+            return; 
+        }
+        this.interrupt();
+        try {
+            if (srv != null) {
+                srv.close();
+                srvrun = false;
+            }
+            this.interrupt();
+            while (!buf.isEmpty()) {
+                logger.debug("closing unused SocketChannel");
+                //((SocketChannel)buf.get()).close();
+                SocketChannel c  = buf.poll();
+                if ( c != null ) {
+                    c.close();
+                }
+            }
+        } catch (IOException e) {
+            //} catch (InterruptedException e) {
+            // Thread.currentThread().interrupt();
+        }
+        try {
+            this.join();
+        } catch (InterruptedException e) {
+            // unfug Thread.currentThread().interrupt();
+        }
+        logger.debug("ChannelFactory terminated");
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/DHTTransport.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/DHTTransport.java
@@ -1,0 +1,289 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.util;
+
+
+import java.io.Serializable;
+import java.io.IOException;
+import java.rmi.MarshalledObject;
+
+
+/**
+ * Transport container for a distributed version of a HashTable. 
+ * <b>Note:</b> Contains code for timing of marshalled versus plain 
+ * object serialization which can be removed later.
+ * @author Heinz Kredel
+ */
+public abstract class DHTTransport<K, V> implements Serializable {
+
+
+    static long etime  = 0L; // encode marshalled
+    static long dtime  = 0L; // decode marshalled
+    static long ertime = 0L; // encode plain raw
+    static long drtime = 0L; // decode plain raw
+
+
+    public static enum Stor { // storage and transport class
+        marshal, plain
+    };
+
+
+    public static final Stor stor = Stor.marshal; //Stor.plain; 
+
+
+    /**
+     * protected constructor.
+     */
+    protected DHTTransport() {
+    }
+
+
+    /**
+     * Create a new DHTTransport Container.
+     * @param key
+     * @param value
+     */
+    public static <K,V> DHTTransport<K,V> create(K key, V value) throws IOException {
+        switch (stor) {
+        case marshal: return new DHTTransportMarshal<K,V>(key,value);
+        case plain:   return new DHTTransportPlain<K,V>(key,value);
+        default: throw new IllegalArgumentException("this should not happen");
+        }
+    }
+
+
+    /**
+     * Get the key from this DHTTransport Container.
+     */
+    public abstract K key() throws IOException, ClassNotFoundException;
+
+
+    /**
+     * Get the value from this DHTTransport Container.
+     */
+    public abstract V value() throws IOException, ClassNotFoundException;
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString() {
+        return this.getClass().getName();
+
+    }
+
+}
+
+
+/**
+ * Transport container to signal termination for a distributed version
+ * of a HashTable. Contains no objects.
+ */
+class DHTTransportTerminate<K, V> extends DHTTransport<K, V> {
+
+    /**
+     * Get the key from this DHTTransport Container.
+     */
+    public K key() throws IOException, ClassNotFoundException {
+        throw new UnsupportedOperationException("this should not happen");
+    }
+
+
+    /**
+     * Get the value from this DHTTransport Container.
+     */
+    public V value() throws IOException, ClassNotFoundException {
+        throw new UnsupportedOperationException("this should not happen");
+    }
+
+}
+
+
+/**
+ * Transport container to signal clearing contents of the 
+ * other HashTables including the server. Contains no objects.
+ */
+class DHTTransportClear<K, V> extends DHTTransport<K, V> {
+
+    /**
+     * Get the key from this DHTTransport Container.
+     */
+    public K key() throws IOException, ClassNotFoundException {
+        throw new UnsupportedOperationException("this should not happen");
+    }
+
+
+    /**
+     * Get the value from this DHTTransport Container.
+     */
+    public V value() throws IOException, ClassNotFoundException {
+        throw new UnsupportedOperationException("this should not happen");
+    }
+
+}
+
+
+/**
+ * Transport container for a distributed version of a HashTable. Immutable
+ * objects. Uses MarshalledObject to avoid deserialization on server side.
+ */
+class DHTTransportMarshal<K, V> extends DHTTransport<K, V> {
+
+
+    protected final MarshalledObject/*<K>*/ key;
+
+
+    protected final MarshalledObject/*<V>*/ value;
+
+
+    /**
+     * Constructs a new DHTTransport Container.
+     * @param key
+     * @param value
+     */
+    @SuppressWarnings("unchecked")
+    public DHTTransportMarshal(K key, V value) throws IOException {
+        long t = System.currentTimeMillis();
+        this.key = new MarshalledObject/*<K>*/(key);
+        this.value = new MarshalledObject/*<V>*/(value);
+        t = System.currentTimeMillis() - t;
+        synchronized( DHTTransport.class ) {
+            etime += t;
+        }
+        //System.out.println("         marshal time = " + t);
+    }
+
+
+    /**
+     * Get the key from this DHTTransport Container.
+     */
+    @SuppressWarnings("unchecked")
+    public K key() throws IOException, ClassNotFoundException {
+        long t = System.currentTimeMillis();
+        K k = (K) this.key.get();
+        t = System.currentTimeMillis() - t;
+        synchronized( DHTTransport.class ) {
+            dtime += t;
+        }
+        return k;
+    }
+
+
+    /**
+     * Get the value from this DHTTransport Container.
+     */
+    @SuppressWarnings("unchecked")
+    public V value() throws IOException, ClassNotFoundException {
+        long t = System.currentTimeMillis();
+        V v = (V) this.value.get();
+        t = System.currentTimeMillis() - t;
+        synchronized( DHTTransport.class ) {
+            dtime += t;
+        }
+        return v;
+    }
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString() {
+        return super.toString() + "(" + key + "," + value + ")";
+    }
+
+
+    private void writeObject(java.io.ObjectOutputStream out) throws IOException {
+        long t = System.currentTimeMillis();
+        out.defaultWriteObject();
+        t = System.currentTimeMillis() - t;
+        synchronized( DHTTransport.class ) {
+            ertime += t;
+        }
+    }
+
+
+    private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
+        long t = System.currentTimeMillis();
+        in.defaultReadObject();
+        t = System.currentTimeMillis() - t; // not meaningful, includes waiting time
+        synchronized( DHTTransport.class ) {
+            drtime += t;
+        }
+    }
+
+}
+
+
+/**
+ * Transport container for a distributed version of a HashTable. Immutable
+ * objects. Uses plain objects.
+ */
+class DHTTransportPlain<K, V> extends DHTTransport<K, V> {
+
+
+    protected final K key;
+
+
+    protected final V value;
+
+
+    /**
+     * Constructs a new DHTTransport Container.
+     * @param key
+     * @param value
+     */
+    public DHTTransportPlain(K key, V value) throws IOException {
+        this.key = key;
+        this.value = value;
+    }
+
+
+    /**
+     * Get the key from this DHTTransport Container.
+     */
+    public K key() throws IOException, ClassNotFoundException {
+        return this.key;
+    }
+
+
+    /**
+     * Get the value from this DHTTransport Container.
+     */
+    public V value() throws IOException, ClassNotFoundException {
+        return this.value;
+    }
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString() {
+        return super.toString() + "(" + key + "," + value + ")";
+    }
+
+
+    private void writeObject(java.io.ObjectOutputStream out) throws IOException {
+        long t = System.currentTimeMillis();
+        out.defaultWriteObject();
+        t = System.currentTimeMillis() - t;
+        synchronized( DHTTransport.class ) {
+            ertime += t;
+        }
+    }
+
+
+    private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
+        long t = System.currentTimeMillis();
+        in.defaultReadObject();
+        t = System.currentTimeMillis() - t;
+        synchronized( DHTTransport.class ) {
+            drtime += t;
+        }
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/DistHashTable.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/DistHashTable.java
@@ -1,0 +1,498 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.util;
+
+
+import java.io.IOException;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+//import java.util.concurrent.ConcurrentSkipListMap;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+
+/**
+ * Distributed version of a HashTable. Implemented with a SortedMap / TreeMap to
+ * keep the sequence order of elements.
+ * @author Heinz Kredel
+ */
+
+public class DistHashTable<K, V> extends AbstractMap<K, V> /* implements Map<K,V> */{
+
+
+    private static final Logger logger = LogManager.getLogger(DistHashTable.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    protected final SortedMap<K, V> theList;
+
+
+    protected final ChannelFactory cf;
+
+
+    protected SocketChannel channel = null;
+
+
+    protected DHTListener<K, V> listener = null;
+
+
+    /**
+     * Constructs a new DistHashTable.
+     * @param host name or IP of server host.
+     */
+    public DistHashTable(String host) {
+        this(host, DistHashTableServer.DEFAULT_PORT);
+    }
+
+
+    /**
+     * DistHashTable.
+     * @param host name or IP of server host.
+     * @param port on server.
+     */
+    public DistHashTable(String host, int port) {
+        this(new ChannelFactory(port + 1), host, port);
+    }
+
+
+    /**
+     * DistHashTable.
+     * @param cf ChannelFactory to use.
+     * @param host name or IP of server host.
+     * @param port on server.
+     */
+    public DistHashTable(ChannelFactory cf, String host, int port) {
+        this.cf = cf;
+        cf.init(); // why? see constructor
+        try {
+            channel = cf.getChannel(host, port);
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+        if (debug) {
+            logger.debug("dl channel = " + channel);
+        }
+        //theList = new ConcurrentSkipListMap<K, V>(); // Java 1.6
+        theList = new TreeMap<K, V>();
+        listener = new DHTListener<K, V>(channel, theList);
+        // listener.start() is in initialize()
+    }
+
+
+    /**
+     * DistHashTable.
+     * @param sc SocketChannel to use.
+     */
+    public DistHashTable(SocketChannel sc) {
+        cf = null;
+        channel = sc;
+        //theList = new ConcurrentSkipListMap<K, V>(); // Java 1.6
+        theList = new TreeMap<K, V>();
+        listener = new DHTListener<K, V>(channel, theList);
+        // listener.start() is in initialize()
+    }
+
+
+    /**
+     * Hash code.
+     */
+    @Override
+    public int hashCode() {
+        return theList.hashCode();
+    }
+
+
+    /**
+     * Equals.
+     */
+    @Override
+    public boolean equals(Object o) {
+        return theList.equals(o);
+    }
+
+
+    /**
+     * Contains key.
+     */
+    @Override
+    public boolean containsKey(Object o) {
+        return theList.containsKey(o);
+    }
+
+
+    /**
+     * Contains value.
+     */
+    @Override
+    public boolean containsValue(Object o) {
+        return theList.containsValue(o);
+    }
+
+
+    /**
+     * Get the values as Collection.
+     */
+    @Override
+    public Collection<V> values() {
+        synchronized (theList) {
+            return new ArrayList<V>(theList.values());
+            //return theList.values();
+        }
+    }
+
+
+    /**
+     * Get the keys as set.
+     */
+    @Override
+    public Set<K> keySet() {
+        synchronized (theList) {
+            return theList.keySet();
+        }
+    }
+
+
+    /**
+     * Get the entries as Set.
+     */
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        synchronized (theList) {
+            return theList.entrySet();
+        }
+    }
+
+
+    /**
+     * Get the internal list, convert from Collection.
+     */
+    // To be fixed?, but is ok.
+    public List<V> getValueList() {
+        synchronized (theList) {
+            return new ArrayList<V>(theList.values());
+        }
+    }
+
+
+    /**
+     * Get the internal sorted map. For synchronization purpose in normalform.
+     */
+    public SortedMap<K, V> getList() {
+        return theList;
+    }
+
+
+    /**
+     * Size of the (local) list.
+     */
+    @Override
+    public int size() {
+        synchronized (theList) {
+            return theList.size();
+        }
+    }
+
+
+    /**
+     * Is the List empty?
+     */
+    @Override
+    public boolean isEmpty() {
+        synchronized (theList) {
+            return theList.isEmpty();
+        }
+    }
+
+
+    /**
+     * List key iterator.
+     */
+    public Iterator<K> iterator() {
+        synchronized (theList) {
+            return theList.keySet().iterator();
+        }
+    }
+
+
+    /**
+     * List value iterator.
+     */
+    public Iterator<V> valueIterator() {
+        synchronized (theList) {
+            return theList.values().iterator();
+        }
+    }
+
+
+    /**
+     * Put object to the distributed hash table. Blocks until the key value pair
+     * is send and received from the server.
+     * @param key
+     * @param value
+     */
+    public void putWait(K key, V value) {
+        //V o = 
+        put(key, value); // = send
+        // assume key does not change multiple times before test:
+        while (!value.equals(getWait(key))) {
+            //System.out.print("#");
+        }
+    }
+
+
+    /**
+     * Put object to the distributed hash table. Returns immediately after
+     * sending, does not block.
+     * @param key
+     * @param value
+     */
+    @Override
+    public V put(K key, V value) {
+        if (key == null || value == null) {
+            throw new NullPointerException("null keys or values not allowed");
+        }
+        try {
+            DHTTransport<K, V> tc = DHTTransport.<K, V> create(key, value);
+            channel.send(tc);
+            //System.out.println("send: "+tc+" @ "+listener);
+        } catch (IOException e) {
+            logger.info("send, exception " + e);
+            e.printStackTrace();
+        } catch (Exception e) {
+            logger.info("send, exception " + e);
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+
+    /**
+     * Get value under key from DHT. Blocks until the object is send and
+     * received from the server (actually it blocks until some value under key
+     * is received).
+     * @param key
+     * @return the value stored under the key.
+     */
+    public V getWait(K key) {
+        V value = null;
+        try {
+            synchronized (theList) {
+                //value = theList.get(key);
+                value = get(key);
+                while (value == null) {
+                    //System.out.print("^");
+                    theList.wait(100);
+                    value = theList.get(key);
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            e.printStackTrace();
+        }
+        return value;
+    }
+
+
+    /**
+     * Get value under key from DHT. If no value is jet available null is
+     * returned.
+     * @param key
+     * @return the value stored under the key.
+     */
+    @Override
+    public V get(Object key) {
+        synchronized (theList) {
+            return theList.get(key);
+        }
+    }
+
+
+    /**
+     * Clear the List. 
+     * Clearance request is distributed to all clients.
+     */
+    @Override
+    public void clear() {
+        synchronized (theList) {
+            theList.clear();
+        }
+        // done after 11 month: send clear message to others
+        try {
+            DHTTransport<K, V> tc = new DHTTransportClear<K, V>();
+            channel.send(tc);
+            //System.out.println("send: "+tc+" @ "+listener);
+        } catch (IOException e) {
+            logger.info("send, exception " + e);
+            e.printStackTrace();
+        } catch (Exception e) {
+            logger.info("send, exception " + e);
+            e.printStackTrace();
+        }
+    }
+
+
+    /**
+     * Initialize and start the list thread.
+     */
+    public void init() {
+        if (listener == null) {
+            return;
+        }
+        if (listener.isDone()) {
+            return;
+        }
+        if (debug) {
+            logger.debug("initialize " + listener);
+        }
+        synchronized (theList) {
+            listener.start();
+        }
+    }
+
+
+    /**
+     * Terminate the list thread.
+     */
+    public void terminate() {
+        if (cf != null) {
+            cf.terminate();
+        }
+        if (channel != null) {
+            channel.close();
+        }
+        //theList.clear();
+        if (listener == null) {
+            return;
+        }
+        if (debug) {
+            logger.debug("terminate " + listener);
+        }
+        listener.setDone();
+        try {
+            while (listener.isAlive()) {
+                //System.out.print("+");
+                listener.interrupt();
+                listener.join(100);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        listener = null;
+    }
+
+}
+
+
+/**
+ * Thread to comunicate with the list server.
+ */
+class DHTListener<K, V> extends Thread {
+
+
+    private static final Logger logger = LogManager.getLogger(DHTListener.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    private final SocketChannel channel;
+
+
+    private final SortedMap<K, V> theList;
+
+
+    private boolean goon;
+
+
+    DHTListener(SocketChannel s, SortedMap<K, V> list) {
+        channel = s;
+        theList = list;
+        goon = true;
+    }
+
+
+    boolean isDone() {
+        return !goon;
+    }
+
+
+    void setDone() {
+        goon = false;
+    }
+
+
+    /**
+     * run.
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public void run() {
+        logger.debug("running ");
+        Object o;
+        DHTTransport<K, V> tc;
+        //goon = true;
+        while (goon) {
+            tc = null;
+            o = null;
+            try {
+                o = channel.receive();
+                if (debug) {
+                    logger.debug("receive(" + o + ")");
+                }
+                if (this.isInterrupted()) {
+                    goon = false;
+                    break;
+                }
+                if (o == null) {
+                    goon = false;
+                    break;
+                }
+                if (o instanceof DHTTransportClear) {
+                    logger.debug("receive, clear");
+                    synchronized (theList) {
+                        theList.clear();
+                        theList.notifyAll();
+                    }
+                    continue;
+                }
+                if (o instanceof DHTTransport) {
+                    tc = (DHTTransport<K, V>) o;
+                    K key = tc.key();
+                    if (key != null) {
+                        logger.info("receive, put(key=" + key + ")");
+                        V val = tc.value();
+                        synchronized (theList) {
+                            theList.put(key, val);
+                            theList.notifyAll();
+                        }
+                    }
+                }
+            } catch (IOException e) {
+                goon = false;
+                logger.info("receive, IO exception " + e);
+                //e.printStackTrace();
+            } catch (ClassNotFoundException e) {
+                goon = false;
+                logger.info("receive, CNF exception " + e);
+                e.printStackTrace();
+            } catch (Exception e) {
+                goon = false;
+                logger.info("receive, exception " + e);
+                e.printStackTrace();
+            }
+        }
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/DistHashTableServer.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/DistHashTableServer.java
@@ -1,0 +1,482 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.util;
+
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+/**
+ * Server for the distributed version of a list. TODO: redistribute list for
+ * late coming clients, removal of elements.
+ * @author Heinz Kredel
+ */
+
+public class DistHashTableServer<K> extends Thread {
+
+
+    private static final Logger logger = LogManager.getLogger(DistHashTableServer.class);
+
+
+    public final static int DEFAULT_PORT = 9009; //ChannelFactory.DEFAULT_PORT + 99;
+
+
+    protected final ChannelFactory cf;
+
+
+    protected List<DHTBroadcaster<K>> servers;
+
+
+    private volatile boolean goon = true;
+
+
+    private volatile Thread mythread = null;
+
+
+    protected final SortedMap<K, DHTTransport> theList;
+
+
+    private long etime;
+
+
+    private long dtime;
+
+
+    private long ertime;
+
+
+    private long drtime;
+
+
+    /**
+     * Constructs a new DistHashTableServer.
+     */
+    public DistHashTableServer() {
+        this(DEFAULT_PORT);
+    }
+
+
+    /**
+     * DistHashTableServer.
+     * @param port to run server on.
+     */
+    public DistHashTableServer(int port) {
+        this(new ChannelFactory(port));
+    }
+
+
+    /**
+     * DistHashTableServer.
+     * @param cf ChannelFactory to use.
+     */
+    public DistHashTableServer(ChannelFactory cf) {
+        this.cf = cf;
+        cf.init();
+        servers = new ArrayList<DHTBroadcaster<K>>();
+        theList = new TreeMap<K, DHTTransport>();
+        etime = DHTTransport.etime;
+        dtime = DHTTransport.dtime;
+        ertime = DHTTransport.ertime;
+        drtime = DHTTransport.drtime;
+    }
+
+
+    /**
+     * main. Usage: DistHashTableServer &lt;port&gt;
+     */
+    public static void main(String[] args) throws InterruptedException {
+        int port = DEFAULT_PORT;
+        if (args.length < 1) {
+            System.out.println("Usage: DistHashTableServer <port>");
+        } else {
+            try {
+                port = Integer.parseInt(args[0]);
+            } catch (NumberFormatException e) {
+            }
+        }
+        DistHashTableServer dhts = new DistHashTableServer/*raw: <K>*/(port);
+        dhts.init();
+        dhts.join();
+        // until CRTL-C
+    }
+
+
+    /**
+     * thread initialization and start.
+     */
+    public void init() {
+        this.start();
+    }
+
+
+    /**
+     * main server method.
+     */
+    @Override
+    public void run() {
+        SocketChannel channel = null;
+        DHTBroadcaster<K> s = null;
+        mythread = Thread.currentThread();
+        Entry<K, DHTTransport> e;
+        DHTTransport tc;
+        while (goon) {
+            //logger.debug("list server " + this + " go on");
+            try {
+                channel = cf.getChannel();
+                if (logger.isDebugEnabled()) {
+                    logger.debug("dls channel = " + channel);
+                }
+                if (mythread.isInterrupted()) {
+                    goon = false;
+                    //logger.info("list server " + this + " interrupted");
+                } else {
+                    s = new DHTBroadcaster<K>(channel, servers, /*listElem,*/theList);
+                    int ls = 0;
+                    synchronized (servers) {
+                        if (goon) {
+                            servers.add(s);
+                            ls = theList.size();
+                            s.start();
+                        }
+                    }
+                    if (logger.isDebugEnabled()) {
+                        logger.info("server " + s + " started " + s.isAlive());
+                    }
+                    if (ls > 0) {
+                        //logger.debug("sending " + ls + " list elements");
+                        synchronized (theList) {
+                            Iterator<Entry<K, DHTTransport>> it = theList.entrySet().iterator();
+                            for (int i = 0; i < ls; i++) {
+                                e = it.next();
+                                // n = e.getKey(); // findbugs, already in tc
+                                tc = e.getValue();
+                                //DHTTransport tc = (DHTTransport) o;                             
+                                try {
+                                    s.sendChannel(tc);
+                                } catch (IOException ioe) {
+                                    // stop s
+                                }
+                            }
+                        }
+                    }
+                }
+            } catch (InterruptedException end) {
+                goon = false;
+                Thread.currentThread().interrupt();
+            }
+        }
+        if (logger.isDebugEnabled()) {
+            logger.info("DHTserver " + this + " terminated");
+        }
+    }
+
+
+    /**
+     * terminate all servers.
+     */
+    public void terminate() {
+        goon = false;
+        logger.info("terminating");
+        if (cf != null) {
+            cf.terminate();
+        }
+        int svs = 0;
+        List<DHTBroadcaster<K>> scopy = null;
+        if (servers != null) {
+            synchronized (servers) {
+                svs = servers.size();
+                scopy = new ArrayList<DHTBroadcaster<K>>(servers);
+                Iterator<DHTBroadcaster<K>> it = scopy.iterator();
+                while (it.hasNext()) {
+                    DHTBroadcaster<K> br = it.next();
+                    br.goon = false;
+                    br.closeChannel();
+                    try {
+                        int c = 0;
+                        while (br.isAlive()) {
+                            c++;
+                            if (c > 10) {
+                                logger.warn("giving up on " + br);
+                                break;
+                            }
+                            //System.out.print(".");
+                            br.interrupt();
+                            br.join(50);
+                        }
+                        if (logger.isDebugEnabled()) {
+                            logger.info("server+ " + br + " terminated");
+                        }
+                        // now possible: 
+                        servers.remove(br);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+                servers.clear();
+            }
+            logger.info("" + svs + " broadcasters terminated " + scopy);
+            //? servers = null;
+        }
+        logger.debug("DHTBroadcasters terminated");
+        long enc = DHTTransport.etime - etime;
+        long dec = DHTTransport.dtime - dtime;
+        long encr = DHTTransport.ertime - ertime;
+        long decr = DHTTransport.drtime - drtime;
+        long drest = (encr * dec) / (enc + 1);
+        logger.info("DHT time: encode = " + enc + ", decode = " + dec + ", enc raw = " + encr
+                        + ", dec raw wait = " + decr + ", dec raw est = " + drest + ", sum est = "
+                        + (enc + dec + encr + drest)); // +decr not meaningful
+        if (mythread == null) {
+            return;
+        }
+        try {
+            while (mythread.isAlive()) {
+                //System.out.print("-");
+                mythread.interrupt();
+                mythread.join(100);
+            }
+            if (logger.isWarnEnabled()) {
+                logger.warn("server terminated " + mythread);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        mythread = null;
+        logger.info("terminated");
+    }
+
+
+    /**
+     * number of servers.
+     */
+    public int size() {
+        if (servers == null) {
+            return -1;
+        }
+        //synchronized (servers) removed
+        return servers.size();
+    }
+
+
+    /**
+     * toString.
+     * @return a string representation of this.
+     */
+    @Override
+    public String toString() {
+        return "DHTServer(" + servers.size() + ", " + cf + ", " + super.toString() + ")";
+    }
+
+}
+
+
+/**
+ * Thread for broadcasting all incoming objects to the list clients.
+ */
+class DHTBroadcaster<K> extends Thread /*implements Runnable*/ {
+
+
+    private static final Logger logger = LogManager.getLogger(DHTBroadcaster.class);
+
+
+    private final SocketChannel channel;
+
+
+    private final List<DHTBroadcaster<K>> bcaster;
+
+
+    private final SortedMap<K, DHTTransport> theList;
+
+
+    volatile boolean goon = true;
+
+
+    /**
+     * DHTBroadcaster.
+     * @param s SocketChannel to use.
+     * @param bc list of broadcasters.
+     * @param sm SortedMap with key value pairs.
+     */
+    public DHTBroadcaster(SocketChannel s, List<DHTBroadcaster<K>> bc, SortedMap<K, DHTTransport> sm) {
+        channel = s;
+        bcaster = bc;
+        theList = sm;
+    }
+
+
+    /**
+     * closeChannel.
+     */
+    public void closeChannel() {
+        channel.close();
+    }
+
+
+    /**
+     * sendChannel.
+     * @param tc DHTTransport.
+     * @throws IOException
+     */
+    public void sendChannel(DHTTransport tc) throws IOException {
+        if (goon) {
+            channel.send(tc);
+        }
+    }
+
+
+    /**
+     * broadcast.
+     * @param o DHTTransport element to broadcast.
+     */
+    @SuppressWarnings({ "unchecked", "cast" })
+    public void broadcast(DHTTransport o) {
+        if (logger.isDebugEnabled()) {
+            logger.debug("broadcast = " + o);
+        }
+        DHTTransport<K, Object> tc = null;
+        if (o == null) {
+            return;
+        }
+        //if ( ! (o instanceof DHTTransport) ) {
+        //   return;
+        //}
+        tc = (DHTTransport<K, Object>) o;
+        K key = null;
+        synchronized (theList) {
+            //test
+            //Object x = theList.get( tc.key );
+            //if ( x != null ) {
+            //   logger.info("theList duplicate key " + tc.key );
+            //}
+            try {
+                if (!(o instanceof DHTTransportClear)) {
+                    key = tc.key();
+                    theList.put(key, tc);
+                }
+            } catch (IOException e) {
+                logger.warn("IO exception: tc.key() not ok " + tc);
+                e.printStackTrace();
+            } catch (ClassNotFoundException e) {
+                logger.warn("CNF exception: tc.key() not ok " + tc);
+                e.printStackTrace();
+            } catch (Exception e) {
+                logger.warn("exception: tc.key() not ok " + tc);
+                e.printStackTrace();
+            }
+        }
+        logger.info("sending key=" + key + " to " + bcaster.size() + " nodes");
+        List<DHTBroadcaster<K>> bccopy = null;
+        synchronized (bcaster) {
+            bccopy = new ArrayList<DHTBroadcaster<K>>(bcaster);
+        }
+        Iterator<DHTBroadcaster<K>> it = bccopy.iterator();
+        while (it.hasNext()) {
+            DHTBroadcaster<K> br = it.next();
+            try {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("bcasting to " + br);
+                }
+                br.sendChannel(tc);
+            } catch (IOException e) {
+                logger.info("bcaster, IOexception " + e);
+                synchronized (bcaster) {
+                    bcaster.remove(br); //no more: ConcurrentModificationException
+                }
+                try {
+                    br.goon = false;
+                    br.closeChannel();
+                    while (br.isAlive()) {
+                        br.interrupt();
+                        br.join(100);
+                    }
+                } catch (InterruptedException w) {
+                    Thread.currentThread().interrupt();
+                }
+                //
+                logger.info("bcaster.remove() " + br);
+            } catch (Exception e) {
+                logger.info("bcaster, exception " + e);
+            }
+        }
+    }
+
+
+    /**
+     * run.
+     */
+    @Override
+    public void run() {
+        goon = true;
+        while (goon) {
+            try {
+                logger.debug("trying to receive");
+                Object o = channel.receive();
+                if (this.isInterrupted()) {
+                    goon = false;
+                    break;
+                }
+                if (logger.isDebugEnabled()) {
+                    logger.debug("received = " + o);
+                }
+                if (!(o instanceof DHTTransport)) {
+                    logger.warn("wrong object type: " + o);
+                    goon = false;
+                    break; //continue;
+                }
+                if (o instanceof DHTTransportClear) {
+                    logger.info("receive, clear");
+                    synchronized (theList) {
+                        theList.clear();
+                        theList.notifyAll();
+                    }
+                }
+                DHTTransport tc = (DHTTransport) o;
+                broadcast(tc);
+                if (this.isInterrupted()) {
+                    goon = false;
+                }
+            } catch (IOException e) {
+                goon = false;
+                logger.info("receive, IO exception " + e);
+                //e.printStackTrace();
+            } catch (ClassNotFoundException e) {
+                goon = false;
+                logger.info("receive, CNF exception " + e);
+                e.printStackTrace();
+            } catch (Exception e) {
+                goon = false;
+                logger.info("receive, exception " + e);
+                e.printStackTrace();
+            }
+        }
+        if (logger.isInfoEnabled()) {
+            logger.info("ending " + this);
+        }
+        synchronized (bcaster) {
+            bcaster.remove(this);
+        }
+        channel.close();
+    }
+
+
+    /**
+     * toString.
+     * @return a string representation of this.
+     */
+    @Override
+    public String toString() {
+        return "DHTBroadcaster(" + channel + "," + bcaster.size() + ")";
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/DistThreadPool.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/DistThreadPool.java
@@ -1,0 +1,494 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.util;
+
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.LinkedList;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+
+/**
+ * Distributed thread pool. Using stack / list work-pile and Executable Channels
+ * and Servers.
+ * @author Heinz Kredel
+ */
+
+public class DistThreadPool /*extends ThreadPool*/{
+
+
+    /**
+     * machine file to use.
+     */
+    private final String mfile;
+
+
+    /**
+     * default machine file for test.
+     */
+    private final static String DEFAULT_MFILE = ExecutableChannels.DEFAULT_MFILE;
+
+
+    /**
+     * Number of threads to use.
+     */
+    protected final int threads;
+
+
+    /**
+     * Default number of threads to use.
+     */
+    static final int DEFAULT_SIZE = 3;
+
+
+    /**
+     * Channels to remote executable servers.
+     */
+    final ExecutableChannels ec;
+
+
+    /**
+     * Array of workers.
+     */
+    protected DistPoolThread[] workers;
+
+
+    /**
+     * Number of idle workers.
+     */
+    protected int idleworkers = 0;
+
+
+    /**
+     * Work queue / stack.
+     */
+    // should be expressed using strategy pattern
+    // List or Collection is not appropriate
+    // LIFO strategy for recursion
+    protected LinkedList<Runnable> jobstack; // FIFO strategy for GB
+
+
+    protected StrategyEnumeration strategy = StrategyEnumeration.LIFO;
+
+
+    private static final Logger logger = LogManager.getLogger(DistThreadPool.class);
+
+
+    private static final boolean debug = true; //logger.isDebugEnabled();
+
+
+    /**
+     * Constructs a new DistThreadPool with strategy StrategyEnumeration.FIFO
+     * and size DEFAULT_SIZE.
+     */
+    public DistThreadPool() {
+        this(StrategyEnumeration.FIFO, DEFAULT_SIZE, null);
+    }
+
+
+    /**
+     * Constructs a new DistThreadPool with size DEFAULT_SIZE.
+     * @param strategy for job processing.
+     */
+    public DistThreadPool(StrategyEnumeration strategy) {
+        this(strategy, DEFAULT_SIZE, null);
+    }
+
+
+    /**
+     * Constructs a new DistThreadPool with strategy StrategyEnumeration.FIFO.
+     * @param size of the pool.
+     */
+    public DistThreadPool(int size) {
+        this(StrategyEnumeration.FIFO, size, null);
+    }
+
+
+    /**
+     * Constructs a new DistThreadPool with strategy StrategyEnumeration.FIFO.
+     * @param size of the pool.
+     * @param mfile machine file.
+     */
+    public DistThreadPool(int size, String mfile) {
+        this(StrategyEnumeration.FIFO, size, mfile);
+    }
+
+
+    /**
+     * Constructs a new DistThreadPool.
+     * @param strategy for job processing.
+     * @param size of the pool.
+     * @param mfile machine file.
+     */
+    public DistThreadPool(StrategyEnumeration strategy, int size, String mfile) {
+        this.strategy = strategy;
+        if (size < 0) {
+            this.threads = 0;
+        } else {
+            this.threads = size;
+        }
+        if (mfile == null || mfile.length() == 0) {
+            this.mfile = DEFAULT_MFILE;
+        } else {
+            this.mfile = mfile;
+        }
+        jobstack = new LinkedList<Runnable>(); // ok for all strategies ?
+        try {
+            ec = new ExecutableChannels(this.mfile);
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+            throw new IllegalArgumentException("DistThreadPool " + e);
+        }
+        if (debug) {
+            logger.info("ec = " + ec);
+        }
+        try {
+            ec.open(threads);
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new IllegalArgumentException("DistThreadPool " + e);
+        }
+        if (debug) {
+            logger.info("ec = " + ec);
+        }
+        workers = new DistPoolThread[0];
+    }
+
+
+    /**
+     * String representation.
+     */
+    @Override
+    public String toString() {
+        StringBuffer s = new StringBuffer("DistThreadPool(");
+        s.append("threads="+threads);
+        s.append(", strategy="+strategy);
+        s.append(", exchan="+ec);
+        s.append(", workers="+workers.length);
+        s.append(")");
+        return s.toString();
+    }
+
+
+    /**
+     * thread initialization and start.
+     */
+    public void init() {
+        if (workers == null || workers.length == 0) {
+            workers = new DistPoolThread[threads];
+            for (int i = 0; i < workers.length; i++) {
+                workers[i] = new DistPoolThread(this, ec, i);
+                workers[i].start();
+            }
+            logger.info("init: " + this.toString());
+        }
+    }
+
+
+    /**
+     * number of worker threads.
+     */
+    public int getNumber() {
+        if (workers == null || workers.length < threads) {
+            init(); // start threads
+        }
+        return workers.length; // not null
+    }
+
+
+    /**
+     * get used strategy.
+     */
+    public StrategyEnumeration getStrategy() {
+        return strategy;
+    }
+
+
+    /**
+     * the used executable channel.
+     */
+    public ExecutableChannels getEC() {
+        return ec; // not null
+    }
+
+
+    /**
+     * Terminates the threads.
+     * @param shutDown true, if shut-down of the remote executable servers is
+     *            requested, false, if remote executable servers stay alive.
+     */
+    public void terminate(boolean shutDown) {
+        if (shutDown) {
+            logger.info("shutdown = " + this);
+            ShutdownRequest sdr = new ShutdownRequest();
+            for (int i = 0; i < workers.length; i++) {
+                addJob(sdr);
+            }
+            try {
+                Thread.sleep(20);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            logger.info("remaining jobs = " + jobstack.size());
+            try {
+                for (int i = 0; i < workers.length; i++) {
+                    while (workers[i].isAlive()) {
+                        workers[i].interrupt();
+                        workers[i].join(100);
+                    }
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            ec.close();
+        } else {
+            terminate();
+        }
+        logger.info("terminated = " + this);
+    }
+
+
+    /**
+     * Terminates the threads.
+     */
+    public void terminate() {
+        logger.info("terminate = " + this);
+        while (hasJobs()) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        for (int i = 0; i < workers.length; i++) {
+            try {
+                while (workers[i].isAlive()) {
+                    workers[i].interrupt();
+                    workers[i].join(100);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        ec.close();
+        logger.info("terminated = " + this);
+    }
+
+
+    /**
+     * adds a job to the workpile.
+     * @param job
+     */
+    public synchronized void addJob(Runnable job) {
+        if (workers == null || workers.length < threads) {
+            init(); // start threads
+        }
+        jobstack.addLast(job);
+        logger.debug("adding job");
+        if (idleworkers > 0) {
+            logger.debug("notifying a jobless worker");
+            notifyAll(); // findbugs
+        }
+    }
+
+
+    /**
+     * get a job for processing.
+     */
+    protected synchronized Runnable getJob() throws InterruptedException {
+        while (jobstack.isEmpty()) {
+            idleworkers++;
+            logger.debug("waiting");
+            wait();
+            idleworkers--;
+        }
+        // is expressed using strategy enumeration
+        if (strategy == StrategyEnumeration.LIFO) {
+            return jobstack.removeLast(); // LIFO
+        }
+        return jobstack.removeFirst(); // FIFO
+    }
+
+
+    /**
+     * check if there are jobs for processing.
+     */
+    public boolean hasJobs() {
+        if (jobstack.size() > 0) {
+            return true;
+        }
+        for (int i = 0; i < workers.length; i++) {
+            if (workers[i].working) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    /**
+     * check if there are more than n jobs for processing.
+     * @param n Integer
+     * @return true, if there are possibly more than n jobs.
+     */
+    public boolean hasJobs(int n) {
+        int j = jobstack.size();
+        if (j > 0 && (j + workers.length > n)) {
+            return true;
+            // if j > 0 no worker should be idle
+            // ( ( j > 0 && ( j+workers.length > n ) ) || ( j > n )
+        }
+        int x = 0;
+        for (int i = 0; i < workers.length; i++) {
+            if (workers[i].working) {
+                x++;
+            }
+        }
+        if ((j + x) > n) {
+            return true;
+        }
+        return false;
+    }
+
+}
+
+
+/**
+ * Implements a shutdown task.
+ */
+class ShutdownRequest implements Runnable {
+
+
+    /**
+     * Run the thread.
+     */
+    public void run() {
+        System.out.println("running ShutdownRequest");
+    }
+
+
+    /**
+     * toString.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "ShutdownRequest";
+    }
+
+}
+
+
+/**
+ * Implements one local part of the distributed thread.
+ */
+class DistPoolThread extends Thread {
+
+
+    final DistThreadPool pool;
+
+
+    final ExecutableChannels ec;
+
+
+    final int myId;
+
+
+    private static final Logger logger = LogManager.getLogger(DistPoolThread.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    boolean working = false;
+
+
+    /**
+     * @param pool DistThreadPool.
+     */
+    public DistPoolThread(DistThreadPool pool, ExecutableChannels ec, int i) {
+        this.pool = pool;
+        this.ec = ec;
+        myId = i;
+    }
+
+
+    /**
+     * Run the thread.
+     */
+    @Override
+    public void run() {
+        logger.info("ready, myId = " + myId);
+        Runnable job;
+        int done = 0;
+        long time = 0;
+        long t;
+        boolean running = true;
+        while (running) {
+            try {
+                logger.debug("looking for a job");
+                job = pool.getJob();
+                working = true;
+                if (debug) {
+                    logger.info("working " + myId + " on " + job);
+                }
+                t = System.currentTimeMillis();
+                // send and wait, like rmi
+                try {
+                    if (job instanceof ShutdownRequest) {
+                        ec.send(myId, ExecutableServer.STOP);
+                    } else {
+                        ec.send(myId, job);
+                    }
+                    if (debug) {
+                        logger.info("send " + myId + " at " + ec + " send job " + job);
+                    }
+                } catch (IOException e) {
+                    e.printStackTrace();
+                    logger.info("error send " + myId + " at " + ec + " e = " + e);
+                    working = false;
+                }
+                // remote: job.run(); 
+                Object o = null;
+                try {
+                    if (working) {
+                        logger.info("waiting " + myId + " on " + job);
+                        o = ec.receive(myId);
+                        if (debug) {
+                            logger.info("receive " + myId + " at " + ec + " send job " + job + " received " + o);
+                        }
+                    }
+                } catch (IOException e) {
+                    logger.info("receive exception " + myId + " send job " + job + ", " + e);
+                    //e.printStackTrace();
+                    running = false;
+                } catch (ClassNotFoundException e) {
+                    logger.info("receive exception " + myId + " send job " + job + ", " + e);
+                    //e.printStackTrace();
+                    running = false;
+                } finally {
+                    if (debug) {
+                        logger.info("receive finally " + myId + " at " + ec + " send job " + job + " received "
+                                    + o + " running " + running);
+                    }
+                }
+                working = false;
+                time += System.currentTimeMillis() - t;
+                done++;
+                if (debug) {
+                    logger.info("done " + myId + " with " + o);
+                }
+            } catch (InterruptedException e) {
+                running = false;
+                Thread.currentThread().interrupt();
+            }
+        }
+        logger.info("terminated " + myId + " , done " + done + " jobs in " + time + " milliseconds");
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/DistributedList.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/DistributedList.java
@@ -1,0 +1,250 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.util;
+
+import java.io.IOException;
+import java.util.Iterator;
+//import java.util.Collection;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+//import edu.unima.ky.parallel.ChannelFactory;
+//import edu.unima.ky.parallel.SocketChannel;
+
+
+/**
+ * Distributed version of a List.
+ * Implemented with a SortedMap / TreeMap to keep the sequence order of elements.
+ * @author Heinz Kredel
+ */
+
+public class DistributedList /* implements List not jet */ {
+
+    private static final Logger logger = LogManager.getLogger(DistributedList.class);
+
+
+    protected final SortedMap<Counter,Object> theList;
+
+    protected final ChannelFactory cf;
+
+    protected SocketChannel channel = null;
+
+    protected Listener listener = null;
+
+
+    /**
+     * Constructor for DistributedList.
+     * @param host name or IP of server host.
+     */ 
+    public DistributedList(String host) {
+        this(host,DistributedListServer.DEFAULT_PORT);
+    }
+
+
+    /**
+     * Constructor for DistributedList.
+     * @param host name or IP of server host.
+     * @param port of server.
+     */
+    public DistributedList(String host,int port) {
+        this(new ChannelFactory(port+1),host,port);
+    }
+
+
+    /**
+     * Constructor for DistributedList.
+     * @param cf ChannelFactory to use.
+     * @param host name or IP of server host.
+     * @param port of server.
+     */
+    public DistributedList(ChannelFactory cf,String host,int port) {
+        this.cf = cf;
+        cf.init();
+        try {
+            channel = cf.getChannel(host,port);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        logger.debug("dl channel = " + channel);
+        theList = new TreeMap<Counter,Object>();
+    }
+
+
+    /**
+     * Constructor for DistributedList.
+     * @param sc SocketChannel to use.
+     */
+    public DistributedList(SocketChannel sc) {
+        cf = null;
+        channel = sc;
+        theList = new TreeMap<Counter,Object>();
+    }
+
+
+    /**
+     * List thread initialization and start.
+     */ 
+    public void init() {
+        listener = new Listener(channel,theList);
+        listener.start();
+    }
+
+
+    /**
+     * Terminate the list thread.
+     */ 
+    public void terminate() {
+        if ( cf != null ) {
+            cf.terminate();
+            //logger.warn("terminating " + cf);
+        }
+        if ( channel != null ) {
+            channel.close();
+        }
+        //theList.clear();
+        if ( listener == null ) { 
+            return;
+        }
+        logger.debug("terminate " + listener);
+        listener.setDone(); 
+        try { 
+            while ( listener.isAlive() ) {
+                listener.interrupt(); 
+                listener.join(100);
+            }
+        } catch (InterruptedException u) { 
+            Thread.currentThread().interrupt();
+        }
+        listener = null;
+    }
+
+
+    /**
+     * Get the internal list, convert from Collection.
+     */ 
+    public List<Object> getList() {
+        return new ArrayList<Object>( theList.values() );
+    }
+
+
+    /**
+     * Size of the (local) list.
+     */ 
+    public int size() {
+        return theList.size();
+    }
+
+
+    /**
+     * Add object to the list and distribute to other lists.
+     * Blocks until the object is send and received from the server
+     * (actually it blocks until some object is received).
+     * @param o
+     */
+    public synchronized void add(Object o) {
+        int sz1 = theList.size() + 1;
+        try {
+            channel.send(o);
+            //System.out.println("send: "+o+" @ "+listener);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        try {
+            while ( theList.size() < sz1 ) {
+                this.wait(100);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            e.printStackTrace();
+        }
+    }
+
+
+    /**
+     * Clear the List.
+     * caveat: must be called on all clients.
+     */ 
+    public synchronized void clear() {
+        theList.clear();
+    }
+
+
+    /**
+     * Is the List empty?
+     */ 
+    public boolean isEmpty() {
+        return theList.isEmpty();
+    }
+
+
+    /**
+     * List iterator.
+     */ 
+    public Iterator iterator() {
+        return theList.values().iterator();
+    }
+
+}
+
+
+/**
+ * Thread to comunicate with the list server.
+ */
+
+class Listener extends Thread {
+
+    private SocketChannel channel;
+
+    private SortedMap<Counter,Object> theList;
+
+    private volatile boolean goon;
+
+
+    Listener(SocketChannel s, SortedMap<Counter,Object> list) {
+        channel = s;
+        theList = list;
+    } 
+
+
+    void setDone() {
+        goon = false;
+    }
+
+
+    @Override
+    public void run() {
+        Counter n;
+        Object o;
+        goon = true;
+        while (goon) {
+            n = null;
+            o = null;
+            try {
+                n = (Counter) channel.receive();
+                if ( this.isInterrupted() ) {
+                    goon = false;
+                } else {
+                    o = channel.receive();
+                    //System.out.println("receive("+n+","+o+" @ "+Thread.currentThread());
+                    if ( this.isInterrupted() ) {
+                        goon = false;
+                    }
+                    theList.put(n,o);
+                }
+            } catch (IOException e) {
+                goon = false;
+            } catch (ClassNotFoundException e) {
+                e.printStackTrace();
+                goon = false;
+            }
+        }
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/DistributedListServer.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/DistributedListServer.java
@@ -1,0 +1,440 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.util;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.Map.Entry;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+//import edu.unima.ky.parallel.ChannelFactory;
+//import edu.unima.ky.parallel.SocketChannel;
+
+
+/**
+ * Server for the distributed version of a list.
+ * @author Heinz Kredel
+ * TODO: redistribute list for late comming clients, removal of elements.
+ */
+public class DistributedListServer extends Thread {
+
+    private static final Logger logger = LogManager.getLogger(DistributedListServer.class);
+
+    public final static int DEFAULT_PORT = ChannelFactory.DEFAULT_PORT + 99;
+
+
+    protected final ChannelFactory cf;
+
+    protected List<Broadcaster> servers;
+
+
+    private volatile boolean goon = true;
+
+    private volatile Thread mythread = null;
+
+
+    private Counter listElem = null;
+
+    protected final SortedMap<Counter,Object> theList;
+
+
+    /**
+     * Constructs a new DistributedListServer.
+     */ 
+
+    public DistributedListServer() {
+        this(DEFAULT_PORT);
+    }
+
+    /**
+     * DistributedListServer.
+     * @param port to run server on.
+     */
+    public DistributedListServer(int port) {
+        this( new ChannelFactory(port) );
+    }
+
+    /**
+     * DistributedListServer.
+     * @param cf ChannelFactory to use.
+     */
+    public DistributedListServer(ChannelFactory cf) {
+        listElem = new Counter(0);
+        this.cf = cf;
+        cf.init();
+        servers = new ArrayList<Broadcaster>();
+        theList = new TreeMap<Counter,Object>();
+    }
+
+
+    /**
+     * main.
+     * Usage: DistributedListServer &lt;port&gt;
+     */
+    public static void main(String[] args) throws InterruptedException {
+        int port = DEFAULT_PORT;
+        if ( args.length < 1 ) {
+            System.out.println("Usage: DistributedListServer <port>");
+        } else {
+            try {
+                port = Integer.parseInt( args[0] );
+            } catch (NumberFormatException e) {
+            }
+        }
+        DistributedListServer dls = new DistributedListServer(port);
+        dls.init();
+        dls.join();
+        // until CRTL-C
+    }
+
+
+    /**
+     * thread initialization and start.
+     */ 
+    public void init() {
+        this.start();
+    }
+
+
+    /**
+     * main server method.
+     */ 
+    @Override
+     public void run() {
+        SocketChannel channel = null;
+        Broadcaster s = null;
+        mythread = Thread.currentThread();
+        Entry e;
+        Object n;
+        Object o;
+        while (goon) {
+            // logger.debug("list server " + this + " go on");
+            try {
+                channel = cf.getChannel();
+                logger.debug("dls channel = "+channel);
+                if ( mythread.isInterrupted() ) {
+                    goon = false;
+                    //logger.info("list server " + this + " interrupted");
+                } else {
+                    s = new Broadcaster(channel,servers,listElem,theList);
+                    int ls = 0;
+                    synchronized (servers) {
+                        servers.add( s );
+                        ls = theList.size();
+                        s.start();
+                    }
+                    //logger.debug("server " + s + " started");
+                    if ( ls > 0 ) {
+                        logger.info("sending " + ls + " list elements");
+                        synchronized (theList) {
+                            Iterator it = theList.entrySet().iterator();
+                            for ( int i = 0; i < ls; i++ ) {
+                                e = (Entry)it.next();
+                                n = e.getKey();
+                                o = e.getValue();
+                                try {
+                                    s.sendChannel( n,o );
+                                } catch (IOException ioe) {
+                                    // stop s
+                                }
+                            }
+                        } 
+                    }
+                }
+            } catch (InterruptedException end) {
+                goon = false;
+                Thread.currentThread().interrupt();
+            }
+        }
+        //logger.debug("listserver " + this + " terminated");
+    }
+
+
+    /**
+     * terminate all servers.
+     */ 
+    public void terminate() {
+        goon = false;
+        logger.debug("terminating ListServer");
+        if ( cf != null ) cf.terminate();
+        if ( servers != null ) {
+            Iterator it = servers.iterator();
+            while ( it.hasNext() ) {
+                Broadcaster br = (Broadcaster) it.next();
+                br.closeChannel();
+                try { 
+                    while ( br.isAlive() ) {
+                        //System.out.print(".");
+                        br.interrupt(); 
+                        br.join(100);
+                    }
+                    //logger.debug("server " + br + " terminated");
+                } catch (InterruptedException e) { 
+                    Thread.currentThread().interrupt();
+                }
+            }
+            servers = null;
+        }
+        logger.debug("Broadcasters terminated");
+        if ( mythread == null ) return;
+        try { 
+            while ( mythread.isAlive() ) {
+                // System.out.print("-");
+                mythread.interrupt(); 
+                mythread.join(100);
+            }
+            //logger.debug("server " + mythread + " terminated");
+        } catch (InterruptedException e) { 
+            Thread.currentThread().interrupt();
+        }
+        mythread = null;
+        logger.debug("ListServer terminated");
+    }
+
+
+    /**
+     * number of servers.
+     */ 
+    public int size() {
+        if ( servers == null ) {
+            return -1;
+        }
+        return servers.size();
+    }
+
+}
+
+
+/**
+ * Class for holding the list index used as key in TreeMap.
+ * Implemented since Integer has no add() method.
+ * Must implement Comparable so that TreeMap works with correct ordering.
+ */ 
+
+class Counter implements Serializable, Comparable<Counter> {
+
+    private int value;
+
+
+    /**
+     * Counter.
+     */
+    public Counter() {
+        this(0);
+    }
+
+
+    /**
+     * Counter.
+     * @param v
+     */
+    public Counter(int v) {
+        value = v;
+    }
+
+
+    /**
+     * intValue.
+     * @return the value.
+     */
+    public int intValue() {
+        return value;
+    }
+
+
+    /**
+     * add.
+     * @param v
+     */
+    public void add(int v) { // synchronized elsewhere
+        value += v;
+    }
+
+
+    /**
+     * equals.
+     * @param ob an Object.
+     * @return true if this is equal to o, else false.
+     */
+    @Override
+    public boolean equals(Object ob) {
+        if ( ! (ob instanceof Counter) ) {
+           return false;
+        }
+        return 0 == compareTo( (Counter)ob );
+    }
+
+
+    /**
+     * compareTo.
+     * @param c a Counter.
+     * @return 1 if (this &lt; c), 0 if (this == c), -1 if (this &gt; c).
+     */
+    public int compareTo(Counter c) {
+        int x = c.intValue();
+        if ( value > x ) { 
+            return 1;
+        }
+        if ( value < x ) { 
+            return -1;
+        }
+        return 0;
+    }
+
+
+    /**
+     * Hash code for this Counter.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return value;
+    }
+
+
+    /**
+     * toString.
+     */  
+    @Override
+     public String toString() {
+        return "Counter("+value+")";
+    }
+
+}
+
+
+/**
+ * Thread for broadcasting all incoming objects to the list clients.
+ */ 
+
+class Broadcaster extends Thread /*implements Runnable*/ {
+
+    private static final Logger logger = LogManager.getLogger(Broadcaster.class);
+    private final SocketChannel channel;
+    private final List bcaster;
+    private Counter listElem;
+    private final SortedMap<Counter,Object> theList;
+
+
+    /**
+     * Broadcaster.
+     * @param s SocketChannel to use.
+     * @param p list of broadcasters.
+     * @param le counter
+     * @param sm SortedMap with counter value pairs.
+     */
+    public Broadcaster(SocketChannel s, List p, Counter le, SortedMap<Counter,Object> sm) {
+        channel = s;
+        bcaster = p;
+        listElem = le;
+        theList = sm;
+    } 
+
+
+    /**
+     * closeChannel.
+     */
+    public void closeChannel() {
+        channel.close();
+    }
+
+
+    /**
+     * sendChannel.
+     * @param n counter.
+     * @param o value.
+     * @throws IOException
+     */
+    public void sendChannel(Object n, Object o) throws IOException {
+        synchronized (channel) {
+            channel.send(n);
+            channel.send(o);
+        }
+    }
+
+
+    /**
+     * broadcast.
+     * @param o object to store and send.
+     */
+    public void broadcast(Object o) {
+        Counter li = null;
+        synchronized (listElem) {
+            listElem.add(1);
+            li = new Counter( listElem.intValue() );
+        }
+        synchronized (theList) {
+            theList.put( li, o );
+        }
+        synchronized (bcaster) {
+            Iterator it = bcaster.iterator();
+            while ( it.hasNext() ) {
+                Broadcaster br = (Broadcaster) it.next();
+                try {
+                    br.sendChannel(li,o);
+                    //System.out.println("bcast: "+o+" to "+x.channel);
+                } catch (IOException e) {
+                    try { 
+                        br.closeChannel();
+                        while ( br.isAlive() ) {
+                            br.interrupt(); 
+                            br.join(100);
+                        }
+                    } catch (InterruptedException u) { 
+                        Thread.currentThread().interrupt();
+                    }
+                    bcaster.remove( br );
+                }
+            }
+        }
+    }
+
+
+    /**
+     * run.
+     */
+    @Override
+     public void run() {
+        Object o;
+        boolean goon = true;
+        while (goon) {
+            try {
+                o = channel.receive();
+                //System.out.println("receive: "+o+" from "+channel);
+                broadcast(o);
+                if ( this.isInterrupted() ) {
+                    goon = false;
+                }
+            } catch (IOException e) {
+                goon = false;
+            } catch (ClassNotFoundException e) {
+                goon = false;
+                e.printStackTrace();
+
+            }
+        }
+        logger.debug("broadcaster terminated "+this);
+        channel.close();
+    }
+
+
+    /**
+     * toString.
+     * @return a string representation of this.
+     */
+    @Override
+     public String toString() {
+        return "Broadcaster("+channel+","+bcaster.size()+","+listElem+")";
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/ExecutableChannels.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/ExecutableChannels.java
@@ -1,0 +1,344 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.util;
+
+
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+
+// import edu.unima.ky.parallel.ChannelFactory;
+// import edu.unima.ky.parallel.SocketChannel;
+
+/**
+ * ExecutableChannels used to receive and execute classes.
+ * @author Heinz Kredel
+ */
+
+
+public class ExecutableChannels {
+
+
+    private static final Logger logger = LogManager.getLogger(ExecutableChannels.class);
+
+
+    /**
+     * default port.
+     */
+    protected final static int DEFAULT_PORT = 7114; //ChannelFactory.DEFAULT_PORT;
+
+
+    /**
+     * default machine file.
+     */
+    protected final static String DEFAULT_MFILE = "examples/machines.test";
+
+
+    protected final ChannelFactory cf;
+
+
+    protected SocketChannel[] channels = null;
+
+
+    protected String[] servers = null;
+
+
+    protected int[] ports = null;
+
+
+    /**
+     * Internal constructor.
+     */
+    protected ExecutableChannels() {
+        cf = new ChannelFactory();
+        cf.init();
+    }
+
+
+    /**
+     * Constructor from array of server:port strings.
+     * @param srvs A String array.
+     */
+    public ExecutableChannels(String[] srvs) {
+        this();
+        if (srvs == null) {
+            return;
+        }
+        servers = new String[srvs.length];
+        ports = new int[srvs.length];
+        for (int i = 0; i < srvs.length; i++) {
+            setServerPort(i, srvs[i]);
+        }
+    }
+
+
+    /**
+     * Constructor from machine file.
+     * @param mfile
+     * @throws FileNotFoundException.
+     */
+    public ExecutableChannels(String mfile) throws FileNotFoundException {
+        this();
+        if (mfile == null || mfile.length() == 0) {
+            mfile = DEFAULT_MFILE;
+        }
+        InputStreamReader isr = new InputStreamReader(new FileInputStream(mfile),Charset.forName("UTF8"));
+        BufferedReader in = new BufferedReader(isr);
+        String line = null;
+        List<String> list = new ArrayList<String>();
+        int x;
+        try {
+            while (true) {
+                if (!in.ready()) {
+                    break;
+                }
+                line = in.readLine();
+                if (line == null) {
+                    break;
+                }
+                x = line.indexOf("#");
+                if (x >= 0) {
+                    line = line.substring(0, x);
+                }
+                line = line.trim();
+                if (line.length() == 0) {
+                    continue;
+                }
+                list.add(line);
+            }
+        } catch (IOException ignored) {
+        } finally {
+            try {
+                in.close();
+                isr.close();
+            } catch (IOException ignore) {
+            }
+        }
+        logger.debug("list.size() in " + mfile + " = " + list.size());
+        if (list.size() == 0) {
+            return;
+        }
+        servers = new String[list.size()];
+        ports = new int[list.size()];
+        for (int i = 0; i < servers.length; i++) {
+            setServerPort(i, list.get(i));
+        }
+    }
+
+
+    /* 
+     * internal method
+     */
+    protected void setServerPort(int i, String srv) {
+        int x = srv.indexOf(":");
+        ports[i] = DEFAULT_PORT;
+        if (x < 0) {
+            servers[i] = srv;
+        } else {
+            servers[i] = srv.substring(0, x);
+            String p = srv.substring(x + 1, srv.length());
+            try {
+                ports[i] = Integer.parseInt(p);
+            } catch (NumberFormatException ignored) {
+            }
+        }
+    }
+
+
+    /**
+     * String representation.
+     */
+    @Override
+    public String toString() {
+        StringBuffer s = new StringBuffer("ExecutableChannels(");
+        if (servers != null) {
+            for (int i = 0; i < servers.length; i++) {
+                s.append(servers[i] + ":" + ports[i]);
+                if (i < servers.length - 1) {
+                    s.append(" ");
+                }
+            }
+        }
+        if (channels != null) {
+            s.append(" channels = ");
+            for (int i = 0; i < channels.length; i++) {
+                s.append(channels[i]);
+                if (i < channels.length - 1) {
+                    s.append(" ");
+                }
+            }
+        }
+        s.append(")");
+        return s.toString();
+    }
+
+
+    /**
+     * number of servers.
+     */
+    public int numServers() {
+        if (servers != null) {
+            return servers.length;
+        }
+        return -1;
+    }
+
+
+    /**
+     * get master host.
+     */
+    public String getMasterHost() {
+        if (servers != null && servers.length > 0) {
+            return servers[0];
+        }
+        return null;
+    }
+
+
+    /**
+     * get master port.
+     */
+    public int getMasterPort() {
+        if (ports != null && ports.length > 0) {
+            return ports[0];
+        }
+        return 0;
+    }
+
+
+    /**
+     * number of channels.
+     */
+    public int numChannels() {
+        if (channels != null) {
+            return channels.length;
+        }
+        return -1;
+    }
+
+
+    /**
+     * open, setup of SocketChannels.
+     * @throws IOException.
+     */
+    public void open() throws IOException {
+        logger.debug("opening " + servers.length + " channels");
+        if (servers.length <= 1) {
+            throw new IOException("to few servers");
+        }
+        channels = new SocketChannel[servers.length - 1];
+        for (int i = 1; i < servers.length; i++) {
+            channels[i - 1] = cf.getChannel(servers[i], ports[i]);
+        }
+    }
+
+
+    /**
+     * open, setup of SocketChannels. If nc &gt; servers.length open in round
+     * robin fashion.
+     * @param nc number of channels to open.
+     * @throws IOException.
+     */
+    public void open(int nc) throws IOException {
+        logger.debug("opening " + nc + " channels");
+        if (servers.length <= 1) {
+            throw new IOException("to few servers");
+        }
+        channels = new SocketChannel[nc];
+        int j = 1; // 0 is master
+        for (int i = 0; i < channels.length; i++) {
+            if (j >= servers.length) { // modulo #servers
+                j = 1;
+            }
+            channels[i] = cf.getChannel(servers[j], ports[j]);
+            j++;
+        }
+    }
+
+
+    /**
+     * close all channels and ChannelFactory.
+     */
+    public void close() {
+        logger.debug("closing ExecutableChannels");
+        if (cf != null) {
+            cf.terminate();
+        }
+        if (channels != null) {
+            for (int i = 0; i < channels.length; i++) {
+                if (channels[i] != null) {
+                    try {
+                        channels[i].send(ExecutableServer.STOP);
+                    } catch (IOException e) {
+                        if (logger.isDebugEnabled()) {
+                            e.printStackTrace();
+                        }
+                    } finally {
+                        channels[i].close();
+                    }
+                    channels[i] = null;
+                }
+            }
+            channels = null;
+        }
+        logger.debug("ExecuteChannels closed");
+    }
+
+
+    /**
+     * getChannel.
+     * @param i channel number.
+     */
+    public SocketChannel getChannel(int i) {
+        if (channels != null && 0 <= i && i < channels.length) {
+            return channels[i];
+        }
+        return null;
+    }
+
+
+    /**
+     * getChannels.
+     */
+    /*package*/SocketChannel[] getChannels() {
+        return channels;
+    }
+
+
+    /**
+     * send on channel i.
+     * @param i channel number.
+     * @param o object to send.
+     */
+    public void send(int i, Object o) throws IOException {
+        if (channels != null && 0 <= i && i < channels.length) {
+            channels[i].send(o);
+        }
+    }
+
+
+    /**
+     * recieve on channel i.
+     * @param i channel number.
+     * @return object recieved.
+     */
+    public Object receive(int i) throws IOException, ClassNotFoundException {
+        if (channels != null && 0 <= i && i < channels.length) {
+            return channels[i].receive();
+        }
+        return null;
+
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/ExecutableServer.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/ExecutableServer.java
@@ -1,0 +1,338 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.util;
+
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ArrayList;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+
+/**
+ * ExecutableServer is used to receive and execute classes.
+ * @author Heinz Kredel
+ */
+
+public class ExecutableServer extends Thread {
+
+
+    private static final Logger logger = LogManager.getLogger(ExecutableServer.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * ChannelFactory to use.
+     */
+    protected final ChannelFactory cf;
+
+
+    /**
+     * List of server threads.
+     */
+    protected List<Executor> servers = null;
+
+
+    /**
+     * Default port to listen to.
+     */
+    public static final int DEFAULT_PORT = 7411;
+
+
+    /**
+     * Constant to signal completion.
+     */
+    public static final String DONE = "Done";
+
+
+    /**
+     * Constant to request shutdown.
+     */
+    public static final String STOP = "Stop";
+
+
+    private volatile boolean goon = true;
+
+
+    private volatile Thread mythread = null;
+
+
+    /**
+     * ExecutableServer on default port.
+     */
+    public ExecutableServer() {
+        this(DEFAULT_PORT);
+    }
+
+
+    /**
+     * ExecutableServer.
+     * @param port
+     */
+    public ExecutableServer(int port) {
+        this(new ChannelFactory(port));
+    }
+
+
+    /**
+     * ExecutableServer.
+     * @param cf channel factory to reuse.
+     */
+    public ExecutableServer(ChannelFactory cf) {
+        this.cf = cf;
+        cf.init();
+        servers = new ArrayList<Executor>();
+    }
+
+
+    /**
+     * main method to start serving thread.
+     * @param args args[0] is port
+     */
+    public static void main(String[] args) throws InterruptedException {
+        int port = DEFAULT_PORT;
+        if (args.length < 1) {
+            System.out.println("Usage: ExecutableServer <port>");
+        } else {
+            try {
+                port = Integer.parseInt(args[0]);
+            } catch (NumberFormatException e) {
+            }
+        }
+        //logger.info("ExecutableServer at port " + port);
+        ExecutableServer es = new ExecutableServer(port);
+        es.init();
+        es.join(); // do not use terminate()
+        // until CRTL-C
+    }
+
+
+    /**
+     * thread initialization and start.
+     */
+    public void init() {
+        this.start();
+        logger.info("ExecutableServer at " + cf);
+    }
+
+
+    /**
+     * number of servers.
+     */
+    public int size() {
+        if ( servers == null ) {
+            return -1;
+        }
+        return servers.size();
+    }
+
+
+    /**
+     * run is main server method.
+     */
+    @Override
+    public void run() {
+        SocketChannel channel = null;
+        Executor s = null;
+        mythread = Thread.currentThread();
+        while (goon) {
+            if (debug) {
+                logger.info("server " + this + " go on");
+            }
+            try {
+                channel = cf.getChannel();
+                logger.info("channel = " + channel);
+                if (mythread.isInterrupted()) {
+                    goon = false;
+                    logger.debug("execute server " + this + " interrupted");
+                    channel.close();
+                } else {
+                    s = new Executor(channel); // ---,servers);
+                    if (goon) { // better synchronize with terminate
+                        servers.add(s);
+                        s.start();
+                        logger.debug("server " + s + " started");
+                    } else {
+                        s = null;
+                        channel.close();
+                    }
+                }
+            } catch (InterruptedException e) {
+                goon = false;
+                Thread.currentThread().interrupt();
+                if (debug) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        if (debug) {
+            logger.info("server " + this + " terminated");
+        }
+    }
+
+
+    /**
+     * terminate all servers.
+     */
+    public void terminate() {
+        goon = false;
+        logger.info("terminating ExecutableServer");
+        if (cf != null)
+            cf.terminate();
+        if (servers != null) {
+            Iterator<Executor> it = servers.iterator();
+            while (it.hasNext()) {
+                Executor x = it.next();
+                if (x.channel != null) {
+                    x.channel.close();
+                }
+                try {
+                    while (x.isAlive()) {
+                        //System.out.print(".");
+                        x.interrupt();
+                        x.join(100);
+                    }
+                    logger.debug("server " + x + " terminated");
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            servers = null;
+        }
+        logger.info("Executors terminated");
+        if (mythread == null)
+            return;
+        try {
+            while (mythread.isAlive()) {
+                //System.out.print("-");
+                mythread.interrupt();
+                mythread.join(100);
+            }
+            //logger.debug("server " + mythread + " terminated");
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        mythread = null;
+        logger.info("terminated");
+    }
+
+
+    /**
+     * String representation.
+     */
+    @Override
+    public String toString() {
+        StringBuffer s = new StringBuffer("ExecutableServer(");
+        s.append(cf.toString());
+        s.append(")");
+        return s.toString();
+    }
+
+}
+
+
+/**
+ * class for executing incoming objects.
+ */
+
+class Executor extends Thread /*implements Runnable*/{
+
+
+    private static final Logger logger = LogManager.getLogger(Executor.class);
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    protected final SocketChannel channel;
+
+
+    Executor(SocketChannel s) {
+        channel = s;
+    }
+
+
+    /**
+     * run.
+     */
+    @Override
+    public void run() {
+        Object o;
+        RemoteExecutable re = null;
+        String d;
+        boolean goon = true;
+        logger.debug("executor started " + this);
+        while (goon) {
+            try {
+                o = channel.receive();
+                logger.info("receive: " + o + " from " + channel);
+                if (this.isInterrupted()) {
+                    goon = false;
+                } else {
+                    if (debug) {
+                        logger.debug("receive: " + o + " from " + channel);
+                    }
+                    if (o instanceof String) {
+                        d = (String) o;
+                        if (ExecutableServer.STOP.equals(d)) {
+                            goon = false; // stop this thread
+                            channel.send(ExecutableServer.DONE);
+                        } else {
+                            logger.warn("invalid/unknown String: " + d + " from " + channel);
+                            goon = false; // stop this thread ?
+                            channel.send(ExecutableServer.DONE);
+                        }
+                    }
+                    // check permission
+                    if (o instanceof RemoteExecutable) {
+                        re = (RemoteExecutable) o;
+                        if (debug) {
+                            logger.info("running " + re);
+                        }
+                        try {
+                            re.run();
+                        } catch(Exception e) {
+                            logger.info("Exception on re.run()" + e);
+                            if (logger.isInfoEnabled()) {
+                                e.printStackTrace();
+                            }
+                        } finally {
+                            logger.info("finally re.run() " + re);
+                        }
+                        if (debug) {
+                            logger.info("finished " + re);
+                        }
+                        if (this.isInterrupted()) {
+                            goon = false;
+                        } else {
+                            channel.send(ExecutableServer.DONE);
+                            logger.info("finished send " + ExecutableServer.DONE);
+                            //goon = false; // stop this thread
+                        }
+                    }
+                }
+            } catch (IOException e) {
+                goon = false;
+                logger.info("IOException " + e);
+                if (debug) {
+                    e.printStackTrace();
+                }
+            } catch (ClassNotFoundException e) {
+                goon = false;
+                logger.info("ClassNotFoundException " + e);
+                e.printStackTrace();
+            } finally {
+                logger.info("finally " + this);
+            }
+        }
+        channel.close();
+        logger.info("terminated " + this);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/KsubSet.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/KsubSet.java
@@ -1,0 +1,283 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.util;
+
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+
+/**
+ * K-Subset with iterator.
+ * @author Heinz Kredel
+ */
+public class KsubSet<E> implements Iterable<List<E>> {
+
+
+    /**
+     * data structure.
+     */
+    public final List<E> set; // Iterable<E> also ok
+
+
+    public final int k;
+
+
+    /**
+     * KsubSet constructor.
+     * @param set generating set.
+     * @param k size of subsets.
+     */
+    public KsubSet(List<E> set, int k) {
+        if (set == null) {
+            throw new IllegalArgumentException("null set not allowed");
+        }
+        if (k < 0 || k > set.size()) {
+            throw new IllegalArgumentException("k out of range");
+        }
+        this.set = set;
+        this.k = k;
+    }
+
+
+    /**
+     * Get an iterator over subsets.
+     * @return an iterator.
+     */
+    public Iterator<List<E>> iterator() {
+        if (k == 0) {
+            return new ZeroSubSetIterator<E>(set);
+        }
+        if (k == 1) {
+            return new OneSubSetIterator<E>(set);
+        }
+        return new KsubSetIterator<E>(set, k);
+    }
+
+}
+
+
+/**
+ * Power set iterator.
+ * @author Heinz Kredel
+ */
+class KsubSetIterator<E> implements Iterator<List<E>> {
+
+
+    /**
+     * data structure.
+     */
+    public final List<E> set;
+
+
+    public final int k;
+
+
+    final List<E> rest;
+
+
+    private E current;
+
+
+    private Iterator<List<E>> recIter;
+
+
+    private final Iterator<E> iter;
+
+
+    /**
+     * KsubSetIterator constructor.
+     * @param set generating set.
+     * @param k subset size.
+     */
+    public KsubSetIterator(List<E> set, int k) {
+        if (set == null || set.size() == 0) {
+            throw new IllegalArgumentException("null or empty set not allowed");
+        }
+        if (k < 2 || k > set.size()) {
+            throw new IllegalArgumentException("k out of range");
+        }
+        this.set = set;
+        this.k = k;
+        iter = this.set.iterator();
+        current = iter.next();
+        //System.out.println("current = " + current);
+        rest = new LinkedList<E>(this.set);
+        rest.remove(0);
+        //System.out.println("rest = " + rest);
+        if (k == 2) {
+            recIter = new OneSubSetIterator<E>(rest);
+        } else {
+            recIter = new KsubSetIterator<E>(rest, k - 1);
+        }
+    }
+
+
+    /**
+     * Test for availability of a next subset.
+     * @return true if the iteration has more subsets, else false.
+     */
+    public boolean hasNext() {
+        return recIter.hasNext() || (iter.hasNext() && rest.size() >= k);
+    }
+
+
+    /**
+     * Get next subset.
+     * @return next subset.
+     */
+    public List<E> next() {
+        if (recIter.hasNext()) {
+            List<E> next = new LinkedList<E>(recIter.next());
+            next.add(0, current);
+            return next;
+        }
+        if (iter.hasNext()) {
+            current = iter.next();
+            //System.out.println("current = " + current);
+            rest.remove(0);
+            //System.out.println("rest = " + rest);
+            if (rest.size() < k - 1) {
+                throw new NoSuchElementException("invalid call of next()");
+            }
+            if (k == 2) {
+                recIter = new OneSubSetIterator<E>(rest);
+            } else {
+                recIter = new KsubSetIterator<E>(rest, k - 1);
+            }
+            return this.next(); // retry
+        }
+        throw new NoSuchElementException("invalid call of next()");
+    }
+
+
+    /**
+     * Remove the last subset returned from underlying set if allowed.
+     */
+    public void remove() {
+        throw new UnsupportedOperationException("cannnot remove subsets");
+    }
+
+}
+
+
+/**
+ * One-subset iterator.
+ * @author Heinz Kredel
+ */
+class OneSubSetIterator<E> implements Iterator<List<E>> {
+
+
+    /**
+     * data structure.
+     */
+    public final List<E> set;
+
+
+    private Iterator<E> iter;
+
+
+    /**
+     * OneSubSetIterator constructor.
+     * @param set generating set.
+     */
+    public OneSubSetIterator(List<E> set) {
+        this.set = set;
+        if (set == null || set.size() == 0) {
+            iter = null;
+            return;
+        }
+        iter = this.set.iterator();
+    }
+
+
+    /**
+     * Test for availability of a next subset.
+     * @return true if the iteration has more subsets, else false.
+     */
+    public boolean hasNext() {
+        if (iter == null) {
+            return false;
+        }
+        return iter.hasNext();
+    }
+
+
+    /**
+     * Get next subset.
+     * @return next subset.
+     */
+    public List<E> next() {
+        List<E> next = new LinkedList<E>();
+        next.add(iter.next());
+        return next;
+    }
+
+
+    /**
+     * Remove the last subset returned from underlying set if allowed.
+     */
+    public void remove() {
+        throw new UnsupportedOperationException("cannnot remove subsets");
+    }
+
+}
+
+
+/**
+ * Zero-subset iterator.
+ * @author Heinz Kredel
+ */
+class ZeroSubSetIterator<E> implements Iterator<List<E>> {
+
+
+    /**
+     * data structure.
+     */
+    private boolean hasNext;
+
+
+    /**
+     * ZeroSubSetIterator constructor.
+     * @param set generating set (ignored).
+     */
+    public ZeroSubSetIterator(List<E> set) {
+        hasNext = true;
+        if (set == null || set.size() == 0) {
+            hasNext = false;
+        }
+    }
+
+
+    /**
+     * Test for availability of a next subset.
+     * @return true if the iteration has more subsets, else false.
+     */
+    public boolean hasNext() {
+        return hasNext;
+    }
+
+
+    /**
+     * Get next subset.
+     * @return next subset.
+     */
+    public List<E> next() {
+        List<E> next = new LinkedList<E>();
+        hasNext = false;
+        return next;
+    }
+
+
+    /**
+     * Remove the last subset returned from underlying set if allowed.
+     */
+    public void remove() {
+        throw new UnsupportedOperationException("cannnot remove subsets");
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/ListUtil.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/ListUtil.java
@@ -1,0 +1,139 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.util;
+
+
+import java.lang.Iterable;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Iterator;
+
+import edu.jas.structure.Element;
+import edu.jas.structure.UnaryFunctor;
+
+
+/**
+ * List utilities. For example map functor on list elements.
+ * @author Heinz Kredel
+ */
+
+public class ListUtil {
+
+
+    //private static final Logger logger = LogManager.getLogger(ListUtil.class);
+
+
+    // private static final boolean debug = logger.isDebugEnabled(); 
+
+
+    /**
+     * Map a unary function to the list.
+     * @param f evaluation functor.
+     * @return new list elements f(list(i)).
+     */
+    public static <C extends Element<C>, D extends Element<D>> List<D> map(List<C> list, UnaryFunctor<C, D> f) {
+        if (list == null) {
+            return null;
+        }
+        List<D> nl;
+        if (list instanceof ArrayList) {
+            nl = new ArrayList<D>(list.size());
+        } else if (list instanceof LinkedList) {
+            nl = new LinkedList<D>();
+        } else {
+            throw new RuntimeException("list type not implemented");
+        }
+        for (C c : list) {
+            D n = f.eval(c);
+            nl.add(n);
+        }
+        return nl;
+    }
+
+
+    /**
+     * Tuple from lists.
+     * @param A list of lists.
+     * @return new list with tuples (a_1,...,an) with ai in Ai,
+     *         i=0,...,length(A)-1.
+     */
+    public static <C> List<List<C>> tupleFromList(List<List<C>> A) {
+        if (A == null) {
+            return null;
+        }
+        List<List<C>> T = new ArrayList<List<C>>(A.size());
+        if (A.size() == 0) {
+            return T;
+        }
+        if (A.size() == 1) {
+            List<C> Ap = A.get(0);
+            for (C a : Ap) {
+                List<C> Tp = new ArrayList<C>(1);
+                Tp.add(a);
+                T.add(Tp);
+            }
+            return T;
+        }
+        List<List<C>> Ap = new ArrayList<List<C>>(A);
+        List<C> f = Ap.remove(0);
+        List<List<C>> Tp = tupleFromList(Ap);
+        //System.out.println("Tp = " + Tp);
+        for (C a : f) {
+            for (List<C> tp : Tp) {
+                List<C> ts = new ArrayList<C>();
+                ts.add(a);
+                ts.addAll(tp);
+                T.add(ts);
+            }
+        }
+        return T;
+    }
+
+
+    /**
+     * Create a list of given length and content.
+     * @param n length of new list
+     * @param e object to be filled in
+     * @return list (e, ..., e) of length n
+     */
+    public static <C> List<C> fill(int n, C e) {
+        List<C> r = new ArrayList<C>(n);
+        for (int m = 0; m < n; m++) {
+            r.add(e);
+        }
+        return r;
+    }
+
+
+    /**
+     * Test two iterables for equal contents and sequence.
+     * @param a iterable
+     * @param b iterable
+     * @return true, if a equals b in sequence and content, else false.
+     */
+    public static <C> boolean equals(Iterable<C> a, Iterable<C> b) {
+        Iterator<C> ai = a.iterator();
+        Iterator<C> bi = b.iterator();
+        while (ai.hasNext() && bi.hasNext()) {
+            C aa = ai.next();
+            C ba = bi.next();
+            if (!aa.equals(ba)) {
+                System.out.println("aa != ba: " + aa + " != " + ba);
+                return false;
+            }
+        }
+        if (ai.hasNext()) {
+            System.out.println("aa: " + ai.next());
+            return false;
+        }
+        if (bi.hasNext()) {
+            System.out.println("ba: " + bi.next());
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/LongIterable.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/LongIterable.java
@@ -1,0 +1,189 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.util;
+
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+
+/**
+ * Iterable for Long.
+ * @author Heinz Kredel
+ */
+public class LongIterable implements Iterable<Long> {
+
+
+    private boolean nonNegative = true;
+
+
+    private long upperBound = Long.MAX_VALUE;
+
+
+    /**
+     * Constructor.
+     */
+    public LongIterable() {
+    }
+
+
+    /**
+     * Constructor.
+     */
+    public LongIterable(long ub) {
+        upperBound = ub;
+    }
+
+
+    /**
+     * Set the upper bound for the iterator.
+     * @param ub an upper bound for the iterator elements.
+     */
+    public void setUpperBound(long ub) {
+        upperBound = ub;
+    }
+
+
+    /**
+     * Get the upper bound for the iterator.
+     * @return the upper bound for the iterator elements.
+     */
+    public long getUpperBound() {
+        return upperBound;
+    }
+
+
+    /**
+     * Set the iteration algorithm to all elements.
+     */
+    public void setAllIterator() {
+        nonNegative = false;
+    }
+
+
+    /**
+     * Set the iteration algorithm to non-negative elements.
+     */
+    public void setNonNegativeIterator() {
+        nonNegative = true;
+    }
+
+
+    /**
+     * Get an iterator over Long.
+     * @return an iterator.
+     */
+    public Iterator<Long> iterator() {
+        return new LongIterator(nonNegative, upperBound);
+    }
+
+}
+
+
+/**
+ * Long iterator.
+ * @author Heinz Kredel
+ */
+class LongIterator implements Iterator<Long> {
+
+
+    /**
+     * data structure.
+     */
+    long current;
+
+
+    boolean empty;
+
+
+    final boolean nonNegative;
+
+
+    protected long upperBound;
+
+
+    /**
+     * Set the upper bound for the iterator.
+     * @param ub an upper bound for the iterator elements.
+     */
+    public void setUpperBound(long ub) {
+        upperBound = ub;
+    }
+
+
+    /**
+     * Get the upper bound for the iterator.
+     * @return the upper bound for the iterator elements.
+     */
+    public long getUpperBound() {
+        return upperBound;
+    }
+
+
+    /**
+     * Long iterator constructor.
+     */
+    public LongIterator() {
+        this(false, Long.MAX_VALUE);
+    }
+
+
+    /**
+     * Long iterator constructor.
+     * @param nn true for an iterator over non-negative longs, false for all
+     *            elements iterator.
+     * @param ub an upper bound for the entries.
+     */
+    public LongIterator(boolean nn, long ub) {
+        current = 0L;
+        //System.out.println("current = " + current);
+        empty = false;
+        nonNegative = nn;
+        upperBound = ub;
+        //System.out.println("upperBound = " + upperBound);
+    }
+
+
+    /**
+     * Test for availability of a next long.
+     * @return true if the iteration has more Longs, else false.
+     */
+    public synchronized boolean hasNext() {
+        return !empty;
+    }
+
+
+    /**
+     * Get next Long.
+     * @return next Long.
+     */
+    public synchronized Long next() {
+        if (empty) {
+            throw new NoSuchElementException("invalid call of next()");
+        }
+        Long res = Long.valueOf(current);
+        if (nonNegative) {
+            current++;
+        } else if (current > 0L) {
+            current = -current;
+        } else {
+            current = -current;
+            current++;
+        }
+        if (current > upperBound) {
+            empty = true;
+        }
+        return res;
+    }
+
+
+    /**
+     * Remove a tuple if allowed.
+     */
+    public void remove() {
+        throw new UnsupportedOperationException("cannnot remove elements");
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/MapEntry.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/MapEntry.java
@@ -1,0 +1,87 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.util;
+
+
+import java.util.Map;
+
+/**
+ * MapEntry helper class implements Map.Entry.
+ * Required until JDK 1.6 becomes every where available.
+ * @see java.util.AbstractMap.SimpleImmutableEntry in JDK 1.6.
+ * @author Heinz Kredel
+ */
+
+public final class MapEntry<K,V> implements Map.Entry<K,V> {
+
+
+    final K key;
+
+
+    final V value;
+
+
+    /**
+     * Constructor.
+     */
+    public MapEntry(K k, V v) {
+        key = k;
+        value = v;
+    }
+
+
+    /**
+     * Get the key.
+     * @see java.util.Map.Entry#getKey()
+     */
+    public K getKey() {
+        return key;
+    }
+
+
+    /**
+     * Get the value.
+     * @see java.util.Map.Entry#getValue()
+     */
+    public V getValue() {
+        return value;
+    }
+
+
+    /**
+     * Set the value.
+     * Is not implemented.
+     * @see java.util.Map.Entry
+     */
+    public V setValue(V value) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object b) {
+        if (!(b instanceof Map.Entry)) {
+            return false;
+        }
+        Map.Entry<K,V> me = (Map.Entry<K,V>) b;
+        return key.equals(me.getKey()) && value.equals(me.getValue());
+    }
+
+
+    /**
+     * Hash code for this MapEntry.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return key.hashCode() * 37 + value.hashCode();
+    }
+ 
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/PowerSet.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/PowerSet.java
@@ -1,0 +1,148 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.util;
+
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+
+/**
+ * Power set with iterator.
+ * @author Heinz Kredel
+ */
+public class PowerSet<E> implements Iterable<List<E>> {
+
+
+    /**
+     * data structure.
+     */
+    public final List<E> set; // Iterable<E> also ok
+
+
+    /**
+     * PowerSet constructor.
+     * @param set generating set.
+     */
+    public PowerSet(List<E> set) {
+        this.set = set;
+    }
+
+
+    /**
+     * get an iterator over subsets.
+     * @return an iterator.
+     */
+    public Iterator<List<E>> iterator() {
+        return new PowerSetIterator<E>(set);
+    }
+
+}
+
+
+/**
+ * Power set iterator.
+ * @author Heinz Kredel
+ */
+class PowerSetIterator<E> implements Iterator<List<E>> {
+
+
+    /**
+     * data structure.
+     */
+    public final List<E> set;
+
+
+    final List<E> rest;
+
+
+    final E current;
+
+
+    private PowerSetIterator<E> recIter;
+
+
+    enum Mode {
+        copy, extend, first, done
+    };
+
+
+    Mode mode;
+
+
+    /**
+     * PowerSetIterator constructor.
+     * @param set generating set.
+     */
+    public PowerSetIterator(List<E> set) {
+        this.set = set;
+        if (set == null || set.size() == 0) {
+            current = null;
+            recIter = null;
+            rest = null;
+            mode = Mode.first;
+            return;
+        }
+        mode = Mode.copy;
+        current = this.set.get(0);
+        rest = new LinkedList<E>(this.set);
+        rest.remove(0);
+        recIter = new PowerSetIterator<E>(rest);
+    }
+
+
+    /**
+     * Test for availability of a next subset.
+     * @return true if the iteration has more subsets, else false.
+     */
+    public boolean hasNext() {
+        if (mode == Mode.first) {
+            return true;
+        }
+        if (recIter == null) {
+            return false;
+        }
+        return recIter.hasNext() || mode == Mode.copy;
+    }
+
+
+    /**
+     * Get next subset.
+     * @return next subset.
+     */
+    public List<E> next() {
+        if (mode == Mode.first) {
+            mode = Mode.done;
+            List<E> first = new LinkedList<E>();
+            return first;
+        }
+        if (mode == Mode.extend) {
+            if (recIter.hasNext()) {
+                List<E> next = new LinkedList<E>(recIter.next());
+                next.add(current);
+                return next;
+            }
+        }
+        if (mode == Mode.copy) {
+            if (recIter.hasNext()) {
+                return recIter.next();
+            }
+            mode = Mode.extend;
+            recIter = new PowerSetIterator<E>(rest);
+            return this.next();
+        }
+        return null;
+    }
+
+
+    /**
+     * Remove the last subset returned from underlying set if allowed.
+     */
+    public void remove() {
+        throw new UnsupportedOperationException("cannnot remove subsets");
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/RemoteExecutable.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/RemoteExecutable.java
@@ -1,0 +1,18 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.util;
+
+import java.io.Serializable;
+
+/**
+ * Interface RemoteExecutable.
+ * Used to mark a Serializable and Runnable class.
+ * @author Heinz Kredel
+ */
+
+
+public interface RemoteExecutable extends Serializable, Runnable {
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/SocketChannel.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/SocketChannel.java
@@ -1,0 +1,118 @@
+/*
+ * $Id$
+ */
+
+//package edu.unima.ky.parallel;
+package edu.jas.util;
+
+
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.ObjectInputStream;
+import java.net.Socket;
+
+
+/**
+ * SocketChannel provides a communication channel for Java objects using TCP/IP
+ * sockets. Refactored for java.util.concurrent.
+ * @author Akitoshi Yoshida
+ * @author Heinz Kredel
+ */
+public class SocketChannel {
+
+
+    /*
+     * Input stream from the socket.
+     */
+    private final ObjectInputStream in;
+
+
+    /*
+     * Output stream to the socket.
+     */
+    private final ObjectOutputStream out;
+
+
+    /*
+     * Underlying socket.
+     */
+    private final Socket soc;
+
+
+    /**
+     * Constructs a socket channel on the given socket s.
+     * @param s A socket object.
+     */
+    public SocketChannel(Socket s) throws IOException {
+        soc = s;
+        out = new ObjectOutputStream(s.getOutputStream());
+        out.flush();
+        in = new ObjectInputStream(s.getInputStream());
+    }
+
+
+    /**
+     * Get the Socket
+     */
+    public Socket getSocket() {
+        return soc;
+    }
+
+
+    /**
+     * Sends an object
+     */
+    public void send(Object v) throws IOException {
+        synchronized (out) {
+            out.writeObject(v);
+            out.flush();
+        }
+    }
+
+
+    /**
+     * Receives an object
+     */
+    public Object receive() throws IOException, ClassNotFoundException {
+        Object v = null;
+        synchronized (in) {
+            v = in.readObject();
+        }
+        return v;
+    }
+
+
+    /**
+     * Closes the channel.
+     */
+    public void close() {
+        if (in != null) {
+            try {
+                in.close();
+            } catch (IOException e) {
+            }
+        }
+        if (out != null) {
+            try {
+                out.close();
+            } catch (IOException e) {
+            }
+        }
+        if (soc != null) {
+            try {
+                soc.close();
+            } catch (IOException e) {
+            }
+        }
+    }
+
+
+    /**
+     * to string
+     */
+    @Override
+    public String toString() {
+        return "socketChannel(" + soc + ")";
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/StrategyEnumeration.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/StrategyEnumeration.java
@@ -1,0 +1,38 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.util;
+
+
+/**
+ * StrategyEnumeration. This class names possible / implemented strategies for
+ * thread pools.
+ * @author Heinz Kredel
+ */
+
+public final class StrategyEnumeration {
+
+
+    public static final StrategyEnumeration FIFO = new StrategyEnumeration();
+
+
+    public static final StrategyEnumeration LIFO = new StrategyEnumeration();
+
+
+    private StrategyEnumeration() {
+    }
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString() {
+        if (this == FIFO) {
+            return "FIFO strategy";
+        }
+        return "LIFO strategy";
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/TaggedSocketChannel.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/TaggedSocketChannel.java
@@ -1,0 +1,425 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.util;
+
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+
+/**
+ * TaggedSocketChannel provides a communication channel with message tags for
+ * Java objects using TCP/IP sockets.
+ * @author Heinz Kredel
+ */
+public class TaggedSocketChannel extends Thread {
+
+
+    private static final Logger logger = LogManager.getLogger(TaggedSocketChannel.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Flag if receiver is running.
+     */
+    private volatile boolean isRunning = false;
+
+
+    /**
+     * End message.
+     */
+    private final static String DONE = "TaggedSocketChannel Done";
+
+
+    /**
+     * Blocked threads count.
+     */
+    private final AtomicInteger blockedCount;
+
+
+    /**
+     * Underlying socket channel.
+     */
+    protected final SocketChannel sc;
+
+
+    /**
+     * Queues for each message tag.
+     */
+    protected final Map<Integer, BlockingQueue> queues;
+
+
+    /**
+     * Constructs a tagged socket channel on the given socket channel s.
+     * @param s A socket channel object.
+     */
+    public TaggedSocketChannel(SocketChannel s) {
+        sc = s;
+        blockedCount = new AtomicInteger(0);
+        queues = new HashMap<Integer, BlockingQueue>();
+    }
+
+
+    /**
+     * thread initialization and start.
+     */
+    public void init() {
+        synchronized (queues) {
+            if ( ! isRunning ) {
+                this.start();
+                isRunning = true;
+            }
+        }
+        logger.info("TaggedSocketChannel at " + sc);
+    }
+
+
+    /**
+     * Get the SocketChannel
+     */
+    public SocketChannel getSocket() {
+        return sc;
+    }
+
+
+    /**
+     * Sends an object.
+     * @param tag message tag
+     * @param v object to send
+     * @throws IOException
+     */
+    public void send(Integer tag, Object v) throws IOException {
+        if (tag == null) {
+            throw new IllegalArgumentException("tag null not allowed");
+        }
+        if (v instanceof Exception) {
+            throw new IllegalArgumentException("message " + v + " not allowed");
+        }
+        TaggedMessage tm = new TaggedMessage(tag, v);
+        sc.send(tm);
+    }
+
+
+    /**
+     * Receive an object.
+     * @param tag message tag
+     * @return object received
+     * @throws InterruptedException
+     * @throws IOException
+     * @throws ClassNotFoundException
+     */
+    public Object receive(Integer tag) throws InterruptedException, IOException, ClassNotFoundException {
+        BlockingQueue tq = null;
+        int i = 0;
+        do {
+            synchronized (queues) {
+                tq = queues.get(tag);
+                if (tq == null) {
+                    if ( ! isRunning ) { // avoid dead-lock
+                        throw new IOException("receiver not running for " + this);
+                    }
+                    //tq = new LinkedBlockingQueue();
+                    //queues.put(tag, tq);
+                    try {
+                        logger.debug("receive wait, tag = " + tag);
+                        i = blockedCount.incrementAndGet();
+                        queues.wait();
+                    } catch (InterruptedException e) {
+                        logger.info("receive wait exception, tag = " + tag + ", blockedCount = " + i);
+                        throw e;
+                    } finally {
+                        i = blockedCount.decrementAndGet();
+                    }
+                }
+            }
+        } while ( tq == null );
+        Object v = null;
+        try {
+            i = blockedCount.incrementAndGet();
+            v = tq.take();
+        } finally {
+            i = blockedCount.decrementAndGet();
+        }
+        if ( v instanceof IOException ) {
+            throw (IOException) v;
+        }
+        if ( v instanceof ClassNotFoundException ) {
+            throw (ClassNotFoundException) v;
+        }
+        if ( v instanceof Exception ) {
+            //throw new RuntimeException(v.toString());
+            throw new IOException(v.toString());
+        }
+        return v;
+    }
+
+
+    /**
+     * Closes the channel.
+     */
+    public void close() {
+        terminate();
+    }
+
+
+    /**
+     * To string.
+     * @see java.lang.Thread#toString()
+     */
+    @Override
+    public String toString() {
+        return "socketChannel(" + sc + ", tags = " + queues.keySet() + ")";
+        //return "socketChannel(" + sc + ", tags = " + queues.keySet() + ", values = " + queues.values() + ")";
+    }
+
+
+    /**
+     * Number of tags.
+     * @return size of key set.
+     */
+    public int tagSize() {
+        return queues.size();
+    }
+
+
+    /**
+     * Number of messages.
+     * @return sum of all messages in queues.
+     */
+    public int messages() {
+        int m = 0;
+        synchronized (queues) {
+            for ( BlockingQueue tq : queues.values() ) {
+                m += tq.size();
+            }
+        }
+        return m;
+    }
+
+
+    /**
+     * Run receive() in an infinite loop.
+     * @see java.lang.Thread#run()
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public void run() {
+        if (sc == null) {
+            isRunning = false;
+            return; // nothing to do
+        }
+        isRunning = true;
+        while (isRunning) {
+            try {
+                Object r = null;
+                try {
+                    logger.debug("waiting for tagged object");
+                    r = sc.receive();
+                    if (this.isInterrupted()) {
+                        //r = new InterruptedException();
+                        isRunning = false;
+                    }
+                } catch (IOException e) {
+                    r = e;
+                } catch (ClassNotFoundException e) {
+                    r = e;
+                } catch (Exception e) {
+                    r = e;
+                }
+                //logger.debug("Socket = " +s);
+                logger.debug("object recieved");
+                if (r instanceof TaggedMessage) {
+                    TaggedMessage tm = (TaggedMessage) r;
+                    BlockingQueue tq = null;
+                    synchronized (queues) {
+                        tq = queues.get(tm.tag);
+                        if (tq == null) {
+                            tq = new LinkedBlockingQueue();
+                            queues.put(tm.tag, tq);
+                            queues.notifyAll();
+                        }
+                    }
+                    tq.put(tm.msg);
+                } else if ( r instanceof Exception ){
+                    if (debug) {
+                        logger.debug("exception " + r);
+                    }
+                    synchronized (queues) { // deliver to all queues
+                        isRunning = false;
+                        for ( BlockingQueue q : queues.values() ) {
+                            final int bc = blockedCount.get();
+                            for ( int i = 0; i <= bc; i++ ) { // one more
+                                q.put(r);
+                            }
+                            if (bc > 0) {
+                                logger.debug("put exception to queue, blockedCount = " + bc);
+                            }
+                        }
+                        queues.notifyAll();
+                    }
+                    //return;
+                } else {
+                    if (debug) {
+                        logger.debug("no tagged message and no exception " + r);
+                    }
+                    synchronized (queues) { // deliver to all queues
+                        isRunning = false;
+                        Exception e;
+                        if ( r.equals(DONE) ) {
+                            e = new Exception("DONE message");
+                        } else {
+                            e = new IllegalArgumentException("no tagged message and no exception '" + r + "'");
+                        }
+                        for ( BlockingQueue q : queues.values() ) {
+                            final int bc = blockedCount.get();
+                            for ( int i = 0; i <= bc; i++ ) { // one more
+                                q.put(e);
+                            }
+                            if (bc > 0) {
+                                logger.debug("put '" + e.toString() + "' to queue, blockedCount = " + bc);
+                            }
+                        }
+                        queues.notifyAll();
+                    }
+                    if ( r.equals(DONE) ) {
+                         logger.info("run terminating by request");
+                         try {
+                             sc.send(DONE); // terminate other end
+                         } catch (IOException e) {
+                             logger.warn("send other done failed " + e);
+                         }
+                         return;
+                    }
+                }
+            } catch (InterruptedException e) {
+                // unfug Thread.currentThread().interrupt();
+                //logger.debug("ChannelFactory IE terminating");
+                if (debug) {
+                    logger.debug("exception " + e);
+                }
+                synchronized (queues) { // deliver to all queues
+                    isRunning = false;
+                    for ( BlockingQueue q : queues.values() ) {
+                        try {
+                            final int bc = blockedCount.get();
+                            for ( int i = 0; i <= bc; i++ ) { // one more
+                                q.put(e);
+                            }
+                            if (bc > 0) {
+                                logger.debug("put interrupted to queue, blockCount = " + bc);
+                            }
+                        } catch (InterruptedException ignored) {
+                        }
+                    }
+                    queues.notifyAll();
+                }
+                //return via isRunning
+            }
+        }
+        if (this.isInterrupted()) {
+            Exception e = new InterruptedException("terminating via interrupt");
+            synchronized (queues) { // deliver to all queues
+                for ( BlockingQueue q : queues.values() ) {
+                    try {
+                        final int bc = blockedCount.get();
+                        for ( int i = 0; i <= bc; i++ ) { // one more
+                            q.put(e);
+                        }
+                        if (bc > 0) {
+                            logger.debug("put terminating via interrupt to queue, blockCount = " + bc);
+                        }
+                    } catch (InterruptedException ignored) {
+                    }
+                }
+                queues.notifyAll();
+            }
+        }
+        logger.info("run terminated");
+    }
+
+
+    /**
+     * Terminate the TaggedSocketChannel.
+     */
+    @SuppressWarnings("unchecked")
+    public void terminate() {
+        isRunning = false;
+        this.interrupt();
+        if (sc != null) {
+            //sc.close();
+            try {
+                sc.send(DONE);
+            } catch (IOException e) {
+                logger.warn("send done failed " + e);
+            }
+            logger.debug(sc + " not yet closed");
+        }
+        this.interrupt();
+        synchronized(queues) {
+            isRunning = false;
+            for (Entry<Integer, BlockingQueue> tq : queues.entrySet()) {
+                BlockingQueue q = tq.getValue();
+                if (q.size() != 0) {
+                    logger.info("queue for tag " + tq.getKey() + " not empty " + q);
+                } 
+                int bc = 0;
+                try {
+                    bc = blockedCount.get();
+                    for ( int i = 0; i <= bc; i++ ) { // one more
+                        q.put(new IOException("queue terminate"));
+                    }
+                } catch (InterruptedException ignored) {
+                }
+                if ( bc > 0 ) {
+                    logger.debug("put IO-end to queue for tag " + tq.getKey() + ", blockCount = " + bc);
+                }
+            }
+            queues.notifyAll();
+        }
+        try {
+            this.join();
+        } catch (InterruptedException e) {
+            // unfug Thread.currentThread().interrupt();
+        }
+        logger.info("terminated");
+    }
+
+}
+
+
+/**
+ * TaggedMessage container.
+ */
+class TaggedMessage implements Serializable {
+
+
+    public final Integer tag;
+
+
+    public final Object msg;
+
+
+    /**
+     * Constructor.
+     * @param tag message tag
+     * @param msg message object
+     */
+    public TaggedMessage(Integer tag, Object msg) {
+        this.tag = tag;
+        this.msg = msg;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/Terminator.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/Terminator.java
@@ -1,0 +1,175 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.util;
+
+
+import java.util.concurrent.Semaphore;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+
+//import edu.unima.ky.parallel.Semaphore;
+
+/**
+ * Terminating helper class. Like a barrier, but with coming and going.
+ * @author Heinz Kredel
+ */
+
+public class Terminator {
+
+
+    private static final Logger logger = LogManager.getLogger(Terminator.class);
+
+
+    private final int workers;
+
+
+    private int idler;
+
+
+    private final Semaphore fin;
+
+
+    private boolean done; // volatile not required since synchronized  
+
+
+    /**
+     * Terminator.
+     * @param workers number of expected threads.
+     */
+    public Terminator(int workers) {
+        this.workers = workers;
+        fin = new Semaphore(0);
+        done = false;
+        idler = 0;
+        logger.info("constructor, workers = " + workers);
+    }
+
+
+    /**
+     * to string
+     */
+    @Override
+    public String toString() {
+        return "Terminator(" + done + ",workers=" + workers + ",idler=" + idler + ")";
+    }
+
+
+    /**
+     * beIdle.
+     * Checks for release().
+     */
+    public synchronized void beIdle() {
+        idler++;
+        logger.info("beIdle, idler = " + idler);
+        if (idler >= workers) {
+            done = true;
+            fin.release(); //fin.V();
+        }
+    }
+
+
+    /**
+     * initIdle.
+     * No check for release().
+     * @param i number of idle threads.
+     */
+    public synchronized void initIdle(int i) {
+        idler += i;
+        logger.info("initIdle, idler = " + idler);
+        if ( idler > workers ) {
+            if (done) {
+                idler = workers;
+            } else {
+                throw new RuntimeException("idler > workers: " + idler + " > " + workers);
+            }
+        }
+    }
+
+
+    /**
+     * beIdle.
+     * Checks for release().
+     * @param i number of idle threads.
+     */
+    public synchronized void beIdle(int i) {
+        idler += i;
+        logger.info("beIdle, idler = " + idler);
+        if (idler >= workers) {
+            done = true;
+            fin.release(); //fin.V();
+        }
+    }
+
+
+    /**
+     * allIdle.
+     * Checks for release().
+     */
+    public synchronized void allIdle() {
+        idler = workers;
+        logger.info("allIdle");
+        done = true;
+        fin.release(); //fin.V();
+    }
+
+
+    /**
+     * notIdle.
+     */
+    public synchronized void notIdle() {
+        idler--;
+        logger.info("notIdle, idler = " + idler);
+        if ( idler < 0 ) {
+            throw new RuntimeException("idler < 0");
+        }
+    }
+
+
+    /**
+     * getJobs.
+     * @return number of possible jobs.
+     */
+    public synchronized int getJobs() {
+        return (workers - idler);
+    }
+
+
+    /**
+     * hasJobs.
+     * @return true, if there are possibly jobs, else false.
+     */
+    public synchronized boolean hasJobs() {
+        return (idler < workers);
+    }
+
+
+    /**
+     * Release if possible.
+     */
+    public synchronized void release() {
+        logger.info("release = " + this);
+        if ( idler >= workers ) {
+            done = true;
+            fin.release(); 
+        }
+        //logger.info("release, idler = " + idler);
+    }
+
+
+    /**
+     * Wait until released.
+     */
+    public void waitDone() {
+        try {
+            fin.acquire(); 
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        logger.info("waitDone " + this);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/ThreadPool.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/ThreadPool.java
@@ -1,0 +1,400 @@
+/*
+ * $Id$
+ */
+
+// package edu.unima.ky.parallel;
+package edu.jas.util;
+
+
+import java.util.LinkedList;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager; 
+
+import edu.jas.kern.PreemptingException;
+
+
+/**
+ * Thread pool using stack / list workpile.
+ * @author Akitoshi Yoshida
+ * @author Heinz Kredel
+ */
+
+public class ThreadPool {
+
+
+    /**
+     * Default number of threads to use.
+     */
+    static final int DEFAULT_SIZE = 3;
+
+
+    /**
+     * Number of threads to use.
+     */
+    final int size;
+
+
+    /**
+     * Array of workers.
+     */
+    protected PoolThread[] workers;
+
+
+    /**
+     * Number of idle workers.
+     */
+    protected int idleworkers = 0;
+
+
+    /**
+     * Shutdown request.
+     */
+    protected volatile boolean shutdown = false;
+
+
+    /**
+     * Work queue / stack.
+     */
+    // should be expressed using strategy pattern
+    // List or Collection is not appropriate
+    // LIFO strategy for recursion
+    protected LinkedList<Runnable> jobstack; // FIFO strategy for GB
+
+
+    protected StrategyEnumeration strategy = StrategyEnumeration.LIFO;
+
+
+    private static final Logger logger = LogManager.getLogger(ThreadPool.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructs a new ThreadPool with strategy StrategyEnumeration.FIFO and
+     * size DEFAULT_SIZE.
+     */
+    public ThreadPool() {
+        this(StrategyEnumeration.FIFO, DEFAULT_SIZE);
+    }
+
+
+    /**
+     * Constructs a new ThreadPool with size DEFAULT_SIZE.
+     * @param strategy for job processing.
+     */
+    public ThreadPool(StrategyEnumeration strategy) {
+        this(strategy, DEFAULT_SIZE);
+    }
+
+
+    /**
+     * Constructs a new ThreadPool with strategy StrategyEnumeration.FIFO.
+     * @param size of the pool.
+     */
+    public ThreadPool(int size) {
+        this(StrategyEnumeration.FIFO, size);
+    }
+
+
+    /**
+     * Constructs a new ThreadPool.
+     * @param strategy for job processing.
+     * @param size of the pool.
+     */
+    public ThreadPool(StrategyEnumeration strategy, int size) {
+        this.size = size;
+        this.strategy = strategy;
+        jobstack = new LinkedList<Runnable>(); // ok for all strategies ?
+        workers = new PoolThread[0];
+    }
+
+
+    /**
+     * thread initialization and start.
+     */
+    public void init() {
+        if (workers == null || workers.length == 0) {
+            workers = new PoolThread[size];
+            for (int i = 0; i < workers.length; i++) {
+                workers[i] = new PoolThread(this);
+                workers[i].start();
+            }
+            logger.info("size = " + size + ", strategy = " + strategy);
+        }
+        if (debug) {
+            Thread.dumpStack();
+        }
+    }
+
+
+    /**
+     * toString.
+     */
+    @Override
+    public String toString() {
+        return "ThreadPool( size=" + getNumber() + ", idle=" + idleworkers + ", " + getStrategy() + ", jobs="
+                        + jobstack.size() + ")";
+    }
+
+
+    /**
+     * number of worker threads.
+     */
+    public int getNumber() {
+        return size;
+        //if (workers == null || workers.length < size) {
+        //    init(); // start threads
+        //}
+        //return workers.length; // not null
+    }
+
+
+    /**
+     * get used strategy.
+     */
+    public StrategyEnumeration getStrategy() {
+        return strategy;
+    }
+
+
+    /**
+     * Terminates the threads.
+     */
+    public void terminate() {
+        while (hasJobs()) {
+            try {
+                Thread.sleep(100);
+                //logger.info("waiting for termination in " + this);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        if (workers == null) {
+            return;
+        }
+        for (int i = 0; i < workers.length; i++) {
+            if (workers[i] == null) {
+                continue;
+            }
+            try {
+                while (workers[i].isAlive()) {
+                    workers[i].interrupt();
+                    workers[i].join(100);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+
+    /**
+     * Cancels the threads.
+     */
+    public int cancel() {
+        shutdown = true;
+        int s = jobstack.size();
+        if (hasJobs()) {
+            synchronized (this) {
+                logger.info("jobs canceled: " + jobstack);
+                jobstack.clear();
+                notifyAll(); // for getJob
+            }
+        }
+        //int re = 0;
+        if (workers == null) {
+            return s;
+        }
+        for (int i = 0; i < workers.length; i++) {
+            if (workers[i] == null) {
+                continue;
+            }
+            try {
+                while (workers[i].isAlive()) {
+                    synchronized (this) {
+                        shutdown = true;
+                        notifyAll(); // for getJob
+                        workers[i].interrupt();
+                    }
+                    //re++;
+                    //if ( re > 3 * workers.length ) {
+                    //    logger.info("give up on: " + workers[i]);
+                    //    break; // give up
+                    //}
+                    workers[i].join(100);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        return s;
+    }
+
+
+    /**
+     * adds a job to the workpile.
+     * @param job
+     */
+    public synchronized void addJob(Runnable job) {
+        if (workers == null || workers.length < size) {
+            init(); // start threads
+        }
+        jobstack.addLast(job);
+        logger.debug("adding job");
+        if (idleworkers > 0) {
+            logger.debug("notifying a jobless worker");
+            notifyAll();
+        }
+    }
+
+
+    /**
+     * get a job for processing.
+     */
+    protected synchronized Runnable getJob() throws InterruptedException {
+        while (jobstack.isEmpty()) {
+            idleworkers++;
+            logger.debug("waiting");
+            wait(1000);
+            idleworkers--;
+            if (shutdown) {
+                throw new InterruptedException("shutdown in getJob");
+            }
+        }
+        // is expressed using strategy enumeration
+        if (strategy == StrategyEnumeration.LIFO) {
+            return jobstack.removeLast(); // LIFO
+        }
+        return jobstack.removeFirst(); // FIFO
+    }
+
+
+    /**
+     * check if there are jobs for processing.
+     */
+    public boolean hasJobs() {
+        if (jobstack.size() > 0) {
+            return true;
+        }
+        for (int i = 0; i < workers.length; i++) {
+            if (workers[i] == null) {
+                continue;
+            }
+            if (workers[i].isWorking) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    /**
+     * check if there are more than n jobs for processing.
+     * @param n Integer
+     * @return true, if there are possibly more than n jobs.
+     */
+    public boolean hasJobs(int n) {
+        int j = jobstack.size();
+        if (j > 0 && (j + workers.length > n)) {
+            return true;
+        }
+        // if j > 0 no worker should be idle
+        // ( ( j > 0 && ( j+workers.length > n ) ) || ( j > n )
+        int x = 0;
+        for (int i = 0; i < workers.length; i++) {
+            if (workers[i] == null) {
+                continue;
+            }
+            if (workers[i].isWorking) {
+                x++;
+            }
+        }
+        if ((j + x) > n) {
+            return true;
+        }
+        return false;
+    }
+
+}
+
+
+/**
+ * Implements one Thread of the pool.
+ */
+class PoolThread extends Thread {
+
+
+    ThreadPool pool;
+
+
+    private static final Logger logger = LogManager.getLogger(PoolThread.class);
+
+
+    private static final boolean debug = logger.isDebugEnabled();
+
+
+    volatile boolean isWorking = false;
+
+
+    /**
+     * @param pool ThreadPool.
+     */
+    public PoolThread(ThreadPool pool) {
+        this.pool = pool;
+    }
+
+
+    /**
+     * Run the thread.
+     */
+    @Override
+    public void run() {
+        logger.info("ready");
+        Runnable job;
+        int done = 0;
+        long time = 0;
+        long t;
+        boolean running = true;
+        while (running) {
+            try {
+                logger.debug("looking for a job");
+                job = pool.getJob();
+                if (job == null) {
+                    break;
+                }
+                if (debug) {
+                    logger.info("working");
+                }
+                t = System.currentTimeMillis();
+                isWorking = true;
+                job.run();
+                isWorking = false;
+                time += System.currentTimeMillis() - t;
+                done++;
+                if (debug) {
+                    logger.info("done");
+                }
+                if (Thread.currentThread().isInterrupted()) {
+                    running = false;
+                    isWorking = false;
+                    //throw new RuntimeException("interrupt in while(running) loop");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                running = false;
+                isWorking = false;
+            } catch (PreemptingException e) {
+                logger.debug("catched " + e);
+                //e.printStackTrace();
+            } catch (RuntimeException e) {
+                logger.warn("catched " + e);
+                e.printStackTrace();
+            }
+        }
+        isWorking = false;
+        logger.info("terminated, done " + done + " jobs in " + time + " milliseconds");
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/machines
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/machines
@@ -1,0 +1,9 @@
+# maschines file for jas
+
+10.1.1.254:7114  # first host is master
+10.1.1.254:8114  # first client host, master-port+1000 
+10.1.1.254:8114  # second host with port
+#localhost:7411  # next host with port
+#localhost:7411  # last host 
+
+# eof

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/machines.localhost
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/machines.localhost
@@ -1,0 +1,9 @@
+# maschines file for jas
+
+localhost:7114   # first host is master
+localhost:8114   # first client host, master-port+1000 
+#localhost:9114   # second host with port
+#localhost:8411  # next host with port
+#localhost:8411  # last host 
+
+# eof

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/package.html
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/package.html
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "../DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>Concurrent programming utility classes</title>
+  </head>
+
+  <body>
+    <h1>Concurrent programming utility classes.</h1>
+
+<p>
+  This package 
+  contains further utilities for parallel and distributed computations
+  like <code>ThreadPool</code>, <code>DistThreadPool</code> 
+  or <code>DistHashTable</code>.
+</p>
+
+
+    <hr />
+    <address><a href="mailto:kredel at rz.uni-mannheim.de">Heinz Kredel</a></address>
+<p>
+<!-- Created: Wed Mar  1 12:29:04 CET 2006 -->
+<!-- hhmts start -->
+Last modified: Mon Jul  9 22:45:40 CEST 2007
+<!-- hhmts end -->
+</p>
+<p>$Id$ 
+</p>
+  </body>
+</html>

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/vector/BasicLinAlg.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/vector/BasicLinAlg.java
@@ -1,0 +1,263 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.vector;
+
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Basic linear algebra methods. Implements Basic linear algebra computations
+ * and tests. <b>Note:</b> will use wrong method dispatch in JRE when used with
+ * GenSolvablePolynomial.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class BasicLinAlg<C extends RingElem<C>> implements Serializable {
+
+
+    private static final Logger logger = LogManager.getLogger(BasicLinAlg.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     */
+    public BasicLinAlg() {
+    }
+
+
+    /**
+     * Scalar product of vectors of ring elements.
+     * @param G a ring element list.
+     * @param F a ring element list.
+     * @return the scalar product of G and F.
+     */
+    public C scalarProduct(List<C> G, List<C> F) {
+        C sp = null;
+        Iterator<C> it = G.iterator();
+        Iterator<C> jt = F.iterator();
+        while (it.hasNext() && jt.hasNext()) {
+            C pi = it.next();
+            C pj = jt.next();
+            if (pi == null || pj == null) {
+                continue;
+            }
+            if (sp == null) {
+                sp = pi.multiply(pj);
+            } else {
+                sp = sp.sum(pi.multiply(pj));
+            }
+        }
+        if (it.hasNext() || jt.hasNext()) {
+            logger.error("scalarProduct wrong sizes");
+        }
+        return sp;
+    }
+
+
+    /**
+     * Scalar product of vectors and a matrix of ring elements.
+     * @param G a ring element list.
+     * @param F a list of ring element lists.
+     * @return the scalar product of G and F.
+     */
+    public List<C> leftScalarProduct(List<C> G, List<List<C>> F) {
+        List<C> sp = null; //new ArrayList<C>(G.size());
+        Iterator<C> it = G.iterator();
+        Iterator<List<C>> jt = F.iterator();
+        while (it.hasNext() && jt.hasNext()) {
+            C pi = it.next();
+            List<C> pj = jt.next();
+            if (pi == null || pj == null) {
+                continue;
+            }
+            List<C> s = scalarProduct(pi, pj);
+            if (sp == null) {
+                sp = s;
+            } else {
+                sp = vectorAdd(sp, s);
+            }
+        }
+        if (it.hasNext() || jt.hasNext()) {
+            logger.error("scalarProduct wrong sizes");
+        }
+        return sp;
+    }
+
+
+    /**
+     * Scalar product of vectors and a matrix of ring elements.
+     * @param G a ring element list.
+     * @param F a list of ring element lists.
+     * @return the right scalar product of G and F.
+     */
+    public List<C> rightScalarProduct(List<C> G, List<List<C>> F) {
+        List<C> sp = null; //new ArrayList<C>(G.size());
+        Iterator<C> it = G.iterator();
+        Iterator<List<C>> jt = F.iterator();
+        while (it.hasNext() && jt.hasNext()) {
+            C pi = it.next();
+            List<C> pj = jt.next();
+            if (pi == null || pj == null) {
+                continue;
+            }
+            List<C> s = scalarProduct(pj, pi);
+            if (sp == null) {
+                sp = s;
+            } else {
+                sp = vectorAdd(sp, s);
+            }
+        }
+        if (it.hasNext() || jt.hasNext()) {
+            logger.error("scalarProduct wrong sizes");
+        }
+        return sp;
+    }
+
+
+    /**
+     * Addition of vectors of ring elements.
+     * @param a a ring element list.
+     * @param b a ring element list.
+     * @return a+b, the vector sum of a and b.
+     */
+
+    public List<C> vectorAdd(List<C> a, List<C> b) {
+        if (a == null) {
+            return b;
+        }
+        if (b == null) {
+            return a;
+        }
+        List<C> V = new ArrayList<C>(a.size());
+        Iterator<C> it = a.iterator();
+        Iterator<C> jt = b.iterator();
+        while (it.hasNext() && jt.hasNext()) {
+            C pi = it.next();
+            C pj = jt.next();
+            C p = pi.sum(pj);
+            V.add(p);
+        }
+        //System.out.println("vectorAdd" + V);
+        if (it.hasNext() || jt.hasNext()) {
+            logger.error("vectorAdd wrong sizes");
+        }
+        return V;
+    }
+
+
+    /**
+     * Test vector of zero ring elements.
+     * @param a a ring element list.
+     * @return true, if all polynomial in a are zero, else false.
+     */
+    public boolean isZero(List<C> a) {
+        if (a == null) {
+            return true;
+        }
+        for (C pi : a) {
+            if (pi == null) {
+                continue;
+            }
+            if (!pi.isZERO()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Scalar product of ring element with vector of ring elements.
+     * @param p a ring element.
+     * @param F a ring element list.
+     * @return the scalar product of p and F.
+     */
+    public List<C> scalarProduct(C p, List<C> F) {
+        List<C> V = new ArrayList<C>(F.size());
+        for (C pi : F) {
+            if (p != null) {
+                pi = p.multiply(pi);
+            } else {
+                pi = null;
+            }
+            V.add(pi);
+        }
+        return V;
+    }
+
+
+    /**
+     * Scalar product of vector of ring element with ring element.
+     * @param F a ring element list.
+     * @param p a ring element.
+     * @return the scalar product of F and p.
+     */
+    public List<C> scalarProduct(List<C> F, C p) {
+        List<C> V = new ArrayList<C>(F.size());
+        for (C pi : F) {
+            if (pi != null) {
+                pi = pi.multiply(p);
+            }
+            V.add(pi);
+        }
+        return V;
+    }
+
+
+    /**
+     * Product of a vector and a matrix of ring elements.
+     * @param G a vectors of ring elements.
+     * @param F a matrix of ring element lists.
+     * @return the left product of G and F.
+     */
+    public GenVector<C> leftProduct(GenVector<C> G, GenMatrix<C> F) {
+        ArrayList<C> sp = new ArrayList<C>(G.val.size());
+        Iterator<ArrayList<C>> jt = F.matrix.iterator();
+        while (jt.hasNext()) {
+            ArrayList<C> pj = jt.next();
+            if (pj == null) {
+                continue;
+            }
+            C s = scalarProduct(G.val, pj);
+            sp.add(s);
+        }
+        return new GenVector<C>(G.modul, sp);
+    }
+
+
+    /**
+     * Product of a vector and a matrix of ring elements.
+     * @param G a vector of element list.
+     * @param F a matrix of ring element lists.
+     * @return the right product of G and F.
+     */
+    public GenVector<C> rightProduct(GenVector<C> G, GenMatrix<C> F) {
+        ArrayList<C> sp = new ArrayList<C>(G.val.size());
+        Iterator<ArrayList<C>> jt = F.matrix.iterator();
+        while (jt.hasNext()) {
+            ArrayList<C> pj = jt.next();
+            if (pj == null) {
+                continue;
+            }
+            C s = scalarProduct(pj, G.val);
+            sp.add(s);
+        }
+        return new GenVector<C>(G.modul, sp);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/vector/Examples.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/vector/Examples.java
@@ -1,0 +1,107 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.vector;
+
+
+import edu.jas.arith.BigInteger;
+import edu.jas.arith.BigRational;
+// import edu.jas.arith.ModInteger;
+
+
+/**
+ * Examples for basic linear algebra.
+ * @author Heinz Kredel
+ */
+
+public class Examples {
+
+
+    /**
+     * main.
+     */
+    public static void main(String[] args) {
+        example1();
+        example2();
+        example3();
+        // ComputerThreads.terminate();
+    }
+
+
+    /**
+     * example1.
+     */
+    public static void example1() {
+        System.out.println("\n\n example 1");
+
+        BigInteger cfac;
+        GenMatrixRing<BigInteger> mfac;
+
+        cfac = new BigInteger();
+        System.out.println("cfac = " + cfac);
+
+        mfac = new GenMatrixRing<BigInteger>(cfac, 5, 5);
+        System.out.println("mfac = " + mfac);
+
+        GenMatrix<BigInteger> m;
+        m = mfac.random(3, 0.4f);
+        System.out.println("\nm = " + m);
+
+        m = m.multiply(m);
+        System.out.println("\nm = " + m);
+    }
+
+
+    /**
+     * example2.
+     */
+    public static void example2() {
+        System.out.println("\n\n example 2");
+
+        BigRational cfac;
+        GenMatrixRing<BigRational> mfac;
+
+        cfac = new BigRational();
+        System.out.println("cfac = " + cfac);
+
+        mfac = new GenMatrixRing<BigRational>(cfac, 5, 5);
+        System.out.println("mfac = " + mfac);
+
+        GenMatrix<BigRational> m;
+        m = mfac.random(3, 0.4f);
+        System.out.println("\nm = " + m);
+
+        m = m.multiply(m);
+        System.out.println("\nm = " + m);
+    }
+
+
+    public static void example3() {
+        System.out.println("\n\n example 3");
+        BigRational r1, r2, r3, r4, r5, r6, fac;
+        r1 = new BigRational(1, 10);
+        r2 = new BigRational(6, 5);
+        r3 = new BigRational(1, 9);
+        r4 = new BigRational(1, 1);
+        r5 = r2.sum(r3);
+        r6 = r1.multiply(r4);
+
+        fac = new BigRational();
+
+        BigRational[][] aa = new BigRational[][] { { r1, r2, r3 }, { r4, r5, r6 }, { r2, r1, r3 } };
+        GenMatrixRing<BigRational> mfac = new GenMatrixRing<BigRational>(fac, aa.length, aa[0].length);
+        GenMatrix<BigRational> a = new GenMatrix<BigRational>(mfac, aa);
+        System.out.println("system = " + a);
+
+        BigRational[] ba = new BigRational[] { r1, r2, r3 };
+        GenVectorModul<BigRational> vfac = new GenVectorModul<BigRational>(fac, ba.length);
+        GenVector<BigRational> b = new GenVector<BigRational>(vfac, ba);
+        System.out.println("right hand side = " + b);
+
+        LinAlg<BigRational> lu = new LinAlg<BigRational>();
+        GenVector<BigRational> x = lu.solve(a, b);
+        System.out.println("solution = " + x);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/vector/GenMatrix.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/vector/GenMatrix.java
@@ -1,0 +1,911 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.vector;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.kern.PrettyPrint;
+import edu.jas.structure.AlgebraElem;
+import edu.jas.structure.NotInvertibleException;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * GenMatrix implements a generic matrix algebra over RingElem entries. Matrix
+ * has n columns and m rows over C.
+ * @author Heinz Kredel
+ */
+
+public class GenMatrix<C extends RingElem<C>> implements AlgebraElem<GenMatrix<C>, C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GenMatrix.class);
+
+
+    public final GenMatrixRing<C> ring;
+
+
+    public final ArrayList<ArrayList<C>> matrix;
+
+
+    private int hashValue = 0;
+
+
+    /**
+     * Constructor for zero GenMatrix.
+     * @param r matrix ring
+     */
+    public GenMatrix(GenMatrixRing<C> r) {
+        this(r, r.getZERO().matrix);
+    }
+
+
+    /**
+     * Constructor for GenMatrix.
+     * @param r matrix ring
+     * @param m matrix
+     */
+    public GenMatrix(GenMatrixRing<C> r, List<List<C>> m) {
+        ring = r;
+        matrix = new ArrayList<ArrayList<C>>(r.rows);
+        for (List<C> row : m) {
+            ArrayList<C> nr = new ArrayList<C>(row);
+            matrix.add(nr);
+        }
+        logger.info(ring.rows + " x " + ring.cols + " matrix constructed");
+    }
+
+
+    /**
+     * Constructor for GenMatrix.
+     * @param r matrix ring
+     * @param m matrix
+     */
+    public GenMatrix(GenMatrixRing<C> r, ArrayList<ArrayList<C>> m) {
+        if (r == null || m == null) {
+            throw new IllegalArgumentException("Empty r or m not allowed, r = " + r + ", m = " + m);
+        }
+        ring = r;
+        matrix = new ArrayList<ArrayList<C>>(m);
+        logger.info(ring.rows + " x " + ring.cols + " matrix constructed");
+    }
+
+
+    /**
+     * Constructor for GenMatrix.
+     * @param r matrix ring
+     * @param m matrix
+     */
+    public GenMatrix(GenMatrixRing<C> r, C[][] m) {
+        ring = r;
+        matrix = new ArrayList<ArrayList<C>>(r.rows);
+        for (C[] row : m) {
+            ArrayList<C> nr = new ArrayList<C>(r.cols);
+            for (int i = 0; i < row.length; i++) {
+                nr.add(row[i]);
+            }
+            matrix.add(nr);
+        }
+        logger.info(ring.rows + " x " + ring.cols + " matrix constructed");
+    }
+
+
+    /**
+     * Get element at row i, column j.
+     * @param i row index.
+     * @param j column index.
+     * @return this(i,j).
+     */
+    public C get(int i, int j) {
+        return matrix.get(i).get(j);
+    }
+
+
+    /**
+     * Set element at row i, column j. Mutates this matrix.
+     * @param i row index.
+     * @param j column index.
+     * @param el element to set.
+     */
+    public void setMutate(int i, int j, C el) {
+        ArrayList<C> ri = matrix.get(i);
+        ri.set(j, el);
+        hashValue = 0; // invalidate
+    }
+
+
+    /**
+     * Set element at row i, column j.
+     * @param i row index.
+     * @param j column index.
+     * @param el element to set.
+     * @return new matrix m, with m(i,j) == el.
+     */
+    public GenMatrix<C> set(int i, int j, C el) {
+        GenMatrix<C> mat = this.copy();
+        mat.setMutate(i, j, el);
+        return mat;
+    }
+
+
+    /**
+     * Get column i.
+     * @param i column index.
+     * @return this(*,i) as vector.
+     */
+    public GenVector<C> getColumn(int i) {
+        List<C> cl = new ArrayList<C>(ring.rows);
+        for (int k = 0; k < ring.rows; k++) {
+            cl.add(matrix.get(k).get(i));
+        }
+        GenVectorModul<C> vfac = new GenVectorModul<C>(ring.coFac, ring.rows);
+        GenVector<C> col = new GenVector<C>(vfac, cl);
+        return col;
+    }
+
+
+    /**
+     * Get row i.
+     * @param i row index.
+     * @return this(i,*) as vector.
+     */
+    public GenVector<C> getRow(int i) {
+        List<C> cl = new ArrayList<C>(ring.cols);
+        cl.addAll(matrix.get(i));
+        GenVectorModul<C> vfac = new GenVectorModul<C>(ring.coFac, ring.cols);
+        GenVector<C> row = new GenVector<C>(vfac, cl);
+        return row;
+    }
+
+
+    /**
+     * Get diagonal.
+     * @return diagonal(this) as vector.
+     */
+    public GenVector<C> getDiagonal() {
+        List<C> cl = new ArrayList<C>(ring.rows);
+        for (int i = 0; i < ring.rows; i++) {
+            cl.add(matrix.get(i).get(i));
+        }
+        GenVectorModul<C> vfac = new GenVectorModul<C>(ring.coFac, ring.rows);
+        GenVector<C> dia = new GenVector<C>(vfac, cl);
+        return dia;
+    }
+
+
+    /**
+     * Get upper triangular U matrix.
+     * @return U as matrix with equal length rows.
+     */
+    public GenMatrix<C> getUpper() {
+        final C zero = ring.coFac.getZERO();
+        final C one = ring.coFac.getONE();
+        List<List<C>> cl = new ArrayList<List<C>>(ring.rows);
+        for (int k = 0; k < ring.rows; k++) {
+            List<C> ul = matrix.get(k);
+            List<C> rl = new ArrayList<C>(ring.cols);
+            for (int i = 0; i < ring.cols; i++) {
+                if (i < k) {
+                    rl.add(zero);
+                } else if (i >= k) {
+                    rl.add(ul.get(i));
+                // } else {
+                //     if (ul.get(i).isZERO()) {
+                //         rl.add(zero);
+                //     } else {
+                //         rl.add(one); // mat(k,k).inverse()
+                //     }
+                }
+            }
+            cl.add(rl);
+        }
+        GenMatrix<C> U = new GenMatrix<C>(ring, cl);
+        return U;
+    }
+
+
+    /**
+     * Get upper triangular U matrix with diagonale 1.
+     * @return U as matrix with equal length rows and diagonale 1.
+     */
+    public GenMatrix<C> getUpperScaled() {
+        final C zero = ring.coFac.getZERO();
+        final C one = ring.coFac.getONE();
+        List<List<C>> cl = new ArrayList<List<C>>(ring.rows);
+        for (int k = 0; k < ring.rows; k++) {
+            List<C> ul = matrix.get(k);
+            C kk = ul.get(k);
+            if (kk.isZERO()) {
+                kk = one;
+            } else {
+                kk = kk.inverse();
+            }
+            List<C> rl = new ArrayList<C>(ring.cols);
+            for (int i = 0; i < ring.cols; i++) {
+                if (i < k) {
+                    rl.add(zero);
+                } else { // if (i >= k)
+                    rl.add( ul.get(i).multiply(kk) );
+                }
+            }
+            cl.add(rl);
+        }
+        GenMatrix<C> U = new GenMatrix<C>(ring, cl);
+        return U;
+    }
+
+
+    /**
+     * Get lower triangular L matrix.
+     * @return L as matrix with equal length rows.
+     */
+    public GenMatrix<C> getLower() {
+        final C zero = ring.coFac.getZERO();
+        List<List<C>> cl = new ArrayList<List<C>>(ring.rows);
+        for (int k = 0; k < ring.rows; k++) {
+            List<C> ul = matrix.get(k);
+            List<C> rl = new ArrayList<C>(ring.cols);
+            for (int i = 0; i < ring.cols; i++) {
+                if (i <= k) {
+                    rl.add(ul.get(i)); // can be zero
+                } else if (i > k) {
+                    rl.add(zero);
+                }
+            }
+            cl.add(rl);
+        }
+        GenMatrix<C> L = new GenMatrix<C>(ring, cl);
+        return L;
+    }
+
+
+    /**
+     * Get the String representation as RingElem.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer s = new StringBuffer();
+        boolean firstRow = true;
+        s.append("[\n");
+        for (List<C> val : matrix) {
+            if (firstRow) {
+                firstRow = false;
+            } else {
+                s.append(",\n");
+            }
+            boolean first = true;
+            s.append("[ ");
+            for (C c : val) {
+                if (first) {
+                    first = false;
+                } else {
+                    s.append(", ");
+                }
+                s.append(c.toString());
+            }
+            s.append(" ]");
+        }
+        s.append(" ] ");
+        if (!PrettyPrint.isTrue()) {
+            s.append(":: " + ring.toString());
+            s.append("\n");
+        }
+        return s.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        StringBuffer s = new StringBuffer();
+        boolean firstRow = true;
+        s.append("( ");
+        for (List<C> val : matrix) {
+            if (firstRow) {
+                firstRow = false;
+            } else {
+                s.append(", ");
+            }
+            boolean first = true;
+            s.append("( ");
+            for (C c : val) {
+                if (first) {
+                    first = false;
+                } else {
+                    s.append(", ");
+                }
+                s.append(c.toScript());
+            }
+            s.append(" )");
+        }
+        s.append(" ) ");
+        return s.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python case
+        return factory().toScript();
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public GenMatrixRing<C> factory() {
+        return ring;
+    }
+
+
+    /**
+     * clone method.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public GenMatrix<C> copy() {
+        //return ring.copy(this);
+        ArrayList<ArrayList<C>> m = new ArrayList<ArrayList<C>>(ring.rows);
+        ArrayList<C> v;
+        for (ArrayList<C> val : matrix) {
+            v = new ArrayList<C>(val); // val.clone();
+            m.add(v);
+        }
+        return new GenMatrix<C>(ring, m);
+    }
+
+
+    /**
+     * Test if this is equal to a zero matrix.
+     */
+    public boolean isZERO() {
+        for (List<C> row : matrix) {
+            for (C elem : row) {
+                if (!elem.isZERO()) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+
+    /**
+     * Test if this is one.
+     * @return true if this is 1, else false.
+     */
+    public boolean isONE() {
+        int i = 0;
+        for (List<C> row : matrix) {
+            int j = 0;
+            for (C elem : row) {
+                if (i == j) {
+                    if (!elem.isONE()) {
+                        //System.out.println("elem.isONE = " + elem);
+                        return false;
+                    }
+                } else if (!elem.isZERO()) {
+                    //System.out.println("elem.isZERO = " + elem);
+                    return false;
+                }
+                j++;
+            }
+            i++;
+        }
+        return true;
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object other) {
+        if (!(other instanceof GenMatrix)) {
+            return false;
+        }
+        GenMatrix om = (GenMatrix) other;
+        if (!ring.equals(om.ring)) {
+            return false;
+        }
+        if (!matrix.equals(om.matrix)) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Hash code for this GenMatrix.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        if (hashValue == 0) {
+            hashValue = 37 * matrix.hashCode() + ring.hashCode();
+            if (hashValue == 0) {
+                hashValue = 1;
+            }
+        }
+        return hashValue;
+    }
+
+
+    /**
+     * compareTo, lexicogaphical comparison.
+     * @param b other
+     * @return 1 if (this &lt; b), 0 if (this == b) or -1 if (this &gt; b).
+     */
+    @Override
+    public int compareTo(GenMatrix<C> b) {
+        if (!ring.equals(b.ring)) {
+            return -1;
+        }
+        ArrayList<ArrayList<C>> om = b.matrix;
+        int i = 0;
+        for (ArrayList<C> val : matrix) {
+            ArrayList<C> ov = om.get(i++);
+            int j = 0;
+            for (C c : val) {
+                int s = c.compareTo(ov.get(j++));
+                if (s != 0) {
+                    return s;
+                }
+            }
+        }
+        return 0;
+    }
+
+
+    /**
+     * Test if this is a unit. I.e. there exists x with this.multiply(x).isONE()
+     * == true. Tests if matrix is not singular.
+     * Was previously a test if all diagonal elements are units and all other
+     *  elements are zero.
+     * @return true if this is a unit, else false.
+     */
+    public boolean isUnit() {
+        LinAlg<C> la = new LinAlg<C>();
+        GenMatrix<C> mat = this.copy();
+        List<Integer> P = la.decompositionLU(mat);
+        if (P == null || P.isEmpty()) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * sign of matrix.
+     * @return 1 if (this &lt; 0), 0 if (this == 0) or -1 if (this &gt; 0).
+     */
+    public int signum() {
+        return compareTo(ring.getZERO());
+    }
+
+
+    /**
+     * Sum of matrices.
+     * @return this+b
+     */
+    public GenMatrix<C> sum(GenMatrix<C> b) {
+        ArrayList<ArrayList<C>> om = b.matrix;
+        ArrayList<ArrayList<C>> m = new ArrayList<ArrayList<C>>(ring.rows);
+        int i = 0;
+        for (ArrayList<C> val : matrix) {
+            ArrayList<C> ov = om.get(i++);
+            ArrayList<C> v = new ArrayList<C>(ring.cols);
+            int j = 0;
+            for (C c : val) {
+                C e = c.sum(ov.get(j++));
+                v.add(e);
+            }
+            m.add(v);
+        }
+        return new GenMatrix<C>(ring, m);
+    }
+
+
+    /**
+     * Difference of matrices.
+     * @return this-b
+     */
+    public GenMatrix<C> subtract(GenMatrix<C> b) {
+        ArrayList<ArrayList<C>> om = b.matrix;
+        ArrayList<ArrayList<C>> m = new ArrayList<ArrayList<C>>(ring.rows);
+        int i = 0;
+        for (ArrayList<C> val : matrix) {
+            ArrayList<C> ov = om.get(i++);
+            ArrayList<C> v = new ArrayList<C>(ring.cols);
+            int j = 0;
+            for (C c : val) {
+                C e = c.subtract(ov.get(j++));
+                v.add(e);
+            }
+            m.add(v);
+        }
+        return new GenMatrix<C>(ring, m);
+    }
+
+
+    /**
+     * Negative of this matrix.
+     * @return -this
+     */
+    public GenMatrix<C> negate() {
+        ArrayList<ArrayList<C>> m = new ArrayList<ArrayList<C>>(ring.rows);
+        //int i = 0;
+        for (ArrayList<C> val : matrix) {
+            ArrayList<C> v = new ArrayList<C>(ring.cols);
+            for (C c : val) {
+                C e = c.negate();
+                v.add(e);
+            }
+            m.add(v);
+        }
+        return new GenMatrix<C>(ring, m);
+    }
+
+
+    /**
+     * Absolute value of this matrix.
+     * @return abs(this)
+     */
+    public GenMatrix<C> abs() {
+        if (signum() < 0) {
+            return negate();
+        }
+        return this;
+    }
+
+
+    /**
+     * Product of this matrix with scalar.
+     * @param s scalar.
+     * @return this*s
+     */
+    public GenMatrix<C> multiply(C s) {
+        return scalarMultiply(s);
+    }
+
+
+    /**
+     * Product of this matrix with scalar.
+     * @return this*s
+     */
+    public GenMatrix<C> scalarMultiply(C s) {
+        ArrayList<ArrayList<C>> m = new ArrayList<ArrayList<C>>(ring.rows);
+        //int i = 0;
+        for (ArrayList<C> val : matrix) {
+            ArrayList<C> v = new ArrayList<C>(ring.cols);
+            for (C c : val) {
+                C e = c.multiply(s);
+                v.add(e);
+            }
+            m.add(v);
+        }
+        return new GenMatrix<C>(ring, m);
+    }
+
+
+    /**
+     * Left product of this matrix with scalar.
+     * @return s*this
+     */
+    public GenMatrix<C> leftScalarMultiply(C s) {
+        ArrayList<ArrayList<C>> m = new ArrayList<ArrayList<C>>(ring.rows);
+        //int i = 0;
+        for (ArrayList<C> val : matrix) {
+            ArrayList<C> v = new ArrayList<C>(ring.cols);
+            for (C c : val) {
+                C e = s.multiply(c);
+                v.add(e);
+            }
+            m.add(v);
+        }
+        return new GenMatrix<C>(ring, m);
+    }
+
+
+    /**
+     * Linear compination of this matrix with scalar multiple of other matrix.
+     * @return this*s+b*t
+     */
+    public GenMatrix<C> linearCombination(C s, GenMatrix<C> b, C t) {
+        ArrayList<ArrayList<C>> om = b.matrix;
+        ArrayList<ArrayList<C>> m = new ArrayList<ArrayList<C>>(ring.rows);
+        int i = 0;
+        for (ArrayList<C> val : matrix) {
+            ArrayList<C> ov = om.get(i++);
+            ArrayList<C> v = new ArrayList<C>(ring.cols);
+            int j = 0;
+            for (C c : val) {
+                C c1 = c.multiply(s);
+                C c2 = ov.get(j++).multiply(t);
+                C e = c1.sum(c2);
+                v.add(e);
+            }
+            m.add(v);
+        }
+        return new GenMatrix<C>(ring, m);
+    }
+
+
+    /**
+     * Linear combination of this matrix with scalar multiple of other matrix.
+     * @return this+b*t
+     */
+    public GenMatrix<C> linearCombination(GenMatrix<C> b, C t) {
+        ArrayList<ArrayList<C>> om = b.matrix;
+        ArrayList<ArrayList<C>> m = new ArrayList<ArrayList<C>>(ring.rows);
+        int i = 0;
+        for (ArrayList<C> val : matrix) {
+            ArrayList<C> ov = om.get(i++);
+            ArrayList<C> v = new ArrayList<C>(ring.cols);
+            int j = 0;
+            for (C c : val) {
+                C c2 = ov.get(j++).multiply(t);
+                C e = c.sum(c2);
+                v.add(e);
+            }
+            m.add(v);
+        }
+        return new GenMatrix<C>(ring, m);
+    }
+
+
+    /**
+     * Left linear combination of this matrix with scalar multiple of other
+     * matrix.
+     * @return this+t*b
+     */
+    public GenMatrix<C> linearCombination(C t, GenMatrix<C> b) {
+        ArrayList<ArrayList<C>> om = b.matrix;
+        ArrayList<ArrayList<C>> m = new ArrayList<ArrayList<C>>(ring.rows);
+        int i = 0;
+        for (ArrayList<C> val : matrix) {
+            ArrayList<C> ov = om.get(i++);
+            ArrayList<C> v = new ArrayList<C>(ring.cols);
+            int j = 0;
+            for (C c : val) {
+                C c2 = t.multiply(ov.get(j++));
+                C e = c.sum(c2);
+                v.add(e);
+            }
+            m.add(v);
+        }
+        return new GenMatrix<C>(ring, m);
+    }
+
+
+    /**
+     * left linear compination of this matrix with scalar multiple of other
+     * matrix.
+     * @return s*this+t*b
+     */
+    public GenMatrix<C> leftLinearCombination(C s, C t, GenMatrix<C> b) {
+        ArrayList<ArrayList<C>> om = b.matrix;
+        ArrayList<ArrayList<C>> m = new ArrayList<ArrayList<C>>(ring.rows);
+        int i = 0;
+        for (ArrayList<C> val : matrix) {
+            ArrayList<C> ov = om.get(i++);
+            ArrayList<C> v = new ArrayList<C>(ring.cols);
+            int j = 0;
+            for (C c : val) {
+                C c1 = s.multiply(c);
+                C c2 = t.multiply(ov.get(j++));
+                C e = c1.sum(c2);
+                v.add(e);
+            }
+            m.add(v);
+        }
+        return new GenMatrix<C>(ring, m);
+    }
+
+
+    /**
+     * Transposed matrix.
+     * @return transpose(this)
+     */
+    public GenMatrix<C> transpose(GenMatrixRing<C> tr) {
+        GenMatrix<C> t = tr.getZERO().copy();
+        ArrayList<ArrayList<C>> m = t.matrix;
+        int i = 0;
+        for (ArrayList<C> val : matrix) {
+            int j = 0;
+            for (C c : val) {
+                (m.get(j)).set(i, c); //A[j,i] = A[i,j]
+                j++;
+            }
+            i++;
+        }
+        // return new GenMatrix<C>(tr,m);
+        return t;
+    }
+
+
+    /**
+     * Transposed matrix.
+     * @return transpose(this)
+     */
+    public GenMatrix<C> transpose() {
+        GenMatrixRing<C> tr = ring.transpose();
+        return transpose(tr);
+    }
+
+
+    /**
+     * Multiply this with S.
+     * @param S
+     * @return this * S.
+     */
+    public GenMatrix<C> multiply(GenMatrix<C> S) {
+        int na = ring.blocksize;
+        int nb = ring.blocksize;
+        //System.out.println("#blocks = " + (matrix.size()/na) + ", na = " + na 
+        //    + " SeqMultBlockTrans");
+        ArrayList<ArrayList<C>> m = matrix;
+        //ArrayList<ArrayList<C>> s = S.matrix;
+
+        GenMatrixRing<C> tr = S.ring.transpose();
+        GenMatrix<C> T = S.transpose(tr);
+        ArrayList<ArrayList<C>> t = T.matrix;
+        //System.out.println("T = " + T); 
+
+        GenMatrixRing<C> pr = ring.product(S.ring);
+        GenMatrix<C> P = pr.getZERO().copy();
+        ArrayList<ArrayList<C>> p = P.matrix;
+        //System.out.println("P = " + P); 
+
+        for (int ii = 0; ii < m.size(); ii += na) {
+            for (int jj = 0; jj < t.size(); jj += nb) {
+
+                for (int i = ii; i < Math.min((ii + na), m.size()); i++) {
+                    ArrayList<C> Ai = m.get(i); //A[i];
+                    for (int j = jj; j < Math.min((jj + nb), t.size()); j++) {
+                        ArrayList<C> Bj = t.get(j); //B[j];
+                        C c = ring.coFac.getZERO();
+                        for (int k = 0; k < Bj.size(); k++) {
+                            c = c.sum(Ai.get(k).multiply(Bj.get(k)));
+                            //  c += Ai[k] * Bj[k];
+                        }
+                        (p.get(i)).set(j, c); // C[i][j] = c;
+                    }
+                }
+
+            }
+        }
+        return new GenMatrix<C>(pr, p);
+    }
+
+
+    /**
+     * Multiply this with S. Simple unblocked algorithm.
+     * @param S
+     * @return this * S.
+     */
+    public GenMatrix<C> multiplySimple(GenMatrix<C> S) {
+        ArrayList<ArrayList<C>> m = matrix;
+        ArrayList<ArrayList<C>> B = S.matrix;
+
+        GenMatrixRing<C> pr = ring.product(S.ring);
+        GenMatrix<C> P = pr.getZERO().copy();
+        ArrayList<ArrayList<C>> p = P.matrix;
+
+        for (int i = 0; i < pr.rows; i++) {
+            ArrayList<C> Ai = m.get(i); //A[i];
+            for (int j = 0; j < pr.cols; j++) {
+                C c = ring.coFac.getZERO();
+                for (int k = 0; k < S.ring.rows; k++) {
+                    c = c.sum(Ai.get(k).multiply(B.get(k).get(j)));
+                    //  c += A[i][k] * B[k][j];
+                }
+                (p.get(i)).set(j, c); // C[i][j] = c;
+            }
+        }
+        return new GenMatrix<C>(pr, p);
+    }
+
+
+    /**
+     * Divide this by S.
+     * @param S
+     * @return this * S^{-1}.
+     */
+    public GenMatrix<C> divide(GenMatrix<C> S) {
+        //throw new UnsupportedOperationException("divide not yet implemented");
+        return multiply(S.inverse());
+    }
+
+
+    /**
+     * Divide left this by S.
+     * @param S
+     * @return S^{-1} * this.
+     */
+    public GenMatrix<C> divideLeft(GenMatrix<C> S) {
+        return S.inverse().multiply(this);
+    }
+
+
+    /**
+     * Remainder after division of this by S.
+     * @param S
+     * @return this - (this / S) * S.
+     */
+    public GenMatrix<C> remainder(GenMatrix<C> S) {
+        throw new UnsupportedOperationException("remainder not implemented");
+    }
+
+
+    /**
+     * Quotient and remainder by division of this by S.
+     * @param S a GenMatrix
+     * @return [this/S, this - (this/S)*S].
+     */
+    public GenMatrix<C>[] quotientRemainder(GenMatrix<C> S) {
+        throw new UnsupportedOperationException("quotientRemainder not implemented, input = " + S);
+    }
+
+
+    /**
+     * Inverse of this.
+     * @return x with this * x = 1, if it exists.
+     * @see edu.jas.vector.LinAlg#inverseLU(edu.jas.vector.GenMatrix,java.util.List)
+     */
+    public GenMatrix<C> inverse() {
+        //throw new UnsupportedOperationException("inverse implemented in LinAlg.inverseLU()");
+        LinAlg<C> la = new LinAlg<C>();
+        GenMatrix<C> mat = this.copy();
+        List<Integer> P = la.decompositionLU(mat);
+        if (P == null || P.isEmpty()) {
+            throw new NotInvertibleException("matrix not invertible");
+        }
+        mat = la.inverseLU(mat,P);
+        return mat;
+    }
+
+
+    /**
+     * Greatest common divisor.
+     * @param b other element.
+     * @return gcd(this,b).
+     */
+    public GenMatrix<C> gcd(GenMatrix<C> b) {
+        throw new UnsupportedOperationException("gcd not implemented");
+    }
+
+
+    /**
+     * Extended greatest common divisor.
+     * @param b other element.
+     * @return [ gcd(this,b), c1, c2 ] with c1*this + c2*b = gcd(this,b).
+     */
+    public GenMatrix<C>[] egcd(GenMatrix<C> b) {
+        throw new UnsupportedOperationException("egcd not implemented");
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/vector/GenMatrixRing.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/vector/GenMatrixRing.java
@@ -1,0 +1,602 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.vector;
+
+
+// import java.io.IOException;
+import java.io.Reader;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.function.BiFunction;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.kern.StringUtil;
+import edu.jas.structure.AlgebraFactory;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * GenMatrixRing implements a generic matrix algebra factory with RingFactory.
+ * Matrices of n rows and m columns over C.
+ * @author Heinz Kredel
+ */
+
+public class GenMatrixRing<C extends RingElem<C>> implements AlgebraFactory<GenMatrix<C>, C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GenMatrixRing.class);
+
+
+    public final RingFactory<C> coFac;
+
+
+    public final int rows;
+
+
+    public final int cols;
+
+
+    public final int blocksize;
+
+
+    public final static int DEFAULT_BSIZE = 10;
+
+
+    public final GenMatrix<C> ZERO;
+
+
+    public final GenMatrix<C> ONE;
+
+
+    private final static Random random = new Random();
+
+
+    public final static float DEFAULT_DENSITY = 0.5f;
+
+
+    private final float density = DEFAULT_DENSITY;
+
+
+    /**
+     * Constructors for GenMatrixRing.
+     * @param b coefficient factory.
+     * @param r number of rows.
+     * @param c number of colums.
+     */
+    public GenMatrixRing(RingFactory<C> b, int r, int c) {
+        this(b, r, c, DEFAULT_BSIZE);
+    }
+
+
+    /**
+     * Constructors for GenMatrixRing.
+     * @param b coefficient factory.
+     * @param r number of rows.
+     * @param c number of colums.
+     * @param s block size for blocked operations.
+     */
+    @SuppressWarnings("unchecked")
+    public GenMatrixRing(RingFactory<C> b, int r, int c, int s) {
+        if (b == null) {
+            throw new IllegalArgumentException("RingFactory is null");
+        }
+        if (r < 1) {
+            throw new IllegalArgumentException("rows < 1 " + r);
+        }
+        if (c < 1) {
+            throw new IllegalArgumentException("cols < 1 " + c);
+        }
+        coFac = b;
+        rows = r;
+        cols = c;
+        blocksize = s;
+        ArrayList<C> z = new ArrayList<C>(cols);
+        for (int i = 0; i < cols; i++) {
+            z.add(coFac.getZERO());
+        }
+        ArrayList<ArrayList<C>> m = new ArrayList<ArrayList<C>>(rows);
+        for (int i = 0; i < rows; i++) {
+            m.add(new ArrayList<C>(z)); // z.clone();
+        }
+        ZERO = new GenMatrix<C>(this, m);
+        m = new ArrayList<ArrayList<C>>(rows);
+        C one = coFac.getONE();
+        ArrayList<C> v;
+        for (int i = 0; i < rows; i++) {
+            if (i < cols) {
+                v = new ArrayList<C>(z); // z.clone();
+                v.set(i, one);
+                m.add(v);
+            }
+        }
+        ONE = new GenMatrix<C>(this, m);
+        logger.info(rows + " x " + cols + " with blocksize " + blocksize + " matrix ring over "
+                        + coFac.toScript() + " constructed");
+    }
+
+
+    /**
+     * Get the String representation as RingElem.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer s = new StringBuffer();
+        s.append(coFac.getClass().getSimpleName());
+        s.append("[" + rows + "," + cols + "]");
+        return s.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.ElemFactory#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        StringBuffer s = new StringBuffer("Mat(");
+        String f = null;
+        try {
+            f = ((RingElem<C>) coFac).toScriptFactory(); // sic
+        } catch (Exception e) {
+            f = coFac.toScript();
+        }
+        s.append(f + "," + rows + "," + cols + ")");
+        return s.toString();
+    }
+
+
+    /**
+     * Get the constant one for the GenMatrix.
+     * @return ZERO.
+     */
+    public GenMatrix<C> getZERO() {
+        return ZERO;
+    }
+
+
+    /**
+     * Get the constant one for the GenMatrix.
+     * @return 1.
+     */
+    public GenMatrix<C> getONE() {
+        return ONE;
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     * @see edu.jas.structure.ElemFactory#generators()
+     */
+    public List<GenMatrix<C>> generators() {
+        List<C> rgens = coFac.generators();
+        List<GenMatrix<C>> gens = new ArrayList<GenMatrix<C>>(rows * cols * rgens.size());
+        for (int i = 0; i < rows; i++) {
+            for (int j = 0; j < cols; j++) {
+                for (C el : rgens) {
+                    GenMatrix<C> g = ZERO.set(i, j, el); // uses clone()
+                    gens.add(g);
+                }
+            }
+        }
+        return gens;
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite()
+     */
+    public boolean isFinite() {
+        return coFac.isFinite();
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof GenMatrixRing)) {
+            return false;
+        }
+        GenMatrixRing omod = (GenMatrixRing) other;
+        if (rows != omod.rows) {
+            return false;
+        }
+        if (cols != omod.cols) {
+            return false;
+        }
+        if (!coFac.equals(omod.coFac)) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Hash code for this matrix ring.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = rows * 17 + cols;
+        h = 37 * h + coFac.hashCode();
+        return h;
+    }
+
+
+    /**
+     * Query if this ring is a field. May return false if it is to hard to
+     * determine if this ring is a field.
+     * @return true if it is known that this ring is a field, else false.
+     */
+    public boolean isField() {
+        return false;
+    }
+
+
+    /**
+     * Query if this monoid is commutative.
+     * @return true if this monoid is commutative, else false.
+     */
+    public boolean isCommutative() {
+        return false;
+    }
+
+
+    /**
+     * Query if this ring is associative.
+     * @return true if this monoid is associative, else false.
+     */
+    public boolean isAssociative() {
+        return (rows == cols) && coFac.isAssociative();
+    }
+
+
+    /**
+     * Characteristic of this ring.
+     * @return characteristic of this ring.
+     */
+    public java.math.BigInteger characteristic() {
+        return coFac.characteristic();
+    }
+
+
+    /**
+     * Transposed matrix ring.
+     * @return transposed ring factory.
+     */
+    public GenMatrixRing<C> transpose() {
+        if (rows == cols) {
+            return this;
+        }
+        return new GenMatrixRing<C>(coFac, cols, rows, blocksize);
+    }
+
+
+    /**
+     * Product matrix ring for multiplication.
+     * @param other matrix ring factory.
+     * @return product ring factory.
+     */
+    public GenMatrixRing<C> product(GenMatrixRing<C> other) {
+        if (cols != other.rows) {
+            throw new IllegalArgumentException("invalid dimensions in product");
+        }
+        if (!coFac.equals(other.coFac)) {
+            throw new IllegalArgumentException("invalid coefficients in product");
+        }
+        if (rows == other.rows && cols == other.cols) {
+            return this;
+        }
+        return new GenMatrixRing<C>(coFac, rows, other.cols, blocksize);
+    }
+
+
+    /**
+     * Get the matrix for a.
+     * @param a long
+     * @return matrix corresponding to a.
+     */
+    public GenMatrix<C> fromInteger(long a) {
+        C c = coFac.fromInteger(a);
+        return ONE.scalarMultiply(c);
+    }
+
+
+    /**
+     * Get the matrix for a.
+     * @param a long
+     * @return matrix corresponding to a.
+     */
+    public GenMatrix<C> fromInteger(BigInteger a) {
+        C c = coFac.fromInteger(a);
+        return ONE.scalarMultiply(c);
+    }
+
+
+    /**
+     * From List of coefficients.
+     * @param om list of list of coefficients.
+     */
+    public GenMatrix<C> fromList(List<List<C>> om) {
+        if (om == null) {
+            return ZERO;
+        }
+        if (om.size() > rows) {
+            throw new IllegalArgumentException("size v > rows " + om + " > " + rows);
+        }
+        ArrayList<ArrayList<C>> m = new ArrayList<ArrayList<C>>(rows);
+        for (int i = 0; i < rows; i++) {
+            List<C> ov = om.get(i);
+            ArrayList<C> v;
+            if (ov == null) {
+                v = ZERO.matrix.get(0);
+            } else {
+                if (ov.size() > cols) {
+                    throw new IllegalArgumentException("size v > cols " + ov + " > " + cols);
+                }
+                v = new ArrayList<C>(cols);
+                v.addAll(ov);
+                // pad with zeros if required:
+                for (int j = v.size(); j < cols; j++) {
+                    v.add(coFac.getZERO());
+                }
+            }
+            m.add(v);
+        }
+        return new GenMatrix<C>(this, m);
+    }
+
+
+    /**
+     * From List of GenVectors.
+     * @param om list of GenVectors.
+     */
+    public GenMatrix<C> fromVectors(List<GenVector<C>> om) {
+        List<List<C>> mat = new ArrayList<List<C>>();
+        for (GenVector<C> row : om) {
+            List<C> nr = new ArrayList<C>(row.val);
+            mat.add(nr);
+        }
+        //List<C> zero = this.getZERO().getRow(0).val;
+        //for (int i = mat.size(); i < rows; i++) {
+        //    mat.add(zero);
+        //}
+        GenMatrixRing<C> rfac = new GenMatrixRing<C>(coFac,mat.size(),cols);
+        return rfac.fromList(mat);
+    }
+
+
+    /**
+     * Random matrix.
+     * @param k size of random coefficients.
+     */
+    public GenMatrix<C> random(int k) {
+        return random(k, density, random);
+    }
+
+
+    /**
+     * Random matrix.
+     * @param k size of random coefficients.
+     * @param q density of nozero coefficients.
+     */
+    public GenMatrix<C> random(int k, float q) {
+        return random(k, q, random);
+    }
+
+
+    /**
+     * Random matrix.
+     * @param k size of random coefficients.
+     * @param random is a source for random bits.
+     * @return a random element.
+     */
+    public GenMatrix<C> random(int k, Random random) {
+        return random(k, density, random);
+    }
+
+
+    /**
+     * Random matrix.
+     * @param k size of random coefficients.
+     * @param q density of nozero coefficients.
+     * @param random is a source for random bits.
+     * @return a random element.
+     */
+    public GenMatrix<C> random(int k, float q, Random random) {
+        ArrayList<ArrayList<C>> m = new ArrayList<ArrayList<C>>(rows);
+        for (int i = 0; i < rows; i++) {
+            ArrayList<C> v = new ArrayList<C>(cols);
+            for (int j = 0; j < cols; j++) {
+                C e;
+                if (random.nextFloat() < q) {
+                    e = coFac.random(k, random);
+                } else {
+                    e = coFac.getZERO();
+                }
+                v.add(e);
+            }
+            m.add(v);
+        }
+        return new GenMatrix<C>(this, m);
+    }
+
+
+    /**
+     * Random upper triangular matrix.
+     * @param k size of random coefficients.
+     * @param q density of nozero coefficients.
+     */
+    public GenMatrix<C> randomUpper(int k, float q) {
+        return randomUpper(k, q, random);
+    }
+
+
+    /**
+     * Random upper triangular matrix.
+     * @param k size of random coefficients.
+     * @param q density of nozero coefficients.
+     * @param random is a source for random bits.
+     * @return a random element.
+     */
+    public GenMatrix<C> randomUpper(int k, float q, Random random) {
+        ArrayList<ArrayList<C>> m = new ArrayList<ArrayList<C>>(rows);
+        for (int i = 0; i < rows; i++) {
+            ArrayList<C> v = new ArrayList<C>(cols);
+            for (int j = 0; j < cols; j++) {
+                C e = coFac.getZERO();
+                if (j >= i) {
+                    if (random.nextFloat() < q) {
+                        e = coFac.random(k, random);
+                    }
+                }
+                v.add(e);
+            }
+            m.add(v);
+        }
+        return new GenMatrix<C>(this, m);
+    }
+
+
+    /**
+     * Random lower triangular matrix.
+     * @param k size of random coefficients.
+     * @param q density of nozero coefficients.
+     */
+    public GenMatrix<C> randomLower(int k, float q) {
+        return randomLower(k, q, random);
+    }
+
+
+    /**
+     * Random lower triangular matrix.
+     * @param k size of random coefficients.
+     * @param q density of nozero coefficients.
+     * @param random is a source for random bits.
+     * @return a random element.
+     */
+    public GenMatrix<C> randomLower(int k, float q, Random random) {
+        ArrayList<ArrayList<C>> m = new ArrayList<ArrayList<C>>(rows);
+        for (int i = 0; i < rows; i++) {
+            ArrayList<C> v = new ArrayList<C>(cols);
+            for (int j = 0; j < cols; j++) {
+                C e = coFac.getZERO();
+                if (j <= i) {
+                    if (random.nextFloat() < q) {
+                        e = coFac.random(k, random);
+                    }
+                }
+                v.add(e);
+            }
+            m.add(v);
+        }
+        return new GenMatrix<C>(this, m);
+    }
+
+
+    /**
+     * Copy matrix.
+     * @param c matrix to copy.
+     * @return copy of the matrix
+     */
+    public GenMatrix<C> copy(GenMatrix<C> c) {
+        if (c == null) {
+            return c;
+        }
+        return c.copy();
+    }
+
+
+    /**
+     * Generate matrix via lambda expression.
+     * @param gener lambda expression.
+     * @return the generated matrix.
+     */
+    public GenMatrix<C> generate(BiFunction<Integer, Integer, C> gener) {
+        ArrayList<ArrayList<C>> m = new ArrayList<ArrayList<C>>(rows);
+        for (int i = 0; i < rows; i++) {
+            ArrayList<C> v = new ArrayList<C>(cols);
+            for (int j = 0; j < cols; j++) {
+                C e = gener.apply(i, j);
+                v.add(e);
+            }
+            m.add(v);
+        }
+        return new GenMatrix<C>(this, m);
+    }
+
+
+    /**
+     * Parse a matrix from a String. Syntax: [ [ c, ..., c ], ..., [ c, ..., c ]
+     * ]
+     * @param s input String.
+     * @return parsed matrix
+     */
+    public GenMatrix<C> parse(String s) {
+        int i = s.indexOf("[");
+        if (i >= 0) {
+            s = s.substring(i + 1);
+        }
+        ArrayList<ArrayList<C>> mat = new ArrayList<ArrayList<C>>(rows);
+        ArrayList<C> v;
+        GenVector<C> vec;
+        GenVectorModul<C> vmod = new GenVectorModul<C>(coFac, cols);
+        String e;
+        int j;
+        do {
+            i = s.indexOf("]"); // delimit vector
+            j = s.lastIndexOf("]"); // delimit matrix
+            if (i != j) {
+                if (i >= 0) {
+                    e = s.substring(0, i);
+                    s = s.substring(i);
+                    vec = vmod.parse(e);
+                    v = new ArrayList<C>(vec.val);
+                    mat.add(v);
+                    i = s.indexOf(",");
+                    if (i >= 0) {
+                        s = s.substring(i + 1);
+                    }
+                }
+            } else { // matrix delimiter
+                if (i >= 0) {
+                    e = s.substring(0, i);
+                    if (e.trim().length() > 0) {
+                        throw new RuntimeException("Error e not empty " + e);
+                    }
+                    //s = s.substring(i + 1);
+                }
+                break;
+            }
+        } while (i >= 0);
+        return new GenMatrix<C>(this, mat);
+    }
+
+
+    /**
+     * Parse a matrix from a Reader.
+     * @param r Reader.
+     * @return parsed matrix
+     */
+    public GenMatrix<C> parse(Reader r) {
+        String s = StringUtil.nextPairedString(r, '[', ']');
+        return parse(s);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/vector/GenVector.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/vector/GenVector.java
@@ -1,0 +1,480 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.vector;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.kern.PrettyPrint;
+import edu.jas.structure.ModulElem;
+import edu.jas.structure.RingElem;
+
+
+/**
+ * GenVector implements generic vectors with RingElem entries. Vectors of n
+ * columns over C.
+ * @author Heinz Kredel
+ */
+
+public class GenVector<C extends RingElem<C>> implements ModulElem<GenVector<C>, C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GenVector.class);
+
+
+    public final GenVectorModul<C> modul;
+
+
+    public final List<C> val;
+
+
+    /**
+     * Constructor for zero GenVector.
+     */
+    public GenVector(GenVectorModul<C> m) {
+        this(m, m.getZERO().val);
+    }
+
+
+    /**
+     * Constructor for GenVector.
+     */
+    public GenVector(GenVectorModul<C> m, List<C> v) {
+        if (m == null || v == null) {
+            throw new IllegalArgumentException("Empty m or v not allowed, m = " + m + ", v = " + v);
+        }
+        modul = m;
+        val = v;
+        logger.debug(modul.cols + " vector constructed");
+    }
+
+
+    /**
+     * Constructor for GenVector.
+     */
+    public GenVector(GenVectorModul<C> m, C[] v) {
+        if (m == null || v == null) {
+            throw new IllegalArgumentException("Empty m or v not allowed, m = " + m + ", v = " + v);
+        }
+        modul = m;
+        val = new ArrayList<C>(v.length);
+        for (int i = 0; i < v.length; i++) {
+            val.add(v[i]);
+        }
+        logger.debug(modul.cols + " vector constructed");
+    }
+
+
+    /**
+     * Get the String representation as RingElem.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer s = new StringBuffer();
+        s.append("[ ");
+        boolean first = true;
+        for (C c : val) {
+            if (first) {
+                first = false;
+            } else {
+                s.append(", ");
+            }
+            s.append(c.toString());
+        }
+        s.append(" ]");
+        if (!PrettyPrint.isTrue()) {
+            s.append(" :: " + modul.toString());
+            s.append("\n");
+        }
+        return s.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this Element.
+     * @see edu.jas.structure.Element#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        StringBuffer s = new StringBuffer();
+        s.append("( ");
+        boolean first = true;
+        for (C c : val) {
+            if (first) {
+                first = false;
+            } else {
+                s.append(", ");
+            }
+            s.append(c.toScript());
+        }
+        s.append(" )");
+        return s.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation of the factory.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.Element#toScriptFactory()
+     */
+    @Override
+    public String toScriptFactory() {
+        // Python case
+        return factory().toScript();
+    }
+
+
+    /**
+     * Get the corresponding element factory.
+     * @return factory for this Element.
+     * @see edu.jas.structure.Element#factory()
+     */
+    public GenVectorModul<C> factory() {
+        return modul;
+    }
+
+
+    /**
+     * clone method.
+     * @see java.lang.Object#clone()
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public GenVector<C> copy() {
+        //return modul.copy(this);
+        ArrayList<C> av = new ArrayList<C>(val);
+        return new GenVector<C>(modul, av);
+    }
+
+
+    /**
+     * test if this is equal to a zero vector.
+     */
+    public boolean isZERO() {
+        return (0 == this.compareTo(modul.getZERO()));
+    }
+
+
+    /**
+     * equals method.
+     */
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof GenVector)) {
+            return false;
+        }
+        GenVector ovec = (GenVector) other;
+        if (!modul.equals(ovec.modul)) {
+            return false;
+        }
+        if (!val.equals(ovec.val)) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Hash code for this GenVector.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        return 37 * val.hashCode() + modul.hashCode();
+    }
+
+
+    /**
+     * compareTo, lexicographical comparison.
+     * @param b other
+     * @return 1 if (this &lt; b), 0 if (this == b) or -1 if (this &gt; b).
+     */
+    @Override
+    public int compareTo(GenVector<C> b) {
+        if (!modul.equals(b.modul)) {
+            return -1;
+        }
+        List<C> oval = b.val;
+        int i = 0;
+        for (C c : val) {
+            int s = c.compareTo(oval.get(i++));
+            if (s != 0) {
+                return s;
+            }
+        }
+        return 0;
+    }
+
+
+    /**
+     * get element.
+     * @param i index
+     * @return e with e = this(i).
+     */
+    public C get(int i) {
+        return val.get(i);
+    }
+
+
+    /**
+     * set element, mutate this.
+     * @param i index
+     * @param e value
+     * @return this with this(i) = e.
+     */
+    public C setMutate(int i, C e) {
+        return val.set(i, e);
+    }
+
+
+    /**
+     * sign of vector.
+     * @return 1 if (this &lt; 0), 0 if (this == 0) or -1 if (this &gt; 0).
+     */
+    public int signum() {
+        return compareTo(modul.getZERO());
+    }
+
+
+    /**
+     * Sum of vectors.
+     * @param b other vector.
+     * @return this+b
+     */
+    public GenVector<C> sum(GenVector<C> b) {
+        List<C> oval = b.val;
+        ArrayList<C> a = new ArrayList<C>(modul.cols);
+        int i = 0;
+        for (C c : val) {
+            C e = c.sum(oval.get(i++));
+            a.add(e);
+        }
+        return new GenVector<C>(modul, a);
+    }
+
+
+    /**
+     * Difference of vectors.
+     * @param b other vector.
+     * @return this-b
+     */
+    public GenVector<C> subtract(GenVector<C> b) {
+        List<C> oval = b.val;
+        ArrayList<C> a = new ArrayList<C>(modul.cols);
+        int i = 0;
+        for (C c : val) {
+            C e = c.subtract(oval.get(i++));
+            a.add(e);
+        }
+        return new GenVector<C>(modul, a);
+    }
+
+
+    /**
+     * Negative of this vector.
+     * @return -this
+     */
+    public GenVector<C> negate() {
+        ArrayList<C> a = new ArrayList<C>(modul.cols);
+        for (C c : val) {
+            C e = c.negate();
+            a.add(e);
+        }
+        return new GenVector<C>(modul, a);
+    }
+
+
+    /**
+     * Absolute value of this vector.
+     * @return abs(this)
+     */
+    public GenVector<C> abs() {
+        if (signum() < 0) {
+            return negate();
+        }
+        return this;
+    }
+
+
+    /**
+     * Product of this vector with scalar.
+     * @param s scalar.
+     * @return this*s
+     */
+    public GenVector<C> multiply(C s) {
+        return scalarMultiply(s);
+    }
+
+
+    /**
+     * Product of this vector with scalar.
+     * @param s scalar.
+     * @return this*s
+     */
+    public GenVector<C> scalarMultiply(C s) {
+        ArrayList<C> a = new ArrayList<C>(modul.cols);
+        for (C c : val) {
+            C e = c.multiply(s);
+            a.add(e);
+        }
+        return new GenVector<C>(modul, a);
+    }
+
+
+    /**
+     * Left product of this vector with scalar.
+     * @param s scalar.
+     * @return s*this
+     */
+    public GenVector<C> leftScalarMultiply(C s) {
+        ArrayList<C> a = new ArrayList<C>(modul.cols);
+        for (C c : val) {
+            C e = s.multiply(c);
+            a.add(e);
+        }
+        return new GenVector<C>(modul, a);
+    }
+
+
+    /**
+     * Linear combination of this vector with scalar multiple of other vector.
+     * @param s scalar.
+     * @param b other vector.
+     * @param t scalar.
+     * @return this*s+b*t
+     */
+    public GenVector<C> linearCombination(C s, GenVector<C> b, C t) {
+        List<C> oval = b.val;
+        ArrayList<C> a = new ArrayList<C>(modul.cols);
+        int i = 0;
+        for (C c : val) {
+            C c1 = c.multiply(s);
+            C c2 = oval.get(i++).multiply(t);
+            C e = c1.sum(c2);
+            a.add(e);
+        }
+        return new GenVector<C>(modul, a);
+    }
+
+
+    /**
+     * Linear combination of this vector with scalar multiple of other vector.
+     * @param b other vector.
+     * @param t scalar.
+     * @return this+b*t
+     */
+    public GenVector<C> linearCombination(GenVector<C> b, C t) {
+        List<C> oval = b.val;
+        ArrayList<C> a = new ArrayList<C>(modul.cols);
+        int i = 0;
+        for (C c : val) {
+            C c2 = oval.get(i++).multiply(t);
+            C e = c.sum(c2);
+            a.add(e);
+        }
+        return new GenVector<C>(modul, a);
+    }
+
+
+    /**
+     * Left linear combination of this vector with scalar multiple of other
+     * vector.
+     * @param b other vector.
+     * @param t scalar.
+     * @return this+t*b
+     */
+    public GenVector<C> linearCombination(C t, GenVector<C> b) {
+        List<C> oval = b.val;
+        ArrayList<C> a = new ArrayList<C>(modul.cols);
+        int i = 0;
+        for (C c : val) {
+            C c2 = t.multiply(oval.get(i++));
+            C e = c.sum(c2);
+            a.add(e);
+        }
+        return new GenVector<C>(modul, a);
+    }
+
+
+    /**
+     * left linear combination of this vector with scalar multiple of other
+     * vector.
+     * @param s scalar.
+     * @param b other vector.
+     * @param t scalar.
+     * @return s*this+t*b
+     */
+    public GenVector<C> leftLinearCombination(C s, C t, GenVector<C> b) {
+        List<C> oval = b.val;
+        ArrayList<C> a = new ArrayList<C>(modul.cols);
+        int i = 0;
+        for (C c : val) {
+            C c1 = s.multiply(c);
+            C c2 = t.multiply(oval.get(i++));
+            C e = c1.sum(c2);
+            a.add(e);
+        }
+        return new GenVector<C>(modul, a);
+    }
+
+
+    /**
+     * scalar / dot product of this vector with other vector.
+     * @param b other vector.
+     * @return this . b
+     */
+    public C scalarProduct(GenVector<C> b) {
+        C a = modul.coFac.getZERO();
+        List<C> oval = b.val;
+        int i = 0;
+        for (C c : val) {
+            C c2 = c.multiply(oval.get(i++));
+            a = a.sum(c2);
+        }
+        return a;
+    }
+
+
+    /**
+     * scalar / dot product of this vector with list of other vectors.
+     * @param B list of vectors.
+     * @return this * b
+     */
+    public GenVector<C> scalarProduct(List<GenVector<C>> B) {
+        GenVector<C> A = modul.getZERO();
+        int i = 0;
+        for (C c : val) {
+            GenVector<C> b = B.get(i++);
+            GenVector<C> a = b.leftScalarMultiply(c);
+            A = A.sum(a);
+        }
+        return A;
+    }
+
+
+    /**
+     * right scalar / dot product of this vector with list of other vectors.
+     * @param B list of vectors.
+     * @return b * this
+     */
+    public GenVector<C> rightScalarProduct(List<GenVector<C>> B) {
+        GenVector<C> A = modul.getZERO();
+        int i = 0;
+        for (C c : val) {
+            GenVector<C> b = B.get(i++);
+            GenVector<C> a = b.scalarMultiply(c);
+            A = A.sum(a);
+        }
+        return A;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/vector/GenVectorModul.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/vector/GenVectorModul.java
@@ -1,0 +1,331 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.vector;
+
+
+import java.io.Reader;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.kern.StringUtil;
+import edu.jas.structure.ModulFactory;
+import edu.jas.structure.RingElem;
+import edu.jas.structure.RingFactory;
+
+
+/**
+ * GenVectorModul implements a generic vector factory with RingElem entries.
+ * Vectors of n columns over C.
+ * @author Heinz Kredel
+ */
+
+public class GenVectorModul<C extends RingElem<C>> implements ModulFactory<GenVector<C>, C> {
+
+
+    private static final Logger logger = LogManager.getLogger(GenVectorModul.class);
+
+
+    public final RingFactory<C> coFac;
+
+
+    public final int cols;
+
+
+    public final GenVector<C> ZERO;
+
+
+    public final List<GenVector<C>> BASIS;
+
+
+    private final static Random random = new Random();
+
+
+    public final static float DEFAULT_DENSITY = 0.5f;
+
+
+    private final float density = DEFAULT_DENSITY;
+
+
+    /**
+     * Constructor for GenVectorModul.
+     */
+    @SuppressWarnings("unchecked")
+    public GenVectorModul(RingFactory<C> b, int s) {
+        coFac = b;
+        cols = s;
+        ArrayList<C> z = new ArrayList<C>(cols);
+        for (int i = 0; i < cols; i++) {
+            z.add(coFac.getZERO());
+        }
+        ZERO = new GenVector<C>(this, z);
+        BASIS = new ArrayList<GenVector<C>>(cols);
+        List<C> cgens = coFac.generators();
+        ArrayList<C> v;
+        for (int i = 0; i < cols; i++) {
+            for (C g : cgens) {
+                v = new ArrayList<C>(z);// z.clone();
+                v.set(i, g);
+                BASIS.add(new GenVector<C>(this, v));
+            }
+        }
+        logger.info(cols + " module over " + coFac + "constructed");
+    }
+
+
+    /**
+     * Get the String representation as RingElem.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuffer s = new StringBuffer();
+        s.append(coFac.getClass().getSimpleName());
+        s.append("[" + cols + "]");
+        return s.toString();
+    }
+
+
+    /**
+     * Get a scripting compatible string representation.
+     * @return script compatible representation for this ElemFactory.
+     * @see edu.jas.structure.ElemFactory#toScript()
+     */
+    @Override
+    public String toScript() {
+        // Python case
+        StringBuffer s = new StringBuffer("Vec(");
+        String f = null;
+        try {
+            f = ((RingElem<C>) coFac).toScriptFactory(); // sic
+        } catch (Exception e) {
+            f = coFac.toScript();
+        }
+        s.append(f + "," + cols + " )");
+        return s.toString();
+    }
+
+
+    /**
+     * getZERO.
+     * @return ZERO.
+     */
+    public GenVector<C> getZERO() {
+        return ZERO;
+    }
+
+
+    /**
+     * Get a list of the generating elements.
+     * @return list of generators for the algebraic structure.
+     * @see edu.jas.structure.ElemFactory#generators()
+     */
+    public List<GenVector<C>> generators() {
+        return BASIS;
+    }
+
+
+    /**
+     * Is this structure finite or infinite.
+     * @return true if this structure is finite, else false.
+     * @see edu.jas.structure.ElemFactory#isFinite()
+     */
+    public boolean isFinite() {
+        return coFac.isFinite();
+    }
+
+
+    /**
+     * Comparison with any other object.
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean equals(Object other) {
+        if (!(other instanceof GenVectorModul)) {
+            return false;
+        }
+        GenVectorModul omod = (GenVectorModul) other;
+        if (cols != omod.cols) {
+            return false;
+        }
+        if (!coFac.equals(omod.coFac)) {
+            return false;
+        }
+        return true;
+    }
+
+
+    /**
+     * Hash code for this vector module.
+     * @see java.lang.Object#hashCode()
+     */
+    @Override
+    public int hashCode() {
+        int h;
+        h = cols;
+        h = 37 * h + coFac.hashCode();
+        return h;
+    }
+
+
+    /**
+     * Get the vector for a.
+     * @param a long
+     * @return vector corresponding to a.
+     */
+    public GenVector<C> fromInteger(long a) {
+        C c = coFac.fromInteger(a);
+        return BASIS.get(0).scalarMultiply(c);
+    }
+
+
+    /**
+     * Get the vector for a.
+     * @param a long
+     * @return vector corresponding to a.
+     */
+    public GenVector<C> fromInteger(BigInteger a) {
+        C c = coFac.fromInteger(a);
+        return BASIS.get(0).scalarMultiply(c);
+    }
+
+
+    /**
+     * From List of coefficients.
+     * @param v list of coefficients.
+     * @return vector from v.
+     */
+    public GenVector<C> fromList(List<C> v) {
+        if (v == null) {
+            return ZERO;
+        }
+        if (v.size() > cols) {
+            throw new IllegalArgumentException("size v > cols " + v + " > " + cols);
+        }
+        List<C> r = new ArrayList<C>(cols);
+        r.addAll(v);
+        // pad with zeros if required:
+        for (int i = r.size(); i < cols; i++) {
+            r.add(coFac.getZERO());
+        }
+        return new GenVector<C>(this, r);
+    }
+
+
+    /**
+     * Random vector.
+     * @param k size of random coefficients.
+     * @return random vector.
+     */
+    public GenVector<C> random(int k) {
+        return random(k, density, random);
+    }
+
+
+    /**
+     * Random vector.
+     * @param k size of random coefficients.
+     * @param q density of nonzero coefficients.
+     * @return random vector.
+     */
+    public GenVector<C> random(int k, float q) {
+        return random(k, q, random);
+    }
+
+
+    /**
+     * Random vector.
+     * @param k size of random coefficients.
+     * @param random is a source for random bits.
+     * @return a random element.
+     */
+    public GenVector<C> random(int k, Random random) {
+        return random(k, density, random);
+    }
+
+
+    /**
+     * Random vector.
+     * @param k size of random coefficients.
+     * @param q density of nonzero coefficients.
+     * @param random is a source for random bits.
+     * @return a random element.
+     */
+    public GenVector<C> random(int k, float q, Random random) {
+        List<C> r = new ArrayList<C>(cols);
+        for (int i = 0; i < cols; i++) {
+            if (random.nextFloat() < q) {
+                r.add(coFac.random(k));
+            } else {
+                r.add(coFac.getZERO());
+            }
+        }
+        return new GenVector<C>(this, r);
+    }
+
+
+    /**
+     * copy vector.
+     * @param c vector.
+     * @return copy of vector c.
+     */
+    public GenVector<C> copy(GenVector<C> c) {
+        if (c == null) {
+            return c;
+        }
+        return c.copy();
+    }
+
+
+    /**
+     * Parse a vector from a String. Syntax: [ c, ..., c ]
+     * @param s String with vector.
+     * @return parsed vector.
+     */
+    public GenVector<C> parse(String s) {
+        int i = s.indexOf("[");
+        if (i >= 0) {
+            s = s.substring(i + 1);
+        }
+        i = s.indexOf("]");
+        if (i >= 0) {
+            s = s.substring(0, i);
+        }
+        List<C> vec = new ArrayList<C>(cols);
+        String e;
+        C c;
+        do {
+            i = s.indexOf(",");
+            if (i >= 0) {
+                e = s.substring(0, i);
+                s = s.substring(i + 1);
+                c = coFac.parse(e);
+                vec.add(c);
+            }
+        } while (i >= 0);
+        if (s.trim().length() > 0) {
+            c = coFac.parse(s);
+            vec.add(c);
+        }
+        return new GenVector<C>(this, vec);
+    }
+
+
+    /**
+     * Parse a vector from a Reader.
+     * @param r Reader containing a vector.
+     * @return parsed vector.
+     */
+    public GenVector<C> parse(Reader r) {
+        String s = StringUtil.nextPairedString(r, '[', ']');
+        return parse(s);
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/vector/LinAlg.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/vector/LinAlg.java
@@ -1,0 +1,558 @@
+/*
+ * $Id$
+ */
+
+package edu.jas.vector;
+
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import edu.jas.structure.RingElem;
+
+
+/**
+ * Linear algebra methods. Implements linear algebra computations and tests,
+ * mainly based on Gauss elimination. Partly based on <a href=
+ * "https://en.wikipedia.org/wiki/LU_decomposition">LU_decomposition</a>.
+ * Computation of Null space basis, row echelon form, inverses and ranks.
+ * @param <C> coefficient type
+ * @author Heinz Kredel
+ */
+
+public class LinAlg<C extends RingElem<C>> implements Serializable {
+
+
+    private static final Logger logger = LogManager.getLogger(LinAlg.class);
+
+
+    //private static final boolean debug = logger.isDebugEnabled();
+
+
+    /**
+     * Constructor.
+     */
+    public LinAlg() {
+    }
+
+
+    /**
+     * Matrix LU decomposition. Matrix A is replaced by its LU decomposition. A
+     * contains a copy of both matrices L-E and U as A=(L-E)+U such that
+     * P*A=L*U. The permutation matrix is not stored as a matrix, but in an
+     * integer vector P of size N+1 containing column indexes where the
+     * permutation matrix has "1". The last element P[N]=S+N, where S is the
+     * number of row exchanges needed for determinant computation, det(P)=(-1)^S
+     * @param A a n&times;n matrix.
+     * @return permutation vector P and modified matrix A.
+     */
+    public List<Integer> decompositionLU(GenMatrix<C> A) {
+        if (A == null) {
+            return null;
+        }
+        GenMatrixRing<C> ring = A.ring;
+        int N = ring.rows;
+        if (N != ring.cols) {
+            logger.warn("nosquare matrix");
+        }
+        int i, imax;
+        C maxA, absA;
+        List<Integer> P = new ArrayList<Integer>(N + 1);
+        for (i = 0; i <= N; i++) {
+            P.add(i); //Unit permutation matrix, P[N] initialized with N
+        }
+        ArrayList<ArrayList<C>> mat = A.matrix;
+        for (i = 0; i < N; i++) {
+            imax = i;
+            maxA = ring.coFac.getZERO();
+            for (int k = i; k < N; k++) {
+                // absA = fabs(A[k][i])
+                absA = mat.get(k).get(i).abs();
+                if (absA.compareTo(maxA) > 0) {
+                    maxA = absA;
+                    imax = k;
+                }
+            }
+            if (maxA.isZERO()) {
+                logger.warn("matrix is degenerate at col " + i);
+                mat.get(i).set(i, ring.coFac.getZERO());
+                //continue;
+                P.clear();
+                return P; //failure, matrix is degenerate
+            }
+            if (imax != i) {
+                //pivoting P
+                int j = P.get(i);
+                P.set(i, P.get(imax));
+                P.set(imax, j);
+                //System.out.println("new pivot " + imax); // + ", P = " + P);
+                //pivoting rows of A
+                ArrayList<C> ptr = mat.get(i);
+                mat.set(i, mat.get(imax));
+                mat.set(imax, ptr);
+                //counting pivots starting from N (for determinant)
+                P.set(N, P.get(N) + 1);
+            }
+            C dd = mat.get(i).get(i).inverse();
+            for (int j = i + 1; j < N; j++) {
+                // A[j][i] /= A[i][i];
+                C d = mat.get(j).get(i).multiply(dd); //divide(dd);
+                mat.get(j).set(i, d);
+                for (int k = i + 1; k < N; k++) {
+                    // A[j][k] -= A[j][i] * A[i][k];
+                    C a = mat.get(j).get(i).multiply(mat.get(i).get(k));
+                    mat.get(j).set(k, mat.get(j).get(k).subtract(a));
+                }
+            }
+        }
+        return P;
+    }
+
+
+    /**
+     * Solve with LU decomposition.
+     * @param A a n&times;n matrix in LU decomposition.
+     * @param P permutation vector.
+     * @param b right hand side vector.
+     * @return x solution vector of A*x = b.
+     */
+    public GenVector<C> solveLU(GenMatrix<C> A, List<Integer> P, GenVector<C> b) {
+        if (A == null || b == null) {
+            return null;
+        }
+        if (P.size() == 0) {
+            return null;
+        }
+        GenMatrixRing<C> ring = A.ring;
+        int N = ring.rows;
+        GenVectorModul<C> xfac = new GenVectorModul<C>(ring.coFac, N);
+        GenVector<C> x = new GenVector<C>(xfac);
+        List<C> vec = x.val;
+        ArrayList<ArrayList<C>> mat = A.matrix;
+        for (int i = 0; i < N; i++) {
+            //x[i] = b[P[i]];
+            vec.set(i, b.get(P.get(i)));
+            C xi = vec.get(i);
+            for (int k = 0; k < i; k++) {
+                //x[i] -= A[i][k] * x[k];
+                C ax = mat.get(i).get(k).multiply(vec.get(k));
+                xi = xi.subtract(ax);
+            }
+            vec.set(i, xi);
+        }
+        //System.out.println("vec = " + vec);
+        for (int i = N - 1; i >= 0; i--) {
+            C xi = vec.get(i);
+            for (int k = i + 1; k < N; k++) {
+                //x[i] -= A[i][k] * x[k];
+                C ax = mat.get(i).get(k).multiply(vec.get(k));
+                xi = xi.subtract(ax);
+            }
+            vec.set(i, xi);
+            //x[i] /= A[i][i];
+            vec.set(i, xi.divide(mat.get(i).get(i)));
+        }
+        return x;
+    }
+
+
+    /**
+     * Solve linear system of equations.
+     * @param A a n&times;n matrix.
+     * @param b right hand side vector.
+     * @return x solution vector of A*x = b.
+     */
+    public GenVector<C> solve(GenMatrix<C> A, GenVector<C> b) {
+        if (A == null || b == null) {
+            return null;
+        }
+        GenMatrix<C> Ap = A.copy();
+        List<Integer> P = decompositionLU(Ap);
+        if (P.size() == 0) {
+            System.out.println("undecomposable");
+            return b.modul.getZERO();
+        }
+        GenVector<C> x = solveLU(Ap, P, b);
+        return x;
+    }
+
+
+    /**
+     * Determinant with LU decomposition.
+     * @param A a n&times;n matrix in LU decomposition.
+     * @param P permutation vector.
+     * @return d determinant of A.
+     */
+    public C determinantLU(GenMatrix<C> A, List<Integer> P) {
+        if (A == null) {
+            return null;
+        }
+        if (P.size() == 0) {
+            return A.ring.coFac.getZERO();
+        }
+        int N = A.ring.rows; //P.size() - 1 - 1;
+        ArrayList<ArrayList<C>> mat = A.matrix;
+        // det = A[0][0];
+        C det = mat.get(0).get(0);
+        for (int i = 1; i < N; i++) {
+            //det *= A[i][i];
+            det = det.multiply(mat.get(i).get(i));
+        }
+        //return (P[N] - N) % 2 == 0 ? det : -det
+        int s = P.get(N) - N;
+        if (s % 2 != 0) {
+            det = det.negate();
+        }
+        return det;
+    }
+
+
+    /**
+     * Inverse with LU decomposition.
+     * @param A a n&times;n matrix in LU decomposition.
+     * @param P permutation vector.
+     * @return inv(A) with A * inv(A) == 1.
+     */
+    public GenMatrix<C> inverseLU(GenMatrix<C> A, List<Integer> P) {
+        GenMatrixRing<C> ring = A.ring;
+        GenMatrix<C> inv = new GenMatrix<C>(ring);
+        int N = ring.rows; //P.size() - 1 - 1;
+        ArrayList<ArrayList<C>> mat = A.matrix;
+        ArrayList<ArrayList<C>> imat = inv.matrix;
+        for (int j = 0; j < N; j++) {
+            // transform right hand vector with L matrix
+            for (int i = 0; i < N; i++) {
+                //IA[i][j] = P[i] == j ? 1.0 : 0.0;
+                C e = (P.get(i) == j) ? ring.coFac.getONE() : ring.coFac.getZERO();
+                imat.get(i).set(j, e);
+                C b = e; //imat.get(i).get(j);
+                for (int k = 0; k < i; k++) {
+                    //IA[i][j] -= A[i][k] * IA[k][j];
+                    C a = mat.get(i).get(k).multiply(imat.get(k).get(j));
+                    b = b.subtract(a);
+                }
+                imat.get(i).set(j, b);
+            }
+            // solve inverse matrix column with U matrix
+            for (int i = N - 1; i >= 0; i--) {
+                C b = imat.get(i).get(j);
+                for (int k = i + 1; k < N; k++) {
+                    //IA[i][j] -= A[i][k] * IA[k][j];
+                    C a = mat.get(i).get(k).multiply(imat.get(k).get(j));
+                    b = b.subtract(a);
+                }
+                imat.get(i).set(j, b);
+                //IA[i][j] /= A[i][i];
+                C e = b; //imat.get(i).get(j);
+                e = e.divide(mat.get(i).get(i));
+                imat.get(i).set(j, e);
+            }
+        }
+        return inv;
+    }
+
+
+    /**
+     * Matrix Null Space basis, cokernel. From the transpose matrix At it
+     * computes the kernel with At*v_i = 0.
+     * @param A a n&times;n matrix.
+     * @return V a list of basis vectors (v_1, ..., v_k) with v_i*A == 0.
+     */
+    public List<GenVector<C>> nullSpaceBasis(GenMatrix<C> A) {
+        if (A == null) {
+            return null;
+        }
+        GenMatrixRing<C> ring = A.ring;
+        int N = ring.rows;
+        int M = ring.cols;
+        if (N != M) {
+            logger.warn("nosquare matrix");
+        }
+        List<GenVector<C>> nspb = new ArrayList<GenVector<C>>();
+        GenVectorModul<C> vfac = new GenVectorModul<C>(ring.coFac, M);
+        ArrayList<ArrayList<C>> mat = A.matrix;
+        for (int i = 0; i < N; i++) {
+            C maxA, absA;
+            // search privot imax
+            int imax = i;
+            maxA = ring.coFac.getZERO();
+            for (int k = i; k < M; k++) { // k = 0 ?
+                // absA = fabs(A[k][i])
+                absA = mat.get(i).get(k).abs();
+                if (absA.compareTo(maxA) > 0 && maxA.isZERO()) {
+                    maxA = absA;
+                    imax = k;
+                }
+            }
+            logger.info("pivot: " + imax + ", i = " + i + ", maxA = " + maxA);
+            if (maxA.isZERO()) {
+                // check for complete zero row or left pivot
+                int imaxl = i;
+                for (int k = 0; k < i; k++) { // k = 0 ?
+                    // absA = fabs(A[k][i])
+                    absA = mat.get(i).get(k).abs();
+                    if (absA.compareTo(maxA) > 0) { // first or last imax: && maxA.isZERO()
+                        imaxl = k;
+                        // check if upper triangular column is zero
+                        boolean iszero = true;
+                        for (int m = 0; m < i; m++) {
+                            C amm = mat.get(m).get(imaxl).abs();
+                            if (!amm.isZERO()) {
+                                iszero = false;
+                                break;
+                            }
+                        }
+                        if (iszero) { // left pivot okay
+                            imax = imaxl;
+                            logger.info("pivot*: " + imax + ", i = " + i + ", absA = " + absA);
+                            maxA = ring.coFac.getONE();
+                        }
+                    }
+                }
+                if (maxA.isZERO()) { // complete zero row
+                    continue;
+                }
+            }
+            if (imax < M) { //!= i
+                //normalize column i
+                C mp = mat.get(i).get(imax).inverse();
+                for (int k = 0; k < N; k++) { // k = i ?
+                    C b = mat.get(k).get(imax);
+                    b = b.multiply(mp);
+                    mat.get(k).set(imax, b);
+                }
+                //pivoting columns of A
+                if (imax != i) {
+                    for (int k = 0; k < N; k++) {
+                        C b = mat.get(k).get(i);
+                        mat.get(k).set(i, mat.get(k).get(imax));
+                        mat.get(k).set(imax, b);
+                    }
+                }
+                //eliminate rest of row i via column operations
+                for (int j = 0; j < M; j++) {
+                    if (i == j) { // is already normalized
+                        continue;
+                    }
+                    C mm = mat.get(i).get(j);
+                    for (int k = 0; k < N; k++) { // or k = 0
+                        C b = mat.get(k).get(j);
+                        C c = mat.get(k).get(i);
+                        C d = b.subtract(c.multiply(mm));
+                        mat.get(k).set(j, d);
+                    }
+                }
+            }
+        }
+        // convert to A-I
+        for (int i = 0; i < N; i++) {
+            C b = mat.get(i).get(i);
+            b = b.subtract(ring.coFac.getONE());
+            mat.get(i).set(i, b);
+        }
+        //System.out.println("mat-1 = " + A);
+        // read off non zero rows of A
+        for (int i = 0; i < N; i++) {
+            List<C> row = mat.get(i);
+            boolean iszero = true;
+            for (int k = 0; k < M; k++) {
+                if (!row.get(k).isZERO()) {
+                    iszero = false;
+                    break;
+                }
+            }
+            if (!iszero) {
+                GenVector<C> v = new GenVector<C>(vfac, row);
+                nspb.add(v);
+            }
+        }
+        return nspb;
+    }
+
+
+    /**
+     * Rank via null space.
+     * @param A a n&times;n matrix.
+     * @return r rank of A.
+     */
+    public long rankNS(GenMatrix<C> A) {
+        if (A == null) {
+            return -1l;
+        }
+        GenMatrix<C> Ap = A.copy();
+        long n = Math.min(A.ring.rows, A.ring.cols);
+        List<GenVector<C>> ns = nullSpaceBasis(Ap);
+        long s = ns.size();
+        return n - s;
+    }
+
+
+    /**
+     * Matrix row echelon form construction. Matrix A is replaced by its row
+     * echelon form, an upper triangle matrix.
+     * @param A a n&times;m matrix.
+     * @return A row echelon form of A, matrix A is modified.
+     */
+    public GenMatrix<C> rowEchelonForm(GenMatrix<C> A) {
+        if (A == null) {
+            return null;
+        }
+        GenMatrixRing<C> ring = A.ring;
+        int N = ring.rows;
+        int M = ring.cols;
+        if (N != M) {
+            logger.warn("nosquare matrix");
+        }
+        int i, imax, kmax;
+        C maxA, absA;
+        kmax = 0;
+        ArrayList<ArrayList<C>> mat = A.matrix;
+        for (i = 0; i < N;) {
+            imax = i;
+            maxA = ring.coFac.getZERO();
+            // search non-zero rows
+            for (int k = i; k < N; k++) {
+                // absA = fabs(A[k][i])
+                absA = mat.get(k).get(kmax).abs();
+                if (absA.compareTo(maxA) > 0) {
+                    maxA = absA;
+                    imax = k;
+                    break; // first
+                }
+            }
+            if (maxA.isZERO()) {
+                //System.out.println("matrix is zero at col " + kmax);
+                kmax++;
+                if (kmax >= M) {
+                    break;
+                }
+                continue;
+            }
+            //System.out.println("matrix is non zero at row " + imax);
+            if (imax != i) {
+                //swap pivoting rows of A
+                ArrayList<C> ptr = mat.get(i);
+                mat.set(i, mat.get(imax));
+                mat.set(imax, ptr);
+            }
+            // A[j][i] /= A[i][i];
+            C dd = mat.get(i).get(kmax).inverse();
+            for (int k = kmax; k < M; k++) {
+                C d = mat.get(i).get(k).multiply(dd); //divide(dd);
+                mat.get(i).set(k, d);
+            }
+            for (int j = i + 1; j < N; j++) {
+                for (int k = kmax; k < M; k++) {
+                    // A[j][k] -= A[j][k] * A[i][k];
+                    C a = mat.get(j).get(k).multiply(mat.get(i).get(k));
+                    if (a.isZERO()) {
+                        continue;
+                    }
+                    mat.get(j).set(k, mat.get(j).get(k).subtract(a));
+                }
+            }
+            mat.get(i).set(kmax, ring.coFac.getONE());
+            i++;
+            kmax++;
+            if (kmax >= M) {
+                break;
+            }
+        }
+        return A;
+    }
+
+
+    /**
+     * Rank via row echelon form.
+     * @param A a n&times;n matrix.
+     * @return r rank of A.
+     */
+    public long rankRE(GenMatrix<C> A) {
+        if (A == null) {
+            return -1l;
+        }
+        long n = A.ring.rows;
+        long m = A.ring.cols;
+        ArrayList<ArrayList<C>> mat = A.matrix;
+        // count non-zero rows
+        long r = 0;
+        for (int i = 0; i < n; i++) {
+            ArrayList<C> row = mat.get(i);
+            for (int j = i; j < m; j++) {
+                if (!row.get(j).isZERO()) {
+                    r++;
+                    break;
+                }
+            }
+        }
+        return r;
+    }
+
+
+    /**
+     * Matrix row echelon form construction. Matrix A is replaced by
+     * its row echelon form, an upper triangle matrix with less
+     * non-zero entries. No column swaps and transforms are performed
+     * as with the Gauss-Jordan algorithm.
+     * @param A a n&times;m matrix.
+     * @return A sparse row echelon form of A, matrix A is modified.
+     */
+    public GenMatrix<C> rowEchelonFormSparse(GenMatrix<C> A) {
+        if (A == null) {
+            return null;
+        }
+        GenMatrixRing<C> ring = A.ring;
+        int N = ring.rows;
+        int M = ring.cols;
+        if (N != M) {
+            logger.warn("nosquare matrix");
+        }
+        int i, imax, kmax;
+        C maxA, absA;
+        ArrayList<ArrayList<C>> mat = A.matrix;
+        for (i = N - 1; i > 0; i--) {
+            imax = i;
+            maxA = ring.coFac.getZERO();
+            //System.out.println("matrix row " + A.getRow(i));
+            kmax = -1;
+            // search non-zero entry in row i
+            for (int k = i; k < M; k++) {
+                // absA = fabs(A[i][k])
+                absA = mat.get(i).get(k).abs();
+                if (absA.compareTo(maxA) > 0) {
+                    //System.out.println("absA(" + i +"," + k + ") = " + absA);
+                    maxA = absA;
+                    kmax = k;
+                    break; // first
+                }
+            }
+            if (maxA.isZERO()) {
+                continue;
+            }
+            // reduce upper rows
+            for (int j = imax - 1; j >= 0; j--) {
+                for (int k = kmax; k < M; k++) {
+                    // A[j,k] -= A[j,k] * A[imax,k]
+                    C mjk = mat.get(j).get(k);
+                    if (mjk.isZERO()) {
+                        continue;
+                    }
+                    C mk = mat.get(imax).get(k);
+                    if (mk.isZERO()) {
+                        continue;
+                    }
+                    C a = mk.multiply(mjk);
+                    //System.out.println("mjk(" + j +"," + k + ") = " + mjk + ", mk = " + mk);
+                    mjk = mjk.subtract(a);
+                    mat.get(j).set(k,mjk);
+                }
+            }
+        }
+        return A;
+    }
+
+}

--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/vector/package.html
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/vector/package.html
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+    "../DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>Generic vector and matrix package</title>
+  </head>
+
+  <body>
+    <h1>Generic vector and matrix package.</h1>
+
+<p>
+  This package contains classes for generic vectors and matices over
+  <code>RingElem</code>s, namely <code>GenVector</code> and
+  <code>GenMatrix</code>.  Algorithms for vector and matrix
+  computation are contained in <code>BasicLinAlg</code> and matrix
+  decompositions in <code>LinAlg</code>.
+</p>
+
+
+    <hr />
+    <address><a href="mailto:kredel at rz.uni-mannheim.de">Heinz Kredel</a></address>
+<p>
+<!-- Created: Wed Mar  1 12:29:04 CET 2006 -->
+<!-- hhmts start -->
+Last modified: Thu Jul  8 17:24:45 CEST 2021
+<!-- hhmts end -->
+</p>
+<p>$Id$ 
+</p>
+  </body>
+</html>

--- a/symja_android_library/pom.xml
+++ b/symja_android_library/pom.xml
@@ -141,12 +141,6 @@
 			</dependency>
 
 			<dependency>
-				<groupId>de.uni-mannheim.rz.krum</groupId>
-				<artifactId>jas</artifactId>
-				<version>2.7.70</version>
-			</dependency>
-
-			<dependency>
 				<groupId>io.github.classgraph</groupId>
 				<artifactId>classgraph</artifactId>
 				<version>4.8.60</version>
@@ -229,6 +223,9 @@
 				<artifactId>poi-ooxml</artifactId>
 				<version>4.1.1</version>
 			</dependency>
+
+			<!-- <dependency> <groupId>de.uni-mannheim.rz.krum</groupId> <artifactId>jas</artifactId> 
+				<version>2.6.6025</version> </dependency> -->
 
 			<dependency>
 				<groupId>org.apfloat</groupId>


### PR DESCRIPTION
Because the JAS artifacts provided via Maven central are compile (and probably also require) Java-11 they cannot be used with Symja which only requires Java-1.8. Therefore this PR reverts the replacement of the embedded JAS sources.