### PR TITLE
[ReadMe] add Maven-Central badges and only use pure Markdown

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,13 @@
 ## Symja Library - Java Symbolic Math System for Android NCalc calculator
 
-<p align="left">
-<a href="https://discord.gg/tYknzr2qam" target="blank"><img src="https://img.shields.io/discord/869895703718166529.svg?color=7289da&label=Join our Discord&logo=discord&style=for-the-badge" alt="Join our Discord" />&nbsp;
-<a href="https://hub.docker.com/r/symja/symja-2.0" target="blank"><img src="https://img.shields.io/docker/pulls/symja/symja-2.0?logo=docker&style=for-the-badge" alt="Symja" />
-</p>
- 
-[![LGTM Alerts](https://img.shields.io/lgtm/alerts/github/axkr/symja_android_library)](https://lgtm.com/projects/g/axkr/symja_android_library/) [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/axkr/symja_android_library)
+[![Join our Discord](https://img.shields.io/discord/869895703718166529?color=7289da&label=Join%20our%20Discord&logo=discord&style=for-the-badge)](https://discord.gg/tYknzr2qam)
+[![Symja](https://img.shields.io/docker/pulls/symja/symja-2.0?logo=docker&style=for-the-badge)](https://hub.docker.com/r/symja/symja-2.0)
+[![Maven Central](https://img.shields.io/maven-central/v/org.matheclipse/matheclipse?style=for-the-badge)](https://search.maven.org/search?q=g:org.matheclipse)
+
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/axkr/symja_android_library)
+[![LGTM Alerts](https://img.shields.io/lgtm/alerts/github/axkr/symja_android_library)](https://lgtm.com/projects/g/axkr/symja_android_library/)
+[![Build Master Snapshot](https://github.com/axkr/symja_android_library/actions/workflows/maven-build-master-and-publish-snapshot.yml/badge.svg)](https://github.com/axkr/symja_android_library/actions/workflows/maven-build-master-and-publish-snapshot.yml)
+[![Sonatype Nexus (Snapshots)](https://img.shields.io/nexus/s/org.matheclipse/matheclipse?server=https%3A%2F%2Foss.sonatype.org)](https://oss.sonatype.org/content/repositories/snapshots/org/matheclipse/)
 
 **Note**: this repository contains the **Java 11** version of the project. The [NCalc](https://github.com/tranleduy2000/ncalc) Android calculator project 
 maintains a **[Java 7 Android branch](https://github.com/tranleduy2000/symja_android_library)** of the [Android *.AAR library](https://github.com/tranleduy2000/symja_android_library/releases).


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

This PR adds Badges to the readme.md for the latest Symja release available on Maven-Central (in the first row) as well as a badge for the master build state and the latest snapshot version in the OSSRH nexus repo.

Finally it looks like this:
![grafik](https://user-images.githubusercontent.com/44067969/158023965-5e4b9006-7671-4d38-aac0-f3788e4421b0.png)
