### PR TITLE
[CleanUp] use interface instead of implementation in method signature

### DIFF
--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/CompilerFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/CompilerFunctions.java
@@ -388,7 +388,7 @@ public class CompilerFunctions {
       }
     }
 
-    public static final HashMap<ISymbol, IConverter> CONVERTERS =
+    public static final Map<ISymbol, IConverter> CONVERTERS =
         new HashMap<ISymbol, IConverter>(199);
 
     static {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/LinearAlgebra.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/LinearAlgebra.java
@@ -708,9 +708,9 @@ public final class LinearAlgebra {
       if (arg1.isAST()) {
         IAST list = (IAST) arg1;
         IExpr header = list.head();
-        // ArrayList<Integer> dims = new ArrayList<Integer>();
+        // List<Integer> dims = new ArrayList<Integer>();
         // arrayDepthRecursive(list, header, dims);
-        ArrayList<Integer> dims = LinearAlgebra.dimensions(list, header);
+        List<Integer> dims = LinearAlgebra.dimensions(list, header);
         return F.ZZ(dims.size());
       }
       if (arg1.isSparseArray()) {
@@ -1358,7 +1358,7 @@ public final class LinearAlgebra {
     private static IAST getDimensions(final IAST ast, int maximumLevel) {
       IAST list = (IAST) ast.arg1();
       IExpr header = list.head();
-      ArrayList<Integer> dims = dimensions(list, header, maximumLevel - 1);
+      List<Integer> dims = dimensions(list, header, maximumLevel - 1);
       int dimsSize = dims.size();
       IASTAppendable res = F.ListAlloc(dimsSize);
       return res.appendArgs(0, dimsSize, i -> F.ZZ(dims.get(i).intValue()));
@@ -1462,11 +1462,11 @@ public final class LinearAlgebra {
           return temp;
         }
 
-        ArrayList<Integer> dimensions1 = dimensions(arg1, S.List, Integer.MAX_VALUE, true);
+        List<Integer> dimensions1 = dimensions(arg1, S.List, Integer.MAX_VALUE, true);
         if (dimensions1.size() == 0) {
           return F.NIL;
         }
-        ArrayList<Integer> dimensions2 = dimensions(arg2, S.List, Integer.MAX_VALUE, true);
+        List<Integer> dimensions2 = dimensions(arg2, S.List, Integer.MAX_VALUE, true);
         if (dimensions2.size() == 0) {
           return F.NIL;
         }
@@ -2286,8 +2286,8 @@ public final class LinearAlgebra {
       }
 
       private IAST inner() {
-        ArrayList<Integer> list1Dimensions = dimensions(list1, list1.head(), Integer.MAX_VALUE);
-        ArrayList<Integer> list2Dimensions = dimensions(list2, list2.head(), Integer.MAX_VALUE);
+        List<Integer> list1Dimensions = dimensions(list1, list1.head(), Integer.MAX_VALUE);
+        List<Integer> list2Dimensions = dimensions(list2, list2.head(), Integer.MAX_VALUE);
         list2Dim0 = list2Dimensions.get(0);
         return recursionInner(new ArrayList<Integer>(), new ArrayList<Integer>(),
             list1Dimensions.subList(0, list1Dimensions.size() - 1),
@@ -2345,12 +2345,12 @@ public final class LinearAlgebra {
       }
 
       @SuppressWarnings("unchecked")
-      private IAST summand(ArrayList<Integer> list1Cur, ArrayList<Integer> list2Cur, final int i) {
+      private IAST summand(List<Integer> list1Cur, List<Integer> list2Cur, final int i) {
         IASTAppendable result = F.ast(f, 2);
-        ArrayList<Integer> list1CurClone = (ArrayList<Integer>) list1Cur.clone();
+        List<Integer> list1CurClone = new ArrayList<>(list1Cur);
         list1CurClone.add(i);
         result.append(list1.getPart(list1CurClone));
-        ArrayList<Integer> list2CurClone = (ArrayList<Integer>) list2Cur.clone();
+        List<Integer> list2CurClone = new ArrayList<>(list2Cur);
         list2CurClone.add(0, i);
         result.append(list2.getPart(list2CurClone));
         return result;
@@ -2376,8 +2376,8 @@ public final class LinearAlgebra {
         if (!list1.head().equals(head2)) {
           return F.NIL;
         }
-        ArrayList<Integer> dim1 = dimensions(list1);
-        ArrayList<Integer> dim2 = dimensions(list2);
+        List<Integer> dim1 = dimensions(list1);
+        List<Integer> dim2 = dimensions(list2);
         if (dim1.size() == 0) {
           // Nonatomic expression expected at position `1` in `2`.
           return IOFunctions.printMessage(S.Inner, "normal", F.List(F.C2, list1), EvalEngine.get());
@@ -4722,7 +4722,7 @@ public final class LinearAlgebra {
       }
 
       try {
-        ArrayList<Integer> dimensions = dimensions(arg1, S.List, Integer.MAX_VALUE, true);
+        List<Integer> dimensions = dimensions(arg1, S.List, Integer.MAX_VALUE, true);
         if (dimensions.size() == 0) {
           return F.NIL;
         }
@@ -4875,8 +4875,7 @@ public final class LinearAlgebra {
       /** The position from which to extract the current element */
       int[] positions;
 
-      private TransposePermute(IAST tensor, ArrayList<Integer> tensorDimensions,
-          int[] permutation) {
+      private TransposePermute(IAST tensor, List<Integer> tensorDimensions, int[] permutation) {
         this.tensor = tensor;
         this.dimensions = new int[tensorDimensions.size()];
         for (int i = 0; i < tensorDimensions.size(); i++) {
@@ -4922,7 +4921,7 @@ public final class LinearAlgebra {
       if (ast.size() == 3) {
         if (ast.arg1().isList() && ast.arg2().isList()) {
           IAST tensor = (IAST) ast.arg1();
-          ArrayList<Integer> dims = dimensions(tensor, tensor.head(), Integer.MAX_VALUE);
+          List<Integer> dims = dimensions(tensor, tensor.head(), Integer.MAX_VALUE);
           int[] permutation = Validate.checkListOfInts(ast, ast.arg2(), 1, dims.size(), engine);
           if (permutation == null) {
             return F.NIL;
@@ -5374,19 +5373,19 @@ public final class LinearAlgebra {
     return matrix;
   }
 
-  public static ArrayList<Integer> dimensions(IAST ast) {
+  public static List<Integer> dimensions(IAST ast) {
     return dimensionsRecursive(ast, ast.head(), Integer.MAX_VALUE, false, new ArrayList<Integer>());
   }
 
-  public static ArrayList<Integer> dimensions(IAST ast, IExpr header) {
+  public static List<Integer> dimensions(IAST ast, IExpr header) {
     return dimensions(ast, header, Integer.MAX_VALUE);
   }
 
-  public static ArrayList<Integer> dimensions(IAST ast, IExpr header, int maxLevel) {
+  public static List<Integer> dimensions(IAST ast, IExpr header, int maxLevel) {
     return dimensionsRecursive(ast, header, maxLevel, false, new ArrayList<Integer>());
   }
 
-  public static ArrayList<Integer> dimensions(IExpr expr, IExpr header, int maxLevel,
+  public static List<Integer> dimensions(IExpr expr, IExpr header, int maxLevel,
       boolean throwIllegalArgumentException) {
     if (expr.isAST()) {
       return dimensionsRecursive((IAST) expr, header, maxLevel, throwIllegalArgumentException,

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/NumberTheory.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/NumberTheory.java
@@ -1724,7 +1724,7 @@ public final class NumberTheory {
      * @param a list of integers
      * @param n the zero-based index of the coefficient. n=0 for the E_0 term.
      */
-    protected void set(ArrayList<IInteger> a, final int n) {
+    protected void set(List<IInteger> a, final int n) {
       while (n >= a.size()) {
         IInteger val = F.C0;
         boolean sigPos = true;
@@ -1753,7 +1753,7 @@ public final class NumberTheory {
      * @param n the index, non-negative.
      * @return the E_0=E_1=1 , E_2=5, E_3=61 etc
      */
-    public IInteger eulerE(ArrayList<IInteger> a, int n) {
+    public IInteger eulerE(List<IInteger> a, int n) {
       set(a, n);
       return (a.get(n));
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/PatternMatching.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/PatternMatching.java
@@ -5,7 +5,7 @@ import static org.matheclipse.core.expression.F.RuleDelayed;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.StringWriter;
-import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -1638,7 +1638,7 @@ public final class PatternMatching {
 
     @Override
     public IExpr evaluate(final IAST ast, EvalEngine engine) {
-      ArrayDeque<IExpr> stack = engine.getStack();
+      Deque<IExpr> stack = engine.getStack();
       if (stack.size() == 1 && ast.head() == S.Sequence) {
         return ast.setAtClone(0, S.Identity);
       }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/Programming.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/Programming.java
@@ -3,8 +3,8 @@ package org.matheclipse.core.builtin;
 import static org.matheclipse.core.expression.F.List;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.IdentityHashMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -2671,7 +2671,7 @@ public final class Programming {
 
     @Override
     public IExpr evaluate(final IAST ast, EvalEngine engine) {
-      ArrayDeque<IExpr> stack = engine.getStack();
+      Deque<IExpr> stack = engine.getStack();
       java.util.Iterator<IExpr> iter = stack.descendingIterator();
       IASTAppendable result = F.ListAlloc(stack.size());
       if (ast.isAST1()) {
@@ -2720,7 +2720,7 @@ public final class Programming {
 
     @Override
     public IExpr evaluate(final IAST ast, EvalEngine engine) {
-      ArrayDeque<IExpr> stack = engine.getStack();
+      Deque<IExpr> stack = engine.getStack();
       try {
         engine.stackBegin();
         return engine.evaluate(ast.arg1());

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/StructureFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/StructureFunctions.java
@@ -1,6 +1,5 @@
 package org.matheclipse.core.builtin;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
@@ -1278,7 +1277,7 @@ public class StructureFunctions {
         }
 
         IAST tensor = (IAST) ast.arg2();
-        ArrayList<Integer> dims = LinearAlgebra.dimensions(tensor, tensor.head());
+        List<Integer> dims = LinearAlgebra.dimensions(tensor, tensor.head());
         if (dims.size() > level) {
           if (level == 0) {
             return tensor.apply(ast.arg1());

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/TensorFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/TensorFunctions.java
@@ -1,6 +1,5 @@
 package org.matheclipse.core.builtin;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -180,7 +179,7 @@ public class TensorFunctions {
     public IExpr evaluate(final IAST ast, EvalEngine engine) {
       IExpr tensor = ast.arg1();
       if (tensor.isList()) {
-        ArrayList<Integer> dims = LinearAlgebra.dimensions((IAST) tensor);
+        List<Integer> dims = LinearAlgebra.dimensions((IAST) tensor);
         if (dims.size() > 0) {
           IInteger d = F.ZZ(dims.get(dims.size() - 1));
           int rank = S.TensorRank.of(engine, tensor).toIntDefault();
@@ -614,7 +613,7 @@ public class TensorFunctions {
       IExpr arg1 = ast.arg1().normal(false);
       if (arg1.isAST()) {
         IAST tensor = (IAST) arg1;
-        ArrayList<Integer> dims = LinearAlgebra.dimensions(tensor, tensor.head());
+        List<Integer> dims = LinearAlgebra.dimensions(tensor, tensor.head());
         if (dims.size() > 0) {
           if (dims.size() == 2 && dims.get(0).equals(dims.get(1))) {
             // square matrix
@@ -774,11 +773,11 @@ public class TensorFunctions {
       }
       if (ast.arg1().isList() && ast.arg2().isList()) {
         IAST tensor1 = (IAST) ast.arg1();
-        ArrayList<Integer> dim1 = LinearAlgebra.dimensions(tensor1, S.List);
+        List<Integer> dim1 = LinearAlgebra.dimensions(tensor1, S.List);
         if (dim1.size() > 0) {
           for (int i = 2; i < ast.size(); i++) {
             IAST tensor2 = (IAST) ast.get(i);
-            ArrayList<Integer> dim2 = LinearAlgebra.dimensions(tensor2, S.List);
+            List<Integer> dim2 = LinearAlgebra.dimensions(tensor2, S.List);
             if (dim2.size() > 0) {
               IExpr temp = tensorProduct(tensor1, tensor2, dim1.size(), engine);
               if (temp.isPresent()) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/convert/CreamConvert.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/convert/CreamConvert.java
@@ -1,5 +1,6 @@
 package org.matheclipse.core.convert;
 
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
@@ -184,7 +185,7 @@ public class CreamConvert {
         expr.toString() + " is no int variable found for Solve(..., Integers)");
   }
 
-  public TreeMap<ISymbol, IntVariable> variableMap() {
+  public Map<ISymbol, IntVariable> variableMap() {
     return map;
   }
 

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/EvalEngine.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/EvalEngine.java
@@ -3,9 +3,11 @@ package org.matheclipse.core.eval;
 import java.io.PrintStream;
 import java.io.Serializable;
 import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
@@ -114,7 +116,7 @@ public class EvalEngine implements Serializable {
 
   public transient Cache<IAST, IExpr> rememberASTCache = null;
 
-  public transient IdentityHashMap<Object, IExpr> rememberMap = null;
+  public transient Map<Object, IExpr> rememberMap = null;
 
   public static final boolean DEBUG = false;
 
@@ -266,7 +268,7 @@ public class EvalEngine implements Serializable {
    * is defined in <code>Sow()</code> tag <code>F.None</code> is used. The odd indices in <code>
    * java.util.List</code> contain the associated reap list for the tag.
    */
-  private transient java.util.List<IExpr> fReapList = null;
+  private transient List<IExpr> fReapList = null;
 
   public transient Set<ISymbol> fModifiedVariablesList;
 
@@ -285,15 +287,15 @@ public class EvalEngine implements Serializable {
    * If <code>fOnOffUnique==true</code> this map contains the unique expressions which occurred
    * during evaluation
    */
-  transient HashMap<IExpr, IExpr> fOnOffUniqueMap = null;
+  transient Map<IExpr, IExpr> fOnOffUniqueMap = null;
 
   /**
    * If not null, this map contains the header symbols for which the interactive trace should be
    * printed.
    */
-  transient IdentityHashMap<ISymbol, ISymbol> fOnOffMap = null;
+  transient Map<ISymbol, ISymbol> fOnOffMap = null;
 
-  transient ArrayDeque<IExpr> fStack;
+  transient Deque<IExpr> fStack;
 
   /** The history list for the <code>Out[]</code> function. */
   private transient EvalHistory fEvalHistory = null;
@@ -2569,7 +2571,7 @@ public class EvalEngine implements Serializable {
    *
    * @return
    */
-  public ArrayDeque<IExpr> getStack() {
+  public Deque<IExpr> getStack() {
     return fStack;
   }
 
@@ -2654,7 +2656,7 @@ public class EvalEngine implements Serializable {
     rememberMap = new IdentityHashMap<Object, IExpr>();
   }
 
-  public ArrayDeque<IExpr> stackBegin() {
+  public Deque<IExpr> stackBegin() {
     fStack = new ArrayDeque<IExpr>(256);
     return fStack;
   }
@@ -2975,7 +2977,7 @@ public class EvalEngine implements Serializable {
    *        expression and _evaluated_ output expression.
    */
   public void setOnOffMode(final boolean onOffMode,
-      IdentityHashMap<ISymbol, ISymbol> headSymbolsMap, boolean uniqueTrace) {
+      Map<ISymbol, ISymbol> headSymbolsMap, boolean uniqueTrace) {
     fOnOffMode = onOffMode;
     fOnOffMap = headSymbolsMap;
     fOnOffUnique = uniqueTrace;
@@ -3073,7 +3075,7 @@ public class EvalEngine implements Serializable {
    *
    * @param stack
    */
-  public void setStack(ArrayDeque<IExpr> stack) {
+  public void setStack(Deque<IExpr> stack) {
     fStack = stack;
   }
 

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/data/NumericArrayExpr.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/data/NumericArrayExpr.java
@@ -6,9 +6,9 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.math.BigInteger;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.hipparchus.complex.Complex;
 import org.matheclipse.core.basic.Config;
@@ -572,7 +572,7 @@ public class NumericArrayExpr extends DataExpr<Object> implements INumericArray,
   private static NumericArrayExpr newList(final IAST list, byte type)
       throws RangeException, TypeException {
     int[] dimension = null;
-    ArrayList<Integer> dims = LinearAlgebra.dimensions(list);
+    List<Integer> dims = LinearAlgebra.dimensions(list);
     if (dims != null && dims.size() > 0) {
       int size = 1;
       dimension = new int[dims.size()];

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/data/SparseArrayExpr.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/data/SparseArrayExpr.java
@@ -4,8 +4,8 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.function.Function;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -1244,7 +1244,7 @@ public class SparseArrayExpr extends DataExpr<Trie<int[], IExpr>>
    * @return <code>null</code> if a new <code>SparseArrayExpr</code> cannot be created.
    */
   public static SparseArrayExpr newDenseList(IAST denseList, IExpr defaultValue) {
-    ArrayList<Integer> dims = LinearAlgebra.dimensions(denseList);
+    List<Integer> dims = LinearAlgebra.dimensions(denseList);
     if (dims != null && dims.size() > 0) {
       defaultValue = defaultValue.orElse(F.C0);
       IAST listOfRules = SparseArrayExpr.arrayRules(denseList, defaultValue);

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/mathml/MathMLFormFactory.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/mathml/MathMLFormFactory.java
@@ -1084,7 +1084,7 @@ public class MathMLFormFactory extends AbstractMathMLFormFactory {
    */
   public static final boolean PLUS_CALL = true;
 
-  public static final HashMap<ISymbol, IConverter> CONVERTERS =
+  public static final Map<ISymbol, IConverter> CONVERTERS =
       new HashMap<ISymbol, IConverter>(199);
 
   private static final TrieBuilder<String, Object, ArrayList<Object>> constantBuilder =
@@ -1101,7 +1101,7 @@ public class MathMLFormFactory extends AbstractMathMLFormFactory {
       converterBuilder.withMatch(TrieMatch.EXACT).build();
 
   /** Table for constant expressions */
-  public static final HashMap<IExpr, String> CONSTANT_EXPRS = new HashMap<IExpr, String>();
+  public static final Map<IExpr, String> CONSTANT_EXPRS = new HashMap<IExpr, String>();
 
   private boolean fRelaxedSyntax;
   private boolean fUseSignificantFigures = false;
@@ -2316,7 +2316,7 @@ public class MathMLFormFactory extends AbstractMathMLFormFactory {
       tagStart(buf, "mtext");
       String text = splittedStr[i].replaceAll("\\&", "&amp;").replaceAll("\\<", "&lt;")
           .replaceAll("\\>", "&gt;");
-      text = text.replaceAll("\\\"", "&quot;").replaceAll(" ", "&nbsp;");
+      text = text.replaceAll("\\\"", "&quot;").replace(" ", "&nbsp;");
       appendUnicodeMapped(buf, text);
       tagEnd(buf, "mtext");
       if (splittedStrLength > 1) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/output/OutputFormFactory.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/output/OutputFormFactory.java
@@ -2,7 +2,7 @@ package org.matheclipse.core.form.output;
 
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.ArrayList;
+import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apfloat.Apcomplex;
@@ -1183,7 +1183,7 @@ public class OutputFormFactory {
                 // see also MatrixForm in MathML or TeX format for "graphical representation".
                 IExpr normal = list.arg1().normal(false);
                 if (normal.isList()) { // && normal.isMatrix() != null) {
-                  ArrayList<Integer> dims = LinearAlgebra.dimensions((IAST) normal, S.List);
+                  List<Integer> dims = LinearAlgebra.dimensions((IAST) normal, S.List);
                   convertList(buf, (IAST) normal, dims.size() >= 2);
                   return;
                 }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/tex/TeXFormFactory.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/tex/TeXFormFactory.java
@@ -1283,10 +1283,10 @@ public class TeXFormFactory {
       ParserConfig.TRIE_STRING2STRING_BUILDER.withMatch(TrieMatch.EXACT).build(); // Tries.forStrings();
 
   /** Table for constant expressions */
-  public static final HashMap<IExpr, String> CONSTANT_EXPRS = new HashMap<IExpr, String>(199);
+  public static final Map<IExpr, String> CONSTANT_EXPRS = new HashMap<IExpr, String>(199);
 
   /** Description of the Field */
-  public static final HashMap<ISymbol, AbstractConverter> operTab =
+  public static final Map<ISymbol, AbstractConverter> operTab =
       new HashMap<ISymbol, AbstractConverter>(199);
 
   public static final boolean USE_IDENTIFIERS = false;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/interfaces/IAssociation.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/interfaces/IAssociation.java
@@ -1,7 +1,7 @@
 package org.matheclipse.core.interfaces;
 
-import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 import java.util.function.Supplier;
 
 public interface IAssociation extends IASTAppendable {
@@ -93,7 +93,7 @@ public interface IAssociation extends IASTAppendable {
    *
    * @return
    */
-  public ArrayList<String> keyNames();
+  public List<String> keyNames();
 
   /**
    * Get the keys of this association as a<code>List(key1, key2,...)</code>

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/visit/ModuleReplaceAll.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/visit/ModuleReplaceAll.java
@@ -1,6 +1,7 @@
 package org.matheclipse.core.visit;
 
 import java.util.IdentityHashMap;
+import java.util.Map;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.expression.F;
 import org.matheclipse.core.expression.S;
@@ -17,20 +18,20 @@ import org.matheclipse.core.interfaces.ISymbol;
  * F.NIL</code> if no substitution occurred.
  */
 public class ModuleReplaceAll extends VisitorExpr {
-  final IdentityHashMap<ISymbol, ? extends IExpr> fModuleVariables;
+  final Map<ISymbol, ? extends IExpr> fModuleVariables;
   final int fOffset;
   final EvalEngine fEngine;
   final String moduleCounter;
 
   public ModuleReplaceAll(
-      IdentityHashMap<ISymbol, ? extends IExpr> moduleVariables,
+      Map<ISymbol, ? extends IExpr> moduleVariables,
       EvalEngine engine,
       String moduleCounter) {
     this(moduleVariables, engine, moduleCounter, 0);
   }
 
   public ModuleReplaceAll(
-      IdentityHashMap<ISymbol, ? extends IExpr> moduleVariables,
+      Map<ISymbol, ? extends IExpr> moduleVariables,
       EvalEngine engine,
       String moduleCounter,
       int offset) {
@@ -163,12 +164,12 @@ public class ModuleReplaceAll extends VisitorExpr {
     IExpr temp = fModuleVariables.get(symbol);
     if (isFunction) {
       if (variables == null) {
-        variables = (IdentityHashMap<ISymbol, IExpr>) fModuleVariables.clone();
+        variables = new IdentityHashMap<>(fModuleVariables);
       }
       variables.put(symbol, F.Dummy(symbol.toString() + varAppend));
     } else if (temp != null) {
       if (variables == null) {
-        variables = (IdentityHashMap<ISymbol, IExpr>) fModuleVariables.clone();
+        variables = new IdentityHashMap<>(fModuleVariables);
       }
       variables.remove(symbol);
       if (!temp.isPresent()) {

--- a/symja_android_library/matheclipse-gpl/src/main/java/de/tilman_neumann/jml/Divisors.java
+++ b/symja_android_library/matheclipse-gpl/src/main/java/de/tilman_neumann/jml/Divisors.java
@@ -13,8 +13,10 @@
  */
 package de.tilman_neumann.jml;
 
-import static de.tilman_neumann.jml.base.BigIntConstants.*;
-
+import static de.tilman_neumann.jml.base.BigIntConstants.I_0;
+import static de.tilman_neumann.jml.base.BigIntConstants.I_1;
+import static de.tilman_neumann.jml.base.BigIntConstants.I_1E4;
+import static de.tilman_neumann.jml.base.BigIntConstants.I_2;
 import java.math.BigInteger;
 import java.security.SecureRandom;
 import java.util.ArrayList;
@@ -23,9 +25,7 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.Stack;
 import java.util.TreeSet;
-
 import org.apache.log4j.Logger;
-
 import de.tilman_neumann.jml.combinatorics.Factorial;
 import de.tilman_neumann.jml.factor.CombinedFactorAlgorithm;
 import de.tilman_neumann.jml.factor.FactorAlgorithm;


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

This PR fixes all infringements of SonarLint Rule java:S1319 in Symjas Code base:
https://github.com/SonarSource/sonar-java/blob/master/java-checks/src/main/resources/org/sonar/l10n/java/rules/java/S1319_java.html

It is generally recommended to use Interfaces rather than implements (of Java Collections) to not restrict the caller to one specific implementation of an interface. Maybe one has a LinkedList but the arguments requires an ArrayList. Then the given List has to be copied first. If there is no strong reason for a specific implementation (like specific methods) the interface should be used.

