### PR TITLE
Fix incorrect endIndex in HMArrayList.stream()

### DIFF
--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/HMArrayList.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/HMArrayList.java
@@ -94,9 +94,6 @@ public abstract class HMArrayList extends AbstractAST
     firstIndex = hashValue = 0;
     lastIndex = arguments.length + 1;
     switch (lastIndex) {
-      case 0:
-        array = new IExpr[] {headExpr};
-        break;
       case 1:
         array = new IExpr[] {headExpr};
         break;
@@ -1071,7 +1068,7 @@ public abstract class HMArrayList extends AbstractAST
 
   @Override
   public Stream<IExpr> stream() {
-    return Arrays.stream(array, firstIndex + 1, lastIndex - firstIndex);
+    return Arrays.stream(array, firstIndex + 1, lastIndex);
   }
 
   @Override


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

The method `Arrays.stream(T[] array, int startInclusive, int endExclusive)` takes the exclusive end-Index as last element, not the length of the stream. This PR adjusts the arguments accordingly.
