### PR TITLE
Rename method name

### DIFF
--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/EvalEngine.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/EvalEngine.java
@@ -1554,7 +1554,7 @@ public class EvalEngine implements Serializable {
    * @param ast
    * @return <code>F.NIL</code> if no evaluation was possible
    */
-  public IAST evalFlatOrderlessAttributesRecursive(final IAST ast) {
+  public IAST evalFlatOrderlessAttrsRecursive(final IAST ast) {
     if (ast.isEvalFlagOn(IAST.IS_FLAT_ORDERLESS_EVALED)) {
       return F.NIL;
     }
@@ -1572,7 +1572,7 @@ public class EvalEngine implements Serializable {
           IExpr expr = ast.arg1();
           if (ast.arg1().isAST()) {
             IAST temp = (IAST) ast.arg1();
-            expr = evalFlatOrderlessAttributesRecursive(temp);
+            expr = evalFlatOrderlessAttrsRecursive(temp);
             if (expr.isPresent()) {
               resultList = ast.setAtCopy(1, expr);
             } else {
@@ -1587,7 +1587,7 @@ public class EvalEngine implements Serializable {
           for (int i = 2; i < astSize; i++) {
             if (ast.get(i).isAST()) {
               IAST temp = (IAST) ast.get(i);
-              IExpr expr = evalFlatOrderlessAttributesRecursive(temp);
+              IExpr expr = evalFlatOrderlessAttrsRecursive(temp);
               if (expr.isPresent()) {
                 if (resultList.isNIL()) {
                   resultList = ast.copy();


### PR DESCRIPTION
Thanks for contributing.

- [yes ] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description
I suggest to rename `evalFlatOrderlessAttributesRecursive` as `evalFlatOrderlessAttrsRecursive` by replacing full term `Attributes` with its well-known abbreviations. In addition, `Attrs` is widely used in this project. Such abbreviations are common and well-known, and thus employing such well-known abbreviation would not result in confusion, but may improve the readability of the source code.

Accordingly, I have renamed the method by applying rename method refactoring, and submitted the pull request. No other changes are involved in the PR.

Would you please kindly review the PR. Thanks.

## Testing

Did you add a unit test?
No
