### PR TITLE
[RelEng] use changelog-updater-action to prepare for subsequent releases

### DIFF
--- a/.github/workflows/maven-perform-release.yml
+++ b/.github/workflows/maven-perform-release.yml
@@ -32,35 +32,21 @@ jobs:
 
     - run: mvn -f symja_android_library -B release:clean release:prepare -DpushChanges=false
 
-    - name: Read release version and date
+    - name: Read release version
       run: | # Create environment variables associcated to release version, derived from the release tag
         releaseGitTag=$(git describe --abbrev=0)
         echo "release_tag=${releaseGitTag}" >> $GITHUB_ENV
         echo "release_version=${releaseGitTag#v}" >> $GITHUB_ENV
-        echo "release_date=$(date +"%Y-%m-%d")" >> $GITHUB_ENV
 
     # Edit the 'release' commit with updates of the changelog:
     - name: Checkout release commit
       run: git checkout ${{ env.release_tag }} # headless checkout!
 
     - name: Finalize changelog entry
-      uses: jacobtomlinson/gha-find-replace@v2
+      uses: stefanzweifel/changelog-updater-action@v1
+      id: "update-changelog"
       with:
-        include: "**CHANGELOG.md"
-        find: '## \[Unreleased\]'
-        replace: "
-          ## [Unreleased](https://github.com/${{ github.repository }}/compare/${{ env.release_tag }}...HEAD)\n
-          \n
-          \n
-          ## [${{ env.release_version }}](https://github.com/${{ github.repository }}/releases/tag/${{ env.release_tag }}) - ${{ env.release_date }}
-          "
-
-    - name: Compose release entry marker
-      run: |
-        text="${{ env.release_version }} - ${{ env.release_date }}"
-        marker=${text//./}		# remove dots
-        marker=${marker// /-}	# replace space by dash
-        echo "release_marker=${marker}" >> $GITHUB_ENV
+        latest-version: ${{ env.release_tag }}
 
     - name: Amend release commit and tag and cherry-pick preparation commit
       run: |
@@ -101,14 +87,15 @@ jobs:
           
           This release is available on Maven central using the following coordinates:
           ```
-          <dependencies>
-          	<dependency>
-          		<groupId>org.matheclipse</groupId>
-          		<artifactId>matheclipse</artifactId>
-          		<version>${{ env.release_version }}</version>
-          	</dependency>
-          </dependencies>
+          <dependency>
+          	<groupId>org.matheclipse</groupId>
+          	<artifactId>matheclipse-core</artifactId>
+          	<version>${{ env.release_version }}</version>
+          </dependency>
           ```
-          For more informations see the [changelog of Symja ${{ env.release_version }}](CHANGELOG.md#${{ env.release_marker }}).
+          You can obtain the other Symja-modules using their corresponding `artifactId`.
+          
+          See the [changelog for Symja ${{ env.release_version }}](CHANGELOG.md${{ steps.update-changelog.outputs.release_url_fragment }}) for all noteworthy changes.
+          The exact changes are: ${{ steps.update-changelog.outputs.release_compare_url }}
           
           Thanks to everyone who contributed to this release!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,29 +2,27 @@
 
 Noteworthy changes are documented in this file.
 
+## [Unreleased](https://github.com/axkr/symja_android_library/compare/v2.0.0...HEAD)
 
- ## [Unreleased](https://github.com/axkr/symja_android_library/compare/v2.0.0...HEAD)
- 
- 
- ## [2.0.0](https://github.com/axkr/symja_android_library/releases/tag/v2.0.0) - 2022-03-12 
+## [v2.0.0](https://github.com/axkr/symja_android_library/releases/tag/v2.0.0) - 2022-03-12
 
 - Java 11 required
 - first Maven Central release (contributed by [@HannesWell](https://github.com/HannesWell))
 - Maven modules matheclipse-parser, matheclipse-logging, matheclipse-core are LGPL licensed
 - Maven modules matheclipse-gpl and dependents are GPL licensed
-- Symja script engine moved to Maven module matheclipse-script 
+- Symja script engine moved to Maven module matheclipse-script
 - unified/refactored logging - moved basics into new matheclipse-logging Maven module (contributed by [@HannesWell](https://github.com/HannesWell))
 - new matheclipse-jar Maven module to create docker container: https://hub.docker.com/r/symja/symja-2.0
 - new matheclipse-discord Maven module for a discord bot based on `Discord4J`
 - improved graphical output in browser apps: https://github.com/axkr/symja_android_library/wiki/Browser-apps
 - browser app Javascript graphics now contains a `jsfiddle` button to analyze the generated `jsxgraph`, `mathcell` and `plotly` iframe sources.
 - improved JSON API: https://github.com/axkr/symja_android_library/wiki/API
-- pattern-matching made more compatible with Mathematica pattern-matching 
+- pattern-matching made more compatible with Mathematica pattern-matching
 - improved rationalization of Java `double` numbers in `Rationalize`
 - improved `FindMinimum, FindMaximum, FindRoot`
 - new `IAST` interface implementation `ASTRRBTree` uses "structural sharing" similar like collections in Scala or Clojure for example for improved `Expand` performance for very large expressions.
 - new functions:  `BioSequence, BioSequenceQ`
-- new functions: `ApplySides, AddSides, DivideSides, MultiplySides, SubtractSides` 
+- new functions: `ApplySides, AddSides, DivideSides, MultiplySides, SubtractSides`
 - improvements for expressions objects: `Association, Dataset, Graph, Quantity, SparseArray`
 - improvements in `PiecewiseExpand, PossibleZeroQ, Solve, Eliminate, FunctionExpand, FullSimplify` functions
 - new `CarlsonRD, CarlsonRF, CarlsonRG, CarlsonRJ,...` functions
@@ -33,8 +31,8 @@ Noteworthy changes are documented in this file.
 - improved String Regex functions for example in `StringSplit, StringReplace` functions
 - uses Janino compiler for `Compile` function: https://github.com/janino-compiler/janino; improved `CompilePrint` function
 
-
 ### Contributers
+
 - [@axkr](https://github.com/axkr)
 - [@HannesWell](https://github.com/HannesWell)
 - [@shaunlebron](https://github.com/shaunlebron)


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

This prepares the release process of Symja for subsequent releases by using [stefanzweifel/changelog-updater-action](https://github.com/stefanzweifel/changelog-updater-action) with the latest enhancements.

Furthermore it formats the changelog.md (which will also be done by the mentioned action during release).

Maybe there will be more improvements in the mentioned action that can be leveraged to simplify the creation of the link in the GH release to the changelog-entry, which is why this is a draft for now.