### PR TITLE
[CleanUp] Remove irrelevant Algebra.DEBUG flag

### DIFF
--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/Algebra.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/Algebra.java
@@ -88,7 +88,6 @@ import edu.jas.ufd.SquarefreeAbstract;
 import edu.jas.ufd.SquarefreeFactory;
 
 public class Algebra {
-  public static boolean DEBUG = false;
 
   /**
    * See <a href="https://pangin.pro/posts/computation-in-static-initializer">Beware of computation

--- a/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/core/rubi/AbstractRubiTestCase.java
+++ b/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/core/rubi/AbstractRubiTestCase.java
@@ -3,9 +3,7 @@ package org.matheclipse.core.rubi;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.concurrent.TimeUnit;
-
 import org.matheclipse.core.basic.Config;
-import org.matheclipse.core.builtin.Algebra;
 import org.matheclipse.core.eval.EvalControlledCallable;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.ExprEvaluator;
@@ -19,7 +17,6 @@ import org.matheclipse.core.parser.ExprParser;
 import org.matheclipse.parser.client.FEConfig;
 import org.matheclipse.parser.client.SyntaxError;
 import org.matheclipse.parser.client.math.MathException;
-
 import junit.framework.TestCase;
 
 /** Tests system.reflection classes */
@@ -50,7 +47,7 @@ public abstract class AbstractRubiTestCase extends TestCase {
     }
 
     if (result.isFree(F.Integrate)) {
-      if (manuallyCheckedResult != null && !Algebra.DEBUG) {
+      if (manuallyCheckedResult != null) {
         manuallyCheckedResult = manuallyCheckedResult.trim();
         if (manuallyCheckedResult.length() > 0) {
           if (manuallyCheckedResult.equals(result.toString())) {


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description
I think the `Algebra.Debug` Flag is not relevant and can be removed. It is only used in AbstractRubiTestCase. My impression is that it is unrelated.