### PR TITLE
[JavaForm] return CharSequence instead String by internalJavaString()

### DIFF
--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/OutputFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/OutputFunctions.java
@@ -452,7 +452,7 @@ public final class OutputFunctions {
    */
   private static class JavaForm extends AbstractCoreFunctionEvaluator {
 
-    public static String javaForm(IExpr arg1, boolean strictJava, boolean usePrefix) {
+    public static CharSequence javaForm(IExpr arg1, boolean strictJava, boolean usePrefix) {
       return arg1.internalJavaString(strictJava, 0, false, usePrefix, false, F.CNullFunction);
     }
 
@@ -554,12 +554,12 @@ public final class OutputFunctions {
 
             return F.$str(toJavaComplex(arg1), IStringX.APPLICATION_JAVA);
           }
-        String resultStr = javaForm(arg1, strictJava, usePrefix);
-        return F.$str(resultStr, IStringX.APPLICATION_JAVA);
-      } catch (Exception rex) {
-        LOGGER.log(engine.getLogLevel(), "JavaForm", rex);
-        return F.NIL;
-      }
+          String resultStr = javaForm(arg1, strictJava, usePrefix).toString();
+          return F.$str(resultStr, IStringX.APPLICATION_JAVA);
+        } catch (Exception rex) {
+          LOGGER.log(engine.getLogLevel(), "JavaForm", rex);
+          return F.NIL;
+        }
     }
 
     @Override

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/MathMLUtilities.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/MathMLUtilities.java
@@ -169,8 +169,8 @@ public class MathMLUtilities {
         parsedExpression = parser.parse(inputExpression);
         // node = fEvalEngine.parseNode(inputExpression);
         // parsedExpression = AST2Expr.CONST.convert(node, fEvalEngine);
-        out.write(
-            parsedExpression.internalJavaString(false, -1, false, true, false, F.CNullFunction));
+        out.write(parsedExpression
+            .internalJavaString(false, -1, false, true, false, F.CNullFunction).toString());
       } catch (final IOException ioe) {
         //
       } catch (final RuntimeException rex) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/AbstractAST.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/AbstractAST.java
