### PR TITLE
[POM] update to log4j 2.15.0

### DIFF
--- a/symja_android_library/pom.xml
+++ b/symja_android_library/pom.xml
@@ -307,25 +307,25 @@
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-api</artifactId>
-				<version>2.13.2</version>
+				<version>2.15.0</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-core</artifactId>
-				<version>2.13.2</version>
+				<version>2.15.0</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-1.2-api</artifactId>
-				<version>2.13.2</version>
+				<version>2.15.0</version>
 			</dependency>
 
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-slf4j-impl</artifactId>
-				<version>2.13.2</version>
+				<version>2.15.0</version>
 			</dependency>
 
 		</dependencies>


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

This PR updates the org.apache.logging.log4j dependencies to version 2.15.0.