### PR TITLE
Add `IExpr#isMachineDouble` to make `IExpr#isRealVector` and `IExpr#isRealMatrix` works when list contains `ApfloatNum`

### DIFF
--- a/symja_android_library/.editorconfig
+++ b/symja_android_library/.editorconfig
@@ -1,3 +1,4 @@
 [*.java]
 indent_size = 2
 indent_style = space
+ij_java_doc_do_not_wrap_if_one_line = true

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/LinearAlgebra.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/LinearAlgebra.java
@@ -1731,10 +1731,6 @@ public final class LinearAlgebra {
           IExpr b = arg2.first();
           return F.TransformationFunction(F.Dot(a, b));
         }
-        IExpr temp = numericalDot(arg1, arg2);
-        if (temp.isPresent()) {
-          return temp;
-        }
 
         final IntList dimensions1 = dimensions(arg1, S.List, Integer.MAX_VALUE, true);
         final int dims1Size = dimensions1.size();
@@ -1792,6 +1788,12 @@ public final class LinearAlgebra {
             }
           }
         }
+
+        IExpr temp = numericalDot(arg1, arg2);
+        if (temp.isPresent()) {
+          return temp;
+        }
+
 
         return S.Inner.ofNIL(EvalEngine.get(), S.Times, arg1, arg2, S.Plus);
       } catch (IllegalArgumentException iae) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/AbstractAST.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/AbstractAST.java
