### PR TITLE
Enable dependabot version updates for Symja

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
+version: 2
+updates:
+
+  - package-ecosystem: maven
+    directory: "/symja_android_library"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

This PR enables the automatic version update PR creation by dependabot for Symja.
Dependabot then checks for more recent versions of dependencies in Symja's pom.xml files on a daily basis. If an update for a dependency is found dependabot automatically creates PR to update that dependency. We can then review it and decide to merge or abandon that PR.
The same is done for GitHub action plug-ins.

This avoids the need to check for dependency updates manually and ensures we get informed about version updates within one day.

The documentation can be found here:
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically
