### PR TITLE
PrintStream handling and Logger improvements

### DIFF
--- a/symja_android_library/matheclipse-beakerx/src/main/java/com/twosigma/beakerx/symjamma/evaluator/SymjaMMAWorkerThread.java
+++ b/symja_android_library/matheclipse-beakerx/src/main/java/com/twosigma/beakerx/symjamma/evaluator/SymjaMMAWorkerThread.java
@@ -23,7 +23,7 @@ import com.twosigma.beakerx.evaluator.JobDescriptor;
 
 class SymjaMMAWorkerThread implements Callable<TryResult> {
 
-  private static final Logger logger = LogManager.getLogger(SymjaMMAWorkerThread.class.getName());
+  private static final Logger LOGGER = LogManager.getLogger();
   private final JobDescriptor j;
   protected SymjaMMAEvaluator symjaEvaluator;
 
@@ -45,7 +45,7 @@ class SymjaMMAWorkerThread implements Callable<TryResult> {
               j.getExecutionOptions());
     } catch (Throwable e) {
       if (e instanceof SymjaMMANotFoundException) {
-        logger.warn(e.getLocalizedMessage());
+        LOGGER.warn(e.getLocalizedMessage());
         r = TryResult.createError(e.getLocalizedMessage());
       } else {
         e.printStackTrace();

--- a/symja_android_library/matheclipse-beakerx/src/main/java/com/twosigma/beakerx/symjamma/widgets/Interactive.java
+++ b/symja_android_library/matheclipse-beakerx/src/main/java/com/twosigma/beakerx/symjamma/widgets/Interactive.java
@@ -25,7 +25,7 @@ public class Interactive extends InteractiveBase {
 
   private static Label label;
 
-  private static final Logger logger = LogManager.getLogger(Interactive.class);
+  private static final Logger LOGGER = LogManager.getLogger();
 
   //  @SuppressWarnings("unchecked")
   //  public static void interact(MethodClosure function, Object... parameters) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/FileFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/FileFunctions.java
@@ -25,7 +25,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-
 import org.matheclipse.core.basic.Config;
 import org.matheclipse.core.convert.AST2Expr;
 import org.matheclipse.core.eval.EvalEngine;
@@ -56,7 +55,6 @@ import org.matheclipse.parser.client.Parser;
 import org.matheclipse.parser.client.SyntaxError;
 import org.matheclipse.parser.client.ast.ASTNode;
 import org.matheclipse.parser.client.ast.FunctionNode;
-
 import com.google.common.io.CharStreams;
 import com.google.common.io.Resources;
 
@@ -558,13 +556,7 @@ public class FileFunctions {
 
         if (arg1.isString()) {
           try (BufferedReader br = new BufferedReader(new FileReader(arg1.toString()))) {
-            final PrintStream s = engine.getOutPrintStream();
-            final PrintStream stream;
-            if (s == null) {
-              stream = System.out;
-            } else {
-              stream = s;
-            }
+            final PrintStream stream = engine.getOutPrintStream();
             String line;
             int numberOfLines = Integer.MAX_VALUE;
             if (ast.isAST2()) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/IOFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/IOFunctions.java
@@ -8,7 +8,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import org.apache.commons.lang3.StringUtils;
 import org.matheclipse.core.basic.Config;
 import org.matheclipse.core.convert.AST2Expr;
@@ -34,7 +33,6 @@ import org.matheclipse.core.patternmatching.RulesData;
 import org.matheclipse.parser.client.FEConfig;
 import org.matheclipse.parser.trie.SuggestTree;
 import org.matheclipse.parser.trie.SuggestTree.Node;
-
 import com.mitchellbosecke.pebble.PebbleEngine;
 import com.mitchellbosecke.pebble.cache.PebbleCache;
 import com.mitchellbosecke.pebble.node.BodyNode;
@@ -136,13 +134,7 @@ public class IOFunctions {
 
     @Override
     public IExpr evaluate(final IAST ast, EvalEngine engine) {
-      final PrintStream s = engine.getOutPrintStream();
-      final PrintStream stream;
-      if (s == null) {
-        stream = System.out;
-      } else {
-        stream = s;
-      }
+      final PrintStream stream = engine.getOutPrintStream();
       final StringBuilder buf = new StringBuilder();
       OutputFormFactory out = OutputFormFactory.get(engine.isRelaxedSyntax());
       boolean[] convert = new boolean[] {true};
@@ -251,13 +243,7 @@ public class IOFunctions {
     }
 
     private static IExpr echo(final IExpr arg1, IExpr headFirst, EvalEngine engine) {
-      final PrintStream s = engine.getOutPrintStream();
-      final PrintStream stream;
-      if (s == null) {
-        stream = System.out;
-      } else {
-        stream = s;
-      }
+      final PrintStream stream = engine.getOutPrintStream();
       final StringBuilder buf = new StringBuilder();
       OutputFormFactory out = OutputFormFactory.get(engine.isRelaxedSyntax());
       boolean[] convert = new boolean[] {true};
@@ -442,13 +428,7 @@ public class IOFunctions {
 
     @Override
     public IExpr evaluate(final IAST ast, EvalEngine engine) {
-      final PrintStream s = engine.getOutPrintStream();
-      final PrintStream stream;
-      if (s == null) {
-        stream = System.out;
-      } else {
-        stream = s;
-      }
+      final PrintStream stream = engine.getOutPrintStream();
       final StringBuilder buf = new StringBuilder();
       OutputFormFactory out = OutputFormFactory.get(engine.isRelaxedSyntax());
       boolean[] convert = new boolean[] {true};

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/PatternMatching.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/PatternMatching.java
@@ -2,14 +2,12 @@ package org.matheclipse.core.builtin;
 
 import static org.matheclipse.core.expression.F.Rule;
 import static org.matheclipse.core.expression.F.RuleDelayed;
-
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.StringWriter;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.Map;
-
 import org.matheclipse.core.basic.Config;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.exception.ConditionException;
@@ -489,11 +487,7 @@ public final class PatternMatching {
       IExpr arg1 = Validate.checkSymbolType(ast, 1, engine);
       if (arg1.isPresent()) {
         ISymbol symbol = (ISymbol) arg1;
-        PrintStream stream;
-        stream = engine.getOutPrintStream();
-        if (stream == null) {
-          stream = System.out;
-        }
+        PrintStream stream = engine.getOutPrintStream();
         try {
           String definitionString;
           if (symbol.equals(S.In)) {
@@ -960,13 +954,7 @@ public final class PatternMatching {
           } else {
             symbol = (ISymbol) ast.arg1();
           }
-          final PrintStream s = engine.getOutPrintStream();
-          final PrintStream stream;
-          if (s == null) {
-            stream = System.out;
-          } else {
-            stream = s;
-          }
+          final PrintStream stream = engine.getOutPrintStream();
 
           // Set[MessageName(f,"usage"),"text")
           IExpr temp = symbol.evalMessage("usage");

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/StructureFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/StructureFunctions.java
@@ -7,7 +7,6 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
-
 import org.matheclipse.core.basic.Config;
 import org.matheclipse.core.convert.Convert;
 import org.matheclipse.core.eval.EvalAttributes;
@@ -516,7 +515,7 @@ public class StructureFunctions {
           return engine.printMessage(ve.getMessage(ast.topHead()));
         }
       } else {
-        // Nonatomic expression expected at position `1` in `2`. 
+        // Nonatomic expression expected at position `1` in `2`.
         return IOFunctions.printMessage(ast.topHead(), "normal", F.List(F.C1, ast), engine);
       }
       return F.NIL;
@@ -1583,9 +1582,10 @@ public class StructureFunctions {
               "",
               engine.getRecursionLimit(),
               engine.getIterationLimit(),
-              engine.getOutPrintStream(),
-              engine.getErrorPrintStream(),
+              null,
+              null,
               engine.isRelaxedSyntax());
+      engine.setPrintStreamsOf(engine);
 
       EvalHistory lch = engine.getEvalHistory();
       if (lch != null) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/EvalControlledCallable.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/EvalControlledCallable.java
@@ -2,7 +2,8 @@ package org.matheclipse.core.eval;
 
 import java.io.StringWriter;
 import java.util.concurrent.Callable;
-
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.matheclipse.core.basic.Config;
 import org.matheclipse.core.builtin.IOFunctions;
 import org.matheclipse.core.eval.exception.IterationLimitExceeded;
@@ -15,6 +16,9 @@ import org.matheclipse.parser.client.SyntaxError;
 import org.matheclipse.parser.client.math.MathException;
 
 public class EvalControlledCallable implements Callable<IExpr> {
+
+  private static final Logger LOGGER = LogManager.getLogger();
+
   protected final EvalEngine fEngine;
   private IExpr fExpr;
 

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/EvalEngine.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/EvalEngine.java
@@ -1597,9 +1597,6 @@ public class EvalEngine implements Serializable {
         }
       }
       PrintStream stream = getOutPrintStream();
-      if (stream == null) {
-        stream = System.out;
-      }
       stream.println("  " + unevaledExpr.toString() + " --> " + evaledExpr.toString() + "\n");
     }
   }
@@ -2234,7 +2231,7 @@ public class EvalEngine implements Serializable {
   }
 
   public PrintStream getErrorPrintStream() {
-    return fErrorPrintStream;
+    return fErrorPrintStream != null ? fErrorPrintStream : System.err;
   }
 
   public int getIterationLimit() {
@@ -2291,7 +2288,7 @@ public class EvalEngine implements Serializable {
   }
 
   public PrintStream getOutPrintStream() {
-    return fOutPrintStream;
+    return fOutPrintStream != null ? fOutPrintStream : System.out;
   }
 
   /**
@@ -2619,9 +2616,6 @@ public class EvalEngine implements Serializable {
   public IAST printMessage(String str) throws ArgumentTypeException {
     if (!isQuietMode()) {
       PrintStream stream = getErrorPrintStream();
-      if (stream == null) {
-        stream = System.err;
-      }
       logger.warn(str);
       stream.println(str);
     }
@@ -2640,9 +2634,6 @@ public class EvalEngine implements Serializable {
     String message = exception.getMessage();
     if (!isQuietMode()) {
       PrintStream stream = getErrorPrintStream();
-      if (stream == null) {
-        stream = System.err;
-      }
       if (message != null) {
         stream.println(symbol + ": " + message);
       } else {
@@ -2826,6 +2817,11 @@ public class EvalEngine implements Serializable {
 
   public void setOutPrintStream(final PrintStream outPrintStream) {
     fOutPrintStream = outPrintStream;
+  }
+
+  public void setPrintStreamsOf(EvalEngine engine) {
+    this.fOutPrintStream = engine.fOutPrintStream;
+    this.fErrorPrintStream = engine.fErrorPrintStream;
   }
 
   public void setPackageMode(boolean packageMode) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/EvalEngine.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/EvalEngine.java
@@ -76,7 +76,7 @@ import com.google.common.cache.Cache;
  */
 public class EvalEngine implements Serializable {
 
-  private static final Logger logger = LogManager.getLogger(EvalEngine.class);
+  private static final Logger LOGGER = LogManager.getLogger();
 
   private static final IStringX EVALUATION_LOOP = StringX.valueOf("EvalLoop");
 
@@ -2616,7 +2616,7 @@ public class EvalEngine implements Serializable {
   public IAST printMessage(String str) throws ArgumentTypeException {
     if (!isQuietMode()) {
       PrintStream stream = getErrorPrintStream();
-      logger.warn(str);
+      LOGGER.warn(str);
       stream.println(str);
     }
     if (fThrowError) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/util/MagicProcessor.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/util/MagicProcessor.java
@@ -1,7 +1,7 @@
 package org.matheclipse.core.eval.util;
 
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.matheclipse.core.eval.MathUtils;
 import org.matheclipse.core.expression.S;
 import org.matheclipse.core.expression.Symbol;
@@ -10,20 +10,20 @@ import org.matheclipse.core.interfaces.IExpr;
 import org.matheclipse.core.interfaces.ISymbol;
 
 public class MagicProcessor {
-  private static final Logger Log = LogManager.getLogger(MagicProcessor.class);
+  private static final Logger LOGGER = LogManager.getLogger();
 
   String outPut = null;
   String err = null;
 
   public String magicSolve(String q, final String function) {
     outPut = q;
-    Log.debug("Input '" + outPut + "'");
+    LOGGER.debug("Input '" + outPut + "'");
     // If user gave single "=" in solve, replace it with "=="
     boolean isSysOfEq = outPut.contains("Solve");
     if (isSysOfEq) {
       String pattern = "([^=])(=)([^=])";
       outPut = outPut.replaceAll(pattern, "$1==$3");
-      Log.debug("Input has Solve so after replacing all = with == we have '" + outPut + "'");
+      LOGGER.debug("Input has Solve so after replacing all = with == we have '" + outPut + "'");
     }
 
     String processedQ = preProcessQues();
@@ -65,14 +65,14 @@ public class MagicProcessor {
 
     IExpr ques = MathUtils.parse(outPut, null);
     if (ques == null) return outPut;
-    Log.debug("ques = " + ques.toString());
+    LOGGER.debug("ques = " + ques.toString());
 
     if (wrtArgumentMising(ques, S.Solve)) {
       IExpr equations = getArg1(ques);
       String vars = solve_get_arg_if_missing(equations);
       if (vars != null && err == null) {
         outPut = ((Symbol) S.Solve).toString() + "(" + equations.toString() + "," + vars + ")";
-        Log.debug(" Result after eq processing " + outPut);
+        LOGGER.debug(" Result after eq processing " + outPut);
       }
     }
 
@@ -97,7 +97,7 @@ public class MagicProcessor {
       outPut = ((Symbol) S.Integrate).toString() + "(" + fn.toString() + "," + var + ")";
     }
 
-    Log.debug("Processed q = " + outPut);
+    LOGGER.debug("Processed q = " + outPut);
 
     return (err == null) ? outPut : err;
   }
@@ -124,7 +124,7 @@ public class MagicProcessor {
       // If equations is AST and num_equations = num variables
       if (equations.isAST() && eVar.isSize(num_equations)) {
         String vars = getVarString(eVar, false);
-        Log.debug("\t list of var = " + vars);
+        LOGGER.debug("\t list of var = " + vars);
         return vars;
       } else {
         // Number of equations and variables are different
@@ -143,7 +143,7 @@ public class MagicProcessor {
 
     ISymbol s = isSymbol(expr.head());
     if (s != null && s == fun) {
-      Log.debug(expr.toString() + "is instanceof" + fun.toString());
+      LOGGER.debug(expr.toString() + "is instanceof" + fun.toString());
       if (expr.isAST()) {
         IAST ast = (IAST) expr;
         if (ast.isAST1()) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/F.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/F.java
@@ -136,7 +136,7 @@ import edu.jas.kern.PreemptStatus;
 /** Factory for creating Symja predefined function expression objects (interface {@link IAST}). */
 public class F extends S {
 
-  private static final Logger logger = LogManager.getLogger(F.class);
+  private static final Logger LOGGER = LogManager.getLogger();
 
   /**
    * In computing, memoization or memoisation is an optimization technique used primarily to speed
@@ -4211,9 +4211,9 @@ public class F extends S {
           }
         } catch (java.security.AccessControlException acex) {
           // no read access for current user
-          logger.warn("Cannot read packages in autoload folder:", acex);
+          LOGGER.warn("Cannot read packages in autoload folder:", acex);
         } catch (RuntimeException ex) {
-          logger.error(ex);
+          LOGGER.error(ex);
         }
         // if (!noPackageLoading) {
         // Reader reader = null;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/numbertheory/SortedMultiset_BottomUp.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/numbertheory/SortedMultiset_BottomUp.java
@@ -24,7 +24,7 @@ public class SortedMultiset_BottomUp<T extends Comparable<T>> extends TreeMap<T,
   private static final long serialVersionUID = -6604624351619809213L;
 
   @SuppressWarnings("unused")
-  private static final Logger LOG = LogManager.getLogger(SortedMultiset_BottomUp.class);
+  private static final Logger LOGGER = LogManager.getLogger();
 
   /**
    * Constructor for an empty multiset, sorted smallest elements first. This sort order is

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/numbertheory/SortedMultiset_TopDown.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/numbertheory/SortedMultiset_TopDown.java
@@ -24,7 +24,7 @@ public class SortedMultiset_TopDown<T extends Comparable<T>> extends TreeMap<T, 
   private static final long serialVersionUID = -6604624351619809213L;
 
   @SuppressWarnings("unused")
-  private static final Logger LOG = LogManager.getLogger(SortedMultiset_TopDown.class);
+  private static final Logger LOGGER = LogManager.getLogger();
 
   /**
    * Constructor for an empty multiset, sorted biggest elements first. This sort order is

--- a/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/servlet/AJAXQueryServlet.java
+++ b/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/servlet/AJAXQueryServlet.java
@@ -105,7 +105,7 @@ public class AJAXQueryServlet extends HttpServlet {
 
   private static final long serialVersionUID = 6265703737413093134L;
 
-  private static final Logger logger = LogManager.getLogger(AJAXQueryServlet.class);
+  private static final Logger LOGGER = LogManager.getLogger();
 
   public static final String UTF8 = "utf-8";
 
@@ -189,7 +189,7 @@ public class AJAXQueryServlet extends HttpServlet {
     PrintStream errors = null;
     HttpSession session = request.getSession();
     try {
-      logger.warn("(" + session.getId() + ") In::" + expression);
+      LOGGER.warn("(" + session.getId() + ") In::" + expression);
       final StringWriter outWriter = new StringWriter();
       WriterOutputStream wouts = new WriterOutputStream(outWriter);
       outs = new PrintStream(wouts);

--- a/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/servlet/MMAAJAXQueryServlet.java
+++ b/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/servlet/MMAAJAXQueryServlet.java
@@ -6,13 +6,11 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
-
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
 import org.apache.logging.log4j.LogManager;
@@ -107,7 +105,7 @@ public class MMAAJAXQueryServlet extends HttpServlet {
 
   private static final long serialVersionUID = 6265703737413093134L;
 
-  private static final Logger logger = LogManager.getLogger(MMAAJAXQueryServlet.class);
+  private static final Logger LOGGER = LogManager.getLogger();
 
   public static final String UTF8 = "utf-8";
 
@@ -190,7 +188,7 @@ public class MMAAJAXQueryServlet extends HttpServlet {
     PrintStream errors = null;
     HttpSession session = request.getSession();
     try {
-      logger.warn("(" + session.getId() + ") In::" + expression);
+      LOGGER.warn("(" + session.getId() + ") In::" + expression);
       final StringWriter outWriter = new StringWriter();
       WriterOutputStream wouts = new WriterOutputStream(outWriter);
       outs = new PrintStream(wouts);
@@ -267,7 +265,7 @@ public class MMAAJAXQueryServlet extends HttpServlet {
             try {
               String html = Config.SVG_PAGE;
               StringBuilder stw = new StringBuilder();
-              GraphicsFunctions.graphicsToSVG((IAST)outExpr, stw); 
+              GraphicsFunctions.graphicsToSVG((IAST)outExpr, stw);
               html = StringUtils.replace(html, "`1`", stw.toString());
               html = StringEscapeUtils.escapeHtml4(html);
               return JSONBuilder.createJSONJavaScript(

--- a/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/io/system/archunit/CodingRulesTest.java
+++ b/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/io/system/archunit/CodingRulesTest.java
@@ -8,7 +8,7 @@ import static com.tngtech.archunit.library.GeneralCodingRules.NO_CLASSES_SHOULD_
 import static com.tngtech.archunit.library.GeneralCodingRules.NO_CLASSES_SHOULD_USE_FIELD_INJECTION;
 import static com.tngtech.archunit.library.GeneralCodingRules.NO_CLASSES_SHOULD_USE_JAVA_UTIL_LOGGING;
 import static com.tngtech.archunit.library.GeneralCodingRules.NO_CLASSES_SHOULD_USE_JODATIME;
-import java.util.logging.Logger;
+import org.apache.logging.log4j.Logger;
 import org.junit.runner.RunWith;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.junit.AnalyzeClasses;


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

- This PR unifies and simplifies how Loggers are obtained (using `LogManager.getLogger();`, which is caller sensitive and makes passing the class obsolete) and unifies the Logger names to the Java convention for static final fields.
- Checks for the right `Logger` class in the `CodingRulesTest`
- Changes `EvalEngine.getOut/ErrPrintStream()` to return `System.out/err` in case the corresponding stream is null.
This way null is never returned. This is mainly for convenience because all callers within Symja behaved like that. Only when the EvalEngine was copied on exit null was useful as return value. Therefore I added a new method `EvalEngine.setPrintStreamsOf()` that copies the references from another EvalEngine. The System.out/err stream should not be copied here, because they can change (via `System.setOut/Err()`).