### PR TITLE
[JavaForm] add option for fully-qualified class-name prefix

### DIFF
--- a/symja_android_library/matheclipse-beakerx/src/main/java/com/twosigma/beakerx/symjamma/evaluator/SymjaMMAEvaluator.java
+++ b/symja_android_library/matheclipse-beakerx/src/main/java/com/twosigma/beakerx/symjamma/evaluator/SymjaMMAEvaluator.java
@@ -26,6 +26,7 @@ import org.matheclipse.core.form.output.OutputFormFactory;
 import org.matheclipse.core.form.tex.TeXFormFactory;
 import org.matheclipse.core.interfaces.IExpr;
 import org.matheclipse.core.interfaces.IExpr.SourceCodeProperties;
+import org.matheclipse.core.interfaces.IExpr.SourceCodeProperties.Prefix;
 import org.matheclipse.io.IOInit;
 import org.matheclipse.parser.client.FEConfig;
 import com.twosigma.beakerx.BeakerXClient;
@@ -234,7 +235,7 @@ public class SymjaMMAEvaluator extends BaseEvaluator {
   }
 
   private static final SourceCodeProperties JAVA_FORM_PROPERTIES =
-      SourceCodeProperties.of(false, false, true, false);
+      SourceCodeProperties.of(false, false, Prefix.CLASS_NAME, false);
 
   /**
    * Print the result in the default output form

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/CompilerFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/CompilerFunctions.java
@@ -27,6 +27,7 @@ import org.matheclipse.core.generic.Functors;
 import org.matheclipse.core.interfaces.IAST;
 import org.matheclipse.core.interfaces.IExpr;
 import org.matheclipse.core.interfaces.IExpr.SourceCodeProperties;
+import org.matheclipse.core.interfaces.IExpr.SourceCodeProperties.Prefix;
 import org.matheclipse.core.interfaces.IStringX;
 import org.matheclipse.core.interfaces.ISymbol;
 
@@ -520,7 +521,7 @@ public class CompilerFunctions {
     }
 
     private static final SourceCodeProperties JAVA_FORM_PROPERTIES =
-        SourceCodeProperties.of(false, false, true, false);
+        SourceCodeProperties.of(false, false, Prefix.CLASS_NAME, false);
 
     private boolean convertSymbolic(StringBuilder buf, IExpr expression) {
       try {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/OutputFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/OutputFunctions.java
@@ -37,6 +37,7 @@ import org.matheclipse.core.interfaces.IASTDataset;
 import org.matheclipse.core.interfaces.IASTMutable;
 import org.matheclipse.core.interfaces.IExpr;
 import org.matheclipse.core.interfaces.IExpr.SourceCodeProperties;
+import org.matheclipse.core.interfaces.IExpr.SourceCodeProperties.Prefix;
 import org.matheclipse.core.interfaces.IInteger;
 import org.matheclipse.core.interfaces.IStringX;
 import org.matheclipse.core.interfaces.ISymbol;
@@ -454,7 +455,8 @@ public final class OutputFunctions {
   private static class JavaForm extends AbstractCoreFunctionEvaluator {
 
     public static CharSequence javaForm(IExpr arg1, boolean strictJava, boolean usePrefix) {
-      SourceCodeProperties p = SourceCodeProperties.of(strictJava, false, usePrefix, false);
+      SourceCodeProperties p =
+          SourceCodeProperties.of(strictJava, false, usePrefix ? Prefix.CLASS_NAME : Prefix.NONE, false);
       return arg1.internalJavaString(p, 0, F.CNullFunction);
     }
 

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/MathMLUtilities.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/MathMLUtilities.java
@@ -8,6 +8,7 @@ import org.matheclipse.core.expression.F;
 import org.matheclipse.core.form.mathml.MathMLFormFactory;
 import org.matheclipse.core.interfaces.IExpr;
 import org.matheclipse.core.interfaces.IExpr.SourceCodeProperties;
+import org.matheclipse.core.interfaces.IExpr.SourceCodeProperties.Prefix;
 import org.matheclipse.core.parser.ExprParser;
 
 /**
@@ -161,7 +162,7 @@ public class MathMLUtilities {
   }
 
   private static final SourceCodeProperties JAVA_FORM_PROPERTIES =
-      SourceCodeProperties.of(false, false, true, false);
+      SourceCodeProperties.of(false, false, Prefix.CLASS_NAME, false);
 
   private synchronized void toJava(
       final String inputExpression, final Writer out, boolean strictJava) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/AbstractAST.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/AbstractAST.java
@@ -63,6 +63,7 @@ import org.matheclipse.core.interfaces.IDiscreteDistribution;
 import org.matheclipse.core.interfaces.IDistribution;
 import org.matheclipse.core.interfaces.IEvaluator;
 import org.matheclipse.core.interfaces.IExpr;
+import org.matheclipse.core.interfaces.IExpr.SourceCodeProperties.Prefix;
 import org.matheclipse.core.interfaces.IInteger;
 import org.matheclipse.core.interfaces.INum;
 import org.matheclipse.core.interfaces.INumber;
@@ -457,7 +458,15 @@ public abstract class AbstractAST implements IASTMutable {
     @Override
     public final CharSequence internalJavaString(SourceCodeProperties properties, int depth,
         Function<IExpr, ? extends CharSequence> variables) {
-      return properties.usePrefix ? "F.NIL" : "NIL";
+      switch (properties.prefix) {
+        case FULLY_QUALIFIED_CLASS_NAME:
+          return "org.matheclipse.core.expression.F.NIL";
+        case CLASS_NAME:
+          return "F.NIL";
+        case NONE:
+        default:
+        return "NIL";
+      }
     }
 
     @Override
@@ -2444,9 +2453,9 @@ public abstract class AbstractAST implements IASTMutable {
   }
 
   private static final SourceCodeProperties STRING_FORM_SYMBOL_FACTORY =
-      SourceCodeProperties.of(true, false, false, false);
+      SourceCodeProperties.of(true, false, Prefix.NONE, false);
   private static final SourceCodeProperties STRING_FORM_NO_SYMBOL_FACTORY =
-      SourceCodeProperties.of(false, false, false, false);
+      SourceCodeProperties.of(false, false, Prefix.NONE, false);
 
   static SourceCodeProperties stringFormProperties(boolean symbolsAsFactoryMethod) {
     return symbolsAsFactoryMethod ? STRING_FORM_SYMBOL_FACTORY : STRING_FORM_NO_SYMBOL_FACTORY;
@@ -2689,7 +2698,15 @@ public abstract class AbstractAST implements IASTMutable {
   }
 
   static String getPrefixF(SourceCodeProperties properties) {
-    return properties.usePrefix ? "F." : "";
+    switch (properties.prefix) {
+      case FULLY_QUALIFIED_CLASS_NAME:
+        return "org.matheclipse.core.expression.F.";
+      case CLASS_NAME:
+        return "F.";
+      case NONE:
+      default:
+        return "";
+    }
   }
 
   private void internalOperatorForm(
@@ -2708,9 +2725,9 @@ public abstract class AbstractAST implements IASTMutable {
   }
 
   private static final SourceCodeProperties SCALA_FORM_SYMBOL_FACTORY =
-      SourceCodeProperties.of(true, true, false, false);
+      SourceCodeProperties.of(true, true, Prefix.NONE, false);
   private static final SourceCodeProperties SCALA_FORM_NO_SYMBOL_FACTORY =
-      SourceCodeProperties.of(false, true, false, false);
+      SourceCodeProperties.of(false, true, Prefix.NONE, false);
 
   static SourceCodeProperties scalaFormProperties(boolean symbolsAsFactoryMethod) {
     return symbolsAsFactoryMethod ? SCALA_FORM_SYMBOL_FACTORY : SCALA_FORM_NO_SYMBOL_FACTORY;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/interfaces/IExpr.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/interfaces/IExpr.java
@@ -6,6 +6,7 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -1054,6 +1055,10 @@ public interface IExpr
   }
 
   public static class SourceCodeProperties {
+    public enum Prefix {
+      NONE, CLASS_NAME, FULLY_QUALIFIED_CLASS_NAME;
+    }
+
     /**
      * If <code>true</code> use the <code>F.symbol()</code> method, otherwise print the symbol name.
      */
