### PR TITLE
[Build] Set up automatic publication of SNAPSHOT master builds (#193)

### DIFF
--- a/.github/workflows/maven-build-master-and-publish-snapshot.yml
+++ b/.github/workflows/maven-build-master-and-publish-snapshot.yml
@@ -1,0 +1,40 @@
+# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
+# For more information see:
+# https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#Publishing-using-Apache-Maven
+# https://docs.github.com/en/actions/publishing-packages/publishing-java-packages-with-maven
+
+name: Maven build and publish Master Snapshot
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  maven-build-master-and-publish-to-maven-central:
+  
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up JDK 11 for Maven Central Repository deployment
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: 'maven' # Cache Maven dependencies between workflow runs
+        # Properties for deployment to OSSRH:
+        server-id: ossrh
+        server-username: MAVEN_USERNAME
+        server-password: MAVEN_PASSWORD
+        # Properties for gpg signing:
+        gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+        gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+    - run: mvn -f symja_android_library -B -U -P publish-to-maven-central deploy
+      # Deployment of all modules is deferred to the last module by nexus-staging-maven-plugin
+      env:
+        MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+        MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+        MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/.github/workflows/maven-build-pr.yml
+++ b/.github/workflows/maven-build-pr.yml
@@ -1,16 +1,14 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Java CI with Maven and staging
+name: Maven build Pull-Request
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 
 jobs:
-  build:
+  maven-build-pr:
 
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/symja_android_library/pom.xml
+++ b/symja_android_library/pom.xml
@@ -9,7 +9,7 @@
 
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>Symja Java Symbolic Math library.</description>
-	<url>https://github.com/axkr/symja_android_library.git</url>
+	<url>https://github.com/axkr/symja_android_library</url>
 
 	<licenses>
 		<license>
@@ -50,6 +50,7 @@
 		<connection>scm:git:git://github.com/axkr/symja_android_library.git</connection>
 		<developerConnection>scm:git:git@github.com:axkr/symja_android_library.git</developerConnection>
 		<url>https://github.com/axkr/symja_android_library.git</url>
+		<tag>HEAD</tag>
 	</scm>
 
 	<issueManagement>
@@ -59,12 +60,11 @@
 
 	<distributionManagement>
 		<repository>
-			<id>sonatype-oss-staging</id>
-			<url>https://oss.sonatype.org/content/repositories/staging</url>
+			<id>ossrh</id>
+			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
 		</repository>
 		<snapshotRepository>
-			<uniqueVersion>false</uniqueVersion>
-			<id>sonatype-oss-snapshots</id>
+			<id>ossrh</id>
 			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
 		</snapshotRepository>
 	</distributionManagement>
@@ -467,10 +467,9 @@
 					<groupId>org.sonatype.plugins</groupId>
 					<artifactId>nexus-staging-maven-plugin</artifactId>
 					<version>1.6.8</version>
-					<extensions>true</extensions>
 					<configuration>
+						<serverId>ossrh</serverId>
 						<nexusUrl>https://oss.sonatype.org/</nexusUrl>
-						<serverId>sonatype-oss-staging</serverId>
 					</configuration>
 				</plugin>
 
@@ -500,45 +499,44 @@
 				</executions>
 			</plugin>
 
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<executions>
-					<execution>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-						<configuration>
-							<doclint>none</doclint>
-							<quiet>true</quiet> <!-- only show warnings/errors -->
-							<failOnError>false</failOnError>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<goals>
-							<goal>jar-no-fork</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-
 		</plugins>
 	</build>
 
 	<profiles>
 
 		<profile>
-			<id>release</id>
+			<id>publish-to-maven-central</id>
 			<build>
 				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-javadoc-plugin</artifactId>
+						<executions>
+							<execution>
+								<goals>
+									<goal>jar</goal>
+								</goals>
+								<configuration>
+									<doclint>none</doclint>
+									<quiet>true</quiet> <!-- only show warnings/errors -->
+									<failOnError>false</failOnError>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-source-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>attach-sources</id>
+								<goals>
+									<goal>jar-no-fork</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
 
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
@@ -549,9 +547,17 @@
 								<goals>
 									<goal>sign</goal>
 								</goals>
-								<phase>verify</phase>
 							</execution>
 						</executions>
+					</plugin>
+
+					<plugin>
+						<groupId>org.sonatype.plugins</groupId>
+						<artifactId>nexus-staging-maven-plugin</artifactId>
+						<extensions>true</extensions>
+						<configuration>
+							<autoReleaseAfterClose>false</autoReleaseAfterClose>
+						</configuration>
 					</plugin>
 
 				</plugins>


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description
This PR is the first preparatory step towards the Symja release deployment to Maven-Central and implements the continuos deployment of a snapshots build to the OSSRH snapshot-repository on each push to the master branch.

To implement the following changes are done

- Create publication profile
	- move source-jar and java-doc creation there (speeds up PR builds)
	- use nexus-staging-maven-plugin for deferred deployment of snapshots

- Create separate workflow to build and build snapshots of master-branch on each push.
The existing workflow is only used for PRs and is renamed accordingly.

- adapt server-ids in pom.xml to workflow and fix deployment data
