### PR TITLE
[Core] speed up rationalization

### DIFF
--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/AbstractFractionSym.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/AbstractFractionSym.java
@@ -1,13 +1,8 @@
 package org.matheclipse.core.expression;
 
 import java.math.BigInteger;
-import java.util.Iterator;
 import java.util.NoSuchElementException;
-import java.util.Spliterator;
-import java.util.Spliterators;
 import java.util.function.DoubleFunction;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apfloat.Apcomplex;
@@ -50,76 +45,46 @@ import it.unimi.dsi.fastutil.ints.Int2IntRBTreeMap;
 public abstract class AbstractFractionSym implements IFraction {
   private static final long serialVersionUID = -8743141041586314213L;
 
-  /**
-   * Generate a {@link Stream stream} of convergents from a real number.
-   * <p>
-   * See:
-   * <a href="https://github.com/Hipparchus-Math/hipparchus/issues/176">hipparchus/issues/176</a>
-   *
-   * @param value value to approximate
-   * @param maxConbvergents maximum number of convergents.
-   * @return stream of {@link BigFraction} convergents approximating {@code value}
-   */
-  // TODO: replace this by Hipparcus BigFraction.convergents() after next Hipparchus release
-  public static Stream<BigFraction> convergents(double value, int maxConvergents) {
-    if (FastMath.abs(value) > Integer.MAX_VALUE) {
-      throw new MathIllegalStateException(LocalizedCoreFormats.FRACTION_CONVERSION_OVERFLOW, value,
-          value, 1l);
-    }
-    return StreamSupport
-        .stream(Spliterators.spliteratorUnknownSize(generatingIterator(value, maxConvergents),
-            Spliterator.DISTINCT | Spliterator.ORDERED), false);
+  @FunctionalInterface
+  private interface ConvergencePredicate {
+    boolean test(long numerator, long denominator);
   }
 
+  private static final long RATIONALIZATION_OVERFLOW = Integer.MAX_VALUE;
+
   /**
-   * Iterator for generating continuous fractions.
+   * Iteratively creates a fraction that converges towards the given value
    *
    * @param value value to approximate
-   * @param maxConbvergents maximum number of convergents.
-   * @return iterator iterating over continuous fractions aproximating {@code value}
-   * @since 2.1
+   * @param maxConbvergents maximum number of iterations.
    */
-  private static Iterator<BigFraction> generatingIterator(double value, int maxConvergents) {
-    return new Iterator<BigFraction>() {
-      private static final long OVERFLOW = Integer.MAX_VALUE;
-      private long p0 = 0;
-      private long q0 = 1;
-      private long p1 = 1;
-      private long q1 = 0;
-      private double r1 = value;
-      private boolean stop = false;
-      private int n = 0;
+  private static BigFraction converge(double value, int maxIterations,
+      ConvergencePredicate convergence) {
+    long p0 = 0;
+    long q0 = 1;
+    long p1 = 1;
+    long q1 = 0;
+    double r1 = value;
 
-      /** {@inheritDoc} */
-      @Override
-      public boolean hasNext() {
-        return n < maxConvergents && !stop;
-      }
+    for (int i = 0; i < maxIterations; i++) {
+      final long a1 = (long) FastMath.floor(r1);
+      long p2 = (a1 * p1) + p0;
+      long q2 = (a1 * q1) + q0;
 
-      /** {@inheritDoc} */
-      @Override
-      public BigFraction next() {
-        ++n;
-
-        final long a1 = (long) FastMath.floor(r1);
-        long p2 = (a1 * p1) + p0;
-        long q2 = (a1 * q1) + q0;
-
-        final double convergent = (double) p2 / (double) q2;
-        // stop = Precision.equals(convergent, value, 1);
-        // if ((p2 > OVERFLOW || q2 > OVERFLOW) && !stop) {
-        // throw new MathIllegalStateException(LocalizedCoreFormats.FRACTION_CONVERSION_OVERFLOW,
-        // value, p2, q2);
-        // }
-        p0 = p1;
-        p1 = p2;
-        q0 = q1;
-        q1 = q2;
-        r1 = 1.0 / (r1 - a1);
+      if (convergence.test(p2, q2)) {
         return new BigFraction(p2, q2);
       }
-
-    };
+      if (p2 > RATIONALIZATION_OVERFLOW || q2 > RATIONALIZATION_OVERFLOW) {
+        throw new MathIllegalStateException(LocalizedCoreFormats.FRACTION_CONVERSION_OVERFLOW,
+            value, p2, q2);
+      }
+      p0 = p1;
+      q0 = q1;
+      p1 = p2;
+      q1 = q2;
+      r1 = 1.0 / (r1 - a1);
+    }
+    return null;
   }
 
   private static final Logger LOGGER = LogManager.getLogger();
@@ -274,23 +239,25 @@ public abstract class AbstractFractionSym implements IFraction {
     return rationalize(value, v -> new BigFraction(v, epsilon, 200));
   }
 
-
   public static IFraction valueOfConvergent(double value) {
-    return rationalize(value,
-        v -> convergents(v, 20).filter(f -> isConverged(v, f)).findFirst().orElseThrow(
-            () -> new NoSuchElementException("No converging fraction found for value " + value)));
+    IFraction fraction = convergeFraction(value, 20, 1E-4);
+    if (fraction == null) {
+      throw new NoSuchElementException("No converging fraction found for value " + value);
+    }
+    return fraction;
   }
 
-  private static boolean isConverged(double value, BigFraction result) {
-    BigInteger denominator = result.getDenominator();
-    double qSquared = denominator.multiply(denominator).doubleValue();
-    double lhs = FastMath.abs(result.doubleValue() - value) * qSquared;
-    return lhs < 1E-4;
+  private static IFraction convergeFraction(double value, int maxIterations, double lhs) {
+    return rationalize(value,
+        v -> converge(v, maxIterations, (p, q) -> FastMath.abs(p * q - v * q * q) < lhs));
   }
 
   private static IFraction rationalize(double value, DoubleFunction<BigFraction> f) {
     try {
       BigFraction fraction = f.apply(value < 0 ? -value : value);
+      if (fraction == null) {
+        return null;
+      }
       return valueOf(value < 0 ? fraction.negate() : fraction);
     } catch (MathIllegalStateException e) {
       return valueOf(new BigFraction(value));
@@ -321,7 +288,6 @@ public abstract class AbstractFractionSym implements IFraction {
   public long accept(IVisitorLong visitor) {
     return visitor.visit(this);
   }
-
 
   /**
    * Returns <code>this+(fac1*fac2)</code>.
@@ -607,7 +573,6 @@ public abstract class AbstractFractionSym implements IFraction {
     BigInteger newdenom = toBigDenominator().multiply(other.toBigDenominator());
     return valueOf(newnum, newdenom);
   }
-
 
   @Override
   public INumber numericNumber() {

--- a/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/io/system/FractionTestCase.java
+++ b/symja_android_library/matheclipse-io/src/test/java/org/matheclipse/io/system/FractionTestCase.java
@@ -2,6 +2,8 @@ package org.matheclipse.io.system;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.matheclipse.core.expression.AbstractFractionSym.valueOf;
+import static org.matheclipse.core.expression.AbstractFractionSym.valueOfConvergent;
+import java.util.NoSuchElementException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.matheclipse.core.eval.exception.ArgumentTypeException;
@@ -63,7 +65,56 @@ class FractionTestCase {
     assertEquals("0", valueOf(0, Long.MAX_VALUE));
   }
 
+  @Test
+  void testValueOfConvergent() {
+    assertEquals("1", valueOfConvergent(1.0));
+    assertEquals("0", valueOfConvergent(0.0));
+    assertEquals("8", valueOfConvergent(8.0));
+    assertEquals("43", valueOfConvergent(43.0));
+    assertEquals("10", valueOfConvergent(10.0));
+    assertEquals("1000", valueOfConvergent(1000.0));
+
+    assertEquals("1/10", valueOfConvergent(0.1));
+    assertEquals("1/5", valueOfConvergent(0.2));
+    assertEquals("3/10", valueOfConvergent(0.3));
+    assertEquals("2/5", valueOfConvergent(0.4));
+    assertEquals("1/2", valueOfConvergent(0.5));
+    assertEquals("3/5", valueOfConvergent(0.6));
+    assertEquals("7/10", valueOfConvergent(0.7));
+    assertEquals("4/5", valueOfConvergent(0.8));
+    assertEquals("9/10", valueOfConvergent(0.9));
+
+    assertEquals("1/10", valueOfConvergent(0.1));
+    assertEquals("1/100", valueOfConvergent(0.01));
+    assertEquals("1/1000", valueOfConvergent(0.001));
+    assertEquals("1/10000", valueOfConvergent(0.0001));
+    assertEquals("0", valueOfConvergent(0.00001)); // rounded to zero
+
+    assertEquals("3/4", valueOfConvergent(0.75));
+    assertEquals("11/5", valueOfConvergent(2.2));
+
+    assertEquals("1943/4", valueOfConvergent(485.75));
+
+    assertEquals("245850922/78256779", valueOfConvergent(Math.PI));
+
+    assertThrows(NoSuchElementException.class, () -> valueOfConvergent(1.1859405905877545));
+    assertThrows(NoSuchElementException.class, () -> valueOfConvergent(1.6265889544859224));
+
+    assertEquals("0", valueOfConvergent(4.547476426840269E-13));
+    assertEquals("0", valueOfConvergent(8.147473162667989E-47));
+    assertEquals("1", valueOfConvergent(0.9999999976191776));
+    assertEquals("2", valueOfConvergent(1.9999992626312268));
+
+    assertEquals("703791863104313034795615518720", valueOfConvergent(7.03791863104313E29));
+    assertEquals(
+        "41443534396435588611213052456670629384928442103203783116298919828494368341312648773632",
+        valueOfConvergent(4.144353439643559E85));
+    assertEquals(
+        "8365327199922553523412142632386866005829989115082364265187442262457444899190991167760856400050282180955268244806847868694420889116879412179164543828412908728421710223689854773971619786645931722628866130880103557100913478166634542534393593856",
+        valueOfConvergent(8.365327199922554E240));
+  }
+
   private static void assertEquals(String expected, IFraction actual) {
-    Assertions.assertEquals(expected, actual.toString());
+    Assertions.assertEquals(expected, actual.toBigFraction().toString().replaceAll("[\\s]", ""));
   }
 }


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

This PR speeds up AbstractFractionSym.valueOfConvergent() by converting the Stream of converging BigFractions into an iterative algorithm that accepts a special predicate to test if the iteration has converged.
This avoids the creation of many unused `BigFraction` objects. In my simple benchmark this improved the runtime about 1/3.

Furthermore this prepares the internal re-use of the converging function with different parameters.