@@ -1063,9 +1068,11 @@ public interface IExpr
      */
     public final boolean useOperators;
     /**
-     * If true usePrefix use the <code>F....</code> class prefix for generating Java code.
+     * If {@link Prefix#CLASS_NAME} use the <code>F....</code> class prefix for generating Java
+     * code, if {@link Prefix#FULLY_QUALIFIED_CLASS_NAME} use the fully qualified class name, if
+     * {@link Prefix#NONE} use no prefix.
      */
-    public final boolean usePrefix;
+    public final Prefix prefix;
     /**
      * If <code>true</code>, for symbols like <code>x,y,z,...</code> don't use the
      * <code>F....</code> class prefix for code generation.
@@ -1073,10 +1080,10 @@ public interface IExpr
     public final boolean noSymbolPrefix;
 
     private SourceCodeProperties(boolean symbolsAsFactoryMethod, boolean useOperators,
-        boolean usePrefix, boolean noSymbolPrefix) {
+        Prefix prefix, boolean noSymbolPrefix) {
       this.symbolsAsFactoryMethod = symbolsAsFactoryMethod;
       this.useOperators = useOperators;
-      this.usePrefix = usePrefix;
+      this.prefix = Objects.requireNonNull(prefix, "Method prefix must not be null");
       this.noSymbolPrefix = noSymbolPrefix;
     }
 
@@ -1087,15 +1094,15 @@ public interface IExpr
      *        otherwise print the symbol name.
      * @param useOperators use operators instead of function names for representation of Plus,
      *        Times, Power,...
-     * @param usePrefix if <code>true</code> usePrefix use the <code>F....</code> class prefix for
-     *        generating Java code.
+     * @param prefix if {@link Prefix#CLASS_NAME} use the <code>F....</code> class prefix for
+     *        generating Java code, if {@link Prefix#FULLY_QUALIFIED_CLASS_NAME} use the fully
+     *        qualified class name, if {@link Prefix#NONE} use no prefix.
      * @param noSymbolPrefix for symbols like <code>x,y,z,...</code> don't use the
      *        <code>F....</code> class prefix for code generation
      */
     public static SourceCodeProperties of(boolean symbolsAsFactoryMethod, boolean useOperators,
-        boolean usePrefix, boolean noSymbolPrefix) {
-      return new SourceCodeProperties(symbolsAsFactoryMethod, useOperators, usePrefix,
-          noSymbolPrefix);
+        Prefix prefix, boolean noSymbolPrefix) {
+      return new SourceCodeProperties(symbolsAsFactoryMethod, useOperators, prefix, noSymbolPrefix);
     }
 
     /**
@@ -1105,7 +1112,7 @@ public interface IExpr
      */
     public static SourceCodeProperties copyWithoutSymbolsAsFactoryMethod(SourceCodeProperties o) {
       return !o.symbolsAsFactoryMethod ? o
-          : new SourceCodeProperties(false, o.useOperators, o.usePrefix, o.noSymbolPrefix);
+          : new SourceCodeProperties(false, o.useOperators, o.prefix, o.noSymbolPrefix);
     }
   }
 

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/tensor/qty/QuantityImpl.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/tensor/qty/QuantityImpl.java
@@ -13,6 +13,7 @@ import org.matheclipse.core.expression.DataExpr;
 import org.matheclipse.core.expression.F;
 import org.matheclipse.core.expression.S;
 import org.matheclipse.core.interfaces.IExpr;
