### PR TITLE
[Build] disable deployment of 'internal' modules and not exclude them

### DIFF
--- a/symja_android_library/matheclipse-beakerx/pom.xml
+++ b/symja_android_library/matheclipse-beakerx/pom.xml
@@ -22,6 +22,11 @@
 		</license>
 	</licenses>
 
+	<properties>
+		<!-- This project is not intended to be published -->
+		<deployment.suppress>true</deployment.suppress>
+	</properties>
+
 	<dependencies>
 
 		<dependency>

--- a/symja_android_library/matheclipse-jar/pom.xml
+++ b/symja_android_library/matheclipse-jar/pom.xml
@@ -22,6 +22,11 @@
 		</license>
 	</licenses>
 
+	<properties>
+		<!-- This project is not intended to be published -->
+		<deployment.suppress>true</deployment.suppress>
+	</properties>
+
 	<dependencies>
 
 		<dependency>

--- a/symja_android_library/pom.xml
+++ b/symja_android_library/pom.xml
@@ -36,6 +36,15 @@
 	</developers>
 
 	<modules>
+
+		<!-- Internal modules (not deployed).
+		Must not be last to not break deployment entirely.
+		See description of ''skipNexusStagingDeployMojo' in 
+		https://github.com/sonatype/nexus-maven-plugins/blob/master/staging/maven-plugin/README.md#plugin-flags-->
+		<module>matheclipse-beakerx</module>
+		<module>matheclipse-jar</module>
+
+		<!-- Deployed modules -->
 		<module>matheclipse-external</module>
 		<module>matheclipse-frontend</module>
 		<module>matheclipse-core</module>
@@ -44,6 +53,7 @@
 		<module>matheclipse-io</module>
 		<module>matheclipse-discord</module>
 		<module>matheclipse-logging</module>
+
 	</modules>
 
 	<scm>
@@ -73,6 +83,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>11</java.version>
 		<release.build>false</release.build>
+		<deployment.suppress>false</deployment.suppress> <!-- child modules can set this true to not be published -->
 	</properties>
 
 	<dependencyManagement>
@@ -572,6 +583,7 @@
 						<artifactId>nexus-staging-maven-plugin</artifactId>
 						<extensions>true</extensions>
 						<configuration>
+							<skipNexusStagingDeployMojo>${deployment.suppress}</skipNexusStagingDeployMojo>
 							<autoReleaseAfterClose>false</autoReleaseAfterClose>
 						</configuration>
 					</plugin>


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

With PR #348 and #355 I removed the `matheclipse-jar` and `matheclipse-beakerx` from the root pom's `modules` element with the intention to not publish those modules to Maven-Central.
Although this approach is perfectly valid in itself, it has two downsides:
1. The Eclipse-M2E importer does not consider those modules at the moment, so one has to explicitly import each excluded module one by one and cannot perform a bulk import.
2. Those projects are not build in Symja's regular build, so compile errors are not observed immediately and the code base might run out of sync over the time (this can be speed up if the projects are also not in the workspace).

Therefore those modules are added to the modules-section/Maven reactor again. To still suppress their deployment the corresponding property to skip deployment of the `nexus-staging-maven-plugin` is set to `true` for those modules.

When using the property `skipNexusStagingDeployMojo` of the `nexus-staging-maven-plugin` it has to be ensured that the the deployment for the last project is not skipped, otherwise the deployment of all modules is not performed:
https://github.com/sonatype/nexus-maven-plugins/blob/master/staging/maven-plugin/README.md#plugin-flags

To  make this more likely the internal, not deployed modules are listed first in the root-pom's modules section:
https://maven.apache.org/guides/mini/guide-multiple-modules.html
Since the order in the modules section is the last criteria to compute the reactor order it is no guarantee that the internal projects are not build last (e.g. if an internal module depends on the next-to-last module) it must be taken care about this.

This effectively reverts 1f70f4b3195705147dec2efcb4d40b62f0a97cc6 and a9d3d70fde2d5ceddf1457ba2493417f181772ab.