### PR TITLE
[Tools] Make 'tools'-folder a Maven project (#271)

### DIFF
--- a/symja_android_library/pom.xml
+++ b/symja_android_library/pom.xml
@@ -43,6 +43,7 @@
 		https://github.com/sonatype/nexus-maven-plugins/blob/master/staging/maven-plugin/README.md#plugin-flags-->
 		<module>matheclipse-beakerx</module>
 		<module>matheclipse-jar</module>
+		<module>tools</module>
 
 		<!-- Deployed modules -->
 		<module>matheclipse-external</module>

--- a/symja_android_library/tools/pom.xml
+++ b/symja_android_library/tools/pom.xml
@@ -1,0 +1,44 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.matheclipse</groupId>
+		<artifactId>matheclipse</artifactId>
+		<version>2.0.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>tools</artifactId>
+	<packaging>jar</packaging>
+	<name>${project.groupId}:${project.artifactId}</name>
+	<description>Tools to support Symja development and examples</description>
+
+	<licenses>
+		<license>
+			<name>GNU General Public License, Version 3</name>
+			<url>https://www.gnu.org/licenses/gpl-3.0.html</url>
+			<distribution>repo</distribution>
+			<comments>A free, copyleft license for software and other kinds of works</comments>
+		</license>
+	</licenses>
+
+	<properties>
+		<!-- This project is not intended to be published -->
+		<deployment.suppress>true</deployment.suppress>
+	</properties>
+
+	<dependencies>
+
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>matheclipse-io</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.lucene</groupId>
+			<artifactId>lucene-analyzers-common</artifactId>
+		</dependency>
+
+	</dependencies>
+
+</project>


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

This PR (as part of #271) adds a `tools/pom.xml` to make the `tools` folder a full-fledged Maven project (the folder structure is already in Maven style). This way the `tools` project is imported in the workspace if one imports all Symja projects and is also build in the regular Symja build it is always kept in sync with the other modules and never forgotten in some refactoring or similar.