### PR TITLE
Assembly

### DIFF
--- a/symja_android_library/matheclipse-discord/pom.xml
+++ b/symja_android_library/matheclipse-discord/pom.xml
@@ -58,22 +58,13 @@
 					<configuration>
 						<archive>
 							<manifest>
-								<mainClass>Class>org.matheclipse.discord.SymjaBot</mainClass>
+								<mainClass>org.matheclipse.discord.SymjaBot</mainClass>
 							</manifest>
 						</archive>
 						<descriptorRefs>
 							<descriptorRef>jar-with-dependencies</descriptorRef>
 						</descriptorRefs>
 					</configuration>
-					<executions>
-						<execution>
-							<id>make-assembly</id> <!-- this is used for inheritance merges -->
-							<goals>
-								<goal>single</goal>
-							</goals>
-							<phase>package</phase> <!-- bind to the packaging phase -->
-						</execution>
-					</executions>
 				</plugin>
 
 				<plugin>

--- a/symja_android_library/matheclipse-discord/pom.xml
+++ b/symja_android_library/matheclipse-discord/pom.xml
@@ -38,9 +38,9 @@
 		</dependency>
 		<dependency>
 			<groupId>com.discord4j</groupId>
-			<artifactId>discord4j-core</artifactId> 
+			<artifactId>discord4j-core</artifactId>
 			<version>3.2.1</version>
-		</dependency> 
+		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>matheclipse-logging</artifactId>
@@ -52,20 +52,6 @@
 	<build>
 		<pluginManagement>
 			<plugins>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-assembly-plugin</artifactId>
-					<configuration>
-						<archive>
-							<manifest>
-								<mainClass>org.matheclipse.discord.SymjaBot</mainClass>
-							</manifest>
-						</archive>
-						<descriptorRefs>
-							<descriptorRef>jar-with-dependencies</descriptorRef>
-						</descriptorRefs>
-					</configuration>
-				</plugin>
 
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
@@ -79,9 +65,10 @@
 							<configuration>
 								<mainClass>org.matheclipse.discord.SymjaBot</mainClass>
 							</configuration>
-						</execution> 
+						</execution>
 					</executions>
 				</plugin>
+
 			</plugins>
 		</pluginManagement>
 	</build>

--- a/symja_android_library/matheclipse-gpl/pom.xml
+++ b/symja_android_library/matheclipse-gpl/pom.xml
@@ -40,22 +40,4 @@
 		</dependency>
 
 	</dependencies>
-
-	<build>
-		<pluginManagement>
-			<plugins>
-
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-assembly-plugin</artifactId>
-					<configuration>
-						<descriptorRefs>
-							<descriptorRef>jar-with-dependencies</descriptorRef>
-						</descriptorRefs>
-					</configuration>
-				</plugin>
-
-			</plugins>
-		</pluginManagement>
-	</build>
 </project>

--- a/symja_android_library/matheclipse-gpl/pom.xml
+++ b/symja_android_library/matheclipse-gpl/pom.xml
@@ -53,15 +53,6 @@
 							<descriptorRef>jar-with-dependencies</descriptorRef>
 						</descriptorRefs>
 					</configuration>
-					<executions>
-						<execution>
-							<id>make-assembly</id> <!-- this is used for inheritance merges -->
-							<goals>
-								<goal>single</goal>
-							</goals>
-							<phase>package</phase> <!-- bind to the packaging phase -->
-						</execution>
-					</executions>
 				</plugin>
 
 			</plugins>

--- a/symja_android_library/matheclipse-io/pom.xml
+++ b/symja_android_library/matheclipse-io/pom.xml
@@ -127,15 +127,6 @@
 							<descriptorRef>jar-with-dependencies</descriptorRef>
 						</descriptorRefs>
 					</configuration>
-					<executions>
-						<execution>
-							<id>make-assembly</id> <!-- this is used for inheritance merges -->
-							<goals>
-								<goal>single</goal>
-							</goals>
-							<phase>package</phase> <!-- bind to the packaging phase -->
-						</execution>
-					</executions>
 				</plugin>
 
 				<plugin>

--- a/symja_android_library/matheclipse-io/pom.xml
+++ b/symja_android_library/matheclipse-io/pom.xml
@@ -115,21 +115,6 @@
 			<plugins>
 
 				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-assembly-plugin</artifactId>
