### PR TITLE
[Logging] make log4j2-config available to log4j-core and improve it

### DIFF
--- a/symja_android_library/log4j2.properties
+++ b/symja_android_library/log4j2.properties
@@ -5,7 +5,7 @@ status = error
 #nok: dest = file://test/log.log
 name = SymjaPropertiesConfig
 
-appenders = console, consoleErr, rolling
+appenders = console, consoleErr
 
 # appender for standard console
 appender.console.type = Console
@@ -27,25 +27,7 @@ appender.consoleErr.layout.pattern = %-4r %-5p [%t] %c - %m%n
 appender.consoleErr.filter.threshold.type = ThresholdFilter
 appender.consoleErr.filter.threshold.level = error
 
-# appender for files
-appender.rolling.type = RollingFile
-appender.rolling.name = RollingFile
-appender.rolling.fileName = symja.log
-appender.rolling.filePattern = symja-%d{MM-dd-yy-HH-mm-ss}-%i.log
-appender.rolling.append = true
-appender.rolling.layout.type = PatternLayout
-appender.rolling.layout.pattern = %-4r [%t] %-5p %c - %m%n
-appender.rolling.policies.type = Policies
-appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
-appender.rolling.policies.time.interval = 2
-appender.rolling.policies.time.modulate = true
-appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
-appender.rolling.policies.size.size=100MB
-appender.rolling.strategy.type = DefaultRolloverStrategy
-appender.rolling.strategy.max = 5
-
 # configure root logger
 rootLogger.level = warn
 rootLogger.appenderRef.stdout.ref = STDOUT
 rootLogger.appenderRef.errout.ref = ERROUT
-rootLogger.appenderRef.rolling.ref = RollingFile

--- a/symja_android_library/log4j2.properties
+++ b/symja_android_library/log4j2.properties
@@ -2,28 +2,38 @@
 
 # logging for log4j2 itself
 status = error
-#status = debug
 #nok: dest = file://test/log.log
 name = SymjaPropertiesConfig
 
-appenders = console, rolling
+appenders = console, consoleErr, rolling
 
-# appender for console
+# appender for standard console
 appender.console.type = Console
 appender.console.name = STDOUT
+appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %-4r %-5p [%t] %c - %m%n
-#appender.console.layout.pattern = %-4r [%t] %-5p %c - %m%n
+appender.console.filter.range.type = LevelRangeFilter
+# in the logic of LevelRangeFilter the following relation applies: FATAL < ERROR < WARN < INFO < DEBUG < TRACE
+appender.console.filter.range.maxLevel = trace
+appender.console.filter.range.minLevel = warn
+
+# appender for error console
+appender.consoleErr.type = Console
+appender.consoleErr.name = ERROUT
+appender.consoleErr.target = SYSTEM_ERR
+appender.consoleErr.layout.type = PatternLayout
+appender.consoleErr.layout.pattern = %-4r %-5p [%t] %c - %m%n
+appender.consoleErr.filter.threshold.type = ThresholdFilter
+appender.consoleErr.filter.threshold.level = error
 
 # appender for files
 appender.rolling.type = RollingFile
 appender.rolling.name = RollingFile
 appender.rolling.fileName = symja.log
 appender.rolling.filePattern = symja-%d{MM-dd-yy-HH-mm-ss}-%i.log
-#appender.rolling.filePattern = test/symja-%d{MM-dd-yy-HH-mm-ss}-%i.log.gz
 appender.rolling.append = true
 appender.rolling.layout.type = PatternLayout
-#appender.rolling.layout.pattern = %d %p %C{1.} [%t] %m%n
 appender.rolling.layout.pattern = %-4r [%t] %-5p %c - %m%n
 appender.rolling.policies.type = Policies
 appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
@@ -34,25 +44,8 @@ appender.rolling.policies.size.size=100MB
 appender.rolling.strategy.type = DefaultRolloverStrategy
 appender.rolling.strategy.max = 5
 
-
-loggers = rolling
- 
-# rolling logger
-logger.rolling.name = org.apache.logging.log4j.core.appender.rolling
-logger.rolling.level = error
-logger.rolling.additivity = true
-logger.rolling.appenderRefs = rolling
-logger.rolling.appenderRef.rolling.ref = RollingFile
-
-
-#rootLogger.level = debug
-#rootLogger.level = info
-#rootLogger.level = warn
-rootLogger.level = error 
-#rootLogger.appenderRefs = stdout
+# configure root logger
+rootLogger.level = warn
 rootLogger.appenderRef.stdout.ref = STDOUT
+rootLogger.appenderRef.errout.ref = ERROUT
 rootLogger.appenderRef.rolling.ref = RollingFile
-
-#rootLogger.appenderRefs = fileio
-#rootLogger.appenderRef.fileio.ref = RollingFile
-

--- a/symja_android_library/matheclipse-api/pom.xml
+++ b/symja_android_library/matheclipse-api/pom.xml
@@ -80,6 +80,31 @@
 		</repository>
 	</repositories>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>add-resource</id>
+						<phase>generate-resources</phase>
+						<goals>
+							<goal>add-resource</goal>
+						</goals>
+						<configuration>
+							<resources>
+								<resource>
+									<directory>${project.basedir}/../</directory>
+									<include>log4j2.properties</include>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 	<profiles>
 		<profile>
 			<id>release</id>

--- a/symja_android_library/matheclipse-io/pom.xml
+++ b/symja_android_library/matheclipse-io/pom.xml
@@ -180,5 +180,28 @@
 
 			</plugins>
 		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>add-resource</id>
+						<phase>generate-resources</phase>
+						<goals>
+							<goal>add-resource</goal>
+						</goals>
+						<configuration>
+							<resources>
+								<resource>
+									<directory>${project.basedir}/../</directory>
+									<include>log4j2.properties</include>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
 	</build>
 </project>

--- a/symja_android_library/pom.xml
+++ b/symja_android_library/pom.xml
@@ -422,6 +422,12 @@
 
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>build-helper-maven-plugin</artifactId>
+					<version>3.2.0</version>
+				</plugin>
+
+				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>exec-maven-plugin</artifactId>
 					<version>3.0.0</version>
 				</plugin>


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description
As already mentioned in PR #254 the log4j-core implementation does not consider the log4j2.properties configuration file located in the root Symja module, because that file is not on the classpath of those sub-modules.

This PR ensures that the log4j2.properties configuration file is included into those Symja modules that depend on the log4j-core implementation (and therefore have it on their classpath), so it is picked-up by log4j-core.

This is an important prerequisite to resolve #272.

Furthermore improve and clean up the log4j2.properties file:
+ Print message with level `error` and above to `System.err` and all messages with level `warn` or below to `System.out`
- remove commented out line
- remove unused logger named rolling (would only be used by a class in package `org.apache.logging.log4j.core.appender.rolling`

Furthermore the rolling-file-appender could be removed completely. It writes all log-output, that is already written to the console, to a file as well. I think especially for the web-application this can be disturbing because not only errors within symja bug also user errors are logged there. Or do you want to have those log files explicitly @axkr?

Additionally the configuration could be further improved. For example the layout pattern could be adjusted to show a time-stamp instead of the time elapsed since the JVM startup.
The layout-pattern reference: https://logging.apache.org/log4j/2.x/manual/layouts.html#PatternLayout