### PR TITLE
[Core] overwrite evalDouble()/evalComplex() in number interfaces

### DIFF
--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Num.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Num.java
@@ -310,12 +310,6 @@ public class Num implements INum {
     return this;
   }
 
-  /** {@inheritDoc} */
-  @Override
-  public double evalDouble() {
-    return fDouble;
-  }
-
   @Override
   public ISignedNumber evalReal() {
     return this;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/interfaces/INumber.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/interfaces/INumber.java
@@ -1,7 +1,9 @@
 package org.matheclipse.core.interfaces;
 
 import org.apfloat.Apcomplex;
+import org.hipparchus.complex.Complex;
 import org.matheclipse.core.eval.EvalEngine;
+import org.matheclipse.core.eval.exception.ArgumentTypeException;
 import org.matheclipse.core.expression.ApcomplexNum;
 import org.matheclipse.core.expression.ComplexNum;
 import org.matheclipse.core.expression.F;
@@ -236,4 +238,9 @@ public interface INumber extends IExpr {
    * @return
    */
   public IAST toPolarCoordinates();
+
+  @Override
+  default Complex evalComplex() throws ArgumentTypeException {
+    return new Complex(reDoubleValue(), imDoubleValue());
+  }
 }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/interfaces/ISignedNumber.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/interfaces/ISignedNumber.java
@@ -1,6 +1,8 @@
 package org.matheclipse.core.interfaces;
 
 import org.apfloat.Apfloat;
+import org.hipparchus.complex.Complex;
+import org.matheclipse.core.eval.exception.ArgumentTypeException;
 import org.matheclipse.core.expression.ApfloatNum;
 import org.matheclipse.core.expression.F;
 import org.matheclipse.core.expression.S;
@@ -50,6 +52,16 @@ public interface ISignedNumber extends INumber {
    * @return the numeric value represented by this object after conversion to type {@code double}.
    */
   public double doubleValue();
+
+  @Override
+  default double evalDouble() throws ArgumentTypeException {
+    return doubleValue();
+  }
+
+  @Override
+  default Complex evalComplex() throws ArgumentTypeException {
+    return new Complex(doubleValue());
+  }
 
   @Override
   public IInteger ceilFraction() throws ArithmeticException;


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Overwriting `IExpr.evalDouble()` and `IExpr.evalComplex()` in `ISignedNumber` respectively overwriting `IExpr.evalComplex()` in `ISignedNumber` avoids the indirection that requires an `EvalEngine`. This change therefore should speed up the mentioned methods for instances of those interfaces.
