### PR TITLE
[Core] make internalJavaString() variables function more specific

### DIFF
--- a/symja_android_library/matheclipse-beakerx/src/main/java/com/twosigma/beakerx/symjamma/evaluator/SymjaMMAEvaluator.java
+++ b/symja_android_library/matheclipse-beakerx/src/main/java/com/twosigma/beakerx/symjamma/evaluator/SymjaMMAEvaluator.java
@@ -247,7 +247,7 @@ public class SymjaMMAEvaluator extends BaseEvaluator {
   TryResult printForm(final SymjaMMACodeRunner symjaMMACodeRunner, final Object result) {
     switch (fUsedForm) {
       case SymjaMMAEvaluator.JAVAFORM:
-        return TryResult.createResult(((IExpr) result).internalJavaString(JAVA_FORM_PROPERTIES, -1, F.CNullFunction));
+        return TryResult.createResult(((IExpr) result).internalJavaString(JAVA_FORM_PROPERTIES, -1, x -> null));
       case SymjaMMAEvaluator.TRADITIONALFORM:
         StringBuilder traditionalBuffer = new StringBuilder();
         fOutputTraditionalFactory.reset(false);

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/CompilerFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/CompilerFunctions.java
@@ -530,16 +530,10 @@ public class CompilerFunctions {
                 JAVA_FORM_PROPERTIES,
                 -1,
                 x -> {
-                  if (x.isSymbol()) {
-                    if (localVariables.contains(x.toString())) {
-                      return "vars.get(\"" + x.toString() + "\")";
-                    }
+                  if (localVariables.contains(x.toString())) {
+                    return "vars.get(\"" + x.toString() + "\")";
                   }
-                  String str = numericVariables.apply(x);
-                  if (x.isSymbol() && str != null) {
-                    return str;
-                  }
-                  return null;
+                  return numericVariables.apply(x);
                 }));
         return true;
       } catch (RuntimeException rex) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/OutputFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/OutputFunctions.java
@@ -460,7 +460,7 @@ public final class OutputFunctions {
       SourceCodeProperties p =
           SourceCodeProperties.of(
               strictJava, false, usePrefix ? Prefix.CLASS_NAME : Prefix.NONE, false);
-      return arg1.internalJavaString(p, 0, F.CNullFunction);
+      return arg1.internalJavaString(p, 0, x -> null);
     }
 
     @Override

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/MathMLUtilities.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/MathMLUtilities.java
@@ -174,7 +174,7 @@ public class MathMLUtilities {
         parsedExpression = parser.parse(inputExpression);
         // node = fEvalEngine.parseNode(inputExpression);
         // parsedExpression = AST2Expr.CONST.convert(node, fEvalEngine);
-        out.write(parsedExpression.internalJavaString(JAVA_FORM_PROPERTIES, -1, F.CNullFunction)
+        out.write(parsedExpression.internalJavaString(JAVA_FORM_PROPERTIES, -1, x -> null)
             .toString());
       } catch (final IOException ioe) {
         //

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/AbstractAST.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/AbstractAST.java
@@ -433,7 +433,7 @@ public abstract class AbstractAST implements IASTMutable {
     /** {@inheritDoc} */
     @Override
     public final CharSequence internalJavaString(SourceCodeProperties properties, int depth,
-        Function<IExpr, ? extends CharSequence> variables) {
+        Function<ISymbol, ? extends CharSequence> variables) {
       switch (properties.prefix) {
         case FULLY_QUALIFIED_CLASS_NAME:
           return "org.matheclipse.core.expression.F.NIL";
@@ -1215,7 +1215,7 @@ public abstract class AbstractAST implements IASTMutable {
 
   private static void internalFormOrderless(IAST ast, StringBuilder text, final String sep,
       SourceCodeProperties properties, int depth,
-      Function<IExpr, ? extends CharSequence> variables) {
+      Function<ISymbol, ? extends CharSequence> variables) {
     for (int i = 1; i < ast.size(); i++) {
       if ((ast.get(i) instanceof IAST) && ast.head().equals(ast.get(i).head())) {
         internalFormOrderless((IAST) ast.get(i), text, sep, properties, depth, variables);
@@ -2458,7 +2458,7 @@ public abstract class AbstractAST implements IASTMutable {
   /** {@inheritDoc} */
   @Override
   public CharSequence internalJavaString(SourceCodeProperties properties, int depth,
-      Function<IExpr, ? extends CharSequence> variables) {
+      Function<ISymbol, ? extends CharSequence> variables) {
     final String sep = ",";
     final IExpr temp = head();
     if (temp.equals(S.HoldForm) && size() == 2) {
@@ -2692,7 +2692,7 @@ public abstract class AbstractAST implements IASTMutable {
     if (isLowerPrecedence) {
       text.append('(');
     }
-    text.append(arg1.internalJavaString(properties, depth + 1, F.CNullFunction));
+    text.append(arg1.internalJavaString(properties, depth + 1, x -> null));
     if (isLowerPrecedence) {
       text.append(')');
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/AbstractIntegerSym.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/AbstractIntegerSym.java
@@ -736,7 +736,7 @@ public abstract class AbstractIntegerSym implements IInteger, Externalizable {
   @Override
   public CharSequence internalFormString(boolean symbolsAsFactoryMethod, int depth) {
     SourceCodeProperties p = AbstractAST.stringFormProperties(symbolsAsFactoryMethod);
-    return internalJavaString(p, depth, F.CNullFunction);
+    return internalJavaString(p, depth, x -> null);
   }
 
   @Override

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/BigFractionSym.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/BigFractionSym.java
@@ -12,6 +12,7 @@ import org.matheclipse.core.interfaces.IFraction;
 import org.matheclipse.core.interfaces.IInteger;
 import org.matheclipse.core.interfaces.IRational;
 import org.matheclipse.core.interfaces.ISignedNumber;
+import org.matheclipse.core.interfaces.ISymbol;
 import org.matheclipse.parser.client.ParserConfig;
 
 /**
@@ -404,7 +405,7 @@ public class BigFractionSym extends AbstractFractionSym {
 
   @Override
   public CharSequence internalJavaString(SourceCodeProperties properties, int depth,
-      Function<IExpr, ? extends CharSequence> variables) {
+      Function<ISymbol, ? extends CharSequence> variables) {
     String prefix = AbstractAST.getPrefixF(properties);
     StringBuilder javaForm = new StringBuilder(prefix);
     int numerator = NumberUtil.toIntDefault(fFraction.getNumerator());

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/BigIntegerSym.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/BigIntegerSym.java
@@ -17,6 +17,7 @@ import org.matheclipse.core.interfaces.IInteger;
 import org.matheclipse.core.interfaces.INumber;
 import org.matheclipse.core.interfaces.IRational;
 import org.matheclipse.core.interfaces.ISignedNumber;
+import org.matheclipse.core.interfaces.ISymbol;
 import org.matheclipse.core.numbertheory.Primality;
 import com.google.common.math.BigIntegerMath;
 
@@ -354,7 +355,7 @@ public class BigIntegerSym extends AbstractIntegerSym {
 
   @Override
   public CharSequence internalJavaString(SourceCodeProperties properties, int depth,
-      Function<IExpr, ? extends CharSequence> variables) {
+      Function<ISymbol, ? extends CharSequence> variables) {
     String prefix = AbstractAST.getPrefixF(properties);
     StringBuilder javaForm = new StringBuilder(prefix);
     int value = toIntDefault(); // NumberUtil.toInt(fBigIntValue);

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Blank.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Blank.java
@@ -256,7 +256,7 @@ public class Blank implements IPattern {
 
   @Override
   public CharSequence internalJavaString(SourceCodeProperties properties, int depth,
-      Function<IExpr, ? extends CharSequence> variables) {
+      Function<ISymbol, ? extends CharSequence> variables) {
     String prefix = AbstractAST.getPrefixF(properties);
     final StringBuilder buffer = new StringBuilder(prefix).append("$b(");
     if (fHeadTest != null) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/BuiltInDummy.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/BuiltInDummy.java
@@ -554,7 +554,7 @@ public class BuiltInDummy implements IBuiltInSymbol, Serializable {
   public CharSequence internalJavaString(
       SourceCodeProperties properties,
       int depth,
-      Function<IExpr, ? extends CharSequence> variables) {
+      Function<ISymbol, ? extends CharSequence> variables) {
     CharSequence result = variables.apply(this);
     if (result != null) {
       return result;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/ComplexNum.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/ComplexNum.java
@@ -582,14 +582,14 @@ public class ComplexNum implements IComplexNum {
   @Override
   public CharSequence internalFormString(boolean symbolsAsFactoryMethod, int depth) {
     SourceCodeProperties p = AbstractAST.stringFormProperties(symbolsAsFactoryMethod);
-    return internalJavaString(p, depth, F.CNullFunction);
+    return internalJavaString(p, depth, x -> null);
   }
 
   @Override
   public CharSequence internalJavaString(
       SourceCodeProperties properties,
       int depth,
-      Function<IExpr, ? extends CharSequence> variables) {
+      Function<ISymbol, ? extends CharSequence> variables) {
     String prefix = AbstractAST.getPrefixF(properties);
     return new StringBuilder(prefix)
         .append("complexNum(")
@@ -602,7 +602,7 @@ public class ComplexNum implements IComplexNum {
   @Override
   public CharSequence internalScalaString(boolean symbolsAsFactoryMethod, int depth) {
     SourceCodeProperties p = AbstractAST.scalaFormProperties(symbolsAsFactoryMethod);
-    return internalJavaString(p, depth, F.CNullFunction);
+    return internalJavaString(p, depth, x -> null);
   }
 
   @Override

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/ComplexSym.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/ComplexSym.java
@@ -489,12 +489,12 @@ public class ComplexSym implements IComplex {
   @Override
   public CharSequence internalFormString(boolean symbolsAsFactoryMethod, int depth) {
     SourceCodeProperties p = AbstractAST.stringFormProperties(symbolsAsFactoryMethod);
-    return internalJavaString(p, depth, F.CNullFunction);
+    return internalJavaString(p, depth, x -> null);
   }
 
   @Override
   public CharSequence internalJavaString(SourceCodeProperties properties, int depth,
-      Function<IExpr, ? extends CharSequence> variables) {
+      Function<ISymbol, ? extends CharSequence> variables) {
     String prefix = AbstractAST.getPrefixF(properties);
     if (fReal.isZero()) {
       if (fImaginary.isOne()) {
@@ -538,7 +538,7 @@ public class ComplexSym implements IComplex {
   @Override
   public CharSequence internalScalaString(boolean symbolsAsFactoryMethod, int depth) {
     SourceCodeProperties p = AbstractAST.scalaFormProperties(symbolsAsFactoryMethod);
-    return internalJavaString(p, depth, F.CNullFunction);
+    return internalJavaString(p, depth, x -> null);
   }
 
   @Override

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/F.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/F.java
@@ -583,8 +583,6 @@ public class F extends S {
   /** Represents <code>List()</code> (i.e. the constant empty list) */
   public static final IAST CEmptyList;
 
-  public static final Function<IExpr, String> CNullFunction = x -> null;
-
   /** Represents <code>Missing("NotFound")</code> */
   public static final IAST CMissingNotFound;
 

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/FractionSym.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/FractionSym.java
@@ -11,6 +11,7 @@ import org.matheclipse.core.interfaces.IFraction;
 import org.matheclipse.core.interfaces.IInteger;
 import org.matheclipse.core.interfaces.IRational;
 import org.matheclipse.core.interfaces.ISignedNumber;
+import org.matheclipse.core.interfaces.ISymbol;
 import org.matheclipse.parser.client.ParserConfig;
 
 /**
@@ -404,12 +405,12 @@ public class FractionSym extends AbstractFractionSym {
   @Override
   public CharSequence internalFormString(boolean symbolsAsFactoryMethod, int depth) {
     SourceCodeProperties p = AbstractAST.stringFormProperties(symbolsAsFactoryMethod);
-    return internalJavaString(p, depth, F.CNullFunction);
+    return internalJavaString(p, depth, x -> null);
   }
 
   @Override
   public CharSequence internalJavaString(SourceCodeProperties properties, int depth,
-      Function<IExpr, ? extends CharSequence> variables) {
+      Function<ISymbol, ? extends CharSequence> variables) {
     String prefix = AbstractAST.getPrefixF(properties);
     StringBuilder javaForm = new StringBuilder(prefix);
     if (fNumerator == 1) {
@@ -440,7 +441,7 @@ public class FractionSym extends AbstractFractionSym {
   @Override
   public CharSequence internalScalaString(boolean symbolsAsFactoryMethod, int depth) {
     SourceCodeProperties p = AbstractAST.scalaFormProperties(symbolsAsFactoryMethod);
-    return internalJavaString(p, depth, F.CNullFunction);
+    return internalJavaString(p, depth, x -> null);
   }
 
   /**

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/IntegerSym.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/IntegerSym.java
@@ -14,6 +14,7 @@ import org.matheclipse.core.interfaces.IInteger;
 import org.matheclipse.core.interfaces.INumber;
 import org.matheclipse.core.interfaces.IRational;
 import org.matheclipse.core.interfaces.ISignedNumber;
+import org.matheclipse.core.interfaces.ISymbol;
 import org.matheclipse.core.numbertheory.Primality;
 import com.google.common.math.IntMath;
 import com.google.common.math.LongMath;
@@ -310,7 +311,7 @@ public class IntegerSym extends AbstractIntegerSym {
 
   @Override
   public CharSequence internalJavaString(SourceCodeProperties properties, int depth,
-      Function<IExpr, ? extends CharSequence> variables) {
+      Function<ISymbol, ? extends CharSequence> variables) {
     String prefix = AbstractAST.getPrefixF(properties);
     StringBuilder javaForm = new StringBuilder(prefix);
     int value = NumberUtil.toInt(fIntValue);
@@ -365,7 +366,7 @@ public class IntegerSym extends AbstractIntegerSym {
   @Override
   public CharSequence internalScalaString(boolean symbolsAsFactoryMethod, int depth) {
     SourceCodeProperties p = AbstractAST.scalaFormProperties(symbolsAsFactoryMethod);
-    return internalJavaString(p, depth, F.CNullFunction);
+    return internalJavaString(p, depth, x -> null);
   }
 
   @Override

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Num.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Num.java
@@ -420,14 +420,14 @@ public class Num implements INum {
   @Override
   public CharSequence internalFormString(boolean symbolsAsFactoryMethod, int depth) {
     SourceCodeProperties p = AbstractAST.stringFormProperties(symbolsAsFactoryMethod);
-    return internalJavaString(p, depth, F.CNullFunction);
+    return internalJavaString(p, depth, x -> null);
   }
 
   @Override
   public CharSequence internalJavaString(
       SourceCodeProperties properties,
       int depth,
-      Function<IExpr, ? extends CharSequence> variables) {
+      Function<ISymbol, ? extends CharSequence> variables) {
     String prefix = AbstractAST.getPrefixF(properties);
     StringBuilder javaForm = new StringBuilder(prefix);
     if (isZero()) {
@@ -443,7 +443,7 @@ public class Num implements INum {
   @Override
   public CharSequence internalScalaString(boolean symbolsAsFactoryMethod, int depth) {
     SourceCodeProperties p = AbstractAST.scalaFormProperties(symbolsAsFactoryMethod);
-    return internalJavaString(p, depth, F.CNullFunction);
+    return internalJavaString(p, depth, x -> null);
   }
 
   /** @return */

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Pattern.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Pattern.java
@@ -232,7 +232,7 @@ public class Pattern extends Blank {
 
   @Override
   public CharSequence internalJavaString(SourceCodeProperties properties, int depth,
-      Function<IExpr, ? extends CharSequence> variables) {
+      Function<ISymbol, ? extends CharSequence> variables) {
     String prefix = AbstractAST.getPrefixF(properties);
     final StringBuilder buffer = new StringBuilder(prefix);
     String symbolStr = fSymbol.toString();

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/PatternSequence.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/PatternSequence.java
@@ -230,7 +230,7 @@ public class PatternSequence implements IPatternSequence {
 
   @Override
   public CharSequence internalJavaString(SourceCodeProperties properties, int depth,
-      Function<IExpr, ? extends CharSequence> variables) {
+      Function<ISymbol, ? extends CharSequence> variables) {
     if (properties.symbolsAsFactoryMethod) {
       String prefix = AbstractAST.getPrefixF(properties);
       final StringBuilder buffer = new StringBuilder();

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/StringX.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/StringX.java
@@ -398,7 +398,7 @@ public class StringX implements IStringX {
   /** {@inheritDoc} */
   @Override
   public CharSequence internalJavaString(SourceCodeProperties properties, int depth,
-      Function<IExpr, ? extends CharSequence> variables) {
+      Function<ISymbol, ? extends CharSequence> variables) {
     String prefix = AbstractAST.getPrefixF(properties);
     return new StringBuilder(prefix).append("$str(\"").append(fString).append("\")");
   }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Symbol.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Symbol.java
@@ -585,7 +585,7 @@ public class Symbol implements ISymbol, Serializable {
   public CharSequence internalJavaString(
       SourceCodeProperties properties,
       int depth,
-      Function<IExpr, ? extends CharSequence> variables) {
+      Function<ISymbol, ? extends CharSequence> variables) {
     CharSequence result = variables.apply(this);
     if (result != null) {
       return result;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/interfaces/IExpr.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/interfaces/IExpr.java
@@ -1125,7 +1125,7 @@ public interface IExpr
    * @return the internal Java form of this expression
    */
   default CharSequence internalJavaString(SourceCodeProperties properties, int depth,
-      Function<IExpr, ? extends CharSequence> variables) {
+      Function<ISymbol, ? extends CharSequence> variables) {
     return toString();
   }
 

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/tensor/qty/QuantityImpl.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/tensor/qty/QuantityImpl.java
@@ -13,6 +13,7 @@ import org.matheclipse.core.expression.F;
 import org.matheclipse.core.expression.S;
 import org.matheclipse.core.interfaces.IExpr;
 import org.matheclipse.core.interfaces.IExpr.SourceCodeProperties.Prefix;
+import org.matheclipse.core.interfaces.ISymbol;
 import org.matheclipse.parser.client.math.MathException;
 
 public class QuantityImpl extends DataExpr<IUnit> implements IQuantity, Externalizable {
@@ -137,7 +138,7 @@ public class QuantityImpl extends DataExpr<IUnit> implements IQuantity, External
 
   @Override
   public CharSequence internalJavaString(SourceCodeProperties properties, int depth,
-      Function<IExpr, ? extends CharSequence> variables) {
+      Function<ISymbol, ? extends CharSequence> variables) {
 
     CharSequence value = value().internalJavaString(properties, depth, variables);
 

--- a/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/eval/Console.java
+++ b/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/eval/Console.java
@@ -487,7 +487,7 @@ public class Console {
     }
     switch (fUsedForm) {
       case JAVAFORM:
-        return result.internalJavaString(JAVA_FORM_PROPERTIES, -1, F.CNullFunction).toString();
+        return result.internalJavaString(JAVA_FORM_PROPERTIES, -1, x -> null).toString();
       case TRADITIONALFORM:
         StringBuilder traditionalBuffer = new StringBuilder();
         fOutputTraditionalFactory.reset(false);

--- a/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/eval/MMAConsole.java
+++ b/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/eval/MMAConsole.java
@@ -508,7 +508,7 @@ public class MMAConsole {
       }
       switch (fUsedForm) {
         case JAVAFORM:
-          return result.internalJavaString(Console.JAVA_FORM_PROPERTIES, -1, F.CNullFunction)
+          return result.internalJavaString(Console.JAVA_FORM_PROPERTIES, -1, x -> null)
               .toString();
         case TRADITIONALFORM:
           StringBuilder traditionalBuffer = new StringBuilder();

--- a/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/io/system/JavaFormTestCase.java
+++ b/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/io/system/JavaFormTestCase.java
@@ -4,6 +4,7 @@ import static org.matheclipse.core.expression.F.CI;
 import static org.matheclipse.core.expression.F.CInfinity;
 import static org.matheclipse.core.expression.F.Sinc;
 import static org.matheclipse.core.expression.F.Times;
+import java.util.function.Function;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.EvalUtilities;
 import org.matheclipse.core.expression.F;
@@ -11,6 +12,7 @@ import org.matheclipse.core.interfaces.IAST;
 import org.matheclipse.core.interfaces.IExpr;
 import org.matheclipse.core.interfaces.IExpr.SourceCodeProperties;
 import org.matheclipse.core.interfaces.IExpr.SourceCodeProperties.Prefix;
+import org.matheclipse.core.interfaces.ISymbol;
 import org.matheclipse.core.tensor.qty.IQuantity;
 import org.matheclipse.core.tensor.qty.IUnit;
 import org.matheclipse.parser.client.ParserConfig;
@@ -49,11 +51,11 @@ public class JavaFormTestCase extends AbstractTestCase {
 
     IExpr result = EvalEngine.get().evalHoldPattern(function);
     assertEquals("F.Sinc(F.DirectedInfinity(F.CI))",
-        result.internalJavaString(SYMBOL_FACTORY_PROPERTIES, -1, F.CNullFunction).toString());
+        result.internalJavaString(SYMBOL_FACTORY_PROPERTIES, -1, x -> null).toString());
 
     result = util.evaluate(function);
     assertEquals("F.oo",
-        result.internalJavaString(SYMBOL_FACTORY_PROPERTIES, -1, F.CNullFunction).toString());
+        result.internalJavaString(SYMBOL_FACTORY_PROPERTIES, -1, x -> null).toString());
   }
 
   public void testJavaForm002_fullyQualifiedName() {
@@ -65,12 +67,12 @@ public class JavaFormTestCase extends AbstractTestCase {
     IExpr result = EvalEngine.get().evalHoldPattern(function);
     assertEquals(
         "org.matheclipse.core.expression.F.Sinc(org.matheclipse.core.expression.F.DirectedInfinity(org.matheclipse.core.expression.F.CI))",
-        result.internalJavaString(SYMBOL_FACTORY_PROPERTIES_FULL_NAMES, -1, F.CNullFunction)
+        result.internalJavaString(SYMBOL_FACTORY_PROPERTIES_FULL_NAMES, -1, x -> null)
             .toString());
 
     result = util.evaluate(function);
     assertEquals("org.matheclipse.core.expression.F.oo", result
-        .internalJavaString(SYMBOL_FACTORY_PROPERTIES_FULL_NAMES, -1, F.CNullFunction).toString());
+        .internalJavaString(SYMBOL_FACTORY_PROPERTIES_FULL_NAMES, -1, x -> null).toString());
   }
 
   private static final SourceCodeProperties NO_SYMBOL_FACTORY_PROPERTIES =

--- a/symja_android_library/tools/src/main/java/org/matheclipse/core/preprocessor/ElementPreprocessor.java
+++ b/symja_android_library/tools/src/main/java/org/matheclipse/core/preprocessor/ElementPreprocessor.java
@@ -64,7 +64,7 @@ public class ElementPreprocessor {
       }
       for (int i = 2; i < rowList.size(); i++) {
         IAST columnList = (IAST) rowList.get(i);
-        System.out.print(columnList.internalJavaString(JAVA_FORM_PROPERTIES, 1, F.CNullFunction));
+        System.out.print(columnList.internalJavaString(JAVA_FORM_PROPERTIES, 1, x -> null));
         System.out.println(", ");
       }
       // return rowList;

--- a/symja_android_library/tools/src/main/java/org/matheclipse/core/preprocessor/ExprPreprocessor.java
+++ b/symja_android_library/tools/src/main/java/org/matheclipse/core/preprocessor/ExprPreprocessor.java
@@ -43,7 +43,7 @@ public class ExprPreprocessor extends AbstractCodeGenerator {
   public boolean apply(String command, StringBuilder buf) {
     ExprParser p = new ExprParser(EvalEngine.get(), true);
     IExpr expr = p.parse(command);
-    buf.append(expr.internalJavaString(JAVA_FORM_PROPERTIES, 1, F.CNullFunction));
+    buf.append(expr.internalJavaString(JAVA_FORM_PROPERTIES, 1, x -> null));
     return true;
   }
 }

--- a/symja_android_library/tools/src/main/java/org/matheclipse/core/preprocessor/RulePreprocessor.java
+++ b/symja_android_library/tools/src/main/java/org/matheclipse/core/preprocessor/RulePreprocessor.java
@@ -80,9 +80,9 @@ public class RulePreprocessor {
     if (evalRHS) {
       rightHandSide = F.eval(rightHandSide);
     }
-    buffer.append(leftHandSide.internalJavaString(p, 1, F.CNullFunction));
+    buffer.append(leftHandSide.internalJavaString(p, 1, x -> null));
     buffer.append(",\n      ");
-    buffer.append(rightHandSide.internalJavaString(p, 1, F.CNullFunction));
+    buffer.append(rightHandSide.internalJavaString(p, 1, x -> null));
     if (last) {
       buffer.append(")\n");
     } else {
@@ -110,9 +110,9 @@ public class RulePreprocessor {
     if (evalRHS) {
       rightHandSide = F.eval(rightHandSide);
     }
-    buffer.append(leftHandSide.internalJavaString(p, 1, F.CNullFunction));
+    buffer.append(leftHandSide.internalJavaString(p, 1, x -> null));
     buffer.append(",\n      ");
-    buffer.append(rightHandSide.internalJavaString(p, 1, F.CNullFunction));
+    buffer.append(rightHandSide.internalJavaString(p, 1, x -> null));
     buffer.append(");\n");
   }
 


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

The variables argument of `IExpr.internalJavaString()` was `Function<IExpr, ? extends CharSequence> variables` but the function is only called with ISymbol objects. Therefore I suggest to make it more specific and change the function's input argument to be of type `ISymbol`:
`Function<ISymbol, ? extends CharSequence> variables`

Then functions passed to `internalJavaString()` don't have to check if the argument is an ISymbol or not.

Furthermore the constant `F.CNullFunction` is inlined. It's lambda is trivial and because it is a non capturing lambda the JVM reuses the same instance at one location for each call (if not for the entire class or JVM).