### PR TITLE
[Build] set 15min timeout, use 'temurin' java and use setup-java cache

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,21 +13,20 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
         java-version: '11'
-        distribution: 'adopt'
-    - name: Cache Maven packages
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2 
-    - run: mvn --batch-mode --update-snapshots verify --file symja_android_library/pom.xml
+        distribution: 'temurin'
+        cache: 'maven' # Cache Maven dependencies between workflow runs
+
+    - run: mvn -f symja_android_library -B -U verify
+
     - uses: actions/upload-artifact@v2
       with:
         name: Package


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

This PR improves the current build workflow in the following ways
- set a timeout at 15min
to guard against long running builds (like in #349) that eat up a significant amount of Symja's free build minutes. At the moment the build runs about 4~5min, so for a regular build the timeout is more than sufficient. If the regular build time increases the timeout can be adjusted accordingly.
- use `temurin` instead of `adopt` java distribution.
Adopt is deprecated according to the [setup-java action doc](https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#adopt).
- use build in maven cache of the `setup-java` action, which avoids the need to use the cache action (internally the `setup-java` action uses that action but it avoids configuration in the workflow) and can be even faster.
- beautify pom by adding some blank lines and using compact parameters for the Maven build command
The commands should be consistent and the up-comming publish command is a bit longer with large parameters.

