### PR TITLE
[Logging] use only log4j-2 Loggers and only depend on api (#254)

### DIFF
--- a/symja_android_library/matheclipse-api/pom.xml
+++ b/symja_android_library/matheclipse-api/pom.xml
@@ -57,6 +57,20 @@
 			<artifactId>encoder</artifactId>
 		</dependency>
 
+		<!-- logging dependencies -->
+
+		<dependency> <!-- provide the logging-framework implementation -->
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+
+		<dependency> <!-- bind slf4j to log4j-2-core -->
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j-impl</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+
 	</dependencies>
 
 	<repositories>

--- a/symja_android_library/matheclipse-beakerx/src/main/java/com/twosigma/beakerx/symjamma/evaluator/SymjaMMAWorkerThread.java
+++ b/symja_android_library/matheclipse-beakerx/src/main/java/com/twosigma/beakerx/symjamma/evaluator/SymjaMMAWorkerThread.java
@@ -15,17 +15,15 @@
  */
 package com.twosigma.beakerx.symjamma.evaluator;
 
+import java.util.concurrent.Callable;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import com.twosigma.beakerx.TryResult;
 import com.twosigma.beakerx.evaluator.JobDescriptor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.concurrent.Callable;
 
 class SymjaMMAWorkerThread implements Callable<TryResult> {
 
-  private static final Logger logger =
-      LoggerFactory.getLogger(SymjaMMAWorkerThread.class.getName());
+  private static final Logger logger = LogManager.getLogger(SymjaMMAWorkerThread.class.getName());
   private final JobDescriptor j;
   protected SymjaMMAEvaluator symjaEvaluator;
 

--- a/symja_android_library/matheclipse-beakerx/src/main/java/com/twosigma/beakerx/symjamma/widgets/Interactive.java
+++ b/symja_android_library/matheclipse-beakerx/src/main/java/com/twosigma/beakerx/symjamma/widgets/Interactive.java
@@ -15,17 +15,17 @@
  */
 package com.twosigma.beakerx.symjamma.widgets;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import com.twosigma.beakerx.widget.InteractiveBase;
 import com.twosigma.beakerx.widget.Label;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class Interactive extends InteractiveBase {
 
   private static Label label;
 
-  private static final Logger logger = LoggerFactory.getLogger(Interactive.class);
+  private static final Logger logger = LogManager.getLogger(Interactive.class);
 
   //  @SuppressWarnings("unchecked")
   //  public static void interact(MethodClosure function, Object... parameters) {

--- a/symja_android_library/matheclipse-core/pom.xml
+++ b/symja_android_library/matheclipse-core/pom.xml
@@ -44,22 +44,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-simple</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>log4j-over-slf4j</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>org.hipparchus</groupId>
 			<artifactId>hipparchus-clustering</artifactId>
 		</dependency>
@@ -118,6 +102,24 @@
 		<dependency>
 			<groupId>com.univocity</groupId>
 			<artifactId>univocity-parsers</artifactId>
+		</dependency>
+
+		<!-- logging dependencies -->
+
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>log4j-over-slf4j</artifactId>
 		</dependency>
 
 	</dependencies>

--- a/symja_android_library/matheclipse-core/pom.xml
+++ b/symja_android_library/matheclipse-core/pom.xml
@@ -108,18 +108,7 @@
 
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-simple</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>log4j-over-slf4j</artifactId>
+			<artifactId>log4j-api</artifactId>
 		</dependency>
 
 	</dependencies>

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/numbertheory/SortedMultiset_BottomUp.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/numbertheory/SortedMultiset_BottomUp.java
@@ -7,8 +7,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeMap;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
-import org.apache.log4j.Logger;
 
 /**
  * A sorted set of elements with multiple occurrences, sorted smallest elements first. Sorting is
@@ -23,7 +24,7 @@ public class SortedMultiset_BottomUp<T extends Comparable<T>> extends TreeMap<T,
   private static final long serialVersionUID = -6604624351619809213L;
 
   @SuppressWarnings("unused")
-  private static final Logger LOG = Logger.getLogger(SortedMultiset_BottomUp.class);
+  private static final Logger LOG = LogManager.getLogger(SortedMultiset_BottomUp.class);
 
   /**
    * Constructor for an empty multiset, sorted smallest elements first. This sort order is

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/numbertheory/SortedMultiset_TopDown.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/numbertheory/SortedMultiset_TopDown.java
@@ -1,7 +1,5 @@
 package org.matheclipse.core.numbertheory;
 
-import org.apache.log4j.Logger;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -10,6 +8,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeMap;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * A sorted set of elements with multiple occurrences, sorted biggest elements first. Sorting is due
@@ -24,7 +24,7 @@ public class SortedMultiset_TopDown<T extends Comparable<T>> extends TreeMap<T, 
   private static final long serialVersionUID = -6604624351619809213L;
 
   @SuppressWarnings("unused")
-  private static final Logger LOG = Logger.getLogger(SortedMultiset_TopDown.class);
+  private static final Logger LOG = LogManager.getLogger(SortedMultiset_TopDown.class);
 
   /**
    * Constructor for an empty multiset, sorted biggest elements first. This sort order is

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/polynomials/longexponent/ExprTermOrderByName.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/polynomials/longexponent/ExprTermOrderByName.java
@@ -10,7 +10,7 @@ package org.matheclipse.core.polynomials.longexponent;
  */
 public class ExprTermOrderByName {
 
-  // private static final Logger logger = Logger.getLogger(ExprTermOrderByName.class);
+  // private static final Logger logger = LogManager.getLogger(ExprTermOrderByName.class);
 
   /** ExprTermOrder named LEX. */
   public static final ExprTermOrder LEX = new ExprTermOrder(ExprTermOrder.LEX);

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/polynomials/symbolicexponent/SymbolicTermOrderByName.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/polynomials/symbolicexponent/SymbolicTermOrderByName.java
@@ -13,7 +13,7 @@ import org.matheclipse.core.polynomials.longexponent.ExpVectorLong;
  */
 public class SymbolicTermOrderByName {
 
-  // private static final Logger logger = Logger.getLogger(ExprTermOrderByName.class);
+  // private static final Logger logger = LogManager.getLogger(ExprTermOrderByName.class);
 
   /** ExpVectorTermOrder named LEX. */
   public static final SymbolicTermOrder LEX = new SymbolicTermOrder(SymbolicTermOrder.LEX);

--- a/symja_android_library/matheclipse-external/pom.xml
+++ b/symja_android_library/matheclipse-external/pom.xml
@@ -28,22 +28,6 @@
 	<dependencies>
 
 		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-simple</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>log4j-over-slf4j</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 		</dependency>
@@ -73,10 +57,28 @@
 			<artifactId>commons-text</artifactId>
 		</dependency>
 
-		<!-- <dependency> <groupId>edu.stanford.nlp</groupId> <artifactId>stanford-corenlp</artifactId> 
-			<version>4.0.0</version> </dependency> <dependency> <groupId>edu.stanford.nlp</groupId> 
-			<artifactId>stanford-corenlp</artifactId> <version>4.0.0</version> <classifier>models</classifier> 
+		<!-- <dependency> <groupId>edu.stanford.nlp</groupId> <artifactId>stanford-corenlp</artifactId>
+			<version>4.0.0</version> </dependency> <dependency> <groupId>edu.stanford.nlp</groupId>
+			<artifactId>stanford-corenlp</artifactId> <version>4.0.0</version> <classifier>models</classifier>
 			</dependency> -->
+
+		<!-- logging dependencies -->
+
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>log4j-over-slf4j</artifactId>
+		</dependency>
 
 	</dependencies>
 </project>

--- a/symja_android_library/matheclipse-external/pom.xml
+++ b/symja_android_library/matheclipse-external/pom.xml
@@ -66,18 +66,7 @@
 
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-simple</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>log4j-over-slf4j</artifactId>
+			<artifactId>log4j-api</artifactId>
 		</dependency>
 
 	</dependencies>

--- a/symja_android_library/matheclipse-gpl/pom.xml
+++ b/symja_android_library/matheclipse-gpl/pom.xml
@@ -32,6 +32,13 @@
 			<version>${project.version}</version>
 		</dependency>
 
+		<!-- logging dependencies -->
+
+		<dependency> <!-- bridge from log4j-1 to log4j-2 -->
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-1.2-api</artifactId>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/symja_android_library/matheclipse-io/pom.xml
+++ b/symja_android_library/matheclipse-io/pom.xml
@@ -83,6 +83,20 @@
 			<artifactId>poi-ooxml</artifactId>
 		</dependency>
 
+		<!-- logging dependencies -->
+
+		<dependency> <!-- provide the logging-framework implementation -->
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+
+		<dependency> <!-- bind slf4j to log4j-2-core -->
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j-impl</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+
 		<!-- test dependencies -->
 
 		<dependency>

--- a/symja_android_library/matheclipse-io/pom.xml
+++ b/symja_android_library/matheclipse-io/pom.xml
@@ -83,6 +83,8 @@
 			<artifactId>poi-ooxml</artifactId>
 		</dependency>
 
+		<!-- test dependencies -->
+
 		<dependency>
 			<groupId>com.tngtech.archunit</groupId>
 			<artifactId>archunit-junit4</artifactId>

--- a/symja_android_library/pom.xml
+++ b/symja_android_library/pom.xml
@@ -207,12 +207,6 @@
 			</dependency>
 
 			<dependency>
-				<groupId>org.apache.logging.log4j</groupId>
-				<artifactId>log4j-core</artifactId>
-				<version>2.13.2</version>
-			</dependency>
-
-			<dependency>
 				<groupId>org.apache.lucene</groupId>
 				<artifactId>lucene-analyzers-common</artifactId>
 				<version>8.5.1</version>
@@ -224,7 +218,7 @@
 				<version>4.1.1</version>
 			</dependency>
 
-			<!-- <dependency> <groupId>de.uni-mannheim.rz.krum</groupId> <artifactId>jas</artifactId> 
+			<!-- <dependency> <groupId>de.uni-mannheim.rz.krum</groupId> <artifactId>jas</artifactId>
 				<version>2.6.6025</version> </dependency> -->
 
 			<dependency>
@@ -249,7 +243,7 @@
 				<groupId>org.gavaghan</groupId>
 				<artifactId>geodesy</artifactId>
 				<version>1.1.3</version>
-			</dependency> 
+			</dependency>
 
 			<dependency>
 				<groupId>org.hipparchus</groupId>
@@ -305,6 +299,14 @@
 				<version>0.8.12</version>
 			</dependency>
 
+			<!-- logging dependencies -->
+
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-core</artifactId>
+				<version>2.13.2</version>
+			</dependency>
+
 			<dependency>
 				<groupId>org.slf4j</groupId>
 				<artifactId>log4j-over-slf4j</artifactId>
@@ -338,8 +340,8 @@
 
 	</dependencies>
 
-	<!-- <repositories> <repository> <id>orekit</id> <url>https://packages.orekit.org/repository/maven-public/</url> 
-		</repository> <repository> <id>sonatype</id> <url>https://oss.sonatype.org/content/groups/public/</url> 
+	<!-- <repositories> <repository> <id>orekit</id> <url>https://packages.orekit.org/repository/maven-public/</url>
+		</repository> <repository> <id>sonatype</id> <url>https://oss.sonatype.org/content/groups/public/</url>
 		</repository> </repositories> -->
 
 	<build>
@@ -429,9 +431,9 @@
 					</configuration>
 				</plugin>
 
-				<!-- <plugin> <groupId>com.google.cloud.tools</groupId> <artifactId>jib-maven-plugin</artifactId> 
-					<version>2.7.0</version> <configuration> <to> <image>servletserver</image> 
-					</to> <container> <mainClass>org.matheclipse.io.servlet.ServletServer</mainClass> 
+				<!-- <plugin> <groupId>com.google.cloud.tools</groupId> <artifactId>jib-maven-plugin</artifactId>
+					<version>2.7.0</version> <configuration> <to> <image>servletserver</image>
+					</to> <container> <mainClass>org.matheclipse.io.servlet.ServletServer</mainClass>
 					</container> </configuration> </plugin> -->
 
 			</plugins>

--- a/symja_android_library/pom.xml
+++ b/symja_android_library/pom.xml
@@ -303,20 +303,26 @@
 
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-api</artifactId>
+				<version>2.13.2</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-core</artifactId>
 				<version>2.13.2</version>
 			</dependency>
 
 			<dependency>
-				<groupId>org.slf4j</groupId>
-				<artifactId>log4j-over-slf4j</artifactId>
-				<version>1.7.32</version>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-1.2-api</artifactId>
+				<version>2.13.2</version>
 			</dependency>
 
 			<dependency>
-				<groupId>org.slf4j</groupId>
-				<artifactId>slf4j-simple</artifactId>
-				<version>1.7.32</version>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-slf4j-impl</artifactId>
+				<version>2.13.2</version>
 			</dependency>
 
 		</dependencies>


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

As discussed in #254 this PR unifies the Logger-APIs used in Symja to be only log4j-2-api and removes transitively visible dependencies from non-application Symja modules to the log4j-core logging framework implementation.

Furthermore log4j-core is now used for tests in (is a test-dependencies of) core instead of slf4j-simple.