### PR TITLE
[External] Remove now unused log4j-api dependency

### DIFF
--- a/symja_android_library/matheclipse-external/pom.xml
+++ b/symja_android_library/matheclipse-external/pom.xml
@@ -15,7 +15,6 @@
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>The Symja external module</description>
 
-
 	<licenses>
 		<license>
 			<name>GNU Lesser General Public License, Version 3</name>
@@ -40,18 +39,6 @@
 		<dependency>
 			<groupId>io.pebbletemplates</groupId>
 			<artifactId>pebble</artifactId>
-		</dependency>
-
-		<!-- <dependency> <groupId>edu.stanford.nlp</groupId> <artifactId>stanford-corenlp</artifactId>
-			<version>4.0.0</version> </dependency> <dependency> <groupId>edu.stanford.nlp</groupId>
-			<artifactId>stanford-corenlp</artifactId> <version>4.0.0</version> <classifier>models</classifier>
-			</dependency> -->
-
-		<!-- logging dependencies -->
-
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
 		</dependency>
 
 	</dependencies>


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Remove the log4j-api dependency of Symja's external module that is not required since JAS is included as Maven-Dependency and not embedded any more with commit 3788b02f561538110312d67cfbc761a2ed5f577e respectively PR #311 (which also contained this removal).