### PR TITLE
[Build] guard against accidental releases and add common enforcer rules

### DIFF
--- a/symja_android_library/pom.xml
+++ b/symja_android_library/pom.xml
@@ -72,6 +72,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>11</java.version>
+		<release.build>false</release.build>
 	</properties>
 
 	<dependencyManagement>
@@ -376,13 +377,6 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-enforcer-plugin</artifactId>
 					<version>3.0.0</version>
-					<configuration>
-						<rules>
-							<requireMavenVersion>
-								<version>3.2.0</version>
-							</requireMavenVersion>
-						</rules>
-					</configuration>
 				</plugin>
 
 				<plugin>
@@ -491,10 +485,32 @@
 				<artifactId>maven-enforcer-plugin</artifactId>
 				<executions>
 					<execution>
-						<id>enforce-maven-version</id>
+						<id>enforce-common-build-rules</id>
 						<goals>
 							<goal>enforce</goal>
 						</goals>
+						<configuration>
+							<rules>
+								<requireMavenVersion>
+									<version>3.2.0</version>
+								</requireMavenVersion>
+								<banDuplicatePomDependencyVersions />
+							</rules>
+						</configuration>
+					</execution>
+					<execution>
+						<id>enforce-snapshot-version</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<skip>${release.build}</skip>
+							<rules>
+								<requireSnapshotVersion>
+									<message>Release versions only permitted for releases!</message>
+								</requireSnapshotVersion>
+							</rules>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description
This PR has the goal to guard against accidental releases (by pushing a release versions to the master branch) and adds the `banDuplicatePomDependencyVersions` enforcer rule.

If one really wants to perform a release the property `-Drelease.build=true` has to be set in the Maven build command to disable the introduced enforcer rule.