### PR TITLE
[Build] remove matheclipse-jar from build

### DIFF
--- a/symja_android_library/eclipse/symja--jib-build.launch
+++ b/symja_android_library/eclipse/symja--jib-build.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
     <booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
-    <stringAttribute key="M2_GOALS" value="compile jib:build -pl matheclipse-jar"/>
+    <stringAttribute key="M2_GOALS" value="-f matheclipse-jar compile jib:build"/>
     <booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
     <booleanAttribute key="M2_OFFLINE" value="false"/>
     <stringAttribute key="M2_PROFILES" value=""/>

--- a/symja_android_library/eclipse/symja--jib-dockerbuild.launch
+++ b/symja_android_library/eclipse/symja--jib-dockerbuild.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
     <booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
-    <stringAttribute key="M2_GOALS" value="compile jib:dockerBuild -pl matheclipse-jar"/>
+    <stringAttribute key="M2_GOALS" value="-f matheclipse-jar compile jib:dockerBuild"/>
     <booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
     <booleanAttribute key="M2_OFFLINE" value="false"/>
     <stringAttribute key="M2_PROFILES" value=""/>

--- a/symja_android_library/pom.xml
+++ b/symja_android_library/pom.xml
@@ -44,7 +44,6 @@
 		<module>matheclipse-gpl</module>
 		<module>matheclipse-api</module>
 		<module>matheclipse-io</module>
-		<module>matheclipse-jar</module>
 		<module>matheclipse-beakerx</module>
 		<module>matheclipse-discord</module>
 		<module>matheclipse-logging</module>


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

As we have discussed the `matheclipse-jar` module is just used to build Symja's docker container and not intended to be published.
This module can therefore should not participate in the default Symja build and can be removed from Symja's root pom.xml.