+import org.matheclipse.core.interfaces.IExpr.SourceCodeProperties.Prefix;
 import org.matheclipse.parser.client.math.MathException;
 
 public class QuantityImpl extends DataExpr<IUnit> implements IQuantity, Externalizable {
@@ -142,11 +143,13 @@ public class QuantityImpl extends DataExpr<IUnit> implements IQuantity, External
     CharSequence value = value().internalJavaString(properties, depth, variables);
 
     StringBuilder javaForm = new StringBuilder();
-    javaForm.append("IQuantity.of(").append(value).append(",");
+    boolean fullName = properties.prefix == Prefix.FULLY_QUALIFIED_CLASS_NAME;
+    String pPrefix = fullName ? "org.matheclipse.core.tensor.qty." : "";
+    javaForm.append(pPrefix).append("IQuantity.of(").append(value).append(",");
     if (IUnit.ONE.equals(unit())) {
-      javaForm.append("IUnit.ONE");
+      javaForm.append(pPrefix).append("IUnit.ONE");
     } else {
-      javaForm.append("IUnit.ofPutIfAbsent(\"").append(unitString()).append("\")");
+      javaForm.append(pPrefix).append("IUnit.ofPutIfAbsent(\"").append(unitString()).append("\")");
     }
     return javaForm.append(")");
   }

