### PR TITLE
[Exceptions] clean up and remove unused/unnecessary elements

### DIFF
--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/ASTElementLimitExceeded.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/ASTElementLimitExceeded.java
@@ -5,7 +5,7 @@ public class ASTElementLimitExceeded extends LimitException {
 
   private static final long serialVersionUID = 8925451277545397036L;
 
-  long fRequestedCapacity;
+  private final long fRequestedCapacity;
 
   public ASTElementLimitExceeded(final long requestedCapacity) {
     fRequestedCapacity = requestedCapacity;
@@ -17,8 +17,8 @@ public class ASTElementLimitExceeded extends LimitException {
    * @param rowDimension
    * @param columnDimension
    */
-  public ASTElementLimitExceeded(final int rowDimension, final int columnDimension) {
-    fRequestedCapacity = (long) rowDimension * (long) columnDimension;
+  public ASTElementLimitExceeded(int rowDimension, int columnDimension) {
+    fRequestedCapacity = rowDimension * (long) columnDimension;
   }
 
   @Override

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/AbortException.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/AbortException.java
@@ -1,12 +1,8 @@
 package org.matheclipse.core.eval.exception;
 
 public class AbortException extends FlowControlException {
-  /** */
+
   private static final long serialVersionUID = 7641731563890805624L;
 
   public static final AbortException ABORTED = new AbortException();
-
-  public AbortException() {
-    super();
-  }
 }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/ArgumentTypeException.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/ArgumentTypeException.java
@@ -7,12 +7,11 @@ import org.matheclipse.core.interfaces.IAST;
 import org.matheclipse.core.interfaces.IExpr;
 import org.matheclipse.core.interfaces.ISymbol;
 
-/** */
 public class ArgumentTypeException extends ValidateException {
 
   private static final long serialVersionUID = 4017342168597803850L;
 
-  final String fMessage;
+  private final String fMessage;
 
   public ArgumentTypeException(String message) {
     fMessage = message;
@@ -42,6 +41,6 @@ public class ArgumentTypeException extends ValidateException {
 
   @Override
   public String getMessage(ISymbol symbol) {
-    return symbol.toString() + ": " + fMessage;
+    return symbol + ": " + fMessage;
   }
 }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/ArgumentTypeStopException.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/ArgumentTypeStopException.java
@@ -11,7 +11,7 @@ public class ArgumentTypeStopException extends LimitException {
 
   private static final long serialVersionUID = -464391877949488192L;
 
-  final String fMessage;
+  private final String fMessage;
 
   public ArgumentTypeStopException(String message) {
     fMessage = message;
@@ -34,6 +34,6 @@ public class ArgumentTypeStopException extends LimitException {
   }
 
   public String getMessage(ISymbol symbol) {
-    return symbol.toString() + ": " + fMessage;
+    return symbol + ": " + fMessage;
   }
 }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/BigIntegerLimitExceeded.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/BigIntegerLimitExceeded.java
@@ -5,7 +5,7 @@ public class BigIntegerLimitExceeded extends LimitException {
 
   private static final long serialVersionUID = 8925451277545397036L;
 
-  long fLimit;
+  private final long fLimit;
 
   public BigIntegerLimitExceeded(final long limit) {
     fLimit = limit;
@@ -17,8 +17,8 @@ public class BigIntegerLimitExceeded extends LimitException {
    * @param rowDimension
    * @param columnDimension
    */
-  public BigIntegerLimitExceeded(final int rowDimension, final int columnDimension) {
-    fLimit = (long) rowDimension * (long) columnDimension;
+  public BigIntegerLimitExceeded(int rowDimension, int columnDimension) {
+    fLimit = rowDimension * (long) columnDimension;
   }
 
   @Override

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/BreakException.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/BreakException.java
@@ -8,10 +8,5 @@ package org.matheclipse.core.eval.exception;
 public class BreakException extends FlowControlException {
   public static final BreakException CONST = new BreakException();
 
-  /** */
   private static final long serialVersionUID = 3859495776051748837L;
-
-  public BreakException() {
-    super();
-  }
 }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/ConditionException.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/ConditionException.java
@@ -8,15 +8,8 @@ import org.matheclipse.core.interfaces.IExpr;
 public class ConditionException extends FlowControlException {
 
   public static final ConditionException CONDITION_NIL = new ConditionException();
-  /** */
-  private static final long serialVersionUID = -1175359074220162860L;
 
-  /**
-   * This exception throws the result value {@link F#NIL} of a Symja {@link S#Condition} function.
-   */
-  public ConditionException() {
-    super();
-  }
+  private static final long serialVersionUID = -1175359074220162860L;
 
   public IExpr getValue() {
     return F.NIL;
@@ -24,6 +17,6 @@ public class ConditionException extends FlowControlException {
 
   @Override
   public String getMessage() {
-    return "Condition[] exception"; // + value.toString();
+    return "Condition[] exception";
   }
 }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/ContinueException.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/ContinueException.java
@@ -9,10 +9,5 @@ public class ContinueException extends FlowControlException {
 
   public static final ContinueException CONST = new ContinueException();
 
-  /** */
   private static final long serialVersionUID = 7698113142556488875L;
-
-  public ContinueException() {
-    super();
-  }
 }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/DialogReturnException.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/DialogReturnException.java
@@ -5,7 +5,6 @@ import org.matheclipse.core.interfaces.IExpr;
 
 public class DialogReturnException extends ReturnException {
 
-  /** */
   private static final long serialVersionUID = -3723154693002116846L;
 
   public static final DialogReturnException DIALOG_RETURN_FALSE =

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/FailedException.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/FailedException.java
@@ -2,12 +2,7 @@ package org.matheclipse.core.eval.exception;
 
 public class FailedException extends FlowControlException {
 
-  /** */
   private static final long serialVersionUID = 5411356928714730288L;
 
   public static final FailedException FAILED = new FailedException();
-
-  public FailedException() {
-    super();
-  }
 }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/FlowControlException.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/FlowControlException.java
@@ -6,7 +6,7 @@ package org.matheclipse.core.eval.exception;
  * (ContinueException).
  */
 public abstract class FlowControlException extends SymjaMathException {
-  /** */
+
   private static final long serialVersionUID = -7700982641897767896L;
 
   /**
@@ -14,7 +14,6 @@ public abstract class FlowControlException extends SymjaMathException {
    * <code>cause=null</code>, <code>enableSuppression=false</code>, and <code>
    * writableStackTrace=false</code> .
    */
-  public FlowControlException() {
-    super();
+  protected FlowControlException() {
   }
 }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/IterationLimitExceeded.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/IterationLimitExceeded.java
@@ -8,17 +8,11 @@ import org.matheclipse.core.interfaces.IExpr;
 /** Exception which will be thrown, if the iteration limit of the evaluation loop was exceeded. */
 public class IterationLimitExceeded extends LimitException {
 
-  /** */
   private static final long serialVersionUID = -5953619629034039117L;
 
-  /** */
-  final long fLimit;
+  private final long fLimit;
 
-  final IExpr fExpr;
-
-  public IterationLimitExceeded(final long limit) {
-    this(limit, F.NIL);
-  }
+  private final IExpr fExpr;
 
   public IterationLimitExceeded(final long limit, IExpr expr) {
     fLimit = limit;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/JASConversionException.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/JASConversionException.java
@@ -1,10 +1,6 @@
 package org.matheclipse.core.eval.exception;
 
 public class JASConversionException extends SymjaMathException {
-  /** */
-  private static final long serialVersionUID = 1572094432627031023L;
 
-  public JASConversionException() {
-    super();
-  }
+  private static final long serialVersionUID = 1572094432627031023L;
 }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/LimitException.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/LimitException.java
@@ -6,7 +6,6 @@ package org.matheclipse.core.eval.exception;
  */
 public abstract class LimitException extends SymjaMathException {
 
-  /** */
   private static final long serialVersionUID = -8898766046639353179L;
 
   /**
@@ -14,11 +13,10 @@ public abstract class LimitException extends SymjaMathException {
    * cause=null</code>, <code>enableSuppression=false</code>, and <code>writableStackTrace=false
    * </code> .
    */
-  public LimitException() {
-    super();
+  protected LimitException() {
   }
 
-  public LimitException(String message) {
+  protected LimitException(String message) {
     super(message);
   }
 }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/MemoryLimitExceeded.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/MemoryLimitExceeded.java
@@ -2,6 +2,8 @@ package org.matheclipse.core.eval.exception;
 
 public class MemoryLimitExceeded extends LimitException {
 
+  private static final long serialVersionUID = -8031017311519064342L;
+
   public MemoryLimitExceeded(String message) {
     super(message);
   }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/NoEvalException.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/NoEvalException.java
@@ -5,10 +5,5 @@ public class NoEvalException extends FlowControlException {
 
   public static final NoEvalException CONST = new NoEvalException();
 
-  /** */
   private static final long serialVersionUID = 3859495776051748837L;
-
-  public NoEvalException() {
-    super();
-  }
 }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/PolynomialDegreeLimitExceeded.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/PolynomialDegreeLimitExceeded.java
@@ -5,7 +5,7 @@ public class PolynomialDegreeLimitExceeded extends LimitException {
 
   private static final long serialVersionUID = 8925451277545397036L;
 
-  long fLimit;
+  private final long fLimit;
 
   public PolynomialDegreeLimitExceeded(final long limit) {
     fLimit = limit;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/RecursionLimitExceeded.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/RecursionLimitExceeded.java
@@ -11,9 +11,9 @@ public class RecursionLimitExceeded extends LimitException {
 
   private static final long serialVersionUID = 3610700158103716674L;
 
-  int fLimit;
+  private final int fLimit;
 
-  IExpr fExpr;
+  private final IExpr fExpr;
 
   public RecursionLimitExceeded(final int limit, final IExpr expr) {
     fLimit = limit;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/ResultException.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/ResultException.java
@@ -9,31 +9,16 @@ public class ResultException extends SymjaMathException {
   public static final ResultException THROW_FALSE = new ResultException(S.False);
 
   public static final ResultException THROW_TRUE = new ResultException(S.True);
-  /** */
-  private static final long serialVersionUID = -8468658696375569705L;
+
+  private static final long serialVersionUID = 8962413213437314808L;
 
   private final IExpr value;
-  private final IExpr tag;
-
-  public ResultException() {
-    this(null);
-  }
 
   public ResultException(final IExpr val) {
-    this(val, S.None);
-  }
-
-  public ResultException(final IExpr val, final IExpr tag) {
-    super();
     this.value = val;
-    this.tag = tag;
   }
 
   public IExpr getValue() {
     return value;
-  }
-
-  public IExpr getTag() {
-    return tag;
   }
 }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/ReturnException.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/ReturnException.java
@@ -9,14 +9,14 @@ import org.matheclipse.core.interfaces.IExpr;
  * function. This exception throws the result of a Symja {@link S#Return} function.
  */
 public class ReturnException extends FlowControlException {
-  /** */
+
   private static final long serialVersionUID = 6165872840807864554L;
 
   public static final ReturnException RETURN_FALSE = new ReturnException(S.False);
 
   public static final ReturnException RETURN_TRUE = new ReturnException(S.True);
 
-  protected final IExpr value;
+  private final IExpr value;
 
   /** This exception throws the result {@link S.Null} of a Symja {@link S#Return} function. */
   public ReturnException() {
@@ -29,7 +29,6 @@ public class ReturnException extends FlowControlException {
    * @param value the returned value
    */
   public ReturnException(final IExpr value) {
-    super();
     this.value = value;
   }
 

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/RuleCreationError.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/RuleCreationError.java
@@ -5,12 +5,12 @@ import org.matheclipse.core.interfaces.IExpr;
 import org.matheclipse.core.interfaces.ISymbol;
 
 public class RuleCreationError extends ValidateException {
-  /** */
+
   private static final long serialVersionUID = 4289111239388531874L;
 
-  IExpr fLHS = null;
+  private final IExpr fLHS;
 
-  public RuleCreationError(final IExpr lhs) {
+  public RuleCreationError(IExpr lhs) {
     fLHS = lhs;
   }
 
@@ -21,32 +21,32 @@ public class RuleCreationError extends ValidateException {
     }
     // if (fCondition != null) {
     // return "Error in rule creation: Condition not allowed in rules containing no pattern (" +
-    // fLHS.toString()
-    // + " " + fRHS.toString() + " " + fCondition.toString() + ")";
+    // fLHS
+    // + " " + fRHS + " " + fCondition + ")";
     // }
     // if (fRHS != null) {
-    // return "Error in rule creation: " + fLHS.toString() + " " + fRHS.toString();
+    // return "Error in rule creation: " + fLHS + " " + fRHS;
     // }
     Context context = fLHS.topHead().getContext();
     return "Not allowed left-hand-side expression: \""
-        + fLHS.toString()
+        + fLHS
         + "\" from context \""
-        + context.toString()
+        + context
         + "\"\nPlease use names which aren't predefined by the system.";
   }
 
   @Override
   public String getMessage(ISymbol symbol) {
     if (fLHS == null) {
-      return symbol.toString() + ": " + "Operation not allowed in server mode.";
+      return symbol + ": " + "Operation not allowed in server mode.";
     }
     Context context = fLHS.topHead().getContext();
-    return symbol.toString()
+    return symbol
         + ": "
         + "Not allowed left-hand-side expression: \""
-        + fLHS.toString()
+        + fLHS
         + "\" from context \""
-        + context.toString()
+        + context
         + "\"\nPlease use names which aren't predefined by the system.";
   }
 }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/SymjaMathException.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/SymjaMathException.java
@@ -1,11 +1,12 @@
 package org.matheclipse.core.eval.exception;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
 import org.matheclipse.core.basic.Config;
 import org.matheclipse.parser.client.math.MathException;
 
 public class SymjaMathException extends MathException {
 
-  /** */
   private static final long serialVersionUID = 3520033778672500363L;
 
   /**
@@ -14,14 +15,8 @@ public class SymjaMathException extends MathException {
    * @throws Exception if any of the listed tensors is null
    */
   public static SymjaMathException of(Object... exprs) {
-    StringBuilder buf = new StringBuilder();
-    for (int i = 0; i < exprs.length; i++) {
-      buf.append(exprs[i].toString());
-      if (i < exprs.length - 1) {
-        buf.append(", ");
-      }
-    }
-    return new SymjaMathException(buf.toString());
+    String args = Arrays.stream(exprs).map(Object::toString).collect(Collectors.joining(", "));
+    return new SymjaMathException(args);
   }
 
   /**

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/ThrowException.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/ThrowException.java
@@ -10,18 +10,14 @@ import org.matheclipse.core.interfaces.IExpr;
  */
 public class ThrowException extends FlowControlException {
 
+  private static final long serialVersionUID = -8468658696375569705L;
+
   public static final ThrowException THROW_FALSE = new ThrowException(S.False);
 
   public static final ThrowException THROW_TRUE = new ThrowException(S.True);
-  /** */
-  private static final long serialVersionUID = -8468658696375569705L;
 
   private final IExpr value;
   private final IExpr tag;
-
-  public ThrowException() {
-    this(null);
-  }
 
   public ThrowException(final IExpr val) {
     this(val, S.None);

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/TimeoutException.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/TimeoutException.java
@@ -7,6 +7,5 @@ public class TimeoutException extends FlowControlException {
   public static final TimeoutException TIMED_OUT = new TimeoutException();
 
   private TimeoutException() {
-    super();
   }
 }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/ValidateException.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/ValidateException.java
@@ -5,12 +5,9 @@ import org.matheclipse.core.interfaces.ISymbol;
 /** Base exception for validating function arguments */
 public abstract class ValidateException extends SymjaMathException {
 
-  /** */
   private static final long serialVersionUID = 5266791137903109695L;
 
-  public ValidateException() {
-    super();
-  }
+  protected ValidateException() {}
 
   public abstract String getMessage(ISymbol symbol);
 }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/visit/VisitorRemoveLevelSpecification.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/visit/VisitorRemoveLevelSpecification.java
@@ -17,8 +17,9 @@ import org.matheclipse.core.interfaces.IExpr;
  */
 public class VisitorRemoveLevelSpecification extends VisitorLevelSpecification {
   /** StopException will be thrown, if maximum number of Cases results are reached */
-  @SuppressWarnings("serial")
   public static class StopException extends SymjaMathException {
+    private static final long serialVersionUID = -8839477630696222675L;
+
     public StopException() {
       super("Stop VisitorDeleteLevelSpecification evaluation");
     }

--- a/symja_android_library/matheclipse-parser/src/main/java/org/matheclipse/parser/client/SyntaxError.java
+++ b/symja_android_library/matheclipse-parser/src/main/java/org/matheclipse/parser/client/SyntaxError.java
@@ -20,24 +20,23 @@ import org.matheclipse.parser.client.math.MathException;
 /** Exception for a syntax error detected by the Symja parsers */
 public class SyntaxError extends MathException {
 
-  /** */
   private static final long serialVersionUID = 1849387697719679119L;
 
   /** offset where the error occurred */
-  final int fStartOffset;
+  private final int fStartOffset;
 
   /** row index where the error occurred2 */
-  final int fRowIndex;
+  private final int fRowIndex;
 
   /** column index where the error occurred (offset relative to rowIndex) */
-  final int fColumnIndex;
+  private final int fColumnIndex;
 
   /** length of the error */
-  final int fLength;
+  private final int fLength;
 
-  final String fCurrentLine;
+  private final String fCurrentLine;
 
-  final String fError;
+  private final String fError;
 
   /**
    * SyntaxError exception

--- a/symja_android_library/matheclipse-parser/src/main/java/org/matheclipse/parser/client/math/ArithmeticMathException.java
+++ b/symja_android_library/matheclipse-parser/src/main/java/org/matheclipse/parser/client/math/ArithmeticMathException.java
@@ -1,7 +1,7 @@
 package org.matheclipse.parser.client.math;
 
 public class ArithmeticMathException extends MathException {
-  /** */
+
   private static final long serialVersionUID = -7859219482948928259L;
 
   public ArithmeticMathException(String message) {

--- a/symja_android_library/matheclipse-parser/src/main/java/org/matheclipse/parser/client/math/MathException.java
+++ b/symja_android_library/matheclipse-parser/src/main/java/org/matheclipse/parser/client/math/MathException.java
@@ -1,8 +1,10 @@
 package org.matheclipse.parser.client.math;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 public class MathException extends RuntimeException {
 
-  /** */
   private static final long serialVersionUID = 3520033778672500363L;
 
   /**
@@ -11,14 +13,8 @@ public class MathException extends RuntimeException {
    * @throws Exception if any of the listed tensors is null
    */
   public static MathException of(Object... exprs) {
-    StringBuilder buf = new StringBuilder();
-    for (int i = 0; i < exprs.length; i++) {
-      buf.append(exprs[i].toString());
-      if (i < exprs.length - 1) {
-        buf.append(", ");
-      }
-    }
-    return new MathException(buf.toString());
+    String args = Arrays.stream(exprs).map(Object::toString).collect(Collectors.joining(", "));
+    return new MathException(args);
   }
 
   /**


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

This PR cleans up Symjas exceptions by:
- removing unused fields/getters/constructors
- removing implicitly created constructors or super-calls 
- restricting visibilities and modifiability as far as possible
- removing empty comments
- removing unnecessary calls of `toString()`
