### PR TITLE
Do not use default locale in String#toLowerCase() and String#toUpperCase() since it causes unpredictable behavior in some languages.

### DIFF
--- a/symja_android_library/matheclipse-api/src/main/java/org/matheclipse/api/Pods.java
+++ b/symja_android_library/matheclipse-api/src/main/java/org/matheclipse/api/Pods.java
@@ -4,12 +4,8 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+
 import org.apache.commons.codec.language.Soundex;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
@@ -133,12 +129,12 @@ public class Pods {
           IAST[] list = ElementData1.ELEMENTS;
           for (int i = 0; i < list.length; i++) {
             String keyWord = list[i].arg3().toString();
-            addElementData(list[i].arg2().toString().toLowerCase(), keyWord);
+            addElementData(list[i].arg2().toString().toLowerCase(Locale.US), keyWord);
             soundexElementData(list[i].arg3().toString(), keyWord);
           }
           for (int i = 0; i < ID.Zeta; i++) {
             ISymbol sym = S.symbol(i);
-            soundexHelp(sym.toString().toLowerCase(), sym);
+            soundexHelp(sym.toString().toLowerCase(Locale.US), sym);
           }
           // for (Map.Entry<String, String> entry : map.entrySet()) {
           // soundexHelp(entry.getKey(), entry.getKey());
@@ -1640,7 +1636,7 @@ public class Pods {
 
   private static ArrayList<IPod> listOfPods(String inputWord) {
     Map<String, ArrayList<IPod>> map = LAZY_SOUNDEX.get();
-    ArrayList<IPod> soundsLike = map.get(inputWord.toLowerCase());
+    ArrayList<IPod> soundsLike = map.get(inputWord.toLowerCase(Locale.US));
     if (soundsLike == null) {
       soundsLike = map.get(SOUNDEX.encode(inputWord));
     }
@@ -1684,7 +1680,7 @@ public class Pods {
         inExpr = flattenTimes((IAST) inExpr).orElse(inExpr);
         IAST rest = ((IAST) inExpr).setAtClone(0, S.List);
         IASTAppendable specialFunction = F.NIL;
-        String stemForm = getStemForm(rest.arg1().toString().toLowerCase());
+        String stemForm = getStemForm(rest.arg1().toString().toLowerCase(Locale.US));
         IExpr head = rest.head();
         if (stemForm != null) {
           head = STEM.getSymbol(stemForm);
@@ -1694,7 +1690,7 @@ public class Pods {
           }
         }
         if (specialFunction.isNIL()) {
-          stemForm = getStemForm(rest.last().toString().toLowerCase());
+          stemForm = getStemForm(rest.last().toString().toLowerCase(Locale.US));
           if (stemForm != null) {
             head = STEM.getSymbol(stemForm);
             if (head != null) {
@@ -1715,7 +1711,7 @@ public class Pods {
 
               int i = 1;
               while (i < specialFunction.size()) {
-                String argStr = specialFunction.get(i).toString().toLowerCase();
+                String argStr = specialFunction.get(i).toString().toLowerCase(Locale.US);
                 if (argStr.equalsIgnoreCase("by") || argStr.equalsIgnoreCase("for")) {
                   specialFunction.remove(i);
                   continue;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/AssumptionFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/AssumptionFunctions.java
@@ -15,6 +15,8 @@ import org.matheclipse.core.interfaces.IBuiltInSymbol;
 import org.matheclipse.core.interfaces.IExpr;
 import org.matheclipse.core.interfaces.ISymbol;
 
+import java.util.Locale;
+
 public class AssumptionFunctions {
   /**
    * See <a href="https://pangin.pro/posts/computation-in-static-initializer">Beware of computation
@@ -206,7 +208,7 @@ public class AssumptionFunctions {
         }
       }
       if (domain.isSymbol()) {
-        String domainString = domain.toString().toLowerCase();
+        String domainString = domain.toString().toLowerCase(Locale.US);
         if (domainString.equals("real") //
             || domainString.equals("prime") //
             || domainString.equals("integer") //

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/ConstantDefinitions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/ConstantDefinitions.java
@@ -418,7 +418,7 @@ public class ConstantDefinitions {
       if (operatingSystem == null) {
         return F.stringx("Unknown");
       }
-      operatingSystem = operatingSystem.toLowerCase();
+      operatingSystem = operatingSystem.toLowerCase(Locale.US);
       if (operatingSystem.contains("mac") //
           || operatingSystem.contains("os2") //
           || operatingSystem.contains("darwin")) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/GraphicsFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/GraphicsFunctions.java
@@ -1636,7 +1636,7 @@ public class GraphicsFunctions {
       if (value != null) {
         g.put("factor", option.evalf());
       } else {
-        g.put("symbol", option.toString().toLowerCase());
+        g.put("symbol", option.toString().toLowerCase(Locale.US));
       }
       ObjectNode aspectRatio = JSON_OBJECT_MAPPER.createObjectNode();
       aspectRatio.set("aspectRatio", g);

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/IOFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/IOFunctions.java
@@ -4,10 +4,8 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.StringWriter;
 import java.io.Writer;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -1274,7 +1272,7 @@ public class IOFunctions {
     }
     SuggestTree suggestTree = AST2Expr.getSuggestTree();
     // name = ParserConfig.PARSER_USE_LOWERCASE_SYMBOLS ? name.toLowerCase() : name;
-    name = name.toLowerCase();
+    name = name.toLowerCase(Locale.US);
     final String autocompleteStr = name;
     Node suggestions = suggestTree.getAutocompleteSuggestions(autocompleteStr);
     if (suggestions != null) {
@@ -1285,7 +1283,7 @@ public class IOFunctions {
           identifierStr = str;
         }
         if (exact) {
-          if (autocompleteStr.equals(identifierStr.toLowerCase())) {
+          if (autocompleteStr.equals(identifierStr.toLowerCase(Locale.US))) {
             return F.$s(identifierStr);
           }
           return F.NIL;
@@ -1302,7 +1300,7 @@ public class IOFunctions {
       return list;
     }
     SuggestTree suggestTree = AST2Expr.getSuggestTree();
-    namePrefix = ParserConfig.PARSER_USE_LOWERCASE_SYMBOLS ? namePrefix.toLowerCase() : namePrefix;
+    namePrefix = ParserConfig.PARSER_USE_LOWERCASE_SYMBOLS ? namePrefix.toLowerCase(Locale.US) : namePrefix;
     Node n = suggestTree.getAutocompleteSuggestions(namePrefix);
     if (n != null) {
       for (int i = 0; i < n.listLength(); i++) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/StatisticsFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/StatisticsFunctions.java
@@ -2,6 +2,7 @@ package org.matheclipse.core.builtin;
 
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.Locale;
 import java.util.Random;
 import java.util.function.DoubleUnaryOperator;
 import java.util.function.Predicate;
@@ -6213,7 +6214,7 @@ public class StatisticsFunctions {
     private static IExpr printMessageUdist(ISymbol head, final IAST ast, IAST dist,
         EvalEngine engine) {
       // The specification `1` is not a random distribution recognized by the system.
-      if (head.getSymbolName().toLowerCase().endsWith("distribution")) {
+      if (head.getSymbolName().toLowerCase(Locale.US).endsWith("distribution")) {
         return IOFunctions.printMessage(ast.topHead(), "udist", F.list(dist), engine);
       }
       return F.NIL;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/StringFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/StringFunctions.java
@@ -4,10 +4,7 @@ import java.io.File;
 import java.io.StringReader;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -687,7 +684,7 @@ public final class StringFunctions {
         }
 
         if (ignoreCase) {
-          return F.ZZ(hammingDistance.apply(str1.toLowerCase(), str2.toLowerCase()));
+          return F.ZZ(hammingDistance.apply(str1.toLowerCase(Locale.US), str2.toLowerCase(Locale.US)));
         }
         return F.ZZ(hammingDistance.apply(str1, str2));
       }
@@ -820,7 +817,7 @@ public final class StringFunctions {
         return ast.arg1().mapThread(ast, 1);
       }
       if (ast.arg1().isString()) {
-        String characters = ast.arg1().toString().toLowerCase();
+        String characters = ast.arg1().toString().toLowerCase(Locale.US);
         String alphabet = LATIN_ALPHABET;
         if (ast.isAST2()) {
           String str = ast.arg2().toString();
@@ -1032,8 +1029,8 @@ public final class StringFunctions {
 
         LevenshteinDistance levenshteinDistance = new LevenshteinDistance();
         if (ignoreCase) {
-          return F.ZZ(levenshteinDistance.apply(arg1.toString().toLowerCase(),
-              arg2.toString().toLowerCase()));
+          return F.ZZ(levenshteinDistance.apply(arg1.toString().toLowerCase(Locale.US),
+              arg2.toString().toLowerCase(Locale.US)));
         }
         return F.ZZ(levenshteinDistance.apply(arg1.toString(), arg2.toString()));
       }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/convert/AST2Expr.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/convert/AST2Expr.java
@@ -353,17 +353,17 @@ public class AST2Expr {
         synchronized (SUGGEST_TREE) {
           for (String str : FUNCTION_STRINGS) {
             if (str.length() > 1) {
-              SUGGEST_TREE.put(str.toLowerCase(), 2);
+              SUGGEST_TREE.put(str.toLowerCase(Locale.US), 2);
             }
           }
           for (String str : SYMBOL_STRINGS) {
             if (str.length() > 1) {
-              SUGGEST_TREE.put(str.toLowerCase(), 1);
+              SUGGEST_TREE.put(str.toLowerCase(Locale.US), 1);
             }
           }
           for (String str : DOLLAR_STRINGS) {
             if (str.length() > 1) {
-              SUGGEST_TREE.put(str.toLowerCase(), 1);
+              SUGGEST_TREE.put(str.toLowerCase(Locale.US), 1);
             }
           }
         }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/S.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/S.java
@@ -1,6 +1,7 @@
 package org.matheclipse.core.expression;
 
 import java.util.IdentityHashMap;
+import java.util.Locale;
 import java.util.Map;
 import org.matheclipse.core.basic.Config;
 import org.matheclipse.core.interfaces.IBuiltInSymbol;
@@ -11274,7 +11275,7 @@ public class S {
   public static IBuiltInSymbol initFinalSymbol(final String symbolName, int ordinal) {
     String str;
     if (ParserConfig.PARSER_USE_LOWERCASE_SYMBOLS) {
-      str = (symbolName.length() == 1) ? symbolName : symbolName.toLowerCase();
+      str = (symbolName.length() == 1) ? symbolName : symbolName.toLowerCase(Locale.US);
     } else {
       str = symbolName;
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/StringX.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/StringX.java
@@ -525,7 +525,7 @@ public class StringX implements IStringX {
   /** @return */
   @Override
   public String toLowerCase() {
-    return fString.toLowerCase();
+    return fString.toLowerCase(Locale.US);
   }
 
   /**
@@ -544,7 +544,7 @@ public class StringX implements IStringX {
   /** @return */
   @Override
   public String toUpperCase() {
-    return fString.toUpperCase();
+    return fString.toUpperCase(Locale.US);
   }
 
   /**

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/tex/TeXFormFactory.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/tex/TeXFormFactory.java
@@ -2,6 +2,7 @@ package org.matheclipse.core.form.tex;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -885,7 +886,7 @@ public class TeXFormFactory {
         if (((IBuiltInSymbol) arg2).isSymbolID(ID.Black, ID.Brown, ID.Blue, ID.Cyan, ID.Green,
             ID.Pink, ID.Red, ID.Yellow, ID.White)) {
           buffer.append("\\textcolor{");
-          buffer.append(arg2.toString().toLowerCase());
+          buffer.append(arg2.toString().toLowerCase(Locale.US));
           buffer.append("}{");
           fFactory.convertInternal(buffer, arg1, Precedence.NO_PRECEDENCE, NO_PLUS_CALL);
           buffer.append("}");

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/graphics/GraphicsOptions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/graphics/GraphicsOptions.java
@@ -1,5 +1,6 @@
 package org.matheclipse.core.graphics;
 
+import java.util.Locale;
 import java.util.function.Function;
 import org.matheclipse.core.builtin.GraphicsFunctions;
 import org.matheclipse.core.convert.Convert;
@@ -75,7 +76,7 @@ public class GraphicsOptions {
   public static Function<IExpr, IExpr> getScaling(ArrayNode array, IExpr scale) {
     if (scale.isString()) {
       String scaleStr = scale.toString();
-      String lowerScaleStr = scale.toString().toLowerCase();
+      String lowerScaleStr = scale.toString().toLowerCase(Locale.US);
       if (scaleStr.equals("Log")) {
         array.add(lowerScaleStr);
         return x -> F.Log(x);

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/graphics/Show3D2ThreeJS.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/graphics/Show3D2ThreeJS.java
@@ -1,6 +1,8 @@
 package org.matheclipse.core.graphics;
 
 import java.io.IOException;
+import java.util.Locale;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.matheclipse.core.eval.EvalEngine;
@@ -90,7 +92,7 @@ public class Show3D2ThreeJS {
     IExpr option = options.getOption(S.ViewPoint);
     if (option.isPresent()) {
       if (option.isSymbol()) {
-        String viewpoint = option.toString().toLowerCase();
+        String viewpoint = option.toString().toLowerCase(Locale.US);
         if (viewpoint.equals("above")) {
           viewpoints[0] = 0.0;
           viewpoints[1] = 0.0;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/io/Extension.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/io/Extension.java
@@ -1,5 +1,7 @@
 package org.matheclipse.core.io;
 
+import java.util.Locale;
+
 /**
  * File extensions format.
  *
@@ -46,7 +48,7 @@ public enum Extension {
 
   public static boolean isAllowedExtension(String extensionString) {
     try {
-      Extension ext = valueOf(extensionString.toUpperCase());
+      Extension ext = valueOf(extensionString.toUpperCase(Locale.US));
       if (ext != null) {
         return true;
       }
@@ -67,7 +69,7 @@ public enum Extension {
     try {
       int pos = filename.lastIndexOf('.');
       if (pos >= 1) {
-        String ucExtension = filename.substring(pos + 1).toUpperCase();
+        String ucExtension = filename.substring(pos + 1).toUpperCase(Locale.US);
         if (ucExtension.equals("DATA")) {
           return DAT;
         }
@@ -97,14 +99,14 @@ public enum Extension {
       if (extensionString.equals("ExpressionJSON")) {
         return EXPRESSIONJSON;
       }
-      String ucExtension = extensionString.toUpperCase();
+      String ucExtension = extensionString.toUpperCase(Locale.US);
       if (ucExtension.equals("DATA")) {
         return DAT;
       }
       if (ucExtension.equals("JPG")) {
         return JPEG;
       }
-      return valueOf(extensionString.toUpperCase());
+      return valueOf(extensionString.toUpperCase(Locale.US));
     } catch (RuntimeException rex) {
       //
     }
@@ -122,7 +124,7 @@ public enum Extension {
     try {
       int pos = filename.lastIndexOf('.');
       if (pos >= 1) {
-        String extensionString = filename.substring(pos + 1).toUpperCase();
+        String extensionString = filename.substring(pos + 1).toUpperCase(Locale.US);
         if (extensionString.equals("TEXT")) {
           return TXT;
         }
@@ -149,7 +151,7 @@ public enum Extension {
    */
   public static Extension importExtension(String extensionString) {
     try {
-      return valueOf(extensionString.toUpperCase());
+      return valueOf(extensionString.toUpperCase(Locale.US));
     } catch (RuntimeException rex) {
       //
     }
@@ -168,6 +170,6 @@ public enum Extension {
    * @throws IllegalArgumentException if given string does not match any known file types
    */
   public static Extension of(String string) {
-    return valueOf(string.toUpperCase());
+    return valueOf(string.toUpperCase(Locale.US));
   }
 }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/tensor/img/ColorDataGradients.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/tensor/img/ColorDataGradients.java
@@ -1,6 +1,7 @@
 // code adapted from https://github.com/datahaki/tensor
 package org.matheclipse.core.tensor.img;
 
+import java.util.Locale;
 import java.util.Optional;
 import org.matheclipse.core.interfaces.IAST;
 import org.matheclipse.core.interfaces.IExpr;
@@ -135,7 +136,7 @@ public enum ColorDataGradients implements ColorDataGradient {
    * @throws Exception if this color data gradient is not backed by such a table
    */
   private IAST _tableRgba() {
-    return ResourceData.of("/img/colorscheme/" + name().toLowerCase() + ".csv");
+    return ResourceData.of("/img/colorscheme/" + name().toLowerCase(Locale.US) + ".csv");
   }
 
   /**

--- a/symja_android_library/matheclipse-core/src/test/java/org/matheclipse/core/config/LocaleTest.java
+++ b/symja_android_library/matheclipse-core/src/test/java/org/matheclipse/core/config/LocaleTest.java
@@ -1,0 +1,30 @@
+package org.matheclipse.core.config;
+
+import junit.framework.TestCase;
+import org.matheclipse.core.convert.AST2Expr;
+import org.matheclipse.core.expression.F;
+import org.matheclipse.parser.trie.SuggestTree;
+
+import java.util.Locale;
+
+public class LocaleTest extends TestCase {
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        Locale.setDefault(Locale.US);
+    }
+
+    public void test001() {
+        Locale turkishLang = Locale.forLanguageTag("tr");
+        Locale.setDefault(turkishLang);
+        F.initSymbols();
+        SuggestTree suggestTree = AST2Expr.getSuggestTree();
+        SuggestTree.Iterator iterator = suggestTree.iterator();
+        while (iterator.hasNext()) {
+            String term = iterator.next().getTerm();
+            assertFalse(term.contains("ı"));
+        }
+    }
+
+}

--- a/symja_android_library/matheclipse-core/src/test/java/org/matheclipse/core/config/SystemConfigurationTest.java
+++ b/symja_android_library/matheclipse-core/src/test/java/org/matheclipse/core/config/SystemConfigurationTest.java
@@ -1,0 +1,68 @@
+package org.matheclipse.core.config;
+
+import junit.framework.TestCase;
+import org.apfloat.Apfloat;
+import org.apfloat.ApfloatContext;
+import org.apfloat.ApfloatMath;
+import org.apfloat.spi.FilenameGenerator;
+import org.matheclipse.core.eval.ExprEvaluator;
+import org.matheclipse.core.expression.ApfloatNum;
+import org.matheclipse.core.expression.F;
+import org.matheclipse.core.form.output.OutputFormFactory;
+import org.matheclipse.core.interfaces.IExpr;
+import org.matheclipse.core.interfaces.IInteger;
+
+import java.util.Locale;
+
+public class SystemConfigurationTest extends TestCase {
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        F.initSymbols();
+    }
+
+    public void testApfloatStorage() {
+        ApfloatContext.getContext().setFilenameGenerator(new FilenameGenerator("default", "0", "default") {
+            @Override
+            public synchronized String generateFilename() {
+                throw new UnsupportedOperationException();
+            }
+        });
+
+        try {
+            Apfloat apfloat = new Apfloat("9".repeat(1_000_000) + "." + "9".repeat(1_000_000));
+            apfloat = ApfloatMath.pow(apfloat, new Apfloat("91212312" + ".1231236"));
+            ApfloatNum apfloatNum = ApfloatNum.valueOf(apfloat);
+            IInteger integerPart = apfloatNum.integerPart();
+            System.out.println(integerPart.bitLength());
+            fail("Should be fail");
+        } catch (UnsupportedOperationException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void testOverflowError() {
+        String expr = "N(1.7*10^1,100)/N(2.5*10^1,100)*N(0,100)";
+        ExprEvaluator evaluator = new ExprEvaluator();
+        IExpr result = evaluator.eval(expr);
+        assertEquals(result.toString(), "0");
+    }
+
+    public void testOverflowError02() {
+        String expr = "ArcSin(N(1.7*10^1,100)/N(2.5*10^1,100)*N(0,100))";
+        ExprEvaluator evaluator = new ExprEvaluator();
+        IExpr result = evaluator.eval(expr);
+        assertEquals(result.toString(), "0");
+    }
+
+
+    public void testLocale() {
+        Locale.setDefault(Locale.forLanguageTag("tr"));
+        ExprEvaluator evaluator = new ExprEvaluator();
+        String input =  "TestIChar[x_] := Sin[x]; Definition[TestIChar]";
+        IExpr result = evaluator.eval(input);
+        String str = OutputFormFactory.get(true).toString(result);
+        assertEquals(str, "1");
+    }
+}

--- a/symja_android_library/matheclipse-core/src/test/java/org/matheclipse/core/config/SystemConfigurationTest.java
+++ b/symja_android_library/matheclipse-core/src/test/java/org/matheclipse/core/config/SystemConfigurationTest.java
@@ -56,13 +56,4 @@ public class SystemConfigurationTest extends TestCase {
         assertEquals(result.toString(), "0");
     }
 
-
-    public void testLocale() {
-        Locale.setDefault(Locale.forLanguageTag("tr"));
-        ExprEvaluator evaluator = new ExprEvaluator();
-        String input =  "TestIChar[x_] := Sin[x]; Definition[TestIChar]";
-        IExpr result = evaluator.eval(input);
-        String str = OutputFormFactory.get(true).toString(result);
-        assertEquals(str, "1");
-    }
 }

--- a/symja_android_library/matheclipse-external/src/main/java/com/baeldung/algorithms/romannumerals/RomanArabicConverter.java
+++ b/symja_android_library/matheclipse-external/src/main/java/com/baeldung/algorithms/romannumerals/RomanArabicConverter.java
@@ -1,6 +1,7 @@
 package com.baeldung.algorithms.romannumerals;
 
 import java.util.List;
+import java.util.Locale;
 
 /**
  * @see <a href="https://www.baeldung.com/java-convert-roman-arabic">Baeldung: Converting Between
@@ -11,7 +12,7 @@ public class RomanArabicConverter {
   public static final int MAX_VALUE = 4000;
 
   public static int romanToArabic(String input) {
-    String romanNumeral = input.toUpperCase();
+    String romanNumeral = input.toUpperCase(Locale.US);
     int result = 0;
 
     List<RomanNumeral> romanNumerals = RomanNumeral.getReverseSortedValues();

--- a/symja_android_library/matheclipse-external/src/main/java/tech/tablesaw/plotly/components/Grid.java
+++ b/symja_android_library/matheclipse-external/src/main/java/tech/tablesaw/plotly/components/Grid.java
@@ -2,6 +2,7 @@ package tech.tablesaw.plotly.components;
 
 import com.google.common.base.Preconditions;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 public class Grid extends Component {
@@ -13,7 +14,7 @@ public class Grid extends Component {
 
     @Override
     public String toString() {
-      return this.name().toLowerCase().replaceAll("_", " ");
+      return this.name().toLowerCase(Locale.US).replaceAll("_", " ");
     }
   }
 
@@ -25,7 +26,7 @@ public class Grid extends Component {
 
     @Override
     public String toString() {
-      return this.name().toLowerCase().replaceAll("_", " ");
+      return this.name().toLowerCase(Locale.US).replaceAll("_", " ");
     }
   }
 
@@ -37,7 +38,7 @@ public class Grid extends Component {
 
     @Override
     public String toString() {
-      return this.name().toLowerCase().replaceAll("_", " ");
+      return this.name().toLowerCase(Locale.US).replaceAll("_", " ");
     }
   }
 
@@ -47,7 +48,7 @@ public class Grid extends Component {
 
     @Override
     public String toString() {
-      return this.name().toLowerCase();
+      return this.name().toLowerCase(Locale.US);
     }
   }
 

--- a/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/builtin/SwingFunctions.java
+++ b/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/builtin/SwingFunctions.java
@@ -13,6 +13,7 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.function.Consumer;
 import javax.swing.AbstractAction;
 import javax.swing.JButton;
@@ -141,7 +142,7 @@ public class SwingFunctions {
     @Override
     public IExpr evaluate(final IAST ast, EvalEngine engine) {
       if (Desktop.isDesktopSupported() && ast.arg1().isString()) {
-        String type = ast.arg1().toString().toLowerCase();
+        String type = ast.arg1().toString().toLowerCase(Locale.US);
         if (type.equals("fileopen")) {
           JFileChooser j = new JFileChooser(FileSystemView.getFileSystemView().getHomeDirectory());
           j.setApproveButtonText("Open");
@@ -528,7 +529,7 @@ public class SwingFunctions {
       exact = false;
     }
     SuggestTree suggestTree = AST2Expr.getSuggestTree();
-    name = ParserConfig.PARSER_USE_LOWERCASE_SYMBOLS ? name.toLowerCase() : name;
+    name = ParserConfig.PARSER_USE_LOWERCASE_SYMBOLS ? name.toLowerCase(Locale.US) : name;
     Node n = suggestTree.getAutocompleteSuggestions(name);
     if (n != null) {
       IASTAppendable list = F.ListAlloc(n.listLength());
@@ -552,7 +553,7 @@ public class SwingFunctions {
       return list;
     }
     SuggestTree suggestTree = AST2Expr.getSuggestTree();
-    namePrefix = ParserConfig.PARSER_USE_LOWERCASE_SYMBOLS ? namePrefix.toLowerCase() : namePrefix;
+    namePrefix = ParserConfig.PARSER_USE_LOWERCASE_SYMBOLS ? namePrefix.toLowerCase(Locale.US) : namePrefix;
     Node n = suggestTree.getAutocompleteSuggestions(namePrefix);
     if (n != null) {
       for (int i = 0; i < n.listLength(); i++) {

--- a/symja_android_library/matheclipse-io/src/main/java/tech/tablesaw/aggregate/Summarizer.java
+++ b/symja_android_library/matheclipse-io/src/main/java/tech/tablesaw/aggregate/Summarizer.java
@@ -20,6 +20,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import tech.tablesaw.api.CategoricalColumn;
@@ -382,7 +383,7 @@ public class Summarizer {
 
   private boolean tableDoesNotContain(String columnName, Table table) {
     List<String> upperCase =
-        table.columnNames().stream().map(String::toUpperCase).collect(Collectors.toList());
-    return !upperCase.contains(columnName.toUpperCase());
+        table.columnNames().stream().map(s -> s.toUpperCase(Locale.US)).collect(Collectors.toList());
+    return !upperCase.contains(columnName.toUpperCase(Locale.US));
   }
 }

--- a/symja_android_library/matheclipse-io/src/main/java/tech/tablesaw/api/Row.java
+++ b/symja_android_library/matheclipse-io/src/main/java/tech/tablesaw/api/Row.java
@@ -4,11 +4,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
+import java.util.*;
 
 import org.matheclipse.core.interfaces.IExpr;
 
@@ -41,7 +37,7 @@ public class Row implements Iterator<Row> {
     }
 
     T get(String columnName) {
-      T column = columnMap.get(columnName.toLowerCase());
+      T column = columnMap.get(columnName.toLowerCase(Locale.US));
       if (column == null) {
         throwWrongTypeError(columnName);
         throwColumnNotPresentError(columnName);
@@ -50,7 +46,7 @@ public class Row implements Iterator<Row> {
     }
 
     void put(String columnName, T column) {
-      columnMap.put(columnName.toLowerCase(), column);
+      columnMap.put(columnName.toLowerCase(Locale.US), column);
     }
 
     /**

--- a/symja_android_library/matheclipse-io/src/main/java/tech/tablesaw/api/Table.java
+++ b/symja_android_library/matheclipse-io/src/main/java/tech/tablesaw/api/Table.java
@@ -27,13 +27,8 @@ import io.github.classgraph.ClassGraph;
 import io.github.classgraph.ScanResult;
 import it.unimi.dsi.fastutil.ints.IntArrays;
 import it.unimi.dsi.fastutil.ints.IntComparator;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
-import java.util.NoSuchElementException;
+
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.IntFunction;
@@ -262,9 +257,9 @@ public class Table extends Relation implements Iterable<Row> {
         newColumn, "Attempted to add a null to the columns in table " + name);
     List<String> stringList = new ArrayList<>();
     for (String name : columnNames()) {
-      stringList.add(name.toLowerCase());
+      stringList.add(name.toLowerCase(Locale.US));
     }
-    if (stringList.contains(newColumn.name().toLowerCase())) {
+    if (stringList.contains(newColumn.name().toLowerCase(Locale.US))) {
       String message =
           String.format(
               "Cannot add column with duplicate name %s to table %s", newColumn.name(), name);

--- a/symja_android_library/matheclipse-io/src/main/java/tech/tablesaw/columns/strings/StringMapFunctions.java
+++ b/symja_android_library/matheclipse-io/src/main/java/tech/tablesaw/columns/strings/StringMapFunctions.java
@@ -20,6 +20,7 @@ import com.google.common.base.Strings;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 import tech.tablesaw.api.DoubleColumn;
 import tech.tablesaw.api.FloatColumn;
@@ -45,7 +46,7 @@ public interface StringMapFunctions extends Column<String> {
       if (value == null) {
         newColumn.append(StringColumnType.missingValueIndicator());
       } else {
-        newColumn.append(value.toUpperCase());
+        newColumn.append(value.toUpperCase(Locale.US));
       }
     }
     return newColumn;
@@ -57,7 +58,7 @@ public interface StringMapFunctions extends Column<String> {
 
     for (int r = 0; r < size(); r++) {
       String value = getString(r);
-      newColumn.append(value.toLowerCase());
+      newColumn.append(value.toLowerCase(Locale.US));
     }
     return newColumn;
   }

--- a/symja_android_library/matheclipse-io/src/main/java/tech/tablesaw/joining/DataFrameJoiner.java
+++ b/symja_android_library/matheclipse-io/src/main/java/tech/tablesaw/joining/DataFrameJoiner.java
@@ -2,10 +2,8 @@ package tech.tablesaw.joining;
 
 import com.google.common.collect.Streams;
 import com.google.common.primitives.Ints;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import tech.tablesaw.api.*;
@@ -815,14 +813,14 @@ public class DataFrameJoiner {
       Set<String> table1ColNames =
           Arrays.stream(cols)
               .map(Column::name)
-              .map(String::toLowerCase)
+              .map(s -> s.toLowerCase(Locale.US))
               .limit(table1.columnCount())
               .collect(Collectors.toSet());
 
       String table2Alias = TABLE_ALIAS + joinTableId.getAndIncrement();
       for (int c = table1.columnCount(); c < cols.length; c++) {
         String columnName = cols[c].name();
-        if (table1ColNames.contains(columnName.toLowerCase())) {
+        if (table1ColNames.contains(columnName.toLowerCase(Locale.US))) {
           cols[c].setName(newName(table2Alias, columnName));
         }
       }

--- a/symja_android_library/matheclipse-io/src/main/java/tech/tablesaw/sorting/Sort.java
+++ b/symja_android_library/matheclipse-io/src/main/java/tech/tablesaw/sorting/Sort.java
@@ -18,11 +18,9 @@ import static java.util.stream.Collectors.toSet;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+
+import java.util.*;
+
 import tech.tablesaw.api.Table;
 
 /**
@@ -74,23 +72,23 @@ public class Sort implements Iterable<Map.Entry<String, Sort.Order>> {
     Preconditions.checkArgument(columnNames.length > 0, "At least one sort column must provided.");
 
     Sort key = null;
-    Set<String> names = table.columnNames().stream().map(String::toUpperCase).collect(toSet());
+    Set<String> names = table.columnNames().stream().map(s -> s.toUpperCase(Locale.US)).collect(toSet());
 
     for (String columnName : columnNames) {
       Sort.Order order = Sort.Order.ASCEND;
-      if (!names.contains(columnName.toUpperCase())) {
+      if (!names.contains(columnName.toUpperCase(Locale.US))) {
         // the column name has been annotated with a prefix.
         // get the prefix which could be - or +
         String prefix = columnName.substring(0, 1);
         Optional<Order> orderOptional = getOrder(prefix);
 
         // Invalid prefix, column name exists on table.
-        if (!orderOptional.isPresent() && names.contains(columnName.substring(1).toUpperCase())) {
+        if (!orderOptional.isPresent() && names.contains(columnName.substring(1).toUpperCase(Locale.US))) {
           throw new IllegalStateException("Column prefix: " + prefix + " is unknown.");
         }
 
         // Valid prefix, column name does not exist on table.
-        if (orderOptional.isPresent() && !names.contains(columnName.substring(1).toUpperCase())) {
+        if (orderOptional.isPresent() && !names.contains(columnName.substring(1).toUpperCase(Locale.US))) {
           throw new IllegalStateException(
               String.format(
                   "Column %s does not exist in table %s", columnName.substring(1), table.name()));

--- a/symja_android_library/matheclipse-parser/src/main/java/org/matheclipse/parser/client/Console.java
+++ b/symja_android_library/matheclipse-parser/src/main/java/org/matheclipse/parser/client/Console.java
@@ -6,6 +6,8 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
 import org.matheclipse.parser.client.eval.DoubleEvaluator;
 import org.matheclipse.parser.client.math.MathException;
 
@@ -28,10 +30,10 @@ public class Console {
       try {
         expr = console.readString(System.out, ">> ");
         if (expr != null) {
-          if ((expr.length() >= 4) && expr.toLowerCase().substring(0, 4).equals("exit")) {
+          if ((expr.length() >= 4) && expr.toLowerCase(Locale.US).substring(0, 4).equals("exit")) {
             break;
           }
-          if ((expr.length() >= 6) && expr.toLowerCase().substring(0, 6).equals("double")) {
+          if ((expr.length() >= 6) && expr.toLowerCase(Locale.US).substring(0, 6).equals("double")) {
             // console.fComplexEvaluatorMode = false;
             System.out
                 .println("Double evaluation mode (switch to other mode with keyword 'complex')");

--- a/symja_android_library/matheclipse-parser/src/main/java/org/matheclipse/parser/client/eval/DoubleEvaluator.java
+++ b/symja_android_library/matheclipse-parser/src/main/java/org/matheclipse/parser/client/eval/DoubleEvaluator.java
@@ -14,6 +14,7 @@
 package org.matheclipse.parser.client.eval;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -434,16 +435,16 @@ public class DoubleEvaluator {
       if (SYMBOL_DOUBLE_MAP.get("pi") == null) {
         // init tables for relaxed mode
         for (Map.Entry<String, Double> entry : SYMBOL_DOUBLE_MAP.entrySet()) {
-          SYMBOL_DOUBLE_MAP.put(entry.getKey().toLowerCase(), entry.getValue());
+          SYMBOL_DOUBLE_MAP.put(entry.getKey().toLowerCase(Locale.US), entry.getValue());
         }
         for (Map.Entry<String, Boolean> entry : SYMBOL_BOOLEAN_MAP.entrySet()) {
-          SYMBOL_BOOLEAN_MAP.put(entry.getKey().toLowerCase(), entry.getValue());
+          SYMBOL_BOOLEAN_MAP.put(entry.getKey().toLowerCase(Locale.US), entry.getValue());
         }
         for (Map.Entry<String, Object> entry : FUNCTION_DOUBLE_MAP.entrySet()) {
-          FUNCTION_DOUBLE_MAP.put(entry.getKey().toLowerCase(), entry.getValue());
+          FUNCTION_DOUBLE_MAP.put(entry.getKey().toLowerCase(Locale.US), entry.getValue());
         }
         for (Map.Entry<String, Object> entry : FUNCTION_BOOLEAN_MAP.entrySet()) {
-          FUNCTION_BOOLEAN_MAP.put(entry.getKey().toLowerCase(), entry.getValue());
+          FUNCTION_BOOLEAN_MAP.put(entry.getKey().toLowerCase(Locale.US), entry.getValue());
         }
       }
     }
@@ -877,7 +878,7 @@ public class DoubleEvaluator {
    */
   public void defineVariable(String variableName, double value) {
     if (fRelaxedSyntax) {
-      fVariableMap.put(variableName.toLowerCase(), new DoubleVariable(value));
+      fVariableMap.put(variableName.toLowerCase(Locale.US), new DoubleVariable(value));
     } else {
       fVariableMap.put(variableName, new DoubleVariable(value));
     }
@@ -891,7 +892,7 @@ public class DoubleEvaluator {
    */
   public void defineVariable(String variableName, IDoubleValue value) {
     if (fRelaxedSyntax) {
-      fVariableMap.put(variableName.toLowerCase(), value);
+      fVariableMap.put(variableName.toLowerCase(Locale.US), value);
     } else {
       fVariableMap.put(variableName, value);
     }
@@ -904,7 +905,7 @@ public class DoubleEvaluator {
    */
   public void defineVariable(String variableName) {
     if (fRelaxedSyntax) {
-      fVariableMap.put(variableName.toLowerCase(), new DoubleVariable(0.0));
+      fVariableMap.put(variableName.toLowerCase(Locale.US), new DoubleVariable(0.0));
     } else {
       fVariableMap.put(variableName, new DoubleVariable(0.0));
     }
@@ -919,7 +920,7 @@ public class DoubleEvaluator {
    */
   public IDoubleValue getVariable(String variableName) {
     if (fRelaxedSyntax) {
-      return fVariableMap.get(variableName.toLowerCase());
+      return fVariableMap.get(variableName.toLowerCase(Locale.US));
     } else {
       return fVariableMap.get(variableName);
     }
@@ -933,7 +934,7 @@ public class DoubleEvaluator {
    */
   public void defineVariable(String variableName, BooleanVariable value) {
     if (fRelaxedSyntax) {
-      fBooleanVariables.put(variableName.toLowerCase(), value);
+      fBooleanVariables.put(variableName.toLowerCase(Locale.US), value);
     } else {
       fBooleanVariables.put(variableName, value);
     }

--- a/symja_android_library/matheclipse-parser/src/main/java/org/matheclipse/parser/client/operator/ASTNodeFactory.java
+++ b/symja_android_library/matheclipse-parser/src/main/java/org/matheclipse/parser/client/operator/ASTNodeFactory.java
@@ -15,6 +15,7 @@ package org.matheclipse.parser.client.operator;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import org.matheclipse.parser.client.ParserConfig;
 import org.matheclipse.parser.client.Scanner;
@@ -588,7 +589,7 @@ public class ASTNodeFactory implements INodeParserFactory {
     String name = symbolName;
     if (fIgnoreCase) {
       if (name.length() > 1) {
-        name = symbolName.toLowerCase();
+        name = symbolName.toLowerCase(Locale.US);
       }
     }
     // if (ParserConfig.RUBI_CONVERT_SYMBOLS) {

--- a/symja_android_library/tools/src/main/java/org/matheclipse/core/preprocessor/EnumGenerator.java
+++ b/symja_android_library/tools/src/main/java/org/matheclipse/core/preprocessor/EnumGenerator.java
@@ -2,6 +2,8 @@ package org.matheclipse.core.preprocessor;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Locale;
+
 import org.matheclipse.core.convert.AST2Expr;
 import org.matheclipse.core.interfaces.IStringX;
 
@@ -47,7 +49,7 @@ public class EnumGenerator {
       if (str.length() == 1) {
         System.out.print(" " + str + "( \"" + str + "\", " + i);
       } else {
-        System.out.print(" " + str + "( \"" + str.toLowerCase() + "\", " + i);
+        System.out.print(" " + str + "( \"" + str.toLowerCase(Locale.US) + "\", " + i);
       }
       if (i < list.size() - 1) {
         System.out.println(" ), //");

--- a/symja_android_library/tools/src/main/java/org/matheclipse/core/preprocessor/JavaObjectFunctionGenerator.java
+++ b/symja_android_library/tools/src/main/java/org/matheclipse/core/preprocessor/JavaObjectFunctionGenerator.java
@@ -3,6 +3,8 @@ package org.matheclipse.core.preprocessor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Locale;
+
 import org.matheclipse.core.convert.AST2Expr;
 import org.matheclipse.core.eval.interfaces.IFunctionEvaluator;
 import org.matheclipse.core.expression.F;
@@ -93,7 +95,7 @@ public class JavaObjectFunctionGenerator {
               continue;
             }
 
-            String lowerCaseArg = arg.toLowerCase();
+            String lowerCaseArg = arg.toLowerCase(Locale.US);
             if (KEYWORDS_SET.contains(lowerCaseArg)) {
               lowerCaseArg = "$" + lowerCaseArg;
             } else {

--- a/symja_android_library/tools/src/main/java/org/matheclipse/core/preprocessor/SymbolnamePreprocessor.java
+++ b/symja_android_library/tools/src/main/java/org/matheclipse/core/preprocessor/SymbolnamePreprocessor.java
@@ -1,6 +1,7 @@
 package org.matheclipse.core.preprocessor;
 
 import java.io.File;
+import java.util.Locale;
 
 /**
  * Generate java init sources for Symja symbol names.
@@ -29,7 +30,7 @@ public class SymbolnamePreprocessor {
           // we are only interested in .java files
           if (files[i].endsWith(".java")) {
             String className = files[i].substring(0, files[i].length() - 5);
-            String lcClassName = className.length() == 1 ? className : className.toLowerCase();
+            String lcClassName = className.length() == 1 ? className : className.toLowerCase(Locale.US);
 
             // public final static ISymbol Collect =
             // initFinalSymbol(Config.PARSER_USE_LOWERCASE_SYMBOLS ?
@@ -61,7 +62,7 @@ public class SymbolnamePreprocessor {
           // we are only interested in .m files
           if (files[i].endsWith(".java")) {
             String className = files[i].substring(0, files[i].length() - 5);
-            String lcClassName = className.length() == 1 ? className : className.toLowerCase();
+            String lcClassName = className.length() == 1 ? className : className.toLowerCase(Locale.US);
             // public final static ISymbol NestWhile =
             // initFinalSymbol(
             // Config.PARSER_USE_LOWERCASE_SYMBOLS ? "nestwhile" :

--- a/symja_android_library/tools/src/main/java/org/matheclipse/core/rubi/RubiASTNodeFactory.java
+++ b/symja_android_library/tools/src/main/java/org/matheclipse/core/rubi/RubiASTNodeFactory.java
@@ -7,6 +7,8 @@ import org.matheclipse.parser.client.ParserConfig;
 import org.matheclipse.parser.client.ast.SymbolNode;
 import org.matheclipse.parser.client.operator.ASTNodeFactory;
 
+import java.util.Locale;
+
 public class RubiASTNodeFactory extends ASTNodeFactory {
   public static final RubiASTNodeFactory RUBI_STYLE_FACTORY = new RubiASTNodeFactory(false);
 
@@ -19,7 +21,7 @@ public class RubiASTNodeFactory extends ASTNodeFactory {
     String name = symbolName;
     if (fIgnoreCase) {
       if (name.length() > 1) {
-        name = symbolName.toLowerCase();
+        name = symbolName.toLowerCase(Locale.US);
       }
     }
     if (Config.RUBI_CONVERT_SYMBOLS) {
@@ -36,7 +38,7 @@ public class RubiASTNodeFactory extends ASTNodeFactory {
       if (nodeStr.length() == 1) {
         return nodeStr;
       }
-      String lowercaseName = nodeStr.toLowerCase();
+      String lowercaseName = nodeStr.toLowerCase(Locale.US);
       String temp = AST2Expr.PREDEFINED_SYMBOLS_MAP.get(lowercaseName);
       if (temp != null) {
         if (!temp.equals(nodeStr)) {
@@ -55,7 +57,7 @@ public class RubiASTNodeFactory extends ASTNodeFactory {
           }
         }
       } else {
-        if (!nodeStr.equals(nodeStr.toLowerCase())) {
+        if (!nodeStr.equals(nodeStr.toLowerCase(Locale.US))) {
           temp = F.PREDEFINED_INTERNAL_FORM_STRINGS.get(nodeStr);
           if (temp == null) {
             if (lowercaseName.length() > 1) {


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Replace all `toLowerCase()` and `toUpperCase()` with `toLowerCase(Locale.US)` and `toUpperCase(Locale.US)` due to  these method calls cause unpredictable behavior in some languages, tested with Turkish.

For more details:

https://stackoverflow.com/questions/11063102/using-locales-with-javas-tolowercase-and-touppercase


## Testing

`org.matheclipse.core.config.LocaleTest`



