### PR TITLE
[JavaForm] introduce SourceCodeProperties parameter object

### DIFF
--- a/symja_android_library/matheclipse-beakerx/src/main/java/com/twosigma/beakerx/symjamma/evaluator/SymjaMMAEvaluator.java
+++ b/symja_android_library/matheclipse-beakerx/src/main/java/com/twosigma/beakerx/symjamma/evaluator/SymjaMMAEvaluator.java
@@ -25,6 +25,7 @@ import org.matheclipse.core.expression.F;
 import org.matheclipse.core.form.output.OutputFormFactory;
 import org.matheclipse.core.form.tex.TeXFormFactory;
 import org.matheclipse.core.interfaces.IExpr;
+import org.matheclipse.core.interfaces.IExpr.SourceCodeProperties;
 import org.matheclipse.io.IOInit;
 import org.matheclipse.parser.client.FEConfig;
 import com.twosigma.beakerx.BeakerXClient;
@@ -232,6 +233,9 @@ public class SymjaMMAEvaluator extends BaseEvaluator {
     return null;
   }
 
+  private static final SourceCodeProperties JAVA_FORM_PROPERTIES =
+      SourceCodeProperties.of(false, false, true, false);
+
   /**
    * Print the result in the default output form
    *
@@ -242,8 +246,7 @@ public class SymjaMMAEvaluator extends BaseEvaluator {
   TryResult printForm(final SymjaMMACodeRunner symjaMMACodeRunner, final Object result) {
     switch (fUsedForm) {
       case SymjaMMAEvaluator.JAVAFORM:
-        return TryResult.createResult(
-            ((IExpr) result).internalJavaString(false, -1, false, true, false, F.CNullFunction));
+        return TryResult.createResult(((IExpr) result).internalJavaString(JAVA_FORM_PROPERTIES, -1, F.CNullFunction));
       case SymjaMMAEvaluator.TRADITIONALFORM:
         StringBuilder traditionalBuffer = new StringBuilder();
         fOutputTraditionalFactory.reset();

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/CompilerFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/CompilerFunctions.java
@@ -26,6 +26,7 @@ import org.matheclipse.core.form.output.JavaDoubleFormFactory;
 import org.matheclipse.core.generic.Functors;
 import org.matheclipse.core.interfaces.IAST;
 import org.matheclipse.core.interfaces.IExpr;
+import org.matheclipse.core.interfaces.IExpr.SourceCodeProperties;
 import org.matheclipse.core.interfaces.IStringX;
 import org.matheclipse.core.interfaces.ISymbol;
 
@@ -518,9 +519,12 @@ public class CompilerFunctions {
       return 0;
     }
 
+    private static final SourceCodeProperties JAVA_FORM_PROPERTIES =
+        SourceCodeProperties.of(false, false, true, false);
+
     private boolean convertSymbolic(StringBuilder buf, IExpr expression) {
       try {
-        buf.append(expression.internalJavaString(false, -1, false, true, false, x -> {
+        buf.append(expression.internalJavaString(JAVA_FORM_PROPERTIES, -1, x -> {
           if (x.isSymbol()) {
             if (localVariables.contains(x.toString())) {
               return "vars.get(\"" + x.toString() + "\")";

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/OutputFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/OutputFunctions.java
@@ -36,6 +36,7 @@ import org.matheclipse.core.interfaces.IAST;
 import org.matheclipse.core.interfaces.IASTDataset;
 import org.matheclipse.core.interfaces.IASTMutable;
 import org.matheclipse.core.interfaces.IExpr;
+import org.matheclipse.core.interfaces.IExpr.SourceCodeProperties;
 import org.matheclipse.core.interfaces.IInteger;
 import org.matheclipse.core.interfaces.IStringX;
 import org.matheclipse.core.interfaces.ISymbol;
@@ -453,7 +454,8 @@ public final class OutputFunctions {
   private static class JavaForm extends AbstractCoreFunctionEvaluator {
 
     public static CharSequence javaForm(IExpr arg1, boolean strictJava, boolean usePrefix) {
-      return arg1.internalJavaString(strictJava, 0, false, usePrefix, false, F.CNullFunction);
+      SourceCodeProperties p = SourceCodeProperties.of(strictJava, false, usePrefix, false);
+      return arg1.internalJavaString(p, 0, F.CNullFunction);
     }
 
     @Override

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/MathMLUtilities.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/MathMLUtilities.java
@@ -7,6 +7,7 @@ import org.apache.logging.log4j.Logger;
 import org.matheclipse.core.expression.F;
 import org.matheclipse.core.form.mathml.MathMLFormFactory;
 import org.matheclipse.core.interfaces.IExpr;
+import org.matheclipse.core.interfaces.IExpr.SourceCodeProperties;
 import org.matheclipse.core.parser.ExprParser;
 
 /**
@@ -159,6 +160,9 @@ public class MathMLUtilities {
     return true;
   }
 
+  private static final SourceCodeProperties JAVA_FORM_PROPERTIES =
+      SourceCodeProperties.of(false, false, true, false);
+
   private synchronized void toJava(
       final String inputExpression, final Writer out, boolean strictJava) {
     IExpr parsedExpression = null;
@@ -169,8 +173,8 @@ public class MathMLUtilities {
         parsedExpression = parser.parse(inputExpression);
         // node = fEvalEngine.parseNode(inputExpression);
         // parsedExpression = AST2Expr.CONST.convert(node, fEvalEngine);
-        out.write(parsedExpression
-            .internalJavaString(false, -1, false, true, false, F.CNullFunction).toString());
+        out.write(parsedExpression.internalJavaString(JAVA_FORM_PROPERTIES, -1, F.CNullFunction)
+            .toString());
       } catch (final IOException ioe) {
         //
       } catch (final RuntimeException rex) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/AbstractIntegerSym.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/AbstractIntegerSym.java
@@ -756,7 +756,8 @@ public abstract class AbstractIntegerSym implements IInteger, Externalizable {
 
   @Override
   public CharSequence internalFormString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, false, false, false, F.CNullFunction);
+    SourceCodeProperties p = AbstractAST.stringFormProperties(symbolsAsFactoryMethod);
+    return internalJavaString(p, depth, F.CNullFunction);
   }
 
   @Override

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/BigFractionSym.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/BigFractionSym.java
@@ -403,14 +403,9 @@ public class BigFractionSym extends AbstractFractionSym {
   }
 
   @Override
-  public CharSequence internalJavaString(
-      boolean symbolsAsFactoryMethod,
-      int depth,
-      boolean useOperators,
-      boolean usePrefix,
-      boolean noSymbolPrefix,
+  public CharSequence internalJavaString(SourceCodeProperties properties, int depth,
       Function<IExpr, ? extends CharSequence> variables) {
-    String prefix = usePrefix ? "F." : "";
+    String prefix = AbstractAST.getPrefixF(properties);
     StringBuilder javaForm = new StringBuilder(prefix);
     int numerator = NumberUtil.toIntDefault(fFraction.getNumerator());
     if (numerator == 1 || numerator == -1) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/BigIntegerSym.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/BigIntegerSym.java
@@ -354,14 +354,9 @@ public class BigIntegerSym extends AbstractIntegerSym {
   }
 
   @Override
-  public CharSequence internalJavaString(
-      boolean symbolsAsFactoryMethod,
-      int depth,
-      boolean useOperators,
-      boolean usePrefix,
-      boolean noSymbolPrefix,
+  public CharSequence internalJavaString(SourceCodeProperties properties, int depth,
       Function<IExpr, ? extends CharSequence> variables) {
-    String prefix = usePrefix ? "F." : "";
+    String prefix = AbstractAST.getPrefixF(properties);
     StringBuilder javaForm = new StringBuilder(prefix);
     int value = toIntDefault(); // NumberUtil.toInt(fBigIntValue);
     if (value != Integer.MIN_VALUE) {
@@ -418,7 +413,8 @@ public class BigIntegerSym extends AbstractIntegerSym {
 
   @Override
   public CharSequence internalScalaString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, true, false, false, x -> null);
+    SourceCodeProperties p = AbstractAST.scalaFormProperties(symbolsAsFactoryMethod);
+    return internalJavaString(p, depth, x -> null);
   }
 
   @Override

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Blank.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Blank.java
@@ -255,19 +255,12 @@ public class Blank implements IPattern {
   }
 
   @Override
-  public CharSequence internalJavaString(
-      boolean symbolsAsFactoryMethod,
-      int depth,
-      boolean useOperators,
-      boolean usePrefix,
-      boolean noSymbolPrefix,
+  public CharSequence internalJavaString(SourceCodeProperties properties, int depth,
       Function<IExpr, ? extends CharSequence> variables) {
-    String prefix = usePrefix ? "F." : "";
+    String prefix = AbstractAST.getPrefixF(properties);
     final StringBuilder buffer = new StringBuilder(prefix).append("$b(");
     if (fHeadTest != null) {
-      buffer.append(
-          fHeadTest.internalJavaString(
-              symbolsAsFactoryMethod, 0, useOperators, usePrefix, noSymbolPrefix, variables));
+      buffer.append(fHeadTest.internalJavaString(properties, 0, variables));
     }
     return buffer.append(')');
   }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/BuiltInDummy.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/BuiltInDummy.java
@@ -546,24 +546,22 @@ public class BuiltInDummy implements IBuiltInSymbol, Serializable {
   /** {@inheritDoc} */
   @Override
   public CharSequence internalFormString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, false, false, false, x -> null);
