### PR TITLE
[Core] Make version literals obsolete and use version of core not parser

### DIFF
--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/basic/Config.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/basic/Config.java
@@ -677,21 +677,17 @@ public class Config {
   public static boolean RUBI_CONVERT_SYMBOLS = false;
 
   public static String getVersion() {
-    InputStream resourceAsStream =
-        new Config()
-            .getClass()
-            .getResourceAsStream(
-                "/META-INF/maven/org.matheclipse/matheclipse-parser/pom.properties");
-    if (resourceAsStream != null) {
-      try {
+    try (InputStream resourceAsStream = Config.class.getResourceAsStream(
+        "/META-INF/maven/org.matheclipse/matheclipse-core/pom.properties")) {
+      if (resourceAsStream != null) {
         Properties prop = new Properties();
         prop.load(resourceAsStream);
-        return prop.get("version").toString();
-      } catch (IOException e) {
-        LOGGER.error("Config.getVersion() failed", e);
+        return prop.getProperty("version");
       }
+    } catch (IOException e) {
+      LOGGER.error("Config.getVersion() failed", e);
     }
-    return "2.0.0-SNAPSHOT";
+    throw new IllegalStateException("Failed to read Symja version");
   }
 
   /** A trie builder for mapping int[] sequences to IExpr. */

--- a/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/io/system/LowercaseTestCase.java
+++ b/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/io/system/LowercaseTestCase.java
@@ -7,8 +7,8 @@ import org.matheclipse.core.expression.F;
 import org.matheclipse.core.expression.ID;
 import org.matheclipse.core.expression.data.ByteArrayExpr;
 import org.matheclipse.core.interfaces.IAST;
-import org.matheclipse.parser.client.ParserConfig;
 import org.matheclipse.parser.client.Parser;
+import org.matheclipse.parser.client.ParserConfig;
 import org.matheclipse.parser.client.ast.ASTNode;
 
 /** Tests built-in functions */
@@ -4139,7 +4139,7 @@ public class LowercaseTestCase extends AbstractTestCase {
 
   public void test$Version() {
     check("$Version", //
-        "2.0.0-SNAPSHOT");
+        Config.getVersion());
   }
 
   public void testContinue() {


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Having version literals in the code is bad because they have to be adjusted for each release. Furthermore it is problematic for the release process, because in that process the SNAPSHOT suffix of the version is removed. In order to run the tests successfully for release versions that literals would have to be adjusted in the release process too (IMHO this is discouraged).
This PR changes the tests to compare the result of the $version expression with the result of `Config.getVersion()`. I think it is not the intention to test the latter but the code that lead to it.

Furthermore I think the case for `resourceAsStream==null` does not need to be handled. At least when each Maven-project is imported individually into Eclipse M2E creates the read `pom.properties` on each workspace build.
@axkr do you still have a 'flat' project structure and not each project imported individually? If yes this change likely does not work for you.

Besides this the `pom.properties` of the module containing the code should be used, otherwise it can cause problems in runtime environments like OSGi that have a strict encapsulation of modules/bundles.