@@ -4283,9 +4283,10 @@ public abstract class AbstractAST implements IASTMutable, Cloneable {
           dim[1] = row.argSize();
           boolean containsNum = false;
           for (int j = 1; j < row.size(); j++) {
-            if (row.get(j).isReal()) {
-              if (row.get(j) instanceof INum) {
-                if (!(row.get(j) instanceof Num)) {
+            IExpr argJ = row.get(j);
+            if (argJ.isReal()) {
+              if (argJ instanceof INum) {
+                if (!argJ.isMachineDouble()) {
                   // Apfloat number
                   return false;
                 }
@@ -4307,9 +4308,10 @@ public abstract class AbstractAST implements IASTMutable, Cloneable {
               return false;
             }
             for (int j = 1; j < row.size(); j++) {
-              if (row.get(j).isReal()) {
-                if (row.get(j) instanceof INum) {
-                  if (!(row.get(j) instanceof Num)) {
+              IExpr argJ = row.get(j);
+              if (argJ.isReal()) {
+                if (argJ instanceof INum) {
+                  if (!argJ.isMachineDouble()) {
                     // Apfloat number
                     return false;
                   }
@@ -4383,9 +4385,10 @@ public abstract class AbstractAST implements IASTMutable, Cloneable {
     if (isList()) {
       boolean containsNum = false;
       for (int i = 1; i < size(); i++) {
-        if (get(i).isReal()) {
-          if (get(i) instanceof INum) {
-            if (!(get(i) instanceof Num)) {
+        IExpr arg = get(i);
+        if (arg.isReal()) {
+          if (arg instanceof INum) {
+            if (!arg.isMachineDouble()) {
               return false;
             }
             containsNum = true;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/ApfloatNum.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/ApfloatNum.java
@@ -434,6 +434,13 @@ public class ApfloatNum implements INum {
   }
 
   @Override
+  public boolean isMachineDouble() {
+    double value = this.fApfloat.doubleValue();
+    return Double.isFinite(value);
+  }
+
+
+  @Override
   public IExpr sqrt() {
     if (isNegative()) {
       return F.complexNum(EvalEngine.getApfloat().sqrt(apcomplexValue()));

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Num.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Num.java
@@ -503,6 +503,11 @@ public class Num implements INum {
     return valueOf(1 / value);
   }
 
+  @Override
+  public boolean isMachineDouble() {
+    return true;
+  }
+
   /** {@inheritDoc} */
   @Override
   public long determinePrecision() {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/NumberUtil.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/NumberUtil.java
@@ -630,4 +630,7 @@ public class NumberUtil {
       throw new ArithmeticException("BigInteger out of long range");
   }
 
+  public static boolean isMachineDouble(double v) {
+    return !Double.isNaN(v) && !Double.isInfinite(v) && Double.isFinite(v);
+  }
 }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/interfaces/IExpr.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/interfaces/IExpr.java
@@ -2819,6 +2819,13 @@ public interface IExpr
   }
 
   /**
+   * @return true if this expression can store in Java Double
+   */
+  default boolean isMachineDouble() {
+    return false;
+  }
+
+  /**
    * If this object mathematical has a negative integer number as the result return
    * <code>true</code>.
    * 

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/interfaces/IReal.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/interfaces/IReal.java
@@ -6,6 +6,7 @@ import org.hipparchus.util.Binary64;
 import org.matheclipse.core.eval.exception.ArgumentTypeException;
 import org.matheclipse.core.expression.ApfloatNum;
 import org.matheclipse.core.expression.F;
+import org.matheclipse.core.expression.NumberUtil;
 import org.matheclipse.core.expression.S;
 
 /**

--- a/symja_android_library/matheclipse-core/src/test/java/org/matheclipse/core/system/LinearAlgebraTestCase.java
+++ b/symja_android_library/matheclipse-core/src/test/java/org/matheclipse/core/system/LinearAlgebraTestCase.java
@@ -334,12 +334,12 @@ public class LinearAlgebraTestCase extends ExprEvaluatorTestCase {
 
     // message Dot: Nonrectangular tensor encountered
     check("Dot({{0,2},{-8,2}},{{{0},0},{0,3}})", //
-        "{{0,2},\n" //
-            + " {-8,2}}.{{{0},0},{0,3}}");
+        "{{0,2}," //
+            + "{-8,2}}.{{{0},0},{0,3}}");
 
     // message Dot: Tensors {{}} and {{}} have incompatible shapes.
     check("{{}}.{{}}", //
-        "{{}}.\n" + "{{}}");
+        "{{}}." + "{{}}");
 
 
     check("#1.#123 // FullForm", //
@@ -359,7 +359,7 @@ public class LinearAlgebraTestCase extends ExprEvaluatorTestCase {
     check("Dimensions(c.a.b.c)", //
         "{3,5}");
     check("{}.{{}}", //
-        "{}.\n" + "{{}}");
+        "{}." + "{{}}");
     check("{}.{ }", //
         "0");
     check("{}.{4,5.0,6}", //
@@ -368,13 +368,13 @@ public class LinearAlgebraTestCase extends ExprEvaluatorTestCase {
         "HoldForm(Times(Times(0.17583681`, 0.41125407852`), 0.0`))");
 
     check("{{1, 2}, {3.0, 4}, {5, 6}}.{1,1}", //
-        "{3.0,7.0,11.0}");
+        "{3,7.0,11}");
     check("{{1, 2}, {3.0, 4}, {5, 6}}.{{1},{1}}", //
-        "{{3.0},\n" + " {7.0},\n" + " {11.0}}");
+        "{{3},\n" + " {7.0},\n" + " {11}}");
     check("{1,1,1}.{{1, 2}, {3.0, 4}, {5, 6}}", //
-        "{9.0,12.0}");
+        "{9.0,12}");
     check("{{1,1,1}}.{{1, 2}, {3.0, 4}, {5, 6}}", //
-        "{{9.0,12.0}}");
+        "{{9.0,12}}");
     check("{1,2,3.0}.{4,5.0,6}", //
         "32.0");
 

--- a/symja_android_library/matheclipse-core/src/test/java/org/matheclipse/core/system/LowercaseTestCase.java
+++ b/symja_android_library/matheclipse-core/src/test/java/org/matheclipse/core/system/LowercaseTestCase.java
@@ -3332,6 +3332,9 @@ public class LowercaseTestCase extends ExprEvaluatorTestCase {
     // distinct elements 5. Only 5 elements will be returned.
     check("Commonest({b, a, c, 2, a, b, 1, 2}, 6)", //
         "{b,a,2,c,1}");
+
+    check("Commonest({1, 1, N[2, 300], N[4,400], 4})", //
+      "{1.0,4.0}");
   }
 
   public void testComplement() {
@@ -22367,6 +22370,8 @@ public class LowercaseTestCase extends ExprEvaluatorTestCase {
         "2.27183");
     check("StandardDeviation(LogNormalDistribution(0, 1))", //
         "Sqrt((-1+E)*E)");
+    check("StandardDeviation({7, -5, N[101, 100], 100})", //
+      "57.65630928181234");
   }
 
   public void testStieltjesGamma() {


### PR DESCRIPTION
Add `IExpr#isMachineDouble` to make `IExpr#isRealVector` and `IExpr#isRealMatrix` works when list contains `ApfloatNum`

Did you add a unit test?

See `NumberTest.java`

