### PR TITLE
[JavaForm] properly implement JavaForm for Quantity

### DIFF
--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/tensor/qty/IQuantity.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/tensor/qty/IQuantity.java
@@ -2,6 +2,7 @@ package org.matheclipse.core.tensor.qty;
 
 import org.matheclipse.core.expression.F;
 import org.matheclipse.core.interfaces.IExpr;
+import org.matheclipse.core.interfaces.INumber;
 import org.matheclipse.core.interfaces.ISignedNumber;
 import org.matheclipse.parser.client.math.MathException;
 import com.univocity.parsers.csv.CsvFormat;
@@ -49,7 +50,7 @@ public interface IQuantity extends IExpr, Comparable<IExpr> {
     return QuantityImpl.of(value, unit);
   }
 
-  static IQuantity of(ISignedNumber value, IUnit unit) {
+  static IQuantity of(INumber value, IUnit unit) {
     return new QuantityImpl(value, unit);
   }
 
@@ -58,13 +59,12 @@ public interface IQuantity extends IExpr, Comparable<IExpr> {
    * problems subsequently.
    *
    * @param value
-   * @param string for instance "m*s^-2"
+   * @param unit for instance "m*s^-2"
    * @return
    * @throws Exception if value is instance of {@code Quantity}
    */
-  static IExpr of(IExpr value, String string) {
-    if (value instanceof IQuantity) throw MathException.of(value);
-    return QuantityImpl.of(value, IUnit.ofPutIfAbsent(string));
+  static IExpr of(IExpr value, String unit) {
+    return of(value, IUnit.ofPutIfAbsent(unit));
   }
 
   /**
@@ -86,12 +86,12 @@ public interface IQuantity extends IExpr, Comparable<IExpr> {
    * creates quantity with number encoded as {@link ISignedNumber}
    *
    * @param number
-   * @param string for instance "kg^3*m*s^-2"
+   * @param unit for instance "kg^3*m*s^-2"
    * @return
    * @throws Exception if either parameter equals null
    */
-  static IExpr of(Number number, String string) {
-    return QuantityImpl.of(F.expr(number), IUnit.ofPutIfAbsent(string));
+  static IExpr of(Number number, String unit) {
+    return of(F.expr(number), unit);
   }
 
   public IQuantity ofUnit(IExpr scalar);

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/tensor/qty/QuantityImpl.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/tensor/qty/QuantityImpl.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Objects;
+import java.util.function.Function;
 import org.matheclipse.core.builtin.IOFunctions;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.exception.ArgumentTypeException;
@@ -33,9 +34,8 @@ public class QuantityImpl extends DataExpr<IUnit> implements IQuantity, External
   }
 
   /* package */ QuantityImpl(IExpr value, IUnit unit) {
-    super(S.Quantity, unit);
+    super(S.Quantity, Objects.requireNonNull(unit, "Unit must not be null"));
     this.arg1 = value;
-    this.fData = unit;
   }
 
   @Override
@@ -150,6 +150,14 @@ public class QuantityImpl extends DataExpr<IUnit> implements IQuantity, External
       return new QuantityImpl(F.C0, fData);
     }
     return new QuantityImpl(F.Im(arg1), fData);
+  }
+
+  @Override
+  public String internalJavaString(boolean symbolsAsFactoryMethod, int depth, boolean useOperators,
+      boolean usePrefix, boolean noSymbolPrefix, Function<IExpr, String> variables) {
+    String value = value().internalJavaString(symbolsAsFactoryMethod, depth, useOperators,
+        usePrefix, noSymbolPrefix, variables);
+    return "IQuantity.of(" + value + ", IUnit.ofPutIfAbsent(\"" + unitString() + "\"))";
   }
 
   /** {@inheritDoc} */
@@ -417,12 +425,7 @@ public class QuantityImpl extends DataExpr<IUnit> implements IQuantity, External
 
   @Override
   public String toString() {
-    StringBuilder stringBuilder = new StringBuilder(32); // initial buffer size
-    stringBuilder.append(arg1);
-    stringBuilder.append(UNIT_OPENING_BRACKET);
-    stringBuilder.append(fData);
-    stringBuilder.append(UNIT_CLOSING_BRACKET);
-    return stringBuilder.toString();
+    return arg1.toString() + UNIT_OPENING_BRACKET + fData + UNIT_CLOSING_BRACKET;
   }
 
   @Override

--- a/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/io/system/JavaFormTestCase.java
+++ b/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/io/system/JavaFormTestCase.java
@@ -9,6 +9,8 @@ import org.matheclipse.core.eval.EvalUtilities;
 import org.matheclipse.core.expression.F;
 import org.matheclipse.core.interfaces.IAST;
 import org.matheclipse.core.interfaces.IExpr;
+import org.matheclipse.core.tensor.qty.IQuantity;
+import org.matheclipse.core.tensor.qty.IUnit;
 import org.matheclipse.parser.client.FEConfig;
 
 /** */
@@ -39,11 +41,17 @@ public class JavaFormTestCase extends AbstractTestCase {
     IAST function = Sinc(Times(CI, CInfinity));
 
     IExpr result = EvalEngine.get().evalHoldPattern(function);
-    assertEquals(
-        result.internalJavaString(true, -1, false, true, false, F.CNullFunction), //
+    assertEquals(result.internalJavaString(true, -1, false, true, false, F.CNullFunction),
         "F.Sinc(F.DirectedInfinity(F.CI))");
 
     result = util.evaluate(function);
     assertEquals(result.internalJavaString(true, -1, false, true, false, F.CNullFunction), "F.oo");
+  }
+
+  public void testJavaFormQuantity() {
+    IExpr quantity = IQuantity.of(F.ZZ(43L), IUnit.ofPutIfAbsent("kg"));
+    String javaForm = quantity.internalJavaString(null);
+    System.out.println(javaForm);
+    assertEquals("IQuantity.of(F.ZZ(43L), IUnit.ofPutIfAbsent(\"kg\"))", javaForm);
   }
 }


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description
This PR aims to properly implement `internalJavaString()` for `QuantityImpl` so that the Java-Code of quantities is correctly generated.
Furthermore `IQantity` was cleaned up a bit.

Do you think one of the given parameters should be considered in the implementation of `QuantityImpl.internalJavaString()`?

## Testing
An additional test-case was added to `JavaFormTestCase.java`