### PR TITLE
[CleanUp] remove commented-out System.out statements

### DIFF
--- a/symja_android_library/matheclipse-api/src/main/java/org/matheclipse/api/Pods.java
+++ b/symja_android_library/matheclipse-api/src/main/java/org/matheclipse/api/Pods.java
@@ -285,10 +285,6 @@ public class Pods {
           + "</body>\n"
           + "</html>"; //
 
-  // public static void main(String[] args) {
-  // System.out.println(HIGHLIGHT_IFRAME);
-  // }
-
   private static void addElementData(String soundex, String value) {
     ArrayList<IPod> list = SOUNDEX_MAP.get(soundex);
     if (list == null) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/Algebra.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/Algebra.java
@@ -17,6 +17,7 @@ import static org.matheclipse.core.expression.S.Assumptions;
 import static org.matheclipse.core.expression.S.E;
 import static org.matheclipse.core.expression.S.I;
 import static org.matheclipse.core.expression.S.Pi;
+import static org.matheclipse.core.expression.S.Power;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -2168,7 +2169,6 @@ public class Algebra {
       if (expr.isAST()) {
         IExpr temp;
         // if (expr.isPower()&&expr.base().isPlus()) {
-        //// System.out.println(ast.toString());
         // temp = factorExpr(ast, expr.base(), varList);
         // temp = F.Power(temp, expr.exponent());
         // } else
@@ -2179,7 +2179,6 @@ public class Algebra {
           }
           return expr;
         } else if (expr.isTimes()) {
-          // System.out.println(ast.toString());
           temp =
               ((IAST) expr)
                   .map(
@@ -2198,7 +2197,6 @@ public class Algebra {
                       1);
           return temp;
         } else {
-          // System.out.println("leafCount " + expr.leafCount());
           return factor((IAST) expr, eVar, factorSquareFree, engine);
         }
       }
@@ -2247,9 +2245,6 @@ public class Algebra {
           if (factorSquareFree) {
             map = factorAbstract.squarefreeFactors(poly); // factors(poly);
           } else {
-            // System.out.println("Variable: " + varList.toString() + " -- " +
-            // expr.fullFormString());
-            // System.out.println(poly);
             map = factorAbstract.factors(poly);
           }
         } catch (RuntimeException rex) {
@@ -2285,7 +2280,6 @@ public class Algebra {
         if (!f.isOne()) {
           result.append(f);
         }
-        // System.out.println("Factor: " + expr.toString() + " ==> " + result.toString());
         return engine.evaluate(result);
       }
       return F.NIL;
@@ -2359,7 +2353,6 @@ public class Algebra {
       if (substitutions.size() == 0) {
         return factorComplex(expr, eVar.getArrayList(), S.Times, gaussianIntegers, engine);
       }
-      // System.out.println(subsPolynomial.toString());
       if (subsPolynomial.isAST()) {
         eVar.addAll(substitutions.substitutedVariablesSet());
         IExpr factorization =

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/Arithmetic.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/Arithmetic.java
@@ -33,8 +33,11 @@ import static org.matheclipse.core.expression.F.Times;
 import static org.matheclipse.core.expression.F.num;
 import static org.matheclipse.core.expression.F.x_;
 import static org.matheclipse.core.expression.F.y_;
+import static org.matheclipse.core.expression.S.Conjugate;
 import static org.matheclipse.core.expression.S.E;
 import static org.matheclipse.core.expression.S.Pi;
+import static org.matheclipse.core.expression.S.Power;
+import static org.matheclipse.core.expression.S.Times;
 import static org.matheclipse.core.expression.S.x;
 import static org.matheclipse.core.expression.S.y;
 import java.util.function.DoubleFunction;
@@ -5790,8 +5793,6 @@ public final class Arithmetic {
 
     @Override
     public IExpr e2ObjArg(IAST ast, final IExpr arg1, final IExpr arg2) {
-
-      // System.out.println(ast.toString());
 
       // the case where both args are numbers is already handled in binaryOperator()
       if (arg1.isReal() || arg2.isReal()) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/AssumptionFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/AssumptionFunctions.java
@@ -301,7 +301,6 @@ public class AssumptionFunctions {
       IAssumptions oldAssumptions = engine.getAssumptions();
       try {
         engine.setAssumptions(assumptions);
-        // System.out.println(expr.toString());
         return engine.evalWithoutNumericReset(expr);
       } finally {
         engine.setAssumptions(oldAssumptions);

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/BooleanFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/BooleanFunctions.java
@@ -996,8 +996,6 @@ public final class BooleanFunctions {
         }
 
         final Formula simplified = formula.transform(simplifier).transform(transformation);
-        // formula = QuineMcCluskeyAlgorithm.compute(formula);
-        // System.out.println(formula.toString());
         IExpr result = lf.booleanFunction2Expr(simplified);
         return result;
       } catch (final ValidateException ve) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/ClusteringFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/ClusteringFunctions.java
@@ -316,7 +316,6 @@ public class ClusteringFunctions {
     public IExpr evaluate(final IAST ast, EvalEngine engine) {
       String method = "";
       DistanceMeasure measure = new EuclideanDistance();
-      // System.out.println(ast.toString());
       try {
         if (ast.arg1().isList() && ast.arg1().size() > 1) {
           IAST listArg1 = (IAST) ast.arg1();

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/CompilerFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/CompilerFunctions.java
@@ -709,7 +709,6 @@ public class CompilerFunctions {
     source = source.replace("{$methods}", methods.toString());
     source = source.replace("{$expression}", buf.toString());
     source = source.replace("{$size}", Integer.toString(variables.argSize()));
-    //    System.out.println(source);
     return source;
   }
 }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/ConstantDefinitions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/ConstantDefinitions.java
@@ -69,8 +69,6 @@ public class ConstantDefinitions {
       // }
       // }
 
-      // System.out.println(VERSION);
-      // System.out.println(TIMESTAMP);
       S.$Assumptions.setEvaluator(new $Assumptions());
       S.$BaseDirectory.setEvaluator(new $BaseDirectory());
       S.$Context.setEvaluator(new $Context());
@@ -105,7 +103,6 @@ public class ConstantDefinitions {
       S.RecordSeparators.setEvaluator(new RecordSeparators());
       S.WordSeparators.setEvaluator(new WordSeparators());
 
-      // System.out.println(S.$CreationDate.of().toString());
       S.Catalan.setEvaluator(new Catalan());
       S.ComplexInfinity.setEvaluator(new ComplexInfinity());
       S.Degree.setEvaluator(new Degree());
@@ -354,7 +351,6 @@ public class ConstantDefinitions {
 
     @Override
     public IExpr evaluate(final ISymbol symbol, EvalEngine engine) {
-      // System.out.println(Config.MACHINE_EPSILON);
       return F.num(Config.MACHINE_EPSILON);
     }
   }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/FileFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/FileFunctions.java
@@ -354,9 +354,6 @@ public class FileFunctions {
             Path path = Paths.get(ast.arg1().toString());
             if (!Files.exists(path)) {
               Files.createDirectory(path);
-              //              System.out.println("Directory created");
-            } else {
-              //              System.out.println("Directory already exists");
             }
             return F.stringx(path.toString());
           }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/GraphFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/GraphFunctions.java
@@ -1381,7 +1381,6 @@ public class GraphFunctions {
       //            new LineGraphConverter<IExpr, ExprEdge, ExprEdge>(g1);
       //        Graph<ExprEdge, ExprEdge> target = new SimpleGraph<>(ExprEdge.class);
       //        lgc.convertToLineGraph(target);
-      //        System.out.println(target.toString());
       //        //	              return GraphExpr.newInstance(target);
       //      } catch (RuntimeException rex) {
       //        if (FEConfig.SHOW_STACKTRACE) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/IOFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/IOFunctions.java
@@ -1188,7 +1188,6 @@ public class IOFunctions {
       Context context = mapEntry.getValue();
       for (Map.Entry<String, ISymbol> entry : context.entrySet()) {
         String fullName = context.completeContextName() + entry.getKey();
-        // System.out.println(fullName);
         java.util.regex.Matcher matcher = pattern.matcher(fullName);
         if (matcher.matches()) {
           if (FEConfig.PARSER_USE_LOWERCASE_SYMBOLS && context.equals(Context.SYSTEM)) {
@@ -1213,7 +1212,6 @@ public class IOFunctions {
       if (!contextMap.containsKey(completeContextName)) {
         for (Map.Entry<String, ISymbol> entry : context.entrySet()) {
           String fullName = completeContextName + entry.getKey();
-          // System.out.println(fullName);
           java.util.regex.Matcher matcher = pattern.matcher(fullName);
           if (matcher.matches()) {
             if (FEConfig.PARSER_USE_LOWERCASE_SYMBOLS && context.equals(Context.SYSTEM)) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/JavaFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/JavaFunctions.java
@@ -198,7 +198,6 @@ public class JavaFunctions {
             for (int i = 0; i < constructors.length; i++) {
               Parameter[] parameters = constructors[i].getParameters();
               if (parameters.length == ast.argSize() - 1) {
-                //                System.out.println("constructor: " + constructors[i]);
                 Object[] params = determineParameters(ast, parameters, 2);
                 if (params != null) {
                   Object obj = constructors[i].newInstance(params);
@@ -412,7 +411,6 @@ public class JavaFunctions {
                   Method method = methods[i];
                   if (Modifier.isStatic(method.getModifiers())) {
                     ISymbol methodName = F.symbol(context, method.getName(), engine);
-                    //                    System.out.println(methodName.fullFormString());
                   }
                 }
 

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/LinearAlgebra.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/LinearAlgebra.java
@@ -5327,7 +5327,6 @@ public final class LinearAlgebra {
     FieldReducedRowEchelonForm ref =
         new FieldReducedRowEchelonForm(matrix, AbstractMatrix1Expr.POSSIBLE_ZEROQ_TEST);
     FieldMatrix<IExpr> rowReduced = ref.getRowReducedMatrix();
-    // System.out.println(rowReduced.toString());
     IExpr lastVarCoefficient = rowReduced.getEntry(rows - 1, cols - 2);
     if (lastVarCoefficient.isZero()) {
       if (!rowReduced.getEntry(rows - 1, cols - 1).isZero()) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/ManipulateFunction.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/ManipulateFunction.java
@@ -1755,7 +1755,6 @@ public class ManipulateFunction {
 
         HistogramTrace trace = HistogramTrace.builder(vector).build();
         Figure figure = new Figure(layout, trace);
-        // System.out.println(figure.asJavascript("plotly"));
         // Plot.show(figure);
         return F.JSFormData(figure.asJavascript("plotly"), "plotly");
       }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/NumberTheory.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/NumberTheory.java
@@ -4710,7 +4710,6 @@ public final class NumberTheory {
       // // Long val = entry.getValue();
       // // result.add(F.Power(jas.integerPoly2Expr(integerCoefficientPoly),
       // // F.integer(val)));
-      // System.out.println(singleFactor);
       // }
       // return result;
       // } catch (ArithmeticException ae) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/PatternMatching.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/PatternMatching.java
@@ -1736,7 +1736,6 @@ public final class PatternMatching {
       try {
         rightHandSide = engine.evaluate(rightHandSide);
       } catch (final ConditionException e) {
-        // System.out.println("Condition[] in right-hand-side of Set[]");
       } catch (final ReturnException e) {
         rightHandSide = e.getValue();
       }
@@ -2090,7 +2089,6 @@ public final class PatternMatching {
         try {
           rightHandSide = engine.evaluate(rightHandSide);
         } catch (final ConditionException e) {
-          // System.out.println("Condition[] in right-hand-side of Set[]");
         } catch (final ReturnException e) {
           rightHandSide = e.getValue();
         }
@@ -2492,7 +2490,6 @@ public final class PatternMatching {
       try {
         rightHandSide = engine.evaluate(rightHandSide);
       } catch (final ConditionException e) {
-        // System.out.println("Condition[] in right-hand-side of UpSet[]");
       } catch (final ReturnException e) {
         rightHandSide = e.getValue();
       }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/PolynomialFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/PolynomialFunctions.java
@@ -1147,7 +1147,6 @@ public class PolynomialFunctions {
     // if (sylvester.isAST0()) {
     // return null;
     // }
-    // // System.out.println(sylvester);
     // return F.eval(F.Det(sylvester));
     // }
 

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/PredicateQ.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/PredicateQ.java
@@ -1760,7 +1760,6 @@ public class PredicateQ {
                 || Double.isInfinite(imaginaryPart)) {
               return IExpr.COMPARE_TERNARY.UNDECIDABLE;
             }
-            //            System.out.println("\n"+temp.toString() +((INumber) result).toString());
             return IExpr.COMPARE_TERNARY.FALSE;
           }
           return IExpr.COMPARE_TERNARY.TRUE;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/Programming.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/Programming.java
@@ -2141,7 +2141,6 @@ public final class Programming {
           return F.NIL;
         }
         try {
-          //        System.out.println(ast.toString() );
           IASTMutable evaledAST = F.NIL;
           IExpr arg1 = engine.evaluateNIL(ast.arg1());
           if (arg1.isPresent()) {
@@ -2912,8 +2911,6 @@ public final class Programming {
         final IExpr result = engine.evaluate(ast.arg1());
         final long end = bean.getCurrentThreadCpuTime();
         double value = (end - begin) / 1000000000.0;
-        //        System.out.println(begin);
-        //        System.out.println(end);
         return List(F.num(value), F.HoldForm(result));
       }
       // fall back to AbsoluteTiming

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/RootsFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/RootsFunctions.java
@@ -124,8 +124,6 @@ public class RootsFunctions {
             rectangleList.append(JASConvert.jas2Complex(refine.getSE()));
             rectangleList.append(JASConvert.jas2Complex(refine.getNE()));
             resultList.append(rectangleList);
-            // System.out.println("refine = " + refine);
-
           }
         }
         return resultList;
@@ -778,8 +776,6 @@ public class RootsFunctions {
                   zDenominator));
         }
       }
-      //      IExpr temp = EvalEngine.get().evaluate(result);
-      //      System.out.println(temp.toString());
       return result;
     } else {
       // even
@@ -809,8 +805,6 @@ public class RootsFunctions {
         result.append(F.Times(F.Power(F.CN1, F.fraction(k, varDegree)), zNumerator, zDenominator));
         k += 2;
       }
-      // IExpr temp = EvalEngine.get().evaluate(result);
-      // System.out.println(temp.toString());
       return result;
     }
   }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/SimplifyFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/SimplifyFunctions.java
@@ -2,6 +2,7 @@ package org.matheclipse.core.builtin;
 
 import static org.matheclipse.core.expression.F.Log;
 import static org.matheclipse.core.expression.F.x_;
+import static org.matheclipse.core.expression.S.Log;
 import static org.matheclipse.core.expression.S.x;
 import java.util.List;
 import java.util.function.Function;
@@ -398,7 +399,6 @@ public class SimplifyFunctions {
         }
 
         try {
-          // System.out.println(expr.toString());
           // TODO: Factor is not fast enough for large expressions!
           // Maybe restricting factoring to smaller expressions is necessary here
           temp = F.NIL;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/StatisticsFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/StatisticsFunctions.java
@@ -1460,7 +1460,6 @@ public class StatisticsFunctions {
     public IExpr evaluate(final IAST ast, EvalEngine engine) {
       try {
         if (ast.isAST1()) {
-          // System.out.println(ast.arg1().toString());
           if (ast.arg1() instanceof ASTRealMatrix) {
             PearsonsCorrelation pc =
                 new PearsonsCorrelation(((ASTRealMatrix) ast.arg1()).getRealMatrix());

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/StringFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/StringFunctions.java
@@ -3274,12 +3274,6 @@ public final class StringFunctions {
       if (!arg1.isString()) {
         return F.NIL;
       }
-      //       Enumeration<String> ids = Transliterator.getAvailableIDs();
-      //
-      //       while (ids.hasMoreElements()) {
-      //       String s = ids.nextElement();
-      //       System.out.println(s);
-      //       }
       if (ast.isAST2()) {
         IExpr arg2 = ast.arg2();
         if (arg2.isRuleAST()) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/WXFFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/WXFFunctions.java
@@ -92,7 +92,6 @@ public class WXFFunctions {
           byte[] bArray = (byte[]) ((IDataExpr) arg1).toData();
           if (bArray.length > 2) {
             IExpr temp = WL.deserialize(bArray);
-            // System.out.println(temp);
             return temp;
           }
         }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/convert/JASConvert.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/convert/JASConvert.java
@@ -291,7 +291,6 @@ public class JASConvert<C extends RingElem<C>> {
       if (Config.SHOW_STACKTRACE) {
         rex.printStackTrace();
       }
-      // System.out.println("expr2JAS"+exprPoly.toString());
       throw new JASConversionException();
     }
   }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/EvalEngine.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/EvalEngine.java
@@ -1540,15 +1540,6 @@ public class EvalEngine implements Serializable {
                 printOnOffTrace(result, temp);
               }
 
-              // if (temp == F.Null&&!result.isAST(F.SetDelayed)) {
-              // System.out.println(expr.toString());
-              // }
-              // if (result.isAST(F.Integrate)) {
-              // System.out.println(result.toString());
-              // System.out.println("("+iterationCounter+") --> " +
-              // temp.toString());
-              // }
-
               if (fIterationLimit >= 0 && fIterationLimit <= ++iterationCounter) {
                 IterationLimitExceeded.throwIt(iterationCounter, temp);
               }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Context.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Context.java
@@ -139,15 +139,7 @@ public class Context implements Serializable {
     return contextName.equals(Context.SYSTEM_CONTEXT_NAME);
   }
 
-  // private static int counter = 0;
-
   public ISymbol put(String key, ISymbol value) {
-    // if (!contextName.equals("System")) {
-    // counter++;
-    // if (counter > 500) {
-    // System.out.println(contextName + "`" + value);
-    // }
-    // }
     return symbolTable.put(key, value);
   }
 

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/F.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/F.java
@@ -754,8 +754,6 @@ public class F extends S {
 
   static {
     try {
-      // long start = System.currentTimeMillis();
-      // System.out.println("Start");
       AST2Expr.initialize();
       ExprParserFactory.initialize();
 
@@ -1082,8 +1080,6 @@ public class F extends S {
 
       COUNT_DOWN_LATCH.countDown();
 
-      // long stop = System.currentTimeMillis();
-      // System.out.println("Milliseconds: " + (stop - start));
     } catch (Throwable th) {
       th.printStackTrace();
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/WL.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/WL.java
@@ -196,7 +196,6 @@ public class WL {
           for (int i = 0; i < length; i++) {
             ast.append(read());
           }
-          // System.out.println(ast.toString());
           IExpr head = ast.head();
           if (head == S.Complex || head == S.Rational || head == S.Pattern || head == S.Optional) {
             // head == F.Blank || //

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/output/ASCIIPrettyPrinter3.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/output/ASCIIPrettyPrinter3.java
@@ -288,7 +288,6 @@ public class ASCIIPrettyPrinter3 {
         }
         out.println(outputExpression[0]);
 
-        // System.out.println(prefix + outputExpression[1]);
         for (int i = 0; i < prefix.length(); i++) {
           out.print(" ");
         }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/integrate/rubi/UtilityFunctionCtors.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/integrate/rubi/UtilityFunctionCtors.java
@@ -6,7 +6,6 @@ import static org.matheclipse.core.expression.F.quaternary;
 import static org.matheclipse.core.expression.F.quinary;
 import static org.matheclipse.core.expression.F.senary;
 import static org.matheclipse.core.expression.S.initFinalHiddenSymbol;
-
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.interfaces.AbstractCoreFunctionEvaluator;
 import org.matheclipse.core.expression.B1;
@@ -2144,7 +2143,6 @@ public class UtilityFunctionCtors {
         temp = astTimes.splice(i).oneIdentity1();
         temp = engine.evaluate(temp);
         if (!temp.isMinusOne()) {
-          // System.out.println("w_*Dist[u_,v_,x_]");
           // Dist[ temp *u,v,x]
           return Dist(F.Times(temp, dist.arg1()), dist.arg2(), dist.arg3());
         }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/io/Extension.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/io/Extension.java
@@ -137,8 +137,4 @@ public enum Extension {
     }
     return STRING;
   }
-
-  // public static void main(String[] args) {
-  // System.out.println(isAllowedExtension("BMP"));
-  // }
 }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/patternmatching/IPatternMap.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/patternmatching/IPatternMap.java
@@ -1,5 +1,6 @@
 package org.matheclipse.core.patternmatching;
 
+import static org.matheclipse.core.patternmatching.IPatternMap.addOptionsPattern;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1936,7 +1937,6 @@ public interface IPatternMap {
       // }
       // // set the eval flags
       // result.isFreeOfPatterns();
-      // // System.out.println(" " + lhsPatternExpr.toString() + " -> " + result.toString());
       // return result;
     }
     return F.NIL;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/patternmatching/PatternMatcher.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/patternmatching/PatternMatcher.java
@@ -1298,7 +1298,6 @@ public class PatternMatcher extends IPatternMatcher implements Externalizable {
   // if (lhsPatternExpr.isOrderlessAST() || lhsPatternExpr.isFlatAST()) {
   // IExpr temp = fPatternMap.substituteASTPatternOrSymbols((IAST) lhsPatternExpr, true);
   // if (temp.isPresent()) {
-  //// System.out.println(lhsPatternExpr+" ==> "+temp+" <==> "+lhsEvalExpr);
   // lhsPatternExpr = temp;
   // }
   // }
@@ -1761,7 +1760,6 @@ public class PatternMatcher extends IPatternMatcher implements Externalizable {
     // if (lhsPatternAST.size() > 1) {
     // IExpr temp = fPatternMap.substituteASTPatternOrSymbols(lhsPatternAST, true);
     // if (temp.isAST(lhsPatternAST.head())) {
-    // // System.out.println(" " + lhsPatternAST.toString() + " -> " + temp.toString());
     // return new IAST[] { (IAST) temp, lhsEvalAST };
     // }
     // }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/polynomials/longexponent/ExprPolynomial.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/polynomials/longexponent/ExprPolynomial.java
@@ -580,8 +580,6 @@ public class ExprPolynomial implements RingElem<ExprPolynomial>, Iterable<ExprMo
       ExpVectorLong be = bie.getKey();
       s = ae.compareTo(be);
       if (s != 0) {
-        // System.out.println("s = " + s + ", " + ring.toScript(ae) + ",
-        // " + ring.toScript(be));
         return s;
       }
       if (c == 0) {
@@ -591,16 +589,11 @@ public class ExprPolynomial implements RingElem<ExprPolynomial>, Iterable<ExprMo
       }
     }
     if (ai.hasNext()) {
-      // System.out.println("ai = " + ai);
       return 1;
     }
     if (bi.hasNext()) {
-      // System.out.println("bi = " + bi);
       return -1;
     }
-    // if (c != 0) {
-    // System.out.println("c = " + c);
-    // }
     // now all keys are equal
     return c;
   }
@@ -1515,7 +1508,6 @@ public class ExprPolynomial implements RingElem<ExprPolynomial>, Iterable<ExprMo
     }
     IExpr lc = leadingBaseCoefficient();
     if (!lc.isUnit()) {
-      // System.out.println("lc = "+lc);
       return this;
     }
     IExpr lm = lc.inverse();
@@ -1838,7 +1830,6 @@ public class ExprPolynomial implements RingElem<ExprPolynomial>, Iterable<ExprMo
       IExpr s = S.leadingBaseCoefficient();
       if (t.isInteger() && s.isInteger()) {
         IExpr[] gg = t.egcd(s);
-        // System.out.println("coeff gcd = " + Arrays.toString(gg));
         ExprPolynomial z = this.ring.getZero();
         ret[0] = z.sum(gg[0]);
         ret[1] = z.sum(gg[1]);

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/polynomials/longexponent/ExprPolynomialRing.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/polynomials/longexponent/ExprPolynomialRing.java
@@ -77,8 +77,6 @@ public class ExprPolynomialRing implements RingFactory<ExprPolynomial> {
       List<Long> ecl = (List<Long>) ec.get(0);
       IExpr c = ec.get(1); // zero
       ExpVectorLong e = ExpVectorLong.create(ecl);
-      // System.out.println("exp = " + e);
-      // System.out.println("coeffs = " + c);
       current = new ExprPolynomial(ring, c, e);
     }
 
@@ -110,8 +108,6 @@ public class ExprPolynomialRing implements RingFactory<ExprPolynomial> {
       }
       List<Long> ecl = (List<Long>) ec.get(0);
       ExpVectorLong e = ExpVectorLong.create(ecl);
-      // System.out.println("exp = " + e);
-      // System.out.println("coeffs = " + c);
       current = new ExprPolynomial(ring, c, e);
 
       return res;
@@ -1104,7 +1100,6 @@ public class ExprPolynomialRing implements RingFactory<ExprPolynomial> {
    */
   @Override
   public ExprPolynomial copy(ExprPolynomial c) {
-    // System.out.println("GP copy = " + this);
     return new ExprPolynomial(this, c.val);
   }
 
@@ -1438,10 +1433,7 @@ public class ExprPolynomialRing implements RingFactory<ExprPolynomial> {
       powers = new ArrayList<ExpVectorLong>();
       ExpVectorLong e = ExpVectorLong.create(eviter.next());
       powers.add(e);
-      // System.out.println("new e = " + e);
-      // System.out.println("powers = " + powers);
       List<IExpr> c = itercoeff.next();
-      // System.out.println("coeffs = " + c);
       current = new ExprPolynomial(ring, c.get(0), e);
     }
 
@@ -1466,8 +1458,6 @@ public class ExprPolynomialRing implements RingFactory<ExprPolynomial> {
       if (!itercoeff.hasNext()) {
         ExpVectorLong e = ExpVectorLong.create(eviter.next());
         powers.add(0, e); // add new ev at beginning
-        // System.out.println("new e = " + e);
-        // System.out.println("powers = " + powers);
         if (coeffiter.size() == 1) { // shorten frist iterator by one
           // element
           coeffiter.add(coeffiter.get(0));
@@ -1486,11 +1476,9 @@ public class ExprPolynomialRing implements RingFactory<ExprPolynomial> {
       }
       List<IExpr> coeffs = itercoeff.next();
       // while ( coeffs.get(0).isZERO() ) {
-      // System.out.println(" skip zero ");
       // coeffs = itercoeff.next(); // skip tuples with zero in first
       // component
       // }
-      // System.out.println("coeffs = " + coeffs);
       ExprPolynomial pol = ring.getZero().copy();
       int i = 0;
       for (ExpVectorLong f : powers) {
@@ -1499,7 +1487,6 @@ public class ExprPolynomialRing implements RingFactory<ExprPolynomial> {
           continue;
         }
         if (pol.val.get(f) != null) {
-          // System.out.println("error f in pol = " + f + ", " + pol.getMap().get(f));
           throw new RuntimeException("error in iterator");
         }
         pol.doPutToMap(f, c);

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/polynomials/longexponent/ExprTermOrder.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/polynomials/longexponent/ExprTermOrder.java
@@ -329,7 +329,6 @@ public final class ExprTermOrder implements Serializable {
       throw new IllegalArgumentException(
           "invalid term order split, r = " + r + ", split = " + split);
     }
-    // System.out.println("evbeg2 " + evbeg2 + ", evend2 " + evend2);
     switch (evord) { // horder = new EVhorder();
       case ExprTermOrder.LEX:
         {
@@ -1792,9 +1791,6 @@ public final class ExprTermOrder implements Serializable {
       }
       return new ExprTermOrder(evord, evord2, r + k, evend1 + k);
     }
-    // System.out.println("evord = " + evord);
-    // System.out.println("DEFAULT_EVORD = " + DEFAULT_EVORD);
-    // System.out.println("tord = " + this);
     return new ExprTermOrder(
         DEFAULT_EVORD /* evord */, evord, r + k, k); // don't change to evord, cause REVITDG
   }
@@ -1834,9 +1830,6 @@ public final class ExprTermOrder implements Serializable {
       }
       return new ExprTermOrder(evord, evord2, r + k, evend1 + k);
     }
-    // System.out.println("evord = " + evord);
-    // System.out.println("DEFAULT_EVORD = " + DEFAULT_EVORD);
-    // System.out.println("tord = " + this);
     return new ExprTermOrder(evord);
   }
 

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/polynomials/symbolicexponent/SymbolicPolynomial.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/polynomials/symbolicexponent/SymbolicPolynomial.java
@@ -578,8 +578,6 @@ public class SymbolicPolynomial
       ExpVectorSymbolic be = bie.getKey();
       s = ae.compareTo(be);
       if (s != 0) {
-        // System.out.println("s = " + s + ", " + ring.toScript(ae) + ",
-        // " + ring.toScript(be));
         return s;
       }
       if (c == 0) {
@@ -589,16 +587,11 @@ public class SymbolicPolynomial
       }
     }
     if (ai.hasNext()) {
-      // System.out.println("ai = " + ai);
       return 1;
     }
     if (bi.hasNext()) {
-      // System.out.println("bi = " + bi);
       return -1;
     }
-    // if (c != 0) {
-    // System.out.println("c = " + c);
-    // }
     // now all keys are equal
     return c;
   }
@@ -1514,7 +1507,6 @@ public class SymbolicPolynomial
     }
     IExpr lc = leadingBaseCoefficient();
     if (!lc.isUnit()) {
-      // System.out.println("lc = "+lc);
       return this;
     }
     IExpr lm = lc.inverse();
@@ -1837,7 +1829,6 @@ public class SymbolicPolynomial
       IExpr s = S.leadingBaseCoefficient();
       if (t.isInteger() && s.isInteger()) {
         IExpr[] gg = t.egcd(s);
-        // System.out.println("coeff gcd = " + Arrays.toString(gg));
         SymbolicPolynomial z = this.ring.getZero();
         ret[0] = z.sum(gg[0]);
         ret[1] = z.sum(gg[1]);

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/polynomials/symbolicexponent/SymbolicPolynomialRing.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/polynomials/symbolicexponent/SymbolicPolynomialRing.java
@@ -208,11 +208,9 @@ public class SymbolicPolynomialRing implements RingFactory<SymbolicPolynomial> {
        */
       public IExprIterator(boolean nn, IExpr ub) {
         current = F.C0;
-        // System.out.println("current = " + current);
         empty = false;
         nonNegative = nn;
         upperBound = ub;
-        // System.out.println("upperBound = " + upperBound);
       }
 
       /**
@@ -1164,7 +1162,6 @@ public class SymbolicPolynomialRing implements RingFactory<SymbolicPolynomial> {
    */
   @Override
   public SymbolicPolynomial copy(SymbolicPolynomial c) {
-    // System.out.println("GP copy = " + this);
     return new SymbolicPolynomial(this, c.val);
   }
 
@@ -1498,10 +1495,7 @@ public class SymbolicPolynomialRing implements RingFactory<SymbolicPolynomial> {
       powers = new ArrayList<ExpVectorSymbolic>();
       ExpVectorSymbolic e = ExpVectorSymbolic.create(eviter.next());
       powers.add(e);
-      // System.out.println("new e = " + e);
-      // System.out.println("powers = " + powers);
       List<IExpr> c = itercoeff.next();
-      // System.out.println("coeffs = " + c);
       current = new SymbolicPolynomial(ring, c.get(0), e);
     }
 
@@ -1526,8 +1520,6 @@ public class SymbolicPolynomialRing implements RingFactory<SymbolicPolynomial> {
       if (!itercoeff.hasNext()) {
         ExpVectorSymbolic e = ExpVectorSymbolic.create(eviter.next());
         powers.add(0, e); // add new ev at beginning
-        // System.out.println("new e = " + e);
-        // System.out.println("powers = " + powers);
         if (coeffiter.size() == 1) { // shorten frist iterator by one
           // element
           coeffiter.add(coeffiter.get(0));
@@ -1546,11 +1538,9 @@ public class SymbolicPolynomialRing implements RingFactory<SymbolicPolynomial> {
       }
       List<IExpr> coeffs = itercoeff.next();
       // while ( coeffs.get(0).isZERO() ) {
-      // System.out.println(" skip zero ");
       // coeffs = itercoeff.next(); // skip tuples with zero in first
       // component
       // }
-      // System.out.println("coeffs = " + coeffs);
       SymbolicPolynomial pol = ring.getZero().copy();
       int i = 0;
       for (ExpVectorSymbolic f : powers) {
@@ -1559,7 +1549,6 @@ public class SymbolicPolynomialRing implements RingFactory<SymbolicPolynomial> {
           continue;
         }
         if (pol.val.get(f) != null) {
-          // System.out.println("error f in pol = " + f + ", " + pol.getMap().get(f));
           throw new RuntimeException("error in iterator");
         }
         pol.doPutToMap(f, c);

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/polynomials/symbolicexponent/SymbolicTermOrder.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/polynomials/symbolicexponent/SymbolicTermOrder.java
@@ -332,7 +332,6 @@ public final class SymbolicTermOrder implements Serializable {
       throw new IllegalArgumentException(
           "invalid term order split, r = " + r + ", split = " + split);
     }
-    // System.out.println("evbeg2 " + evbeg2 + ", evend2 " + evend2);
     switch (evord) { // horder = new EVhorder();
       case SymbolicTermOrder.LEX:
         {
@@ -1797,9 +1796,6 @@ public final class SymbolicTermOrder implements Serializable {
       }
       return new SymbolicTermOrder(evord, evord2, r + k, evend1 + k);
     }
-    // System.out.println("evord = " + evord);
-    // System.out.println("DEFAULT_EVORD = " + DEFAULT_EVORD);
-    // System.out.println("tord = " + this);
     return new SymbolicTermOrder(
         DEFAULT_EVORD /* evord */, evord, r + k, k); // don't change to evord, cause
     // REVITDG
@@ -1839,9 +1835,6 @@ public final class SymbolicTermOrder implements Serializable {
       }
       return new SymbolicTermOrder(evord, evord2, r + k, evend1 + k);
     }
-    // System.out.println("evord = " + evord);
-    // System.out.println("DEFAULT_EVORD = " + DEFAULT_EVORD);
-    // System.out.println("tord = " + this);
     return new SymbolicTermOrder(evord);
   }
 

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/ExpToTrig.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/ExpToTrig.java
@@ -52,7 +52,6 @@ public class ExpToTrig extends AbstractEvaluator {
                 } else if (base.isNumber()) {
                   // base^exponent => E ^(exponent*Log(base))
                   exponent = S.Expand.of(engine, F.Times(x.exponent(), F.Log(base)));
-                  // System.out.println(exponent);
                 }
                 if (exponent.isPresent()) {
                   if (exponent.isPlus()) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/Integrate.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/Integrate.java
@@ -96,7 +96,6 @@ public class Integrate extends AbstractFunctionEvaluator {
 
     @Override
     public void run() {
-      // long start = System.currentTimeMillis();
       if (!INTEGRATE_RULES_READ.get()) {
         INTEGRATE_RULES_READ.set(true);
         final EvalEngine engine = EvalEngine.get();
@@ -160,8 +159,6 @@ public class Integrate extends AbstractFunctionEvaluator {
                 F.And(
                     F.SameQ(F.Head(F.Slot1), S.Power),
                     F.SameQ(F.Head(F.Part(F.Slot1, F.C2)), S.Rational))));
-        // long stop = System.currentTimeMillis();
-        // System.out.println("Milliseconds: " + (stop - start));
         COUNT_DOWN_LATCH.countDown();
       }
     }
@@ -174,7 +171,6 @@ public class Integrate extends AbstractFunctionEvaluator {
       //        IExpr lhs=binaryList.arg1();
       //        IExpr rhs=binaryList.arg2();
       //        F.IIntegrate(i, (IAST)lhs, rhs);
-      //        System.out.println(rhs.toString());
       //      }
       UtilityFunctionCtors.getRuleASTRubi45();
 
@@ -761,7 +757,6 @@ public class Integrate extends AbstractFunctionEvaluator {
               engine.setRecursionLimit(Config.INTEGRATE_RUBI_RULES_RECURSION_LIMIT);
             }
 
-            // System.out.println(ast.toString());
             engine.rememberASTCache.put(ast, F.NIL);
             IExpr temp = S.Integrate.evalDownRule(EvalEngine.get(), ast);
             if (temp.isPresent()) {

--- a/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/builtin/SemanticImport.java
+++ b/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/builtin/SemanticImport.java
@@ -50,8 +50,6 @@ public class SemanticImport extends AbstractEvaluator {
       File file = new File(fileName);
       if (file.exists()) {
         Table table = Table.read().csv(file);
-        // System.out.println(table.printAll());
-        // System.out.println(table.structure().printAll());
         return ASTDataset.newTablesawTable(table);
       }
       return engine.printMessage("SemanticImport: file " + fileName + " does not exist!");

--- a/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/builtin/SwingFunctions.java
+++ b/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/builtin/SwingFunctions.java
@@ -482,7 +482,6 @@ public class SwingFunctions {
           if (expr.isPresent()) {
             dynamic.assignValue(expr, false);
           }
-          // System.out.println(F.eval(dynamic).toString());
         }
       }
     }
@@ -510,19 +509,6 @@ public class SwingFunctions {
 
       MyDocumentListener dl = new MyDocumentListener(inputField, dynamic, headID);
       inputField.getDocument().addDocumentListener(dl);
-      // inputField.addActionListener(new ActionListener() {
-      // @Override
-      // public void actionPerformed(ActionEvent e) {
-      // try {
-      // System.out.println(inputField.getText());
-      // } catch (DialogReturnException rex) {
-      // result[0] = rex.getValue();
-      // dialog.dispose();
-      // } catch (RuntimeException rex) {
-      // //
-      // }
-      // }
-      // });
     }
 
     @Override

--- a/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/expression/ASTDataset.java
+++ b/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/expression/ASTDataset.java
@@ -641,7 +641,6 @@ public class ASTDataset extends AbstractAST
    * @return
    */
   private ASTDataset selectColumns(IAST list) {
-    // System.out.println(fData.columnNames().toString());
     String[] strList = new String[list.argSize()];
     int[] vector = list.toIntVector();
     Table table = fTable;

--- a/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/servlet/AJAXQueryServlet.java
+++ b/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/servlet/AJAXQueryServlet.java
@@ -120,7 +120,6 @@ public class AJAXQueryServlet extends HttpServlet {
 
   @Override
   protected void doPost(HttpServletRequest req, HttpServletResponse res) throws IOException {
-    //    System.out.println("/ajax/query");
     res.setContentType("text/html; charset=UTF-8");
     res.setCharacterEncoding("UTF-8");
     res.setHeader("Cache-Control", "no-cache");


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description
As preliminary step towards #272 this PR removes the commented-out `System.out` statements to prevent future accidental use of them. Not commented-out `System.out` statements will be replaced by corresponding LOGGER.info() respectively LOGGER.debug() statements in a subsequent PR. In case the traced information is needed in the future one should use `LOGGER.info/debug/trace()` instead.