+    SourceCodeProperties p = AbstractAST.stringFormProperties(symbolsAsFactoryMethod);
+    return internalJavaString(p, depth, x -> null);
   }
 
   /** {@inheritDoc} */
   @Override
   public CharSequence internalJavaString(
-      boolean symbolsAsFactoryMethod,
+      SourceCodeProperties properties,
       int depth,
-      boolean useOperators,
-      boolean usePrefix,
-      boolean noSymbolPrefix,
       Function<IExpr, ? extends CharSequence> variables) {
     CharSequence result = variables.apply(this);
     if (result != null) {
       return result;
     }
-    String prefix = usePrefix ? "F." : "";
-    if (symbolsAsFactoryMethod) {
+    String prefix = AbstractAST.getPrefixF(properties);
+    if (properties.symbolsAsFactoryMethod) {
       return new StringBuilder(prefix).append(internalJavaStringAsFactoryMethod());
     }
     if (FEConfig.PARSER_USE_LOWERCASE_SYMBOLS) {
@@ -583,7 +581,7 @@ public class BuiltInDummy implements IBuiltInSymbol, Serializable {
       }
     }
     char ch = fSymbolName.charAt(0);
-    if (!noSymbolPrefix && fSymbolName.length() == 1 && ('a' <= ch && ch <= 'z')) {
+    if (!properties.noSymbolPrefix && fSymbolName.length() == 1 && ('a' <= ch && ch <= 'z')) {
       return new StringBuilder(prefix).append(fSymbolName);
     } else {
       return fSymbolName;
@@ -634,7 +632,8 @@ public class BuiltInDummy implements IBuiltInSymbol, Serializable {
   /** {@inheritDoc} */
   @Override
   public CharSequence internalScalaString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, true, false, false, x -> null);
+    SourceCodeProperties p = AbstractAST.scalaFormProperties(symbolsAsFactoryMethod);
+    return internalJavaString(p, depth, x -> null);
   }
 
   /** {@inheritDoc} */

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/ComplexNum.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/ComplexNum.java
@@ -581,25 +581,22 @@ public class ComplexNum implements IComplexNum {
 
   @Override
   public CharSequence internalFormString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, false, false, false, F.CNullFunction);
+    SourceCodeProperties p = AbstractAST.stringFormProperties(symbolsAsFactoryMethod);
+    return internalJavaString(p, depth, F.CNullFunction);
   }
 
   @Override
-  public CharSequence internalJavaString(
-      boolean symbolsAsFactoryMethod,
-      int depth,
-      boolean useOperators,
-      boolean usePrefix,
-      boolean noSymbolPrefix,
+  public CharSequence internalJavaString(SourceCodeProperties properties, int depth,
       Function<IExpr, ? extends CharSequence> variables) {
-    String prefix = usePrefix ? "F." : "";
+    String prefix = AbstractAST.getPrefixF(properties);
     return new StringBuilder(prefix).append("complexNum(").append(fComplex.getReal()).append(",")
         .append(fComplex.getImaginary()).append(")");
   }
 
   @Override
   public CharSequence internalScalaString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, true, false, false, F.CNullFunction);
+    SourceCodeProperties p = AbstractAST.scalaFormProperties(symbolsAsFactoryMethod);
+    return internalJavaString(p, depth, F.CNullFunction);
   }
 
   @Override

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/ComplexSym.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/ComplexSym.java
@@ -488,18 +488,14 @@ public class ComplexSym implements IComplex {
 
   @Override
   public CharSequence internalFormString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, false, false, false, F.CNullFunction);
+    SourceCodeProperties p = AbstractAST.stringFormProperties(symbolsAsFactoryMethod);
+    return internalJavaString(p, depth, F.CNullFunction);
   }
 
   @Override
