### PR TITLE
[MathScriptEngineFactory] remove static F.initSymbols()

### DIFF
--- a/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/script/engine/MathScriptEngineFactory.java
+++ b/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/script/engine/MathScriptEngineFactory.java
@@ -4,13 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.script.ScriptEngine;
 import org.matheclipse.core.basic.Config;
-import org.matheclipse.core.expression.F;
 
 public class MathScriptEngineFactory implements javax.script.ScriptEngineFactory {
-
-  static {
-    F.initSymbols();
-  }
 
   public MathScriptEngineFactory() {
     Config.SERVER_MODE = false;


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

This PR has to goal to fix (local) Maven builds that were broken since PR #369.
The problem is that that the MathScriptEngineFactory is called when the log4j `LoggerManager` is started because it searches for javax.script.ScriptEngineFactory services and instantiates them.

The `LoggerManager` is for example started while the class `S` is initialized (because it retrieves a Logger). Consequently the `MathScriptEngineFactory` was initialized too and `F.initSymbols();` was called which initialized class F. But the initialization of the subclass `F` of `S` while S is being initialized let the initialization of F fail. As a consequence was not properly initialized so subsequent calls to  `F.initSymbols();` failed as well and caused other class initializations failures for classes who called this method in their static initializers. This led to cryptic error messages like:
`Could not initialize class org.matheclipse.core.eval.EvalUtilities`

The simplest solution is to remove the call to `F.initSymbols();` in MathScriptEngineFactory's static initializer as proposed by this PR.
@axkr I wonder, if this call was even necessary? F is not used in `MathScriptEngineFactory` and other classes that relay on F should call `F.initSymbols();` any ways. Maybe F should call it itself?