-					<configuration>
-						<archive>
-							<manifest>
-								<mainClass>org.matheclipse.io.eval.Console</mainClass>
-							</manifest>
-						</archive>
-						<descriptorRefs>
-							<descriptorRef>jar-with-dependencies</descriptorRef>
-						</descriptorRefs>
-					</configuration>
-				</plugin>
-
-				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>exec-maven-plugin</artifactId>
 					<executions>

--- a/symja_android_library/matheclipse-jar/pom.xml
+++ b/symja_android_library/matheclipse-jar/pom.xml
@@ -60,20 +60,6 @@
 						</container>
 					</configuration>
 				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-assembly-plugin</artifactId>
-					<configuration>
-						<archive>
-							<manifest>
-								<mainClass>org.matheclipse.io.eval.Console</mainClass>
-							</manifest>
-						</archive>
-						<descriptorRefs>
-							<descriptorRef>jar-with-dependencies</descriptorRef>
-						</descriptorRefs>
-					</configuration>
-				</plugin>
 
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>

--- a/symja_android_library/matheclipse-jar/pom.xml
+++ b/symja_android_library/matheclipse-jar/pom.xml
@@ -73,15 +73,6 @@
 							<descriptorRef>jar-with-dependencies</descriptorRef>
 						</descriptorRefs>
 					</configuration>
-					<executions>
-						<execution>
-							<id>make-assembly</id> <!-- this is used for inheritance merges -->
-							<goals>
-								<goal>single</goal>
-							</goals>
-							<phase>package</phase> <!-- bind to the packaging phase -->
-						</execution>
-					</executions>
 				</plugin>
 
 				<plugin>

--- a/symja_android_library/pom.xml
+++ b/symja_android_library/pom.xml
@@ -370,14 +370,51 @@
 
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-clean-plugin</artifactId>
+					<version>3.1.0</version>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.8.1</version>
 				</plugin>
 
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-deploy-plugin</artifactId>
+					<version>3.0.0-M2</version>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-enforcer-plugin</artifactId>
+					<version>3.0.0</version>
+					<configuration>
+						<rules>
+							<requireMavenVersion>
+								<version>3.2.0</version>
+							</requireMavenVersion>
+						</rules>
+					</configuration>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-gpg-plugin</artifactId>
 					<version>3.0.1</version>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-install-plugin</artifactId>
+					<version>3.0.0-M1</version>
+				</plugin>
+
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-jar-plugin</artifactId>
+					<version>3.2.0</version>
 				</plugin>
 
 				<plugin>
@@ -389,7 +426,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-release-plugin</artifactId>
-					<version>2.5.3</version>
+					<version>3.0.0-M4</version>
 					<configuration>
 						<tagNameFormat>@{project.version}</tagNameFormat>
 					</configuration>
@@ -429,6 +466,12 @@
 				</plugin>
 
 				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<version>3.0.0-M5</version>
+				</plugin>
+
+				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>exec-maven-plugin</artifactId>
 					<version>3.0.0</version>
@@ -465,6 +508,19 @@
 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>enforce-maven-version</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<executions>
 					<execution>
@@ -473,7 +529,7 @@
 						</goals>
 						<configuration>
 							<doclint>none</doclint>
-							<quiet>true</quiet><!-- only show warnings/errors -->
+							<quiet>true</quiet> <!-- only show warnings/errors -->
 							<failOnError>false</failOnError>
 						</configuration>
 					</execution>

--- a/symja_android_library/pom.xml
+++ b/symja_android_library/pom.xml
@@ -364,12 +364,6 @@
 
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-assembly-plugin</artifactId>
-					<version>3.3.0</version>
-				</plugin>
-
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-clean-plugin</artifactId>
 					<version>3.1.0</version>
 				</plugin>


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

This PR aims to remove the execution-sections of the `maven-assembly-plugin` used in the child-module poms that are only declared in the pluginManagement section and therefore never run.

This PR also corrects the `mainClass` element in the `matheclipse-discord/pom.xml` whoose value starts with `class>` . @axkr or is this intentional?

@axkr do you use the `maven-assembly-plugin` in some manual Maven executions to assemble fat jars? Because `assembly` is not executed in the build (because it was only configured in the plug-in management). If you don't use it somewhere else the entire plug-in could be removed.