### PR TITLE
Fix syntax of tasks in .gitpod.yml

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -16,4 +16,4 @@ github:
     addLabel: prebuilt-in-gitpod
 tasks:
   - init: mvn -f symja_android_library/pom.xml clean install -DskipTests
-    command: mvn -f symja_android_library/pom.xml exec:java -pl matheclipse-io -Dexec.mainClass="org.matheclipse.io.eval.Console"
+  - command: mvn -f symja_android_library/pom.xml exec:java -pl matheclipse-io -Dexec.mainClass="org.matheclipse.io.eval.Console"


### PR DESCRIPTION
The syntax of the tasks was wrong.

See https://www.gitpod.io/docs/prebuilds

In YAML
```yml
tasks:
  - a
    b
```
is different than
```yml
tasks:
  - a
  - b
```