### PR TITLE
[Build] configure plug-ins inherited from super-pom and enforce Maven 3.2.0+

### DIFF
--- a/symja_android_library/pom.xml
+++ b/symja_android_library/pom.xml
@@ -370,14 +370,51 @@
 
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-clean-plugin</artifactId>
+					<version>3.1.0</version>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.8.1</version>
 				</plugin>
 
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-deploy-plugin</artifactId>
+					<version>3.0.0-M2</version>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-enforcer-plugin</artifactId>
+					<version>3.0.0</version>
+					<configuration>
+						<rules>
+							<requireMavenVersion>
+								<version>3.2.0</version>
+							</requireMavenVersion>
+						</rules>
+					</configuration>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-gpg-plugin</artifactId>
 					<version>3.0.1</version>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-install-plugin</artifactId>
+					<version>3.0.0-M1</version>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-jar-plugin</artifactId>
+					<version>3.2.0</version>
 				</plugin>
 
 				<plugin>
@@ -389,7 +426,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-release-plugin</artifactId>
-					<version>2.5.3</version>
+					<version>3.0.0-M4</version>
 					<configuration>
 						<tagNameFormat>@{project.version}</tagNameFormat>
 					</configuration>
@@ -429,6 +466,12 @@
 				</plugin>
 
 				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<version>3.0.0-M5</version>
+				</plugin>
+
+				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>exec-maven-plugin</artifactId>
 					<version>3.0.0</version>
@@ -465,6 +508,19 @@
 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>enforce-maven-version</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<executions>
 					<execution>
@@ -473,7 +529,7 @@
 						</goals>
 						<configuration>
 							<doclint>none</doclint>
-							<quiet>true</quiet><!-- only show warnings/errors -->
+							<quiet>true</quiet> <!-- only show warnings/errors -->
 							<failOnError>false</failOnError>
 						</configuration>
 					</execution>

--- a/symja_android_library/pom.xml
+++ b/symja_android_library/pom.xml
@@ -468,7 +468,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>3.0.0-M5</version>
+					<version>2.12.4</version>
 				</plugin>
 
 				<plugin>


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description
This PR specifies the versions of all plug-ins that were previously just inherited from the (implicitly specified) super-pom.
Because this pom changes with the Maven versions the stability of the build can be negatively influenced.

Specifying the versions of all used plug-ins improves stability of the Maven build.

Furthermore the minimal required Maven version of 3.2.0 is enforced now.

Available updates for build plug-ins can be checked with the following
command:

mvn versions:display-plugin-updates versions:display-property-updates
