### PR TITLE
[Tests] Update to maven-surefire-plugin 3.0.0-M5 (#347)

### DIFF
--- a/symja_android_library/pom.xml
+++ b/symja_android_library/pom.xml
@@ -461,7 +461,15 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.12.4</version>
+					<version>3.0.0-M5</version>
+					<configuration>
+						<includes>
+							<include>**/Test*.java</include>
+							<include>**/*Test.java</include>
+							<!-- TODO: fix those tests and enable them too <include>**/*Tests.java</include>	-->
+							<include>**/*TestCase.java</include>
+						</includes>
+					</configuration>
 				</plugin>
 
 				<plugin>


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

This PR resolves #347.
As suspected since version 2.20 the `maven-surefire-plugin` additionally detects classes with names like `*Tests.java` as tests and runs them in its test goal.
Unfortunately those tests do not pass respectively hang.
On the long run we should fix and enable those tests. For now I just exclude them to be able to perform the update.