### PR TITLE
[CleanUp] access static members through class and not through objects

### DIFF
--- a/symja_android_library/matheclipse-api/src/test/java/org/matheclipse/api/TestPods.java
+++ b/symja_android_library/matheclipse-api/src/test/java/org/matheclipse/api/TestPods.java
@@ -143,7 +143,7 @@ public class TestPods {
   @Test
   public void testMarkdownHelp() {
     // assumeTrue(System.getProperty("os.name").contains("Windows"));
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
 
     ObjectNode messageJSON = TestPods.createJUnitResult("Sin", formatsHTML);
     final String jsonStr = toPrettyStringNormalizingNewline(messageJSON);
@@ -868,7 +868,7 @@ public class TestPods {
   @Test
   public void testPlotSin() {
     // assumeTrue(System.getProperty("os.name").contains("Windows"));
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
     ObjectNode messageJSON = TestPods.createJUnitResult("Plot(Sin(x), {x, 0, 6*Pi} )", formatsTEX);
     final String jsonStr = toPrettyStringNormalizingNewline(messageJSON);
 
@@ -907,7 +907,7 @@ public class TestPods {
   @Test
   public void testPlot002() {
     // assumeTrue(System.getProperty("os.name").contains("Windows"));
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
     ObjectNode messageJSON =
         TestPods.createJUnitResult(
             "Plot({Sin(x),Cos(x),Tan(x)},{x,-2*Pi,2*Pi}) // JSForm", formatsTEX);
@@ -947,7 +947,7 @@ public class TestPods {
   @Test
   public void testPlotF() {
     // assumeTrue(System.getProperty("os.name").contains("Windows"));
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
 
     ObjectNode messageJSON = TestPods.createJUnitResult("Plot(f(x), {x, 0, 6*Pi} )", formatsTEX);
     final String jsonStr = toPrettyStringNormalizingNewline(messageJSON);
@@ -988,7 +988,7 @@ public class TestPods {
   @Test
   public void testPlotBessel() {
     // assumeTrue(System.getProperty("os.name").contains("Windows"));
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
 
     ObjectNode messageJSON =
         TestPods.createJUnitResult(
@@ -1030,7 +1030,7 @@ public class TestPods {
   @Test
   public void testSin() {
     // assumeTrue(System.getProperty("os.name").contains("Windows"));
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
 
     ObjectNode messageJSON = TestPods.createJUnitResult("Sin(x)", formatsTEX);
     final String jsonStr = toPrettyStringNormalizingNewline(messageJSON);
@@ -1100,7 +1100,7 @@ public class TestPods {
   @Test
   public void testPolynomialQuotientRemainder() {
     // assumeTrue(System.getProperty("os.name").contains("Windows"));
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
 
     ObjectNode messageJSON = TestPods.createJUnitResult(" x**2-4,x-2", formatsTEX);
     final String jsonStr = toPrettyStringNormalizingNewline(messageJSON);
@@ -1318,7 +1318,7 @@ public class TestPods {
   @Test
   public void testList() {
     // assumeTrue(System.getProperty("os.name").contains("Windows"));
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
 
     ObjectNode messageJSON = TestPods.createJUnitResult("1,2,3", formatsMATHML);
     final String jsonStr = toPrettyStringNormalizingNewline(messageJSON);
@@ -2277,7 +2277,7 @@ public class TestPods {
   @Test
   public void testListPlot001() {
     // assumeTrue(System.getProperty("os.name").contains("Windows"));
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
     ObjectNode messageJSON = TestPods.createJUnitResult("3,Sin(1),Pi,3/4,42,1.2", formatsTEX);
     final String jsonStr = toPrettyStringNormalizingNewline(messageJSON);
 
@@ -2375,7 +2375,7 @@ public class TestPods {
   @Test
   public void testListPlot002() {
     // assumeTrue(System.getProperty("os.name").contains("Windows"));
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
 
     ObjectNode messageJSON =
         TestPods.createJUnitResult("Table({Sin(t*0.33), Cos(t*1.1)}, {t, 100})", formatsTEX);
@@ -2426,7 +2426,7 @@ public class TestPods {
   @Test
   public void testListPlot004() {
     // assumeTrue(System.getProperty("os.name").contains("Windows"));
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
     ObjectNode messageJSON =
         TestPods.createJUnitResult("1, 2, 3, None, 3, 5, f(), 2, 1, foo, 2, 3", formatsTEX);
     final String jsonStr = toPrettyStringNormalizingNewline(messageJSON);
@@ -2476,7 +2476,7 @@ public class TestPods {
   @Test
   public void testListPlot005() {
     // assumeTrue(System.getProperty("os.name").contains("Windows"));
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
 
     ObjectNode messageJSON = TestPods.createJUnitResult("1, 2, 3, 4, 5", formatsTEX);
     final String jsonStr = toPrettyStringNormalizingNewline(messageJSON);
@@ -2546,7 +2546,7 @@ public class TestPods {
   @Test
   public void testListPlot003() {
     // assumeTrue(System.getProperty("os.name").contains("Windows"));
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
     ObjectNode messageJSON = TestPods.createJUnitResult("plot ([x,x**2,x**3,x**4])", formatsTEX);
     final String jsonStr = toPrettyStringNormalizingNewline(messageJSON);
 
@@ -2659,7 +2659,7 @@ public class TestPods {
   @Test
   public void testHornerForm() {
     // assumeTrue(System.getProperty("os.name").contains("Windows"));
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
     String s = System.getProperty("os.name");
     ObjectNode messageJSON = TestPods.createJUnitResult("HornerForm(x^2+x^3+2*x^14)", formatsTEX);
     final String jsonStr = toPrettyStringNormalizingNewline(messageJSON);
@@ -2793,7 +2793,7 @@ public class TestPods {
   @Test
   public void testCoshIntegral001() {
     // assumeTrue(System.getProperty("os.name").contains("Windows"));
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
     String s = System.getProperty("os.name");
     ObjectNode messageJSON =
         TestPods.createJUnitResult( //
@@ -2845,7 +2845,7 @@ public class TestPods {
   @Test
   public void testPolynomial001() {
     // assumeTrue(System.getProperty("os.name").contains("Windows"));
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
     ObjectNode messageJSON = TestPods.createJUnitResult("-x^2 + 4*x + 4", formatsTEX);
     final String jsonStr = toPrettyStringNormalizingNewline(messageJSON);
 
@@ -2924,7 +2924,7 @@ public class TestPods {
   @Test
   public void testRound001() {
     // assumeTrue(System.getProperty("os.name").contains("Windows"));
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
     ObjectNode messageJSON = TestPods.createJUnitResult("1/0", formatsTEX);
     final String jsonStr = toPrettyStringNormalizingNewline(messageJSON);
 

--- a/symja_android_library/matheclipse-api/src/test/java/org/matheclipse/api/TestPodsStrict.java
+++ b/symja_android_library/matheclipse-api/src/test/java/org/matheclipse/api/TestPodsStrict.java
@@ -767,7 +767,7 @@ public class TestPodsStrict {
 
   @Test
   public void testPlotSin() {
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
     ObjectNode messageJSON = TestPods.createJUnitResult("Plot(Sin(x), {x, 0, 6*Pi} )", formatsTEX);
     final String jsonStr = TestPods.toPrettyStringNormalizingNewline(messageJSON);
     assertEquals(
@@ -804,7 +804,7 @@ public class TestPodsStrict {
 
   @Test
   public void testPlot002() {
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
     ObjectNode messageJSON =
         TestPods.createJUnitResult(
             "Plot({Sin(x),Cos(x),Tan(x)},{x,-2*Pi,2*Pi}) // JSForm", formatsTEX);
@@ -842,7 +842,7 @@ public class TestPodsStrict {
 
   @Test
   public void testPlotF() {
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
     ObjectNode messageJSON = TestPods.createJUnitResult("Plot(f(x), {x, 0, 6*Pi} )", formatsTEX);
     final String jsonStr = TestPods.toPrettyStringNormalizingNewline(messageJSON);
     assertEquals(
@@ -918,7 +918,7 @@ public class TestPodsStrict {
 
   @Test
   public void testPolynomialQuotientRemainder() {
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
     ObjectNode messageJSON = TestPods.createJUnitResult(" x**2-4,x-2", formatsTEX);
     final String jsonStr = TestPods.toPrettyStringNormalizingNewline(messageJSON);
     assertEquals(
@@ -1655,7 +1655,7 @@ public class TestPodsStrict {
 
   @Test
   public void testListPlot001() {
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
 
     ObjectNode messageJSON =
         Pods.createResult(
@@ -1699,7 +1699,7 @@ public class TestPodsStrict {
 
   @Test
   public void testListPlot002() {
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
 
     ObjectNode messageJSON =
         Pods.createResult(
@@ -1743,7 +1743,7 @@ public class TestPodsStrict {
 
   @Test
   public void testListPlot004() {
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
     ObjectNode messageJSON =
         Pods.createResult(
             "Histogram({1, 2, 3, None, 3, 5, f(), 2, 1, foo, 2, 3})",
@@ -1786,7 +1786,7 @@ public class TestPodsStrict {
 
   @Test
   public void testListPlot005() {
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
 
     ObjectNode messageJSON =
         Pods.createResult(
@@ -1830,7 +1830,7 @@ public class TestPodsStrict {
 
   @Test
   public void testListPlot003() {
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
     ObjectNode messageJSON =
         Pods.createResult(
             "plot({x,x^2,x^3,x^4},{x,-5,5})",

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/Algebra.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/Algebra.java
@@ -17,6 +17,7 @@ import static org.matheclipse.core.expression.S.Assumptions;
 import static org.matheclipse.core.expression.S.E;
 import static org.matheclipse.core.expression.S.I;
 import static org.matheclipse.core.expression.S.Pi;
+import static org.matheclipse.core.expression.S.Power;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -949,7 +950,7 @@ public class Algebra {
           // append a BlankNullSequence[] to match the parts of an Orderless expression into a
           // "rest" variable
           IPatternSequence blankNullRest =
-              F.$ps(F.Dummy("§rest§" + engine.incModuleCounter()), true);
+              F.$ps(F.Dummy("§rest§" + EvalEngine.incModuleCounter()), true);
           IASTAppendable newLHS = ((IAST) x).copyAppendable();
           newLHS.append(blankNullRest);
           final IPatternMatcher matcher = engine.evalPatternMatcher(newLHS);

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/BooleanFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/BooleanFunctions.java
@@ -259,10 +259,9 @@ public final class BooleanFunctions {
       if (s != null) {
         return s;
       }
-      EvalEngine engine = EvalEngine.get();
-      // long moduleCounter = engine.incModuleCounter();
+      // long moduleCounter = EvalEngine.incModuleCounter();
       // final String varAppend = "LF" + "$" + moduleCounter;
-      s = F.Dummy(engine.uniqueName("LF$"));
+      s = F.Dummy(EvalEngine.uniqueName("LF$"));
       variable2symbolMap.put(v, s);
       return s;
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/ManipulateFunction.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/ManipulateFunction.java
@@ -1119,7 +1119,7 @@ public class ManipulateFunction {
       IAST listOfFunctions = (IAST) arg1;
       String[] functionNames = new String[listOfFunctions.size() - 1];
       for (int i = 0; i < functionNames.length; i++) {
-        functionNames[i] = engine.uniqueName("$f");
+        functionNames[i] = EvalEngine.uniqueName("$f");
       }
       for (int i = 1; i < listOfFunctions.size(); i++) {
         function.append("function ");
@@ -1195,7 +1195,7 @@ public class ManipulateFunction {
 
       String[] functionNames = new String[list.size() - 1];
       for (int i = 0; i < functionNames.length; i++) {
-        functionNames[i] = engine.uniqueName("$f");
+        functionNames[i] = EvalEngine.uniqueName("$f");
       }
       for (int i = 1; i < list.size(); i++) {
         IAST listOfFunctions = (IAST) list.get(i);
@@ -1287,7 +1287,7 @@ public class ManipulateFunction {
 
       String[] functionNames = new String[listOfFunctions.size() - 1];
       for (int i = 0; i < functionNames.length; i++) {
-        functionNames[i] = engine.uniqueName("$f");
+        functionNames[i] = EvalEngine.uniqueName("$f");
       }
       for (int i = 1; i < listOfFunctions.size(); i++) {
         function.append("function ");

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/OutputFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/OutputFunctions.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
-
 import org.hipparchus.linear.FieldMatrix;
 import org.hipparchus.linear.FieldVector;
 import org.matheclipse.core.basic.Config;
@@ -41,7 +40,6 @@ import org.matheclipse.core.interfaces.IInteger;
 import org.matheclipse.core.interfaces.IStringX;
 import org.matheclipse.core.interfaces.ISymbol;
 import org.matheclipse.core.polynomials.HornerScheme;
-
 import com.baeldung.algorithms.romannumerals.RomanArabicConverter;
 import com.ibm.icu.text.NumberFormat;
 import com.ibm.icu.text.RuleBasedNumberFormat;
@@ -492,7 +490,7 @@ public final class OutputFunctions {
             VariablesSet varSet = new VariablesSet(arg1);
             List<IExpr> functionsParameters = varSet.getArrayList();
             StringBuilder buf = new StringBuilder();
-            long functionCounter = engine.incModuleCounter();
+            long functionCounter = EvalEngine.incModuleCounter();
             buf.append("double f");
             buf.append(functionCounter);
             buf.append("(");
@@ -528,7 +526,7 @@ public final class OutputFunctions {
               VariablesSet varSet = new VariablesSet(arg1);
               List<IExpr> functionsParameters = varSet.getArrayList();
               StringBuilder buf = new StringBuilder();
-              long functionCounter = engine.incModuleCounter();
+              long functionCounter = EvalEngine.incModuleCounter();
               buf.append("Complex f");
               buf.append(functionCounter);
               buf.append("(");

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/PatternMatching.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/PatternMatching.java
@@ -2283,15 +2283,15 @@ public final class PatternMatching {
     public IExpr evaluate(final IAST ast, EvalEngine engine) {
       if (ast.isAST1()) {
         if (ast.arg1().isSymbol()) {
-          final String varAppend = ast.arg1().toString() + engine.uniqueName("$");
+          final String varAppend = ast.arg1().toString() + EvalEngine.uniqueName("$");
           return F.symbol(varAppend, engine);
         } else if (ast.arg1() instanceof IStringX) {
           // TODO start counter by 1....
-          final String varAppend = engine.uniqueName(ast.arg1().toString());
+          final String varAppend = EvalEngine.uniqueName(ast.arg1().toString());
           return F.symbol(varAppend, engine);
         }
       }
-      return F.symbol(engine.uniqueName("$"), engine);
+      return F.symbol(EvalEngine.uniqueName("$"), engine);
     }
 
     @Override

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/Programming.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/Programming.java
@@ -3531,7 +3531,7 @@ public final class Programming {
   private static IExpr moduleSubstVariables(
       IAST intializerList, IExpr moduleBlock, final EvalEngine engine) {
     // final long moduleCounter = engine.incModuleCounter();
-    final String varAppend = engine.uniqueName("$");
+    final String varAppend = EvalEngine.uniqueName("$");
     final java.util.IdentityHashMap<ISymbol, IExpr> moduleVariables =
         new IdentityHashMap<ISymbol, IExpr>();
     if (rememberModuleVariables(intializerList, varAppend, moduleVariables, engine)) {
@@ -3559,7 +3559,7 @@ public final class Programming {
         new IdentityHashMap<ISymbol, IExpr>();
     if (rememberWithVariables(intializerList, moduleVariables, engine)) {
       IExpr result =
-          withBlock.accept(new ModuleReplaceAll(moduleVariables, engine, engine.uniqueName("$")));
+          withBlock.accept(new ModuleReplaceAll(moduleVariables, engine, EvalEngine.uniqueName("$")));
       return result.orElse(withBlock);
     }
     return F.NIL;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/StructureFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/StructureFunctions.java
@@ -641,7 +641,7 @@ public class StructureFunctions {
                 new IdentityHashMap<ISymbol, IExpr>();
             // final long moduleCounter = engine.incModuleCounter();
             IExpr subst =
-                arg2.accept(new ModuleReplaceAll(moduleVariables, engine, engine.uniqueName("$")));
+                arg2.accept(new ModuleReplaceAll(moduleVariables, engine, EvalEngine.uniqueName("$")));
             if (subst.isPresent()) {
               arg2 = subst;
             }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/WL.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/WL.java
@@ -499,7 +499,7 @@ public class WL {
       }
       ContextPath contextPath = engine.getContextPath();
       Context context = contextPath.getContext(contextName);
-      return contextPath.getSymbol(lcSymbolName, context, engine.isRelaxedSyntax());
+      return ContextPath.getSymbol(lcSymbolName, context, engine.isRelaxedSyntax());
     }
   }
 

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/polynomials/PolynomialHomogenization.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/polynomials/PolynomialHomogenization.java
@@ -344,7 +344,7 @@ public class PolynomialHomogenization {
         }
         return newSymbol;
       }
-      newSymbol = F.Dummy(engine.uniqueName("jas$"));
+      newSymbol = F.Dummy(EvalEngine.uniqueName("jas$"));
       substitutedVariables.put(newSymbol, exprPoly);
       substitutedExpr.put(exprPoly, newSymbol);
 

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/polynomials/PolynomialHomogenizationNew.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/polynomials/PolynomialHomogenizationNew.java
@@ -350,7 +350,7 @@ public class PolynomialHomogenizationNew {
         }
         return newSymbol;
       }
-      newSymbol = F.Dummy(engine.uniqueName("hg$"));
+      newSymbol = F.Dummy(EvalEngine.uniqueName("hg$"));
       substitutedVariables.put(newSymbol, exprPoly);
       substitutedExpr.put(exprPoly, newSymbol);
 

--- a/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/io/eval/MMAConsoleTestSingleRun.java
+++ b/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/io/eval/MMAConsoleTestSingleRun.java
@@ -32,7 +32,7 @@ public class MMAConsoleTestSingleRun extends TestCase {
     PrintStream old = System.out;
     System.setOut(ps);
 
-    console.main(args);
+    MMAConsole.main(args);
 
     System.out.flush();
     System.setOut(old);

--- a/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/io/others/HomogenizationJUnit.java
+++ b/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/io/others/HomogenizationJUnit.java
@@ -51,28 +51,27 @@ public class HomogenizationJUnit extends AbstractTestCase {
   }
 
   public void testHomogenization() {
-    EvalEngine engine = EvalEngine.get();
-    engine.resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
     // TODO jas$1->Sqrt(x)
     check(
         "Homogenization(x+2*Sqrt(x)+1)", //
         "{1+2*jas$1+jas$1^2,{jas$1->Sqrt(x)}}");
-    engine.resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
     check(
         "Homogenization(Sin(x))", //
         "{jas$1,{jas$1->Sin(x)}}");
 
-    engine.resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
     check(
         "Homogenization(x^2+Sin(x)+Sin(x)^3)", //
         "{jas$1^2+jas$2+jas$2^3,{jas$1->x,jas$2->Sin(x)}}");
 
-    engine.resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
     check(
         "Homogenization((1+x^2)^(-1))", //
         "{1/jas$1,{jas$1->1+x^2}}");
 
-    engine.resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
     check(
         "Homogenization(f(x)^(-1))", //
         "{1/jas$1,{jas$1->f(x)}}");

--- a/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/io/system/LowercaseTestCase.java
+++ b/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/io/system/LowercaseTestCase.java
@@ -14054,7 +14054,7 @@ public class LowercaseTestCase extends AbstractTestCase {
   }
 
   public void testFunction() {
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
     check(
         "g = (#1 + #2) &[3,4]", //
         "7");
@@ -18494,7 +18494,7 @@ public class LowercaseTestCase extends AbstractTestCase {
   }
 
   public void testJavaForm() {
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
     check(
         "JavaForm(Sqrt(x), Complex)", //
         "(x).sqrt()");
@@ -18570,7 +18570,7 @@ public class LowercaseTestCase extends AbstractTestCase {
   }
 
   public void testJSForm() {
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
     // check("JSForm(Ramp(x))", //
     // "((x>=0) ? x : ( 0 ))");
     check(
@@ -22621,7 +22621,7 @@ public class LowercaseTestCase extends AbstractTestCase {
   }
 
   public void testModule() {
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
     // check("num=Sin(3*I);Module({v=N(num)},If(PossibleZeroQ(Re(v)),Im(v)>0,Re(v)>0))",
     // "True");
     // check("Module({x=5}, Hold(x))", "Hold(x$1)");
@@ -38378,7 +38378,7 @@ public class LowercaseTestCase extends AbstractTestCase {
   }
 
   public void testUnique() {
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
     check(
         "Unique()", //
         "$1");
@@ -39142,12 +39142,12 @@ public class LowercaseTestCase extends AbstractTestCase {
   }
 
   public void testWith() {
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
 
     check(
         "With({x = 2 + y}, Hold(With({y = 4}, x + y)))", //
         "Hold(With({y$1=4},2+y+y$1))");
-    EvalEngine.get().resetModuleCounter4JUnit();
+    EvalEngine.resetModuleCounter4JUnit();
     check(
         "xm=10;With({xm=xm}, Print(xm));xm", //
         "10");


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Access static members through the class instead via an object of that class to fix corresponding warnings.
Or is it important that an EvalEngine is created in the cases where for example `EvalEngine.get().resetModuleCounter4JUnit();` was called like in `TestPods`?