@@ -455,13 +455,13 @@ public abstract class AbstractAST implements IASTMutable {
 
     /** {@inheritDoc} */
     @Override
-    public final String internalJavaString(
+    public final CharSequence internalJavaString(
         boolean symbolsAsFactoryMethod,
         int depth,
         boolean useOperators,
         boolean usePrefix,
         boolean noSymbolPrefix,
-        Function<IExpr, String> variables) {
+        Function<IExpr, ? extends CharSequence> variables) {
       return usePrefix ? "F.NIL" : "NIL";
     }
 
@@ -1148,7 +1148,7 @@ public abstract class AbstractAST implements IASTMutable {
       boolean useOperators,
       boolean usePrefix,
       boolean noSymbolPrefix,
-      Function<IExpr, String> variables) {
+      Function<IExpr, ? extends CharSequence> variables) {
     for (int i = 1; i < ast.size(); i++) {
       if ((ast.get(i) instanceof IAST) && ast.head().equals(ast.get(i).head())) {
         internalFormOrderless(
@@ -2471,21 +2471,21 @@ public abstract class AbstractAST implements IASTMutable {
   /** {@inheritDoc} */
   @Override
   public final String internalFormString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, false, false, false, x -> null);
+    return internalJavaString(symbolsAsFactoryMethod, depth, false, false, false, x -> null)
+        .toString();
   }
 
   /** {@inheritDoc} */
   @Override
-  public String internalJavaString(
+  public CharSequence internalJavaString(
       boolean symbolsAsFactoryMethod,
       int depth,
       boolean useOperators,
       boolean usePrefix,
       boolean noSymbolPrefix,
-      Function<IExpr, String> variables) {
+      Function<IExpr, ? extends CharSequence> variables) {
     final String sep = ",";
     final IExpr temp = head();
-    String prefix = usePrefix ? "F." : "";
     if (temp.equals(S.HoldForm) && size() == 2) {
       return arg1()
           .internalJavaString(
@@ -2496,20 +2496,21 @@ public abstract class AbstractAST implements IASTMutable {
           .internalJavaString(
               symbolsAsFactoryMethod, depth, useOperators, usePrefix, noSymbolPrefix, variables);
     }
+    String prefix = usePrefix ? "F." : "";
     if (isInfinity()) {
-      return prefix + "oo";
+      return new StringBuilder(prefix).append("oo");
     }
     if (isNegativeInfinity()) {
-      return prefix + "Noo";
+      return new StringBuilder(prefix).append("Noo");
     }
     if (isComplexInfinity()) {
-      return prefix + "CComplexInfinity";
+      return new StringBuilder(prefix).append("CComplexInfinity");
     }
     if (this.equals(F.Slot1)) {
-      return prefix + "Slot1";
+      return new StringBuilder(prefix).append("Slot1");
     }
     if (this.equals(F.Slot2)) {
-      return prefix + "Slot2";
+      return new StringBuilder(prefix).append("Slot2");
     }
     if (temp.equals(S.Inequality) && size() >= 4) {
       return BooleanFunctions.inequality2And(this)
@@ -2527,90 +2528,90 @@ public abstract class AbstractAST implements IASTMutable {
       if (arg1().isInteger() && arg2().isMinusOne()) {
         IInteger i = (IInteger) arg1();
         if (i.equals(F.C2)) {
-          return prefix + "C1D2";
+          return new StringBuilder(prefix).append("C1D2");
         } else if (i.equals(F.C3)) {
-          return prefix + "C1D3";
+          return new StringBuilder(prefix).append("C1D3");
         } else if (i.equals(F.C4)) {
-          return prefix + "C1D4";
+          return new StringBuilder(prefix).append("C1D4");
         } else if (i.equals(F.CN2)) {
-          return prefix + "CN1D2";
+          return new StringBuilder(prefix).append("CN1D2");
         } else if (i.equals(F.CN3)) {
-          return prefix + "CN1D3";
+          return new StringBuilder(prefix).append("CN1D3");
         } else if (i.equals(F.CN4)) {
-          return prefix + "CN1D4";
+          return new StringBuilder(prefix).append("CN1D4");
         }
       }
       if (equalsAt(1, S.E)) {
-        return prefix
-            + "Exp("
-            + arg2()
+        return new StringBuilder(prefix)
+            .append("Exp(")
+            .append(arg2()
                 .internalJavaString(
                     symbolsAsFactoryMethod,
                     depth + 1,
                     useOperators,
                     usePrefix,
                     noSymbolPrefix,
-                    variables)
-            + ")";
+                    variables))
+            .append(")");
       }
       if (equalsAt(2, F.C1D2)) {
         if (base().isInteger()) {
           // square root of an integer number
           IInteger i = (IInteger) base();
           if (i.equals(F.C2)) {
-            return prefix + "CSqrt2";
+            return new StringBuilder(prefix).append("CSqrt2");
           } else if (i.equals(F.C3)) {
-            return prefix + "CSqrt3";
+            return new StringBuilder(prefix).append("CSqrt3");
           } else if (i.equals(F.C5)) {
-            return prefix + "CSqrt5";
+            return new StringBuilder(prefix).append("CSqrt5");
           } else if (i.equals(F.C6)) {
-            return prefix + "CSqrt6";
+            return new StringBuilder(prefix).append("CSqrt6");
           } else if (i.equals(F.C7)) {
-            return prefix + "CSqrt7";
+            return new StringBuilder(prefix).append("CSqrt7");
           } else if (i.equals(F.C10)) {
-            return prefix + "CSqrt10";
+            return new StringBuilder(prefix).append("CSqrt10");
           }
         }
-        return prefix
-            + "Sqrt("
-            + arg1()
+        return new StringBuilder(prefix)
+            .append("Sqrt(")
+            .append(arg1()
                 .internalJavaString(
                     symbolsAsFactoryMethod,
                     depth + 1,
                     useOperators,
                     usePrefix,
                     noSymbolPrefix,
-                    variables)
-            + ")";
+                    variables))
+            .append(")");
       }
       if (equalsAt(2, F.C2)) {
-        return prefix
-            + "Sqr("
-            + arg1()
+        return new StringBuilder(prefix)
+            .append("Sqr(")
+            .append(arg1()
                 .internalJavaString(
                     symbolsAsFactoryMethod,
                     depth + 1,
                     useOperators,
                     usePrefix,
                     noSymbolPrefix,
-                    variables)
-            + ")";
+                    variables))
+            .append(")");
       }
       if (equalsAt(2, F.CN1D2) && arg1().isInteger()) {
         // negative square root of an integer number
         IInteger i = (IInteger) arg1();
         if (i.equals(F.C2)) {
-          return prefix + "C1DSqrt2";
+          return new StringBuilder(prefix).append("C1DSqrt2");
         } else if (i.equals(F.C3)) {
-          return prefix + "C1DSqrt3";
+          return new StringBuilder(prefix).append("C1DSqrt3");
         } else if (i.equals(F.C5)) {
-          return prefix + "C1DSqrt5";
+          return new StringBuilder(prefix).append("C1DSqrt5");
         } else if (i.equals(F.C6)) {
-          return prefix + "C1DSqrt6";
+          return new StringBuilder(prefix).append("C1DSqrt6");
         } else if (i.equals(F.C7)) {
-          return prefix + "C1DSqrt7";
+          return new StringBuilder(prefix).append("C1DSqrt7");
         } else if (i.equals(F.C10)) {
-          return prefix + "C1DSqrt10";
+          return new StringBuilder(prefix).append("C1DSqrt10");
         }
       }
       // don't optimize if arg2() is integer
@@ -2627,7 +2628,7 @@ public abstract class AbstractAST implements IASTMutable {
         name = AST2Expr.PREDEFINED_SYMBOLS_MAP.get(name);
       }
       if (name == null && !Character.isUpperCase(sym.toString().charAt(0))) {
-        text.append(prefix + "$(");
+        text.append(prefix).append("$(");
         for (int i = 0; i < size(); i++) {
           text.append(
               get(i)
@@ -2642,11 +2643,10 @@ public abstract class AbstractAST implements IASTMutable {
             text.append(sep);
           }
         }
-        text.append(')');
-        return text.toString();
+        return text.append(')');
       }
     } else if (temp.isPattern() || temp.isAST()) {
-      text.append(prefix + "$(");
+      text.append(prefix).append("$(");
       for (int i = 0; i < size(); i++) {
         text.append(
             get(i)
@@ -2661,21 +2661,20 @@ public abstract class AbstractAST implements IASTMutable {
           text.append(sep);
         }
       }
-      text.append(')');
-      return text.toString();
+      return text.append(')');
     }
 
     if (isAST(S.Times, 3)) {
       if (equals(F.CNPi)) {
-        return prefix + "CNPi";
+        return new StringBuilder(prefix).append("CNPi");
       } else if (equals(F.CN2Pi)) {
-        return prefix + "CN2Pi";
+        return new StringBuilder(prefix).append("CN2Pi");
       } else if (equals(F.C2Pi)) {
-        return prefix + "C2Pi";
+        return new StringBuilder(prefix).append("C2Pi");
       } else if (equals(F.CNPiHalf)) {
-        return prefix + "CNPiHalf";
+        return new StringBuilder(prefix).append("CNPiHalf");
       } else if (equals(F.CPiHalf)) {
-        return prefix + "CPiHalf";
+        return new StringBuilder(prefix).append("CPiHalf");
       }
       if (arg1().isMinusOne() && !arg2().isTimes()) {
         if (arg2().isNumber()) {
@@ -2688,41 +2687,40 @@ public abstract class AbstractAST implements IASTMutable {
               noSymbolPrefix,
               variables);
         }
-        return prefix
-            + "Negate("
-            + arg2()
+        return new StringBuilder(prefix)
+            .append("Negate(")
+            .append(arg2()
                 .internalJavaString(
                     symbolsAsFactoryMethod,
                     depth + 1,
                     useOperators,
                     usePrefix,
                     noSymbolPrefix,
-                    variables)
-            + ")";
+                    variables))
+            .append(")");
       }
     } else if (isAST(S.Plus, 3)) {
       if (arg2().isAST(S.Times, 3) && arg2().first().isMinusOne()) {
-        return prefix
-            + "Subtract("
-            + arg1()
+        return new StringBuilder(prefix)
+            .append("Subtract(")
+            .append(arg1()
                 .internalJavaString(
                     symbolsAsFactoryMethod,
                     depth + 1,
                     useOperators,
                     usePrefix,
                     noSymbolPrefix,
-                    variables)
-            + ","
-            + arg2()
-                .second()
+                    variables))
+            .append(",")
+            .append(arg2().second()
                 .internalJavaString(
                     symbolsAsFactoryMethod,
                     depth + 1,
                     useOperators,
                     usePrefix,
                     noSymbolPrefix,
-                    variables)
-            + ")";
+                    variables))
+            .append(")");
       }
     }
 
@@ -2751,7 +2749,7 @@ public abstract class AbstractAST implements IASTMutable {
             usePrefix,
             noSymbolPrefix,
             text);
-        return text.toString();
+        return text;
       } else if (isPlus()) {
         IExpr arg1 = arg1();
         IExpr arg2 = arg2();
@@ -2774,7 +2772,7 @@ public abstract class AbstractAST implements IASTMutable {
             usePrefix,
             noSymbolPrefix,
             text);
-        return text.toString();
+        return text;
       } else if (isPower()) {
         IExpr arg1 = arg1();
         IExpr arg2 = arg2();
@@ -2799,7 +2797,7 @@ public abstract class AbstractAST implements IASTMutable {
             usePrefix,
             noSymbolPrefix,
             text);
-        return text.toString();
+        return text;
       }
     }
     text.append(
@@ -2844,8 +2842,7 @@ public abstract class AbstractAST implements IASTMutable {
     if (depth == 0 && isList()) {
       text.append('\n');
     }
-    text.append(')');
-    return text.toString();
+    return text.append(')');
   }
 
   private void internalOperatorForm(
@@ -2876,7 +2873,8 @@ public abstract class AbstractAST implements IASTMutable {
   /** {@inheritDoc} */
   @Override
   public final String internalScalaString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, true, false, false, x -> null);
+    return internalJavaString(symbolsAsFactoryMethod, depth, true, false, false, x -> null)
+        .toString();
   }
 
   /** {@inheritDoc} */

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/AbstractIntegerSym.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/AbstractIntegerSym.java
@@ -756,7 +756,8 @@ public abstract class AbstractIntegerSym implements IInteger, Externalizable {
 
   @Override
   public String internalFormString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, false, false, false, F.CNullFunction);
+    return internalJavaString(symbolsAsFactoryMethod, depth, false, false, false, F.CNullFunction)
+        .toString();
   }
 
   @Override

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/BigFractionSym.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/BigFractionSym.java
@@ -403,45 +403,46 @@ public class BigFractionSym extends AbstractFractionSym {
   }
 
   @Override
-  public String internalJavaString(
+  public CharSequence internalJavaString(
       boolean symbolsAsFactoryMethod,
       int depth,
       boolean useOperators,
       boolean usePrefix,
       boolean noSymbolPrefix,
-      Function<IExpr, String> variables) {
+      Function<IExpr, ? extends CharSequence> variables) {
     String prefix = usePrefix ? "F." : "";
+    StringBuilder javaForm = new StringBuilder(prefix);
     int numerator = NumberUtil.toIntDefault(fFraction.getNumerator());
     if (numerator == 1 || numerator == -1) {
       int denominator = NumberUtil.toIntDefault(fFraction.getDenominator());
       if (numerator == 1) {
         switch (denominator) {
           case 2:
-            return prefix + "C1D2";
+            return javaForm.append("C1D2");
           case 3:
-            return prefix + "C1D3";
+            return javaForm.append("C1D3");
           case 4:
-            return prefix + "C1D4";
+            return javaForm.append("C1D4");
           default:
         }
       } else if (numerator == -1) {
         switch (denominator) {
           case 2:
-            return prefix + "CN1D2";
+            return javaForm.append("CN1D2");
           case 3:
-            return prefix + "CN1D3";
+            return javaForm.append("CN1D3");
           case 4:
-            return prefix + "CN1D4";
+            return javaForm.append("CN1D4");
           default:
         }
       }
     }
-    return prefix
-        + "QQ("
-        + fFraction.getNumerator().toString()
-        + "L,"
-        + fFraction.getDenominator().toString()
-        + "L)";
+    return javaForm
+        .append("QQ(")
+        .append(fFraction.getNumerator().toString())
+        .append("L,")
+        .append(fFraction.getDenominator().toString())
+        .append("L)");
   }
 
   /**

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/BigIntegerSym.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/BigIntegerSym.java
@@ -354,70 +354,72 @@ public class BigIntegerSym extends AbstractIntegerSym {
   }
 
   @Override
-  public String internalJavaString(
+  public CharSequence internalJavaString(
       boolean symbolsAsFactoryMethod,
       int depth,
       boolean useOperators,
       boolean usePrefix,
       boolean noSymbolPrefix,
-      Function<IExpr, String> variables) {
+      Function<IExpr, ? extends CharSequence> variables) {
     String prefix = usePrefix ? "F." : "";
+    StringBuilder javaForm = new StringBuilder(prefix);
     int value = toIntDefault(); // NumberUtil.toInt(fBigIntValue);
     if (value != Integer.MIN_VALUE) {
       switch (value) {
         case -1:
-          return prefix + "CN1";
+          return javaForm.append("CN1");
         case -2:
-          return prefix + "CN2";
+          return javaForm.append("CN2");
         case -3:
-          return prefix + "CN3";
+          return javaForm.append("CN3");
         case -4:
-          return prefix + "CN4";
+          return javaForm.append("CN4");
         case -5:
-          return prefix + "CN5";
+          return javaForm.append("CN5");
         case -6:
-          return prefix + "CN6";
+          return javaForm.append("CN6");
         case -7:
-          return prefix + "CN7";
+          return javaForm.append("CN7");
         case -8:
-          return prefix + "CN8";
+          return javaForm.append("CN8");
         case -9:
-          return prefix + "CN9";
+          return javaForm.append("CN9");
         case -10:
-          return prefix + "CN10";
+          return javaForm.append("CN10");
         case 0:
-          return prefix + "C0";
+          return javaForm.append("C0");
         case 1:
-          return prefix + "C1";
+          return javaForm.append("C1");
         case 2:
-          return prefix + "C2";
+          return javaForm.append("C2");
         case 3:
-          return prefix + "C3";
+          return javaForm.append("C3");
         case 4:
-          return prefix + "C4";
+          return javaForm.append("C4");
         case 5:
-          return prefix + "C5";
+          return javaForm.append("C5");
         case 6:
-          return prefix + "C6";
+          return javaForm.append("C6");
         case 7:
-          return prefix + "C7";
+          return javaForm.append("C7");
         case 8:
-          return prefix + "C8";
+          return javaForm.append("C8");
         case 9:
-          return prefix + "C9";
+          return javaForm.append("C9");
         case 10:
-          return prefix + "C10";
+          return javaForm.append("C10");
         default:
-          return prefix + "ZZ(" + value + "L)";
+          return javaForm.append("ZZ(").append(value).append("L)");
       }
     } else {
-      return prefix + "ZZ(\"" + fBigIntValue.toString() + "\", 10)";
+      return javaForm.append("ZZ(\"").append(fBigIntValue.toString()).append("\", 10)");
     }
   }
 
   @Override
   public String internalScalaString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, true, false, false, x -> null);
+    return internalJavaString(symbolsAsFactoryMethod, depth, true, false, false, x -> null)
+        .toString();
   }
 
   @Override

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Blank.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Blank.java
@@ -255,23 +255,21 @@ public class Blank implements IPattern {
   }
 
   @Override
-  public String internalJavaString(
+  public CharSequence internalJavaString(
       boolean symbolsAsFactoryMethod,
       int depth,
       boolean useOperators,
       boolean usePrefix,
       boolean noSymbolPrefix,
-      Function<IExpr, String> variables) {
+      Function<IExpr, ? extends CharSequence> variables) {
     String prefix = usePrefix ? "F." : "";
-    final StringBuilder buffer = new StringBuilder();
-    buffer.append(prefix + "$b(");
+    final StringBuilder buffer = new StringBuilder(prefix).append("$b(");
     if (fHeadTest != null) {
       buffer.append(
           fHeadTest.internalJavaString(
               symbolsAsFactoryMethod, 0, useOperators, usePrefix, noSymbolPrefix, variables));
     }
-    buffer.append(')');
-    return buffer.toString();
+    return buffer.append(')');
   }
 
   /** {@inheritDoc} */

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/BuiltInDummy.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/BuiltInDummy.java
@@ -546,25 +546,26 @@ public class BuiltInDummy implements IBuiltInSymbol, Serializable {
   /** {@inheritDoc} */
   @Override
   public String internalFormString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, false, false, false, x -> null);
+    return internalJavaString(symbolsAsFactoryMethod, depth, false, false, false, x -> null)
+        .toString();
   }
 
   /** {@inheritDoc} */
   @Override
-  public String internalJavaString(
+  public CharSequence internalJavaString(
       boolean symbolsAsFactoryMethod,
       int depth,
       boolean useOperators,
       boolean usePrefix,
       boolean noSymbolPrefix,
-      Function<IExpr, String> variables) {
-    String result = variables.apply(this);
+      Function<IExpr, ? extends CharSequence> variables) {
+    CharSequence result = variables.apply(this);
     if (result != null) {
       return result;
     }
     String prefix = usePrefix ? "F." : "";
     if (symbolsAsFactoryMethod) {
-      return prefix + internalJavaStringAsFactoryMethod();
+      return new StringBuilder(prefix).append(internalJavaStringAsFactoryMethod());
     }
     if (FEConfig.PARSER_USE_LOWERCASE_SYMBOLS) {
       String name;
@@ -574,17 +575,17 @@ public class BuiltInDummy implements IBuiltInSymbol, Serializable {
         name = AST2Expr.PREDEFINED_SYMBOLS_MAP.get(fSymbolName.toLowerCase(Locale.ENGLISH));
       }
       if (name != null) {
-        return prefix + name;
+        return new StringBuilder(prefix).append(name);
       }
     } else {
       String name = AST2Expr.PREDEFINED_SYMBOLS_MAP.get(fSymbolName.toLowerCase(Locale.ENGLISH));
       if (name != null && name.equals(fSymbolName)) {
-        return prefix + name;
+        return new StringBuilder(prefix).append(name);
       }
     }
     char ch = fSymbolName.charAt(0);
     if (!noSymbolPrefix && fSymbolName.length() == 1 && ('a' <= ch && ch <= 'z')) {
-      return prefix + fSymbolName;
+      return new StringBuilder(prefix).append(fSymbolName);
     } else {
       return fSymbolName;
     }
@@ -634,7 +635,8 @@ public class BuiltInDummy implements IBuiltInSymbol, Serializable {
   /** {@inheritDoc} */
   @Override
   public String internalScalaString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, true, false, false, x -> null);
+    return internalJavaString(symbolsAsFactoryMethod, depth, true, false, false, x -> null)
+        .toString();
   }
 
   /** {@inheritDoc} */

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/BuiltInSymbol.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/BuiltInSymbol.java
@@ -232,14 +232,12 @@ public class BuiltInSymbol extends Symbol implements IBuiltInSymbol {
   }
 
   @Override
-  protected String internalJavaStringAsFactoryMethod() {
-    if (Config.RUBI_CONVERT_SYMBOLS) {
-      if (fOrdinal >= 1) {
-        if (Config.RUBI_CONVERT_SYMBOLS && "C".equals(fSymbolName)) {
-          return fSymbolName + "Symbol";
-        }
-        return fSymbolName;
+  protected CharSequence internalJavaStringAsFactoryMethod() {
+    if (Config.RUBI_CONVERT_SYMBOLS && fOrdinal >= 1) {
+      if (Config.RUBI_CONVERT_SYMBOLS && "C".equals(fSymbolName)) {
+        return new StringBuilder(fSymbolName).append("Symbol");
       }
+      return fSymbolName;
     }
     return super.internalJavaStringAsFactoryMethod();
   }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/ComplexNum.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/ComplexNum.java
@@ -581,24 +581,27 @@ public class ComplexNum implements IComplexNum {
 
   @Override
   public String internalFormString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, false, false, false, F.CNullFunction);
+    return internalJavaString(symbolsAsFactoryMethod, depth, false, false, false, F.CNullFunction)
+        .toString();
   }
 
   @Override
-  public String internalJavaString(
+  public CharSequence internalJavaString(
       boolean symbolsAsFactoryMethod,
       int depth,
       boolean useOperators,
       boolean usePrefix,
       boolean noSymbolPrefix,
-      Function<IExpr, String> variables) {
+      Function<IExpr, ? extends CharSequence> variables) {
     String prefix = usePrefix ? "F." : "";
-    return prefix + "complexNum(" + fComplex.getReal() + "," + fComplex.getImaginary() + ")";
+    return new StringBuilder(prefix).append("complexNum(").append(fComplex.getReal()).append(",")
+        .append(fComplex.getImaginary()).append(")");
   }
 
   @Override
   public String internalScalaString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, true, false, false, F.CNullFunction);
+    return internalJavaString(symbolsAsFactoryMethod, depth, true, false, false, F.CNullFunction)
+        .toString();
   }
 
   @Override

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/ComplexSym.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/ComplexSym.java
@@ -488,24 +488,25 @@ public class ComplexSym implements IComplex {
 
   @Override
   public String internalFormString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, false, false, false, F.CNullFunction);
+    return internalJavaString(symbolsAsFactoryMethod, depth, false, false, false,
+        F.CNullFunction).toString();
   }
 
   @Override
-  public String internalJavaString(
+  public CharSequence internalJavaString(
       boolean symbolsAsFactoryMethod,
       int depth,
       boolean useOperators,
       boolean usePrefix,
       boolean noSymbolPrefix,
-      Function<IExpr, String> variables) {
+      Function<IExpr, ? extends CharSequence> variables) {
     String prefix = usePrefix ? "F." : "";
     if (fReal.isZero()) {
       if (fImaginary.isOne()) {
-        return prefix + "CI";
+        return new StringBuilder(prefix).append("CI");
       }
       if (fImaginary.isMinusOne()) {
-        return prefix + "CNI";
+        return new StringBuilder(prefix).append("CNI");
       }
     }
 
@@ -520,34 +521,31 @@ public class ComplexSym implements IComplex {
         imagNumerator != Integer.MIN_VALUE
         && //
         imagDenominator != Integer.MIN_VALUE) {
-      return prefix
-          + "CC("
-          + realNumerator
-          + "L,"
-          + realDenominator
-          + "L,"
-          + imagNumerator
-          + "L,"
-          + imagDenominator
-          + "L)";
+      return new StringBuilder(prefix)
+          .append("CC(")
+          .append(realNumerator)
+          .append("L,")
+          .append(realDenominator)
+          .append("L,")
+          .append(imagNumerator)
+          .append("L,")
+          .append(imagDenominator)
+          .append("L)");
     }
-    return prefix
-        + "CC("
-        + //
-        fReal.internalJavaString(
-            symbolsAsFactoryMethod, depth, useOperators, usePrefix, noSymbolPrefix, variables)
-        + //
-        ","
-        + //
-        fImaginary.internalJavaString(
-            symbolsAsFactoryMethod, depth, useOperators, usePrefix, noSymbolPrefix, variables)
-        + //
-        ")";
+    return new StringBuilder(prefix)
+        .append("CC(")
+        .append(fReal.internalJavaString(
+            symbolsAsFactoryMethod, depth, useOperators, usePrefix, noSymbolPrefix, variables))
+        .append(",")
+        .append(fImaginary.internalJavaString(
+            symbolsAsFactoryMethod, depth, useOperators, usePrefix, noSymbolPrefix, variables))
+        .append(")");
   }
 
   @Override
   public String internalScalaString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, true, false, false, F.CNullFunction);
+    return internalJavaString(symbolsAsFactoryMethod, depth, true, false, false, F.CNullFunction)
+        .toString();
   }
 
   @Override

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/FractionSym.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/FractionSym.java
@@ -403,46 +403,49 @@ public class FractionSym extends AbstractFractionSym {
 
   @Override
   public String internalFormString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, false, false, false, F.CNullFunction);
+    return internalJavaString(symbolsAsFactoryMethod, depth, false, false, false, F.CNullFunction)
+        .toString();
   }
 
   @Override
-  public String internalJavaString(
+  public CharSequence internalJavaString(
       boolean symbolsAsFactoryMethod,
       int depth,
       boolean useOperators,
       boolean usePrefix,
       boolean noSymbolPrefix,
-      Function<IExpr, String> variables) {
+      Function<IExpr, ? extends CharSequence> variables) {
     String prefix = usePrefix ? "F." : "";
+    StringBuilder javaForm = new StringBuilder(prefix);
     if (fNumerator == 1) {
       switch (fDenominator) {
         case 2:
-          return prefix + "C1D2";
+          return javaForm.append("C1D2");
         case 3:
-          return prefix + "C1D3";
+          return javaForm.append("C1D3");
         case 4:
-          return prefix + "C1D4";
+          return javaForm.append("C1D4");
         default:
       }
     }
     if (fNumerator == -1) {
       switch (fDenominator) {
         case 2:
-          return prefix + "CN1D2";
+          return javaForm.append("CN1D2");
         case 3:
-          return prefix + "CN1D3";
+          return javaForm.append("CN1D3");
         case 4:
-          return prefix + "CN1D4";
+          return javaForm.append("CN1D4");
         default:
       }
     }
-    return prefix + "QQ(" + fNumerator + "L," + fDenominator + "L)";
+    return javaForm.append("QQ(").append(fNumerator).append("L,").append(fDenominator).append("L)");
   }
 
   @Override
   public String internalScalaString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, true, false, false, F.CNullFunction);
+    return internalJavaString(symbolsAsFactoryMethod, depth, true, false, false, F.CNullFunction)
+        .toString();
   }
 
   /**

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/IntegerSym.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/IntegerSym.java
@@ -312,66 +312,68 @@ public class IntegerSym extends AbstractIntegerSym {
   }
 
   @Override
-  public String internalJavaString(
+  public CharSequence internalJavaString(
       boolean symbolsAsFactoryMethod,
       int depth,
       boolean useOperators,
       boolean usePrefix,
       boolean noSymbolPrefix,
-      Function<IExpr, String> variables) {
+      Function<IExpr, ? extends CharSequence> variables) {
     String prefix = usePrefix ? "F." : "";
+    StringBuilder javaForm = new StringBuilder(prefix);
     int value = NumberUtil.toInt(fIntValue);
     switch (value) {
       case -1:
-        return prefix + "CN1";
+        return javaForm.append("CN1");
       case -2:
-        return prefix + "CN2";
+        return javaForm.append("CN2");
       case -3:
-        return prefix + "CN3";
+        return javaForm.append("CN3");
       case -4:
-        return prefix + "CN4";
+        return javaForm.append("CN4");
       case -5:
-        return prefix + "CN5";
+        return javaForm.append("CN5");
       case -6:
-        return prefix + "CN6";
+        return javaForm.append("CN6");
       case -7:
-        return prefix + "CN7";
+        return javaForm.append("CN7");
       case -8:
-        return prefix + "CN8";
+        return javaForm.append("CN8");
       case -9:
-        return prefix + "CN9";
+        return javaForm.append("CN9");
       case -10:
-        return prefix + "CN10";
+        return javaForm.append("CN10");
       case 0:
-        return prefix + "C0";
+        return javaForm.append("C0");
       case 1:
-        return prefix + "C1";
+        return javaForm.append("C1");
       case 2:
-        return prefix + "C2";
+        return javaForm.append("C2");
       case 3:
-        return prefix + "C3";
+        return javaForm.append("C3");
       case 4:
-        return prefix + "C4";
+        return javaForm.append("C4");
       case 5:
-        return prefix + "C5";
+        return javaForm.append("C5");
       case 6:
-        return prefix + "C6";
+        return javaForm.append("C6");
       case 7:
-        return prefix + "C7";
+        return javaForm.append("C7");
       case 8:
-        return prefix + "C8";
+        return javaForm.append("C8");
       case 9:
-        return prefix + "C9";
+        return javaForm.append("C9");
       case 10:
-        return prefix + "C10";
+        return javaForm.append("C10");
       default:
     }
-    return prefix + "ZZ(" + value + "L)";
+    return javaForm.append("ZZ(").append(value).append("L)");
   }
 
   @Override
   public String internalScalaString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, true, false, false, F.CNullFunction);
+    return internalJavaString(symbolsAsFactoryMethod, depth, true, false, false, F.CNullFunction)
+        .toString();
   }
 
   @Override

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Num.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Num.java
@@ -425,26 +425,30 @@ public class Num implements INum {
 
   @Override
   public String internalFormString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, false, false, false, F.CNullFunction);
+    return internalJavaString(symbolsAsFactoryMethod, depth, false, false, false, F.CNullFunction)
+        .toString();
   }
 
   @Override
-  public String internalJavaString(boolean symbolsAsFactoryMethod, int depth, boolean useOperators,
-      boolean usePrefix, boolean noSymbolPrefix, Function<IExpr, String> variables) {
+  public CharSequence internalJavaString(boolean symbolsAsFactoryMethod, int depth,
+      boolean useOperators, boolean usePrefix, boolean noSymbolPrefix,
+      Function<IExpr, ? extends CharSequence> variables) {
     String prefix = usePrefix ? "F." : "";
+    StringBuilder javaForm = new StringBuilder(prefix);
     if (isZero()) {
-      return prefix + "CD0";
+      return javaForm.append("CD0");
     } else if (isOne()) {
-      return prefix + "CD1";
+      return javaForm.append("CD1");
     } else if (isMinusOne()) {
-      return prefix + "CND1";
+      return javaForm.append("CND1");
     }
-    return prefix + "num(" + fDouble + ")";
+    return javaForm.append("num(").append(fDouble).append(")");
   }
 
   @Override
   public String internalScalaString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, true, false, false, F.CNullFunction);
+    return internalJavaString(symbolsAsFactoryMethod, depth, true, false, false, F.CNullFunction)
+        .toString();
   }
 
   /** @return */

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Pattern.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Pattern.java
@@ -231,16 +231,15 @@ public class Pattern extends Blank {
   }
 
   @Override
-  public String internalJavaString(
+  public CharSequence internalJavaString(
       boolean symbolsAsFactoryMethod,
       int depth,
       boolean useOperaators,
       boolean usePrefix,
       boolean noSymbolPrefix,
-      Function<IExpr, String> variables) {
-    final StringBuilder buffer = new StringBuilder();
+      Function<IExpr, ? extends CharSequence> variables) {
     String prefix = usePrefix ? "F." : "";
-    buffer.append(prefix + "$p(");
+    final StringBuilder buffer = new StringBuilder(prefix);
     String symbolStr = fSymbol.toString();
     char ch = symbolStr.charAt(0);
     if (symbolStr.length() == 1) { // && fOptionalValue == null) {
@@ -250,13 +249,13 @@ public class Pattern extends Blank {
           || ch == 'Q') {
         if (!fDefault) {
           if (fHeadTest == null) {
-            return prefix + symbolStr + "_";
+            return buffer.append(symbolStr).append("_");
           } else if (fHeadTest == S.Symbol) {
-            return prefix + symbolStr + "_Symbol";
+            return buffer.append(symbolStr).append("_Symbol");
           }
         } else {
           if (fHeadTest == null) {
-            return prefix + symbolStr + "_DEFAULT";
+            return buffer.append(symbolStr).append("_DEFAULT");
           }
         }
       }
@@ -267,21 +266,21 @@ public class Pattern extends Blank {
         if ('a' <= ch2 && ch2 <= 'z') {
           if (!fDefault) {
             if (fHeadTest == null) {
-              return prefix + "p" + ch2 + "_";
+              return buffer.append("p").append(ch2).append("_");
             }
           } else {
             if (fHeadTest == null) {
-              return prefix + "p" + ch2 + "_DEFAULT";
+              return buffer.append("p").append(ch2).append("_DEFAULT");
             }
           }
         }
       }
     }
-
+    buffer.append("$p(");
     if (symbolStr.length() == 1 && ('a' <= ch && ch <= 'z')) {
-      buffer.append(prefix + symbolStr);
+      buffer.append(prefix).append(symbolStr);
     } else {
-      buffer.append("\"" + symbolStr + "\"");
+      buffer.append("\"").append(symbolStr).append("\"");
     }
     if (fHeadTest != null) {
       if (fHeadTest == S.Integer) {
@@ -289,9 +288,8 @@ public class Pattern extends Blank {
       } else if (fHeadTest == S.Symbol) {
         buffer.append(", Symbol");
       } else {
-        buffer.append(
-            ","
-                + fHeadTest.internalJavaString(
+        buffer.append(",")
+              .append(fHeadTest.internalJavaString(
                     symbolsAsFactoryMethod,
                     0,
                     useOperaators,
@@ -303,9 +301,7 @@ public class Pattern extends Blank {
     if (fDefault) {
       buffer.append(",true");
     }
-
-    buffer.append(')');
-    return buffer.toString();
+    return buffer.append(')');
   }
 
   /** {@inheritDoc} */

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/PatternSequence.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/PatternSequence.java
@@ -229,23 +229,22 @@ public class PatternSequence implements IPatternSequence {
   }
 
   @Override
-  public String internalJavaString(
+  public CharSequence internalJavaString(
       boolean symbolsAsFactoryMethod,
       int depth,
       boolean useOperators,
       boolean usePrefix,
       boolean noSymbolPrefix,
-      Function<IExpr, String> variables) {
+      Function<IExpr, ? extends CharSequence> variables) {
     if (symbolsAsFactoryMethod) {
       String prefix = usePrefix ? "F." : "";
       final StringBuilder buffer = new StringBuilder();
-      buffer.append(prefix + "$ps(");
+      buffer.append(prefix).append("$ps(");
       if (fSymbol == null) {
         buffer.append("(ISymbol)null");
         if (fHeadTest != null) {
-          buffer.append(
-              ","
-                  + fHeadTest.internalJavaString(
+          buffer.append(",")
+              .append(fHeadTest.internalJavaString(
                       symbolsAsFactoryMethod,
                       0,
                       useOperators,
@@ -262,9 +261,8 @@ public class PatternSequence implements IPatternSequence {
       } else {
         buffer.append("\"" + fSymbol.toString() + "\"");
         if (fHeadTest != null) {
-          buffer.append(
-              ","
-                  + fHeadTest.internalJavaString(
+          buffer.append(",")
+              .append(fHeadTest.internalJavaString(
                       symbolsAsFactoryMethod,
                       0,
                       useOperators,
@@ -276,14 +274,17 @@ public class PatternSequence implements IPatternSequence {
           buffer.append(",true");
         }
       }
-      buffer.append(')');
-      return buffer.toString();
+      return buffer.append(')');
     }
-    return toString();
+    return toCharSequence();
   }
 
   @Override
   public String toString() {
+    return toCharSequence().toString();
+  }
+
+  private CharSequence toCharSequence() {
     final StringBuilder buffer = new StringBuilder();
     if (fSymbol == null) {
       buffer.append("__");
@@ -318,7 +319,7 @@ public class PatternSequence implements IPatternSequence {
         buffer.append(fHeadTest.toString());
       }
     }
-    return buffer.toString();
+    return buffer;
   }
 
   @Override

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/StringX.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/StringX.java
@@ -401,19 +401,15 @@ public class StringX implements IStringX {
 
   /** {@inheritDoc} */
   @Override
-  public String internalJavaString(
+  public CharSequence internalJavaString(
       boolean symbolsAsFactoryMethod,
       int depth,
       boolean useOperators,
       boolean usePrefix,
       boolean noSymbolPrefix,
-      Function<IExpr, String> variables) {
-    final StringBuilder buffer = new StringBuilder();
+      Function<IExpr, ? extends CharSequence> variables) {
     String prefix = usePrefix ? "F." : "";
-    buffer.append(prefix + "$str(\"");
-    buffer.append(fString);
-    buffer.append("\")");
-    return buffer.toString();
+    return new StringBuilder(prefix).append("$str(\"").append(fString).append("\")");
   }
 
   /**

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Symbol.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Symbol.java
@@ -558,25 +558,26 @@ public class Symbol implements ISymbol, Serializable {
   /** {@inheritDoc} */
   @Override
   public String internalFormString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, false, false, false, x -> null);
+    return internalJavaString(symbolsAsFactoryMethod, depth, false, false, false, x -> null)
+        .toString();
   }
 
   /** {@inheritDoc} */
   @Override
-  public String internalJavaString(
+  public CharSequence internalJavaString(
       boolean symbolsAsFactoryMethod,
       int depth,
       boolean useOperators,
       boolean usePrefix,
       boolean noSymbolPrefix,
-      Function<IExpr, String> variables) {
-    String result = variables.apply(this);
+      Function<IExpr, ? extends CharSequence> variables) {
+    CharSequence result = variables.apply(this);
     if (result != null) {
       return result;
     }
     String prefix = usePrefix ? "F." : "";
     if (symbolsAsFactoryMethod) {
-      return prefix + internalJavaStringAsFactoryMethod();
+      return new StringBuilder(prefix).append(internalJavaStringAsFactoryMethod());
     }
     if (FEConfig.PARSER_USE_LOWERCASE_SYMBOLS) {
       String name;
@@ -586,17 +587,17 @@ public class Symbol implements ISymbol, Serializable {
         name = AST2Expr.PREDEFINED_SYMBOLS_MAP.get(fSymbolName.toLowerCase(Locale.ENGLISH));
       }
       if (name != null) {
-        return prefix + name;
+        return new StringBuilder(prefix).append(name);
       }
     } else {
       String name = AST2Expr.PREDEFINED_SYMBOLS_MAP.get(fSymbolName.toLowerCase(Locale.ENGLISH));
       if (name != null && name.equals(fSymbolName)) {
-        return prefix + name;
+        return new StringBuilder(prefix).append(name);
       }
     }
     char ch = fSymbolName.charAt(0);
     if (!noSymbolPrefix && fSymbolName.length() == 1 && ('a' <= ch && ch <= 'z')) {
-      return prefix + fSymbolName;
+      return new StringBuilder(prefix).append(fSymbolName);
     } else {
       return fSymbolName;
     }
@@ -607,20 +608,15 @@ public class Symbol implements ISymbol, Serializable {
    *
    * @return
    */
-  protected String internalJavaStringAsFactoryMethod() {
+  protected CharSequence internalJavaStringAsFactoryMethod() {
     if (fSymbolName.length() == 1) {
       char ch = fSymbolName.charAt(0);
       if ('a' <= ch && ch <= 'z') {
         return fSymbolName;
       }
-      if (Config.RUBI_CONVERT_SYMBOLS && 'A' <= ch && ch <= 'G' && ch != 'D' && ch != 'E') {
-        return fSymbolName + "Symbol";
-      }
-      if ('A' <= ch && ch <= 'G' && ch != 'D' && ch != 'E') {
-        return fSymbolName + "Symbol";
-      }
-      if ('P' == ch || ch == 'Q') {
-        return fSymbolName + "Symbol";
+      if ((Config.RUBI_CONVERT_SYMBOLS && 'A' <= ch && ch <= 'G' && ch != 'D' && ch != 'E')
+          || ('A' <= ch && ch <= 'G' && ch != 'D' && ch != 'E') || ('P' == ch || ch == 'Q')) {
+        return new StringBuilder(fSymbolName).append("Symbol");
       }
     }
     if (Config.RUBI_CONVERT_SYMBOLS) {
@@ -629,7 +625,7 @@ public class Symbol implements ISymbol, Serializable {
           && Character.isLowerCase(fSymbolName.charAt(1))) {
         char ch = fSymbolName.charAt(1);
         if ('a' <= ch && ch <= 'z') {
-          return "p" + ch;
+          return new StringBuilder("p").append(ch);
         }
       } else if (fSymbolName.equals("Int")) {
         return "Integrate";
@@ -638,21 +634,20 @@ public class Symbol implements ISymbol, Serializable {
     if (Character.isUpperCase(fSymbolName.charAt(0))) {
       String alias = F.getPredefinedInternalFormString(fSymbolName);
       if (alias != null) {
-        if (Config.RUBI_CONVERT_SYMBOLS) {
-          if (alias.startsWith("Rubi`")) {
-            return "$rubi(\"" + alias.substring(5) + "\")";
-          }
+        if (Config.RUBI_CONVERT_SYMBOLS && alias.startsWith("Rubi`")) {
+          return new StringBuilder("$rubi(\"").append(alias, 5, alias.length()).append("\")");
         }
         return alias;
       }
     }
-    return "$s(\"" + fSymbolName + "\")";
+    return new StringBuilder("$s(\"").append(fSymbolName).append("\")");
   }
 
   /** {@inheritDoc} */
   @Override
   public String internalScalaString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, true, false, false, x -> null);
+    return internalJavaString(symbolsAsFactoryMethod, depth, true, false, false, x -> null)
+        .toString();
   }
 
   /** {@inheritDoc} */

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/interfaces/IExpr.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/interfaces/IExpr.java
@@ -1068,17 +1068,17 @@ public interface IExpr
    * @param variables TODO
    * @return the internal Java form of this expression
    */
-  default String internalJavaString(
+  default CharSequence internalJavaString(
       boolean symbolsAsFactoryMethod,
       int depth,
       boolean useOperators,
       boolean usePrefix,
       boolean noSymbolPrefix,
-      Function<IExpr, String> variables) {
+      Function<IExpr, ? extends CharSequence> variables) {
     return toString();
   }
 
-  default String internalJavaString(Function<IExpr, String> variables) {
+  default CharSequence internalJavaString(Function<IExpr, ? extends CharSequence> variables) {
     return internalJavaString(false, -1, false, true, false, variables);
   }
 

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/tensor/qty/QuantityImpl.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/tensor/qty/QuantityImpl.java
@@ -136,9 +136,10 @@ public class QuantityImpl extends DataExpr<IUnit> implements IQuantity, External
   }
 
   @Override
-  public String internalJavaString(boolean symbolsAsFactoryMethod, int depth, boolean useOperators,
-      boolean usePrefix, boolean noSymbolPrefix, Function<IExpr, String> variables) {
-    String value = value().internalJavaString(symbolsAsFactoryMethod, depth, useOperators,
+  public CharSequence internalJavaString(boolean symbolsAsFactoryMethod, int depth,
+      boolean useOperators, boolean usePrefix, boolean noSymbolPrefix,
+      Function<IExpr, ? extends CharSequence> variables) {
+    CharSequence value = value().internalJavaString(symbolsAsFactoryMethod, depth, useOperators,
         usePrefix, noSymbolPrefix, variables);
     StringBuilder javaForm = new StringBuilder();
     javaForm.append("IQuantity.of(").append(value).append(",");
@@ -147,7 +148,7 @@ public class QuantityImpl extends DataExpr<IUnit> implements IQuantity, External
     } else {
       javaForm.append("IUnit.ofPutIfAbsent(\"").append(unitString()).append("\")");
     }
-    return javaForm.append(")").toString();
+    return javaForm.append(")");
   }
 
   /** {@inheritDoc} */

--- a/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/eval/Console.java
+++ b/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/eval/Console.java
@@ -497,7 +497,7 @@ public class Console {
     }
     switch (fUsedForm) {
       case JAVAFORM:
-        return result.internalJavaString(false, -1, false, true, false, F.CNullFunction);
+        return result.internalJavaString(false, -1, false, true, false, F.CNullFunction).toString();
       case TRADITIONALFORM:
         StringBuilder traditionalBuffer = new StringBuilder();
         fOutputTraditionalFactory.reset();

--- a/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/eval/MMAConsole.java
+++ b/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/eval/MMAConsole.java
@@ -531,7 +531,8 @@ public class MMAConsole {
       }
       switch (fUsedForm) {
         case JAVAFORM:
-          return result.internalJavaString(false, -1, false, true, false, F.CNullFunction);
+          return result.internalJavaString(false, -1, false, true, false, F.CNullFunction)
+              .toString();
         case TRADITIONALFORM:
           StringBuilder traditionalBuffer = new StringBuilder();
           fOutputTraditionalFactory.reset();

--- a/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/io/system/JavaFormTestCase.java
+++ b/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/io/system/JavaFormTestCase.java
@@ -27,10 +27,10 @@ public class JavaFormTestCase extends AbstractTestCase {
     IAST function = Sinc(Times(CI, CInfinity));
 
     IExpr result = EvalEngine.get().evalHoldPattern(function);
-    assertEquals(result.internalFormString(true, -1), "Sinc(DirectedInfinity(CI))");
+    assertEquals("Sinc(DirectedInfinity(CI))", result.internalFormString(true, -1));
 
     result = util.evaluate(function);
-    assertEquals(result.internalFormString(true, -1), "oo");
+    assertEquals("oo", result.internalFormString(true, -1));
   }
 
   public void testJavaForm002() {
@@ -41,22 +41,23 @@ public class JavaFormTestCase extends AbstractTestCase {
     IAST function = Sinc(Times(CI, CInfinity));
 
     IExpr result = EvalEngine.get().evalHoldPattern(function);
-    assertEquals(result.internalJavaString(true, -1, false, true, false, F.CNullFunction),
-        "F.Sinc(F.DirectedInfinity(F.CI))");
+    assertEquals("F.Sinc(F.DirectedInfinity(F.CI))",
+        result.internalJavaString(true, -1, false, true, false, F.CNullFunction).toString());
 
     result = util.evaluate(function);
-    assertEquals(result.internalJavaString(true, -1, false, true, false, F.CNullFunction), "F.oo");
+    assertEquals("F.oo",
+        result.internalJavaString(true, -1, false, true, false, F.CNullFunction).toString());
   }
 
   public void testJavaFormQuantity_withUnitKG() {
     IExpr quantity = IQuantity.of(F.ZZ(43L), IUnit.ofPutIfAbsent("kg"));
-    String javaForm = quantity.internalJavaString(null);
+    String javaForm = quantity.internalJavaString(null).toString();
     assertEquals("IQuantity.of(F.ZZ(43L),IUnit.ofPutIfAbsent(\"kg\"))", javaForm);
   }
 
   public void testJavaFormQuantity_withUnitOne() {
     IExpr quantity = IQuantity.of(F.ZZ(43L), IUnit.ONE);
-    String javaForm = quantity.internalJavaString(null);
+    String javaForm = quantity.internalJavaString(null).toString();
     assertEquals("IQuantity.of(F.ZZ(43L),IUnit.ONE)", javaForm);
   }
 }


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

This PR aims to improve the performance by returning a `CharSequence` instead of a `String` by `IExpr.internalJavaString()` which allows to return a `StringBuilder` containing the assembled String and avoids creation of intermediate `String`-Objects.