### PR TITLE
[Core] Use cached constant for int 1000 and move int-cache to IntegerSym

### DIFF
--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/AbstractIntegerSym.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/AbstractIntegerSym.java
@@ -51,17 +51,6 @@ import it.unimi.dsi.fastutil.ints.IntList;
 public abstract class AbstractIntegerSym implements IInteger, Externalizable {
   private static final Logger LOGGER = LogManager.getLogger();
 
-  static final int low = -128;
-  static final int high = 128;
-  static final IntegerSym cache[];
-
-  static {
-    cache = new IntegerSym[(high - low) + 1];
-    int j = low;
-    for (int k = 0; k < cache.length; k++) {
-      cache[k] = new IntegerSym(j++);
-    }
-  }
   /** The BigInteger constant minus one. */
   public static final BigInteger BI_MINUS_ONE = BigInteger.valueOf(-1L);
 
@@ -228,7 +217,12 @@ public abstract class AbstractIntegerSym implements IInteger, Externalizable {
     if (newnum == Integer.MIN_VALUE) {
       return new BigIntegerSym(newnum);
     }
-    return (newnum >= low && newnum <= high) ? cache[newnum + (-low)] : new IntegerSym(newnum);
+    if (newnum == 1000) {
+      return F.C1000;
+    }
+    return (newnum >= IntegerSym.LOW && newnum <= IntegerSym.HIGH)
+        ? IntegerSym.CACHE[newnum + (-IntegerSym.LOW)]
+        : new IntegerSym(newnum);
   }
 
   public static IInteger valueOf(final long newnum) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/F.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/F.java
@@ -519,7 +519,7 @@ public class F extends S {
   public static final IInteger C100 = AbstractIntegerSym.valueOf(100);
 
   /** Constant integer &quot;1000&quot; */
-  public static final IInteger C1000 = AbstractIntegerSym.valueOf(1000);
+  public static final IInteger C1000 = new IntegerSym(1000);
 
   /**
    * Complex imaginary unit. The parsed symbol &quot;I&quot; is converted on input to this constant.

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/IntegerSym.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/IntegerSym.java
@@ -27,8 +27,19 @@ import com.google.common.math.LongMath;
  */
 public class IntegerSym extends AbstractIntegerSym {
 
-  /** */
   private static final long serialVersionUID = 6389228668633533063L;
+
+  static final int LOW = -128;
+  static final int HIGH = 128;
+  static final IntegerSym[] CACHE;
+
+  static {
+    CACHE = new IntegerSym[(HIGH - LOW) + 1];
+    int j = LOW;
+    for (int k = 0; k < CACHE.length; k++) {
+      CACHE[k] = new IntegerSym(j++);
+    }
+  }
 
   /* package private */ int fIntValue;
 


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

This PR ensures that the constant for the integer value 1000 from `F` is used in `AbstractIntegerSym.valueOf()`. 1000 is a commonly used constant when it comes to conversion of SI Units and it is the only integer constant not covered by the integer-expression cache. Using the cached constant can reduce the number of created objects.

Furthermore the `CACHE` of `IntegerSym` is moved to `IntegerSym` because it can cause classloading issues if a sub-class is referenced during the initialization of the super class.