### PR TITLE
[Build] remove matheclipse-beakerx module from build

### DIFF
--- a/symja_android_library/pom.xml
+++ b/symja_android_library/pom.xml
@@ -42,7 +42,6 @@
 		<module>matheclipse-gpl</module>
 		<module>matheclipse-api</module>
 		<module>matheclipse-io</module>
-		<module>matheclipse-beakerx</module>
 		<module>matheclipse-discord</module>
 		<module>matheclipse-logging</module>
 	</modules>


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

As we have discussed the `matheclipse-beakerx` module is stale and not intended to be published.
This module can therefore should not participate in the default Symja build and can be removed from Symja's root pom.xml.

Furthermore it relies on dependencies not available on Maven-Central which is discouraged for artefacts deployed there.