-  public CharSequence internalJavaString(
-      boolean symbolsAsFactoryMethod,
-      int depth,
-      boolean useOperators,
-      boolean usePrefix,
-      boolean noSymbolPrefix,
+  public CharSequence internalJavaString(SourceCodeProperties properties, int depth,
       Function<IExpr, ? extends CharSequence> variables) {
-    String prefix = usePrefix ? "F." : "";
+    String prefix = AbstractAST.getPrefixF(properties);
     if (fReal.isZero()) {
       if (fImaginary.isOne()) {
         return new StringBuilder(prefix).append("CI");
@@ -533,17 +529,16 @@ public class ComplexSym implements IComplex {
     }
     return new StringBuilder(prefix)
         .append("CC(")
-        .append(fReal.internalJavaString(
-            symbolsAsFactoryMethod, depth, useOperators, usePrefix, noSymbolPrefix, variables))
+        .append(fReal.internalJavaString(properties, depth, variables))
         .append(",")
-        .append(fImaginary.internalJavaString(
-            symbolsAsFactoryMethod, depth, useOperators, usePrefix, noSymbolPrefix, variables))
+        .append(fImaginary.internalJavaString(properties, depth, variables))
         .append(")");
   }
 
   @Override
   public CharSequence internalScalaString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, true, false, false, F.CNullFunction);
+    SourceCodeProperties p = AbstractAST.scalaFormProperties(symbolsAsFactoryMethod);
+    return internalJavaString(p, depth, F.CNullFunction);
   }
 
   @Override

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/FractionSym.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/FractionSym.java
@@ -403,18 +403,14 @@ public class FractionSym extends AbstractFractionSym {
 
   @Override
   public CharSequence internalFormString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, false, false, false, F.CNullFunction);
+    SourceCodeProperties p = AbstractAST.stringFormProperties(symbolsAsFactoryMethod);
+    return internalJavaString(p, depth, F.CNullFunction);
   }
 
   @Override
