### PR TITLE
Revert "#253 set docker image to openjdk:11-slim-buster"

### DIFF
--- a/symja_android_library/matheclipse-jar/pom.xml
+++ b/symja_android_library/matheclipse-jar/pom.xml
@@ -42,7 +42,7 @@
 					<version>3.1.2</version>
 					<configuration>
 						<from>
-							<image>openjdk:11-slim-buster</image>
+							<image>openjdk:8-alpine</image>
 						</from>
 						<to>
 							<image>registry.hub.docker.com/symja/symja-2.0</image>


### PR DESCRIPTION
This reverts commit 639ae843b680fe8223fa1bad893510e8bbc2eb21.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)