### PR TITLE
[SyntaxError] always fill stackTrace

### DIFF
--- a/symja_android_library/matheclipse-parser/src/main/java/org/matheclipse/parser/client/ParserConfig.java
+++ b/symja_android_library/matheclipse-parser/src/main/java/org/matheclipse/parser/client/ParserConfig.java
@@ -6,8 +6,6 @@ import org.matheclipse.parser.trie.TrieBuilder;
 
 /** Parser configuration */
 public class ParserConfig {
-  /** Show the stack trace, if an exception is thrown in evaluation */
-  public static final boolean SHOW_STACKTRACE = false;
 
   /** Use <code>Num</code> objects for numeric calculations up to 16 digits precision. */
   public static final long MACHINE_PRECISION = 16L;

--- a/symja_android_library/matheclipse-parser/src/main/java/org/matheclipse/parser/client/SyntaxError.java
+++ b/symja_android_library/matheclipse-parser/src/main/java/org/matheclipse/parser/client/SyntaxError.java
@@ -56,7 +56,6 @@ public class SyntaxError extends MathException {
       final String currentLine,
       final String error,
       final int length) {
-    super(null, null, false, false);
     fStartOffset = startOffset;
     fRowIndex = rowIndx;
     fColumnIndex = columnIndx;
@@ -115,15 +114,5 @@ public class SyntaxError extends MathException {
   /** offset where the error occurred */
   public int getStartOffset() {
     return fStartOffset;
-  }
-
-  @Override
-  public synchronized Throwable fillInStackTrace() {
-    if (ParserConfig.SHOW_STACKTRACE) {
-      // doesn't fill the stack for FlowControlExceptions
-      return super.fillInStackTrace();
-    } else {
-      return this;
-    }
   }
 }


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

As we have discussed a while ago this enables capturing of the stack-trace for `SyntaxError` Exceptions all the time.
Syntax errors are not performance sensitive and their stack-trace is usually helpful to identify problems.