-  public CharSequence internalJavaString(
-      boolean symbolsAsFactoryMethod,
-      int depth,
-      boolean useOperators,
-      boolean usePrefix,
-      boolean noSymbolPrefix,
+  public CharSequence internalJavaString(SourceCodeProperties properties, int depth,
       Function<IExpr, ? extends CharSequence> variables) {
-    String prefix = usePrefix ? "F." : "";
+    String prefix = AbstractAST.getPrefixF(properties);
     StringBuilder javaForm = new StringBuilder(prefix);
     if (fNumerator == 1) {
       switch (fDenominator) {
@@ -443,7 +439,8 @@ public class FractionSym extends AbstractFractionSym {
 
   @Override
   public CharSequence internalScalaString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, true, false, false, F.CNullFunction);
+    SourceCodeProperties p = AbstractAST.scalaFormProperties(symbolsAsFactoryMethod);
+    return internalJavaString(p, depth, F.CNullFunction);
   }
 
   /**

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/IntegerSym.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/IntegerSym.java
@@ -312,14 +312,9 @@ public class IntegerSym extends AbstractIntegerSym {
   }
 
   @Override
-  public CharSequence internalJavaString(
-      boolean symbolsAsFactoryMethod,
-      int depth,
-      boolean useOperators,
-      boolean usePrefix,
-      boolean noSymbolPrefix,
+  public CharSequence internalJavaString(SourceCodeProperties properties, int depth,
       Function<IExpr, ? extends CharSequence> variables) {
-    String prefix = usePrefix ? "F." : "";
+    String prefix = AbstractAST.getPrefixF(properties);
     StringBuilder javaForm = new StringBuilder(prefix);
     int value = NumberUtil.toInt(fIntValue);
     switch (value) {
@@ -372,7 +367,8 @@ public class IntegerSym extends AbstractIntegerSym {
 
   @Override
   public CharSequence internalScalaString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, true, false, false, F.CNullFunction);
+    SourceCodeProperties p = AbstractAST.scalaFormProperties(symbolsAsFactoryMethod);
+    return internalJavaString(p, depth, F.CNullFunction);
   }
 
   @Override

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Num.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Num.java
@@ -425,14 +425,14 @@ public class Num implements INum {
 
   @Override
   public CharSequence internalFormString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, false, false, false, F.CNullFunction);
+    SourceCodeProperties p = AbstractAST.stringFormProperties(symbolsAsFactoryMethod);
+    return internalJavaString(p, depth, F.CNullFunction);
   }
 
   @Override
-  public CharSequence internalJavaString(boolean symbolsAsFactoryMethod, int depth,
-      boolean useOperators, boolean usePrefix, boolean noSymbolPrefix,
+  public CharSequence internalJavaString(SourceCodeProperties properties, int depth,
       Function<IExpr, ? extends CharSequence> variables) {
-    String prefix = usePrefix ? "F." : "";
+    String prefix = AbstractAST.getPrefixF(properties);
     StringBuilder javaForm = new StringBuilder(prefix);
     if (isZero()) {
       return javaForm.append("CD0");
@@ -446,7 +446,8 @@ public class Num implements INum {
 
   @Override
   public CharSequence internalScalaString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, true, false, false, F.CNullFunction);
+    SourceCodeProperties p = AbstractAST.scalaFormProperties(symbolsAsFactoryMethod);
+    return internalJavaString(p, depth, F.CNullFunction);
   }
 
   /** @return */

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Pattern.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Pattern.java
@@ -231,14 +231,9 @@ public class Pattern extends Blank {
   }
 
   @Override
-  public CharSequence internalJavaString(
-      boolean symbolsAsFactoryMethod,
-      int depth,
-      boolean useOperaators,
-      boolean usePrefix,
-      boolean noSymbolPrefix,
+  public CharSequence internalJavaString(SourceCodeProperties properties, int depth,
       Function<IExpr, ? extends CharSequence> variables) {
-    String prefix = usePrefix ? "F." : "";
+    String prefix = AbstractAST.getPrefixF(properties);
     final StringBuilder buffer = new StringBuilder(prefix);
     String symbolStr = fSymbol.toString();
     char ch = symbolStr.charAt(0);
@@ -288,14 +283,7 @@ public class Pattern extends Blank {
       } else if (fHeadTest == S.Symbol) {
         buffer.append(", Symbol");
       } else {
-        buffer.append(",")
-              .append(fHeadTest.internalJavaString(
-                    symbolsAsFactoryMethod,
-                    0,
-                    useOperaators,
-                    usePrefix,
-                    noSymbolPrefix,
-                    variables));
+        buffer.append(",").append(fHeadTest.internalJavaString(properties, 0, variables));
       }
     }
     if (fDefault) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/PatternSequence.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/PatternSequence.java
@@ -229,28 +229,16 @@ public class PatternSequence implements IPatternSequence {
   }
 
   @Override
-  public CharSequence internalJavaString(
-      boolean symbolsAsFactoryMethod,
-      int depth,
-      boolean useOperators,
-      boolean usePrefix,
-      boolean noSymbolPrefix,
+  public CharSequence internalJavaString(SourceCodeProperties properties, int depth,
       Function<IExpr, ? extends CharSequence> variables) {
-    if (symbolsAsFactoryMethod) {
-      String prefix = usePrefix ? "F." : "";
+    if (properties.symbolsAsFactoryMethod) {
+      String prefix = AbstractAST.getPrefixF(properties);
       final StringBuilder buffer = new StringBuilder();
       buffer.append(prefix).append("$ps(");
       if (fSymbol == null) {
         buffer.append("(ISymbol)null");
         if (fHeadTest != null) {
-          buffer.append(",")
-              .append(fHeadTest.internalJavaString(
-                      symbolsAsFactoryMethod,
-                      0,
-                      useOperators,
-                      usePrefix,
-                      noSymbolPrefix,
-                      variables));
+          buffer.append(",").append(fHeadTest.internalJavaString(properties, 0, variables));
         }
         if (fDefault) {
           if (fHeadTest == null) {
@@ -261,14 +249,7 @@ public class PatternSequence implements IPatternSequence {
       } else {
         buffer.append("\"" + fSymbol.toString() + "\"");
         if (fHeadTest != null) {
-          buffer.append(",")
-              .append(fHeadTest.internalJavaString(
-                      symbolsAsFactoryMethod,
-                      0,
-                      useOperators,
-                      usePrefix,
-                      noSymbolPrefix,
-                      variables));
+          buffer.append(",").append(fHeadTest.internalJavaString(properties, 0, variables));
         }
         if (fDefault) {
           buffer.append(",true");

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/StringX.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/StringX.java
@@ -397,14 +397,9 @@ public class StringX implements IStringX {
 
   /** {@inheritDoc} */
   @Override
-  public CharSequence internalJavaString(
-      boolean symbolsAsFactoryMethod,
-      int depth,
-      boolean useOperators,
-      boolean usePrefix,
-      boolean noSymbolPrefix,
+  public CharSequence internalJavaString(SourceCodeProperties properties, int depth,
       Function<IExpr, ? extends CharSequence> variables) {
-    String prefix = usePrefix ? "F." : "";
+    String prefix = AbstractAST.getPrefixF(properties);
     return new StringBuilder(prefix).append("$str(\"").append(fString).append("\")");
   }
 

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Symbol.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Symbol.java
@@ -558,24 +558,20 @@ public class Symbol implements ISymbol, Serializable {
   /** {@inheritDoc} */
   @Override
   public CharSequence internalFormString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, false, false, false, x -> null);
+    SourceCodeProperties p = AbstractAST.stringFormProperties(symbolsAsFactoryMethod);
+    return internalJavaString(p, depth, x -> null);
   }
 
   /** {@inheritDoc} */
   @Override
-  public CharSequence internalJavaString(
-      boolean symbolsAsFactoryMethod,
-      int depth,
-      boolean useOperators,
-      boolean usePrefix,
-      boolean noSymbolPrefix,
+  public CharSequence internalJavaString(SourceCodeProperties properties, int depth,
       Function<IExpr, ? extends CharSequence> variables) {
     CharSequence result = variables.apply(this);
     if (result != null) {
       return result;
     }
-    String prefix = usePrefix ? "F." : "";
-    if (symbolsAsFactoryMethod) {
+    String prefix = AbstractAST.getPrefixF(properties);
+    if (properties.symbolsAsFactoryMethod) {
       return new StringBuilder(prefix).append(internalJavaStringAsFactoryMethod());
     }
     if (FEConfig.PARSER_USE_LOWERCASE_SYMBOLS) {
@@ -595,7 +591,7 @@ public class Symbol implements ISymbol, Serializable {
       }
     }
     char ch = fSymbolName.charAt(0);
-    if (!noSymbolPrefix && fSymbolName.length() == 1 && ('a' <= ch && ch <= 'z')) {
+    if (!properties.noSymbolPrefix && fSymbolName.length() == 1 && ('a' <= ch && ch <= 'z')) {
       return new StringBuilder(prefix).append(fSymbolName);
     } else {
       return fSymbolName;
@@ -645,7 +641,8 @@ public class Symbol implements ISymbol, Serializable {
   /** {@inheritDoc} */
   @Override
   public CharSequence internalScalaString(boolean symbolsAsFactoryMethod, int depth) {
-    return internalJavaString(symbolsAsFactoryMethod, depth, true, false, false, x -> null);
+    SourceCodeProperties p = AbstractAST.scalaFormProperties(symbolsAsFactoryMethod);
+    return internalJavaString(p, depth, x -> null);
   }
 
   /** {@inheritDoc} */

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/interfaces/IExpr.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/interfaces/IExpr.java
@@ -1053,27 +1053,72 @@ public interface IExpr
     return toString();
   }
 
+  public static class SourceCodeProperties {
+    /**
+     * If <code>true</code> use the <code>F.symbol()</code> method, otherwise print the symbol name.
+     */
+    public final boolean symbolsAsFactoryMethod;
+    /**
+     * If true use operators instead of function names for representation of Plus, Times, Power,...
+     */
+    public final boolean useOperators;
+    /**
+     * If true usePrefix use the <code>F....</code> class prefix for generating Java code.
+     */
+    public final boolean usePrefix;
+    /**
+     * If <code>true</code>, for symbols like <code>x,y,z,...</code> don't use the
+     * <code>F....</code> class prefix for code generation.
+     */
+    public final boolean noSymbolPrefix;
+
+    private SourceCodeProperties(boolean symbolsAsFactoryMethod, boolean useOperators,
+        boolean usePrefix, boolean noSymbolPrefix) {
+      this.symbolsAsFactoryMethod = symbolsAsFactoryMethod;
+      this.useOperators = useOperators;
+      this.usePrefix = usePrefix;
+      this.noSymbolPrefix = noSymbolPrefix;
+    }
+
+    /**
+     * Reaturns a {@link SourceCodeProperties} object with the specified parameters.
+     * 
+     * @param symbolsAsFactoryMethod if <code>true</code> use the <code>F.symbol()</code> method,
+     *        otherwise print the symbol name.
+     * @param useOperators use operators instead of function names for representation of Plus,
+     *        Times, Power,...
+     * @param usePrefix if <code>true</code> usePrefix use the <code>F....</code> class prefix for
+     *        generating Java code.
+     * @param noSymbolPrefix for symbols like <code>x,y,z,...</code> don't use the
+     *        <code>F....</code> class prefix for code generation
+     */
+    public static SourceCodeProperties of(boolean symbolsAsFactoryMethod, boolean useOperators,
+        boolean usePrefix, boolean noSymbolPrefix) {
+      return new SourceCodeProperties(symbolsAsFactoryMethod, useOperators, usePrefix,
+          noSymbolPrefix);
+    }
+
+    /**
+     * Returns a {@link SourceCodeProperties} objects with the same values as the given one except
+     * that the field {@link #symbolsAsFactoryMethod} of the returned object is always
+     * <code>false</code>.
+     */
+    public static SourceCodeProperties copyWithoutSymbolsAsFactoryMethod(SourceCodeProperties o) {
+      return !o.symbolsAsFactoryMethod ? o
+          : new SourceCodeProperties(false, o.useOperators, o.usePrefix, o.noSymbolPrefix);
+    }
+  }
+
   /**
    * Return the internal Java form of this expression.
    *
-   * @param symbolsAsFactoryMethod if <code>true</code> use the <code>F.symbol()</code> method,
-   *     otherwise print the symbol name.
+   * @param properties the settings to use for code generation.
    * @param depth the recursion depth of this call. <code>0</code> indicates &quot;recurse without a
-   *     limit&quot;.
-   * @param useOperators use operators instead of function names for representation of Plus, Times,
-   *     Power,...
-   * @param usePrefix use the <code>F....</code> class prefix for generating Java code.
-   * @param noSymbolPrefix for symbols like <code>x,y,z,...</code> don't use the <code>F....</code>
-   *     class prefix for code generation
+   *        limit&quot;.
    * @param variables TODO
    * @return the internal Java form of this expression
    */
-  default CharSequence internalJavaString(
-      boolean symbolsAsFactoryMethod,
-      int depth,
-      boolean useOperators,
-      boolean usePrefix,
-      boolean noSymbolPrefix,
+  default CharSequence internalJavaString(SourceCodeProperties properties, int depth,
       Function<IExpr, ? extends CharSequence> variables) {
     return toString();
   }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/tensor/qty/QuantityImpl.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/tensor/qty/QuantityImpl.java
@@ -136,11 +136,11 @@ public class QuantityImpl extends DataExpr<IUnit> implements IQuantity, External
   }
 
   @Override
-  public CharSequence internalJavaString(boolean symbolsAsFactoryMethod, int depth,
-      boolean useOperators, boolean usePrefix, boolean noSymbolPrefix,
+  public CharSequence internalJavaString(SourceCodeProperties properties, int depth,
       Function<IExpr, ? extends CharSequence> variables) {
-    CharSequence value = value().internalJavaString(symbolsAsFactoryMethod, depth, useOperators,
-        usePrefix, noSymbolPrefix, variables);
+
+    CharSequence value = value().internalJavaString(properties, depth, variables);
+
     StringBuilder javaForm = new StringBuilder();
     javaForm.append("IQuantity.of(").append(value).append(",");
     if (IUnit.ONE.equals(unit())) {

--- a/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/eval/Console.java
+++ b/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/eval/Console.java
@@ -25,6 +25,7 @@ import org.matheclipse.core.form.Documentation;
 import org.matheclipse.core.form.output.ASCIIPrettyPrinter3;
 import org.matheclipse.core.form.output.OutputFormFactory;
 import org.matheclipse.core.interfaces.IExpr;
+import org.matheclipse.core.interfaces.IExpr.SourceCodeProperties;
 import org.matheclipse.io.IOInit;
 import org.matheclipse.parser.client.FEConfig;
 import org.matheclipse.parser.client.Scanner;
@@ -491,13 +492,16 @@ public class Console {
     return buf.toString();
   }
 
+  static final SourceCodeProperties JAVA_FORM_PROPERTIES =
+      SourceCodeProperties.of(false, false, true, false);
+
   private String printResult(IExpr result) {
     if (result.equals(S.Null)) {
       return "";
     }
     switch (fUsedForm) {
       case JAVAFORM:
-        return result.internalJavaString(false, -1, false, true, false, F.CNullFunction).toString();
+        return result.internalJavaString(JAVA_FORM_PROPERTIES, -1, F.CNullFunction).toString();
       case TRADITIONALFORM:
         StringBuilder traditionalBuffer = new StringBuilder();
         fOutputTraditionalFactory.reset();

--- a/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/eval/MMAConsole.java
+++ b/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/eval/MMAConsole.java
@@ -531,7 +531,7 @@ public class MMAConsole {
       }
       switch (fUsedForm) {
         case JAVAFORM:
-          return result.internalJavaString(false, -1, false, true, false, F.CNullFunction)
+          return result.internalJavaString(Console.JAVA_FORM_PROPERTIES, -1, F.CNullFunction)
               .toString();
         case TRADITIONALFORM:
           StringBuilder traditionalBuffer = new StringBuilder();

--- a/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/io/system/JavaFormTestCase.java
+++ b/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/io/system/JavaFormTestCase.java
@@ -9,6 +9,7 @@ import org.matheclipse.core.eval.EvalUtilities;
 import org.matheclipse.core.expression.F;
 import org.matheclipse.core.interfaces.IAST;
 import org.matheclipse.core.interfaces.IExpr;
+import org.matheclipse.core.interfaces.IExpr.SourceCodeProperties;
 import org.matheclipse.core.tensor.qty.IQuantity;
 import org.matheclipse.core.tensor.qty.IUnit;
 import org.matheclipse.parser.client.FEConfig;
@@ -33,6 +34,9 @@ public class JavaFormTestCase extends AbstractTestCase {
     assertEquals("oo", result.internalFormString(true, -1).toString());
   }
 
+  private static final SourceCodeProperties SYMBOL_FACTORY_PROPERTIES =
+      SourceCodeProperties.of(true, false, true, false);
+
   public void testJavaForm002() {
     // don't distinguish between lower- and uppercase identifiers
     FEConfig.PARSER_USE_LOWERCASE_SYMBOLS = true;
@@ -42,22 +46,25 @@ public class JavaFormTestCase extends AbstractTestCase {
 
     IExpr result = EvalEngine.get().evalHoldPattern(function);
     assertEquals("F.Sinc(F.DirectedInfinity(F.CI))",
-        result.internalJavaString(true, -1, false, true, false, F.CNullFunction).toString());
+        result.internalJavaString(SYMBOL_FACTORY_PROPERTIES, -1, F.CNullFunction).toString());
 
     result = util.evaluate(function);
     assertEquals("F.oo",
-        result.internalJavaString(true, -1, false, true, false, F.CNullFunction).toString());
+        result.internalJavaString(SYMBOL_FACTORY_PROPERTIES, -1, F.CNullFunction).toString());
   }
 
-  public void testJavaFormQuantity_withUnitKG() {
+  private static final SourceCodeProperties NO_SYMBOL_FACTORY_PROPERTIES =
+      SourceCodeProperties.of(false, false, true, false);
+
+  public void testJavaFormQuantity_unitKG() {
     IExpr quantity = IQuantity.of(F.ZZ(43L), IUnit.ofPutIfAbsent("kg"));
-    String javaForm = quantity.internalJavaString(false, -1, false, true, false, null).toString();
-    assertEquals("IQuantity.of(F.ZZ(43L),IUnit.ofPutIfAbsent(\"kg\"))", javaForm);
+    assertEquals("IQuantity.of(F.ZZ(43L),IUnit.ofPutIfAbsent(\"kg\"))",
+        quantity.internalJavaString(NO_SYMBOL_FACTORY_PROPERTIES, -1, null).toString());
   }
 
-  public void testJavaFormQuantity_withUnitOne() {
+  public void testJavaFormQuantity_unitOne() {
     IExpr quantity = IQuantity.of(F.ZZ(43L), IUnit.ONE);
-    String javaForm = quantity.internalJavaString(false, -1, false, true, false, null).toString();
-    assertEquals("IQuantity.of(F.ZZ(43L),IUnit.ONE)", javaForm);
+    assertEquals("IQuantity.of(F.ZZ(43L),IUnit.ONE)",
+        quantity.internalJavaString(NO_SYMBOL_FACTORY_PROPERTIES, -1, null).toString());
   }
 }


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description
This PR introduces the parameter-object `SourceCodeProperties` for the method internalJavaString() that wraps the four boolean parameters of that method.
Not only does this save a lot of code and therefore improves readability, it also makes the method more type safe because one cannot confuse arguments with each other without compiler error, like it is the case for multiple subsequent boolean arguments.