### PR TITLE
Change Limit-, Result- and StopExceptions to be FlowControlExceptions

### DIFF
--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/EvalEngine.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/EvalEngine.java
@@ -27,7 +27,6 @@ import org.matheclipse.core.eval.exception.AbortException;
 import org.matheclipse.core.eval.exception.ArgumentTypeException;
 import org.matheclipse.core.eval.exception.FlowControlException;
 import org.matheclipse.core.eval.exception.IterationLimitExceeded;
-import org.matheclipse.core.eval.exception.LimitException;
 import org.matheclipse.core.eval.exception.RecursionLimitExceeded;
 import org.matheclipse.core.eval.exception.SymjaMathException;
 import org.matheclipse.core.eval.exception.TimeoutException;
@@ -954,7 +953,7 @@ public class EvalEngine implements Serializable {
           }
         } catch (ValidateException ve) {
           return IOFunctions.printMessage(ast.topHead(), ve, this);
-        } catch (FlowControlException | LimitException e) {
+        } catch (FlowControlException e) {
           throw e;
         } catch (SymjaMathException ve) {
           LOGGER.log(getLogLevel(), ast.topHead(), ve);

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/FlowControlException.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/FlowControlException.java
@@ -16,4 +16,8 @@ public abstract class FlowControlException extends SymjaMathException {
    */
   protected FlowControlException() {
   }
+
+  protected FlowControlException(String message) {
+    super(message);
+  }
 }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/LimitException.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/LimitException.java
@@ -4,17 +4,16 @@ package org.matheclipse.core.eval.exception;
  * Base exception for exceptions, which are used to implement &quot;limit control&quot; functions
  * like for example <code>ASTElementLimitExceeded</code> and <code>RecursionLimitExceeded</code> .
  */
-public abstract class LimitException extends SymjaMathException {
+public abstract class LimitException extends FlowControlException {
 
-  private static final long serialVersionUID = -8898766046639353179L;
+  private static final long serialVersionUID = 3573641258131547324L;
 
   /**
    * Constructs a new exception with the specified detail <code>message=null</code>, <code>
    * cause=null</code>, <code>enableSuppression=false</code>, and <code>writableStackTrace=false
    * </code> .
    */
-  protected LimitException() {
-  }
+  protected LimitException() {}
 
   protected LimitException(String message) {
     super(message);

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/ResultException.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/ResultException.java
@@ -4,13 +4,13 @@ import org.matheclipse.core.expression.S;
 import org.matheclipse.core.interfaces.IExpr;
 
 /** Exception for the <code>First...</code> functions. */
-public class ResultException extends SymjaMathException {
+public class ResultException extends FlowControlException {
+
+  private static final long serialVersionUID = 6451923502427489113L;
 
   public static final ResultException THROW_FALSE = new ResultException(S.False);
 
   public static final ResultException THROW_TRUE = new ResultException(S.True);
-
-  private static final long serialVersionUID = 8962413213437314808L;
 
   private final IExpr value;
 

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/AbstractAST.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/AbstractAST.java
@@ -44,7 +44,6 @@ import org.matheclipse.core.convert.VariablesSet;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.exception.ArgumentTypeException;
 import org.matheclipse.core.eval.exception.FlowControlException;
-import org.matheclipse.core.eval.exception.LimitException;
 import org.matheclipse.core.eval.exception.SymjaMathException;
 import org.matheclipse.core.eval.exception.Validate;
 import org.matheclipse.core.eval.exception.ValidateException;
@@ -1881,7 +1880,7 @@ public abstract class AbstractAST implements IASTMutable {
             return functionEvaluator.evaluate(ast, engine);
           } catch (ValidateException ve) {
             return IOFunctions.printMessage(topHead(), ve, engine);
-          } catch (FlowControlException | LimitException e) {
+          } catch (FlowControlException e) {
             throw e;
           } catch (SymjaMathException ve) {
             LOGGER.log(engine.getLogLevel(), topHead(), ve);

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/visit/VisitorRemoveLevelSpecification.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/visit/VisitorRemoveLevelSpecification.java
@@ -2,6 +2,7 @@ package org.matheclipse.core.visit;
 
 import java.util.function.Function;
 import org.matheclipse.core.eval.EvalEngine;
+import org.matheclipse.core.eval.exception.FlowControlException;
 import org.matheclipse.core.eval.exception.SymjaMathException;
 import org.matheclipse.core.expression.F;
 import org.matheclipse.core.interfaces.IAST;
@@ -17,7 +18,7 @@ import org.matheclipse.core.interfaces.IExpr;
  */
 public class VisitorRemoveLevelSpecification extends VisitorLevelSpecification {
   /** StopException will be thrown, if maximum number of Cases results are reached */
-  public static class StopException extends SymjaMathException {
+  public static class StopException extends FlowControlException {
     private static final long serialVersionUID = -8839477630696222675L;
 
     public StopException() {

--- a/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/core/fuzz/ExprEvaluatorTests.java
+++ b/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/core/fuzz/ExprEvaluatorTests.java
@@ -12,7 +12,6 @@ import org.matheclipse.core.convert.AST2Expr;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.ExprEvaluator;
 import org.matheclipse.core.eval.exception.FlowControlException;
-import org.matheclipse.core.eval.exception.LimitException;
 import org.matheclipse.core.eval.exception.ValidateException;
 import org.matheclipse.core.eval.interfaces.IFunctionEvaluator;
 import org.matheclipse.core.expression.F;
@@ -358,12 +357,6 @@ public class ExprEvaluatorTests extends TestCase {
             if (!quietMode) {
               System.err.println(mutant.toString());
               mex.printStackTrace();
-              System.err.println();
-            }
-          } catch (LimitException ile) {
-            if (!quietMode) {
-              System.err.println(mutant.toString());
-              ile.printStackTrace();
               System.err.println();
             }
           } catch (SyntaxError se) {
@@ -1048,12 +1041,6 @@ public class ExprEvaluatorTests extends TestCase {
         if (!quietMode) {
           System.err.println(ast.toString());
           mex.printStackTrace();
-          System.err.println();
-        }
-      } catch (LimitException ile) {
-        if (!quietMode) {
-          System.err.println(ast.toString());
-          ile.printStackTrace();
           System.err.println();
         }
       } catch (SyntaxError se) {

--- a/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/core/fuzz/TeXTests.java
+++ b/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/core/fuzz/TeXTests.java
@@ -9,7 +9,6 @@ import org.matheclipse.core.basic.Config;
 import org.matheclipse.core.convert.AST2Expr;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.exception.FlowControlException;
-import org.matheclipse.core.eval.exception.LimitException;
 import org.matheclipse.core.expression.F;
 import org.matheclipse.core.expression.S;
 import org.matheclipse.core.form.output.OutputFormFactory;
@@ -153,10 +152,6 @@ public class TeXTests extends TestCase {
               mex.printStackTrace();
               System.err.println();
             }
-          } catch (LimitException ile) {
-            System.err.println(mutantStr);
-            ile.printStackTrace();
-            System.err.println();
           } catch (SyntaxError se) {
             if (!quietMode) {
               System.err.println(mutantStr);


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

As we have discussed a while ago, this PR changes the following `SymjaMathException` to be `FlowControlExceptions`:
- LimitException
- ResultException
- StopException

Affected Catch-clauses are simplified and the `serialVersionUID` of long standing classes are re-generated to reflect the change in the class-hierarchy. 