--- a/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/eval/Console.java
+++ b/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/eval/Console.java
@@ -26,6 +26,7 @@ import org.matheclipse.core.form.output.ASCIIPrettyPrinter3;
 import org.matheclipse.core.form.output.OutputFormFactory;
 import org.matheclipse.core.interfaces.IExpr;
 import org.matheclipse.core.interfaces.IExpr.SourceCodeProperties;
+import org.matheclipse.core.interfaces.IExpr.SourceCodeProperties.Prefix;
 import org.matheclipse.io.IOInit;
 import org.matheclipse.parser.client.FEConfig;
 import org.matheclipse.parser.client.Scanner;
@@ -493,7 +494,7 @@ public class Console {
   }
 
   static final SourceCodeProperties JAVA_FORM_PROPERTIES =
-      SourceCodeProperties.of(false, false, true, false);
+      SourceCodeProperties.of(false, false, Prefix.CLASS_NAME, false);
 
   private String printResult(IExpr result) {
     if (result.equals(S.Null)) {

--- a/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/io/system/JavaFormTestCase.java
+++ b/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/io/system/JavaFormTestCase.java
@@ -10,6 +10,7 @@ import org.matheclipse.core.expression.F;
 import org.matheclipse.core.interfaces.IAST;
 import org.matheclipse.core.interfaces.IExpr;
 import org.matheclipse.core.interfaces.IExpr.SourceCodeProperties;
+import org.matheclipse.core.interfaces.IExpr.SourceCodeProperties.Prefix;
 import org.matheclipse.core.tensor.qty.IQuantity;
 import org.matheclipse.core.tensor.qty.IUnit;
 import org.matheclipse.parser.client.FEConfig;
@@ -35,7 +36,9 @@ public class JavaFormTestCase extends AbstractTestCase {
   }
 
   private static final SourceCodeProperties SYMBOL_FACTORY_PROPERTIES =
-      SourceCodeProperties.of(true, false, true, false);
+      SourceCodeProperties.of(true, false, Prefix.CLASS_NAME, false);
+  private static final SourceCodeProperties SYMBOL_FACTORY_PROPERTIES_FULL_NAMES =
+      SourceCodeProperties.of(true, false, Prefix.FULLY_QUALIFIED_CLASS_NAME, false);
 
   public void testJavaForm002() {
     // don't distinguish between lower- and uppercase identifiers
@@ -53,8 +56,27 @@ public class JavaFormTestCase extends AbstractTestCase {
         result.internalJavaString(SYMBOL_FACTORY_PROPERTIES, -1, F.CNullFunction).toString());
   }
 
+  public void testJavaForm002_fullyQualifiedName() {
+    // don't distinguish between lower- and uppercase identifiers
+    FEConfig.PARSER_USE_LOWERCASE_SYMBOLS = true;
+    EvalUtilities util = new EvalUtilities(false, true);
+    IAST function = Sinc(Times(CI, CInfinity));
+
+    IExpr result = EvalEngine.get().evalHoldPattern(function);
+    assertEquals(
+        "org.matheclipse.core.expression.F.Sinc(org.matheclipse.core.expression.F.DirectedInfinity(org.matheclipse.core.expression.F.CI))",
+        result.internalJavaString(SYMBOL_FACTORY_PROPERTIES_FULL_NAMES, -1, F.CNullFunction)
+            .toString());
+
+    result = util.evaluate(function);
+    assertEquals("org.matheclipse.core.expression.F.oo", result
+        .internalJavaString(SYMBOL_FACTORY_PROPERTIES_FULL_NAMES, -1, F.CNullFunction).toString());
+  }
+
   private static final SourceCodeProperties NO_SYMBOL_FACTORY_PROPERTIES =
-      SourceCodeProperties.of(false, false, true, false);
+      SourceCodeProperties.of(false, false, Prefix.CLASS_NAME, false);
+  private static final SourceCodeProperties NO_SYMBOL_FACTORY_PROPERTIES_FULL_NAMES =
+      SourceCodeProperties.of(false, false, Prefix.FULLY_QUALIFIED_CLASS_NAME, false);
 
   public void testJavaFormQuantity_unitKG() {
     IExpr quantity = IQuantity.of(F.ZZ(43L), IUnit.ofPutIfAbsent("kg"));
@@ -62,9 +84,26 @@ public class JavaFormTestCase extends AbstractTestCase {
         quantity.internalJavaString(NO_SYMBOL_FACTORY_PROPERTIES, -1, null).toString());
   }
 
+  public void testJavaFormQuantity_unitKGAndFullyQualifiedName() {
+    IExpr quantity =
+        org.matheclipse.core.tensor.qty.IQuantity.of(org.matheclipse.core.expression.F.ZZ(43L),
+            org.matheclipse.core.tensor.qty.IUnit.ofPutIfAbsent("kg"));
+    assertEquals(
+        "org.matheclipse.core.tensor.qty.IQuantity.of(org.matheclipse.core.expression.F.ZZ(43L),org.matheclipse.core.tensor.qty.IUnit.ofPutIfAbsent(\"kg\"))",
+        quantity.internalJavaString(NO_SYMBOL_FACTORY_PROPERTIES_FULL_NAMES, -1, null).toString());
+  }
+
   public void testJavaFormQuantity_unitOne() {
     IExpr quantity = IQuantity.of(F.ZZ(43L), IUnit.ONE);
     assertEquals("IQuantity.of(F.ZZ(43L),IUnit.ONE)",
         quantity.internalJavaString(NO_SYMBOL_FACTORY_PROPERTIES, -1, null).toString());
+  }
+
+  public void testJavaFormQuantity_unitOneAndFullyQualifiedName() {
+    IExpr quantity = org.matheclipse.core.tensor.qty.IQuantity
+        .of(org.matheclipse.core.expression.F.ZZ(43L), org.matheclipse.core.tensor.qty.IUnit.ONE);
+    assertEquals(
+        "org.matheclipse.core.tensor.qty.IQuantity.of(org.matheclipse.core.expression.F.ZZ(43L),org.matheclipse.core.tensor.qty.IUnit.ONE)",
+        quantity.internalJavaString(NO_SYMBOL_FACTORY_PROPERTIES_FULL_NAMES, -1, null).toString());
   }
 }


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

This PR extends the `SourceCodeProperties` to specify if the prefix for generated Java-Code is only the simple class-name (like `F`) or the fully qualified class name (like `org.matheclipse.core.expression.F`).

If `SourceCodeProperties.prefix` is changed from `CLASS_NAME` to `FULLY_QUALIFIED_CLASS_NAME` the generated java-code changes from 
```
"IQuantity.of(F.ZZ(43L),IUnit.ONE)"
```
to
```
"org.matheclipse.core.tensor.qty.IQuantity.of(org.matheclipse.core.expression.F.ZZ(43L),org.matheclipse.core.tensor.qty.IUnit.ONE)"
```
which is useful if one does not want to generate imports.

## Testing

Added more cases to `JavaFormTestCase`.
