### PR TITLE
[CleanUp] avoid unnecessary object creation and fix java-doc

### DIFF
--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/LinearAlgebra.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/LinearAlgebra.java
@@ -1994,7 +1994,7 @@ public final class LinearAlgebra {
           // Positive integer (less equal 2147483647) expected at position `2` in `1`.
           return IOFunctions.printMessage(S.IdentityMatrix, "intpm", F.List(ast, F.C1), engine);
         }
-        return F.matrix((i, j) -> i.equals(j) ? F.C1 : F.C0, m, m);
+        return F.matrix((i, j) -> i == j ? F.C1 : F.C0, m, m);
       }
       return F.NIL;
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/EvalEngine.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/EvalEngine.java
@@ -364,23 +364,14 @@ public class EvalEngine implements Serializable {
       final PrintStream outStream,
       PrintStream errorStream,
       boolean relaxedSyntax) {
-    fOptionsStack = new OptionsStack();
     fSessionID = sessionID;
-    // fExpressionFactory = f;
     fRecursionLimit = recursionLimit;
     fIterationLimit = iterationLimit;
     fOutPrintStream = outStream;
-    if (errorStream == null) {
-      fErrorPrintStream = outStream;
-    } else {
-      fErrorPrintStream = errorStream;
-    }
+    fErrorPrintStream = errorStream == null ? outStream : errorStream;
     fRelaxedSyntax = relaxedSyntax;
     fOutListDisabled = true;
-    // fNamespace = fExpressionFactory.getNamespace();
-
     init();
-    // fContextPath = new ContextPath();
   }
 
   /**

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/util/BiIntFunction.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/util/BiIntFunction.java
@@ -1,0 +1,15 @@
+package org.matheclipse.core.eval.util;
+
+import java.util.function.BiFunction;
+
+/**
+ * Represents a function that accepts two int-valued arguments and produces a result. This is the
+ * {@code int}-consuming primitive specialization for {@link BiFunction}.
+ * 
+ * @param <R> the type of the result of the function
+ * @see BiFunction
+ */
+@FunctionalInterface
+public interface BiIntFunction<R> {
+  R apply(int value, int value2);
+}

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/F.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/F.java
@@ -94,6 +94,7 @@ import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.exception.ASTElementLimitExceeded;
 import org.matheclipse.core.eval.interfaces.AbstractCoreFunctionEvaluator;
 import org.matheclipse.core.eval.interfaces.ICoreFunctionEvaluator;
+import org.matheclipse.core.eval.util.BiIntFunction;
 import org.matheclipse.core.eval.util.IAssumptions;
 import org.matheclipse.core.eval.util.Lambda;
 import org.matheclipse.core.expression.data.GraphExpr;
@@ -8740,8 +8741,7 @@ public class F extends S {
    * @param m the number of elements in one row
    * @return
    */
-  public static IAST matrix(
-      BiFunction<Integer, Integer, ? extends IExpr> biFunction, int n, int m) {
+  public static IAST matrix(BiIntFunction<? extends IExpr> biFunction, int n, int m) {
     if (n > Config.MAX_MATRIX_DIMENSION_SIZE || m > Config.MAX_MATRIX_DIMENSION_SIZE) {
       ASTElementLimitExceeded.throwIt(((long) n) * ((long) m));
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/interfaces/IExpr.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/interfaces/IExpr.java
@@ -2152,7 +2152,7 @@ public interface IExpr
   }
 
   /**
-   * Test if this expression is a list (i.e. an AST with head List) with exactly 2 arguments
+   * Test if this expression is a list (i.e. an AST with head List) with exactly 1 arguments
    *
    * @return
    */
@@ -2170,7 +2170,7 @@ public interface IExpr
   }
 
   /**
-   * Test if this expression is a list (i.e. an AST with head List) with exactly 2 arguments
+   * Test if this expression is a list (i.e. an AST with head List) with exactly 3 arguments
    *
    * @return
    */


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description
This PR has the goal to avoid unnecessary object creation.

1. Avoid creation of two `OptionsStack` objects when creating a new `EvalEngine` object, because `fOptionsStack` was initialized twice with a new OptionsStack. Once in the constructor and again in `init()`.
2. Avoid creation of Integer objects when populating a matrix in `F.matrix()`. For this a new functional interface BiIntFunction is added that is a specialization of `BiFunction` for two int arguments.

And this PR also fixes minor Java-doc mistakes.