### PR TITLE
[IQuantity] fix Java-Form creation with Unit.ONE and remove whitespace

### DIFF
--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/tensor/qty/QuantityImpl.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/tensor/qty/QuantityImpl.java
@@ -157,7 +157,14 @@ public class QuantityImpl extends DataExpr<IUnit> implements IQuantity, External
       boolean usePrefix, boolean noSymbolPrefix, Function<IExpr, String> variables) {
     String value = value().internalJavaString(symbolsAsFactoryMethod, depth, useOperators,
         usePrefix, noSymbolPrefix, variables);
-    return "IQuantity.of(" + value + ", IUnit.ofPutIfAbsent(\"" + unitString() + "\"))";
+    StringBuilder javaForm = new StringBuilder();
+    javaForm.append("IQuantity.of(").append(value).append(",");
+    if (IUnit.ONE.equals(unit())) {
+      javaForm.append("IUnit.ONE");
+    } else {
+      javaForm.append("IUnit.ofPutIfAbsent(\"").append(unitString()).append("\")");
+    }
+    return javaForm.append(")").toString();
   }
 
   /** {@inheritDoc} */

--- a/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/io/system/JavaFormTestCase.java
+++ b/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/io/system/JavaFormTestCase.java
@@ -48,10 +48,15 @@ public class JavaFormTestCase extends AbstractTestCase {
     assertEquals(result.internalJavaString(true, -1, false, true, false, F.CNullFunction), "F.oo");
   }
 
-  public void testJavaFormQuantity() {
+  public void testJavaFormQuantity_withUnitKG() {
     IExpr quantity = IQuantity.of(F.ZZ(43L), IUnit.ofPutIfAbsent("kg"));
     String javaForm = quantity.internalJavaString(null);
-    System.out.println(javaForm);
-    assertEquals("IQuantity.of(F.ZZ(43L), IUnit.ofPutIfAbsent(\"kg\"))", javaForm);
+    assertEquals("IQuantity.of(F.ZZ(43L),IUnit.ofPutIfAbsent(\"kg\"))", javaForm);
+  }
+
+  public void testJavaFormQuantity_withUnitOne() {
+    IExpr quantity = IQuantity.of(F.ZZ(43L), IUnit.ONE);
+    String javaForm = quantity.internalJavaString(null);
+    assertEquals("IQuantity.of(F.ZZ(43L),IUnit.ONE)", javaForm);
   }
 }


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

This PR fixes the Java-Form creation of IQuantities with Unit.ONE and removes the whitespace in the generated code.

## Testing
`JavaFormTestCase` was extended and console print-out was removed.
