### PR TITLE
[Config] return "0.0.0" if version read failed in getVersion()

### DIFF
--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/basic/Config.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/basic/Config.java
@@ -687,7 +687,7 @@ public class Config {
     } catch (IOException e) {
       LOGGER.error("Config.getVersion() failed", e);
     }
-    throw new IllegalStateException("Failed to read Symja version");
+    return "0.0.0";
   }
 
   /** A trie builder for mapping int[] sequences to IExpr. */


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description
In some circumstances in the IDE the pom.properties to be read is not
generated/available. To not break developers applications/tests a
default version is returned instead of throwing an exception.
