### PR TITLE
[CleanUp-Logging] remove unused print methods and in-line duplicates

### DIFF
--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/IOFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/IOFunctions.java
@@ -922,7 +922,7 @@ public class IOFunctions {
     if (message == null) {
       message = "Undefined message shortcut: " + messageShortcut;
       engine.setMessageShortcut(messageShortcut);
-      engine.printMessage(symbol.toString() + ": " + message);
+      engine.printMessage(symbol + ": " + message);
     } else {
       try {
         Writer writer = new StringWriter();
@@ -935,7 +935,7 @@ public class IOFunctions {
 
         templateApply(message, writer, context);
         engine.setMessageShortcut(messageShortcut);
-        engine.printMessage(symbol.toString() + ": " + writer.toString());
+        engine.printMessage(symbol + ": " + writer);
       } catch (IOException e) {
         e.printStackTrace();
       }
@@ -964,17 +964,6 @@ public class IOFunctions {
     }
     engine.setMessageShortcut(messageShortcut);
     return message;
-  }
-
-  public static IAST printMessage(ISymbol symbol, Exception ex, EvalEngine engine) {
-    String message = ex.getMessage();
-    if (message != null) {
-      engine.printMessage(symbol.toString() + ": " + message);
-    } else {
-      engine.printMessage(symbol.toString() + ": " + ex.getClass().toString());
-    }
-
-    return F.NIL;
   }
 
   private static String rawMessage(final IAST list, String message) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/IntegerFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/IntegerFunctions.java
@@ -1513,7 +1513,7 @@ public class IntegerFunctions {
           }
         }
       } catch (NumberFormatException | ArgumentTypeException atex) {
-        return IOFunctions.printMessage(ast.topHead(), atex, engine);
+        return engine.printMessage(ast.topHead(), atex);
       }
 
       if (arg1.isNumber()) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/JavaFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/JavaFunctions.java
@@ -68,7 +68,7 @@ public class JavaFunctions {
           Config.URL_CLASS_LOADER = child;
         }
       } catch (MalformedURLException ex) {
-        return IOFunctions.printMessage(ast.topHead(), ex, engine);
+        return engine.printMessage(ast.topHead(), ex);
       }
       return F.NIL;
     }
@@ -122,7 +122,7 @@ public class JavaFunctions {
           }
           arg2 = JavaClassExpr.newInstance(arg2.toString(), Config.URL_CLASS_LOADER);
         } catch (ClassNotFoundException cnfex) {
-          IOFunctions.printMessage(ast.topHead(), cnfex, engine);
+          engine.printMessage(ast.topHead(), cnfex);
           return F.False;
         }
       }
@@ -188,7 +188,7 @@ public class JavaFunctions {
             }
             arg1 = JavaClassExpr.newInstance(arg1.toString(), Config.URL_CLASS_LOADER);
           } catch (ClassNotFoundException cnfex) {
-            return IOFunctions.printMessage(ast.topHead(), cnfex, engine);
+            return engine.printMessage(ast.topHead(), cnfex);
           }
         }
         if (arg1 instanceof JavaClassExpr) {
@@ -211,7 +211,7 @@ public class JavaFunctions {
               | IllegalArgumentException
               | InvocationTargetException
               | SecurityException ex) {
-            return IOFunctions.printMessage(ast.topHead(), ex, engine);
+            return engine.printMessage(ast.topHead(), ex);
           }
         }
       }
@@ -301,7 +301,7 @@ public class JavaFunctions {
           }
 
         } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
-          return IOFunctions.printMessage(S.JavaObject, ex, engine);
+          return engine.printMessage(S.JavaObject, ex);
         }
       }
       return F.NIL;
@@ -422,7 +422,7 @@ public class JavaFunctions {
             }
             return jClazz;
           } catch (ClassNotFoundException cnfex) {
-            return IOFunctions.printMessage(ast.topHead(), cnfex, engine);
+            return engine.printMessage(ast.topHead(), cnfex);
           }
         }
         if (arg1 instanceof JavaClassExpr) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/LinearAlgebra.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/LinearAlgebra.java
@@ -4052,7 +4052,7 @@ public final class LinearAlgebra {
             }
           }
         } catch (MathRuntimeException mrex) {
-          IOFunctions.printMessage(ast.topHead(), mrex, engine);
+          engine.printMessage(ast.topHead(), mrex);
         }
       }
       return F.NIL;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/ManipulateFunction.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/ManipulateFunction.java
@@ -1971,7 +1971,7 @@ public class ManipulateFunction {
         if (Config.SHOW_STACKTRACE) {
           rex.printStackTrace();
         }
-        return IOFunctions.printMessage(S.Manipulate, rex, engine);
+        return engine.printMessage(S.Manipulate, rex);
       }
       return F.NIL;
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/NumberTheory.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/NumberTheory.java
@@ -2807,7 +2807,7 @@ public final class NumberTheory {
           } catch (ArithmeticException aex) {
             // java.lang.ArithmeticException: Inverse root of zero
             // at org.apfloat.ApfloatMath.inverseRoot(ApfloatMath.java:280)
-            return IOFunctions.printMessage(ast.topHead(), aex, engine);
+            return engine.printMessage(ast.topHead(), aex);
           }
         }
       }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/StatisticsFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/StatisticsFunctions.java
@@ -1501,7 +1501,7 @@ public class StatisticsFunctions {
         }
         return F.NIL;
       } catch (MathRuntimeException mrex) {
-        return IOFunctions.printMessage(ast.topHead(), mrex, engine);
+        return engine.printMessage(ast.topHead(), mrex);
       }
     }
 

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/StringFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/StringFunctions.java
@@ -3428,7 +3428,7 @@ public final class StringFunctions {
           F.List(F.$str(pse.getPattern()), F.$str(pse.getMessage())),
           engine);
     } else {
-      return IOFunctions.printMessage(ast.topHead(), iae, engine);
+      return engine.printMessage(ast.topHead(), iae);
     }
   }
 

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/Solve.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/Solve.java
@@ -1160,12 +1160,12 @@ public class Solve extends AbstractFunctionEvaluator {
       if (Config.SHOW_STACKTRACE) {
         le.printStackTrace();
       }
-      return IOFunctions.printMessage(S.Solve, le, engine);
+      return engine.printMessage(S.Solve, le);
     } catch (ValidateException ve) {
       if (Config.SHOW_STACKTRACE) {
         ve.printStackTrace();
       }
-      return IOFunctions.printMessage(S.Solve, ve, engine);
+      return engine.printMessage(S.Solve, ve);
       //      return engine.printMessage(S.Solve, ve);
     } catch (RuntimeException rex) {
       if (Config.SHOW_STACKTRACE) {

--- a/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/builtin/SwingFunctions.java
+++ b/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/builtin/SwingFunctions.java
@@ -586,61 +586,6 @@ public class SwingFunctions {
     return F.NIL;
   }
 
-  public static IExpr printArgMessage(IAST ast, int[] expected, EvalEngine engine) {
-    final ISymbol topHead = ast.topHead();
-    int argSize = ast.argSize();
-    if (expected[0] == expected[1]) {
-      if (expected[0] == 1) {
-        return printMessage(
-            topHead, "argx", F.List(topHead, F.ZZ(argSize), F.ZZ(expected[0])), engine);
-      }
-      if (argSize == 1) {
-        return printMessage(topHead, "argr", F.List(topHead, F.ZZ(expected[0])), engine);
-      }
-      return printMessage(
-          topHead, "argrx", F.List(topHead, F.ZZ(argSize), F.ZZ(expected[0])), engine);
-    }
-    return printMessage(
-        topHead,
-        "argt",
-        F.List(topHead, F.ZZ(argSize), F.ZZ(expected[0]), F.ZZ(expected[1])),
-        engine);
-  }
-
-  /**
-   * @param symbol
-   * @param messageShortcut the message shortcut defined in <code>MESSAGES</code> array
-   * @param listOfArgs a list of arguments which should be inserted into the message shortcuts
-   *     placeholder
-   * @param engine
-   * @return always <code>F.NIL</code>
-   */
-  public static IAST printMessage(
-      ISymbol symbol, String messageShortcut, final IAST listOfArgs, EvalEngine engine) {
-    IExpr temp = symbol.evalMessage(messageShortcut);
-    String message = null;
-    if (temp.isPresent()) {
-      message = temp.toString();
-    } else {
-      temp = S.General.evalMessage(messageShortcut);
-      if (temp.isPresent()) {
-        message = temp.toString();
-      }
-    }
-    if (message == null) {
-      message = "Undefined message shortcut: " + messageShortcut;
-      engine.setMessageShortcut(messageShortcut);
-      engine.printMessage(symbol.toString() + ": " + message);
-    } else {
-      for (int i = 1; i < listOfArgs.size(); i++) {
-        message = StringUtils.replace(message, "`" + (i) + "`", shorten(listOfArgs.get(i)));
-      }
-      engine.setMessageShortcut(messageShortcut);
-      engine.printMessage(symbol.toString() + ": " + message);
-    }
-    return F.NIL;
-  }
-
   public static String getMessage(String messageShortcut, final IAST listOfArgs) {
     return getMessage(messageShortcut, listOfArgs, EvalEngine.get());
   }
@@ -662,17 +607,6 @@ public class SwingFunctions {
     }
     engine.setMessageShortcut(messageShortcut);
     return message;
-  }
-
-  public static IAST printMessage(ISymbol symbol, Exception ex, EvalEngine engine) {
-    String message = ex.getMessage();
-    if (message != null) {
-      engine.printMessage(symbol.toString() + ": " + message);
-    } else {
-      engine.printMessage(symbol.toString() + ": " + ex.getClass().toString());
-    }
-
-    return F.NIL;
   }
 
   private static String rawMessage(final IAST list, String message) {


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

The method `IOFunctions.printMessage(ISymbol, Exception, EvalEngine)` is equivalent to call `engine.printMessage(symbol, exception)` and can therefore be replaced by such a corresponding call and removed.

Furthermore the methods
- `SwingFunctions.printArgMessage(IAST, int[], EvalEngine)`
- `SwingFunctions.printMessage(ISymbol, String, final IAST, EvalEngine)`
- `SwingFunctions.printMessage(ISymbol, Exception, EvalEngine)`

are never used within Symja and could therefore be removed. Or are they intended to be used by users?