### PR TITLE
Replace Guava with standard Java where easily possible

### DIFF
--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/GraphFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/GraphFunctions.java
@@ -60,7 +60,6 @@ import org.matheclipse.core.interfaces.IInteger;
 import org.matheclipse.core.interfaces.INum;
 import org.matheclipse.core.interfaces.ISymbol;
 import com.google.common.collect.Sets;
-import com.google.common.collect.Sets.SetView;
 
 /** Functions for graph theory algorithms. */
 public class GraphFunctions {
@@ -184,7 +183,7 @@ public class GraphFunctions {
       for (IExpr v : Sets.intersection(graph1.vertexSet(), graph2.vertexSet())) {
         resultGraph.addVertex(v);
       }
-      SetView<? extends IExprEdge> graphSet = Sets.intersection(graph1.edgeSet(), graph2.edgeSet());
+      Set<? extends IExprEdge> graphSet = Sets.intersection(graph1.edgeSet(), graph2.edgeSet());
       for (IExprEdge e : graphSet) {
         IExpr v1 = e.lhs();
         IExpr v2 = e.rhs();
@@ -283,7 +282,7 @@ public class GraphFunctions {
       for (IExpr v : Sets.union(graph1.vertexSet(), graph2.vertexSet())) {
         resultGraph.addVertex(v);
       }
-      SetView<? extends IExprEdge> graphSet = Sets.difference(graph1.edgeSet(), graph2.edgeSet());
+      Set<? extends IExprEdge> graphSet = Sets.difference(graph1.edgeSet(), graph2.edgeSet());
       for (IExprEdge e : graphSet) {
         IExpr v1 = e.lhs();
         IExpr v2 = e.rhs();
@@ -362,7 +361,7 @@ public class GraphFunctions {
       for (IExpr v : Sets.union(graph1.vertexSet(), graph2.vertexSet())) {
         resultGraph.addVertex(v);
       }
-      SetView<? extends IExprEdge> graphSet = Sets.union(graph1.edgeSet(), graph2.edgeSet());
+      Set<? extends IExprEdge> graphSet = Sets.union(graph1.edgeSet(), graph2.edgeSet());
       for (IExprEdge e : graphSet) {
         IExpr v1 = e.lhs();
         IExpr v2 = e.rhs();

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/UnitTestingFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/UnitTestingFunctions.java
@@ -2,11 +2,13 @@ package org.matheclipse.core.builtin;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.function.Consumer;
 import org.apache.logging.log4j.LogManager;
@@ -27,8 +29,6 @@ import org.matheclipse.core.interfaces.IExpr;
 import org.matheclipse.core.interfaces.IStringX;
 import org.matheclipse.core.interfaces.ISymbol;
 import org.matheclipse.parser.client.ast.ASTNode;
-import com.google.common.io.Files;
-import com.google.common.io.Resources;
 
 public class UnitTestingFunctions {
   private static final Logger LOGGER = LogManager.getLogger();
@@ -104,7 +104,7 @@ public class UnitTestingFunctions {
       // boolean packageMode = engine.isPackageMode();
       try {
         // engine.setPackageMode(true);
-        String str = Files.asCharSource(file, Charset.defaultCharset()).read();
+        String str = Files.readString(file.toPath(), Charset.defaultCharset());
         return runTests(engine, str);
       } catch (IOException e) {
         LOGGER.debug("TestReport.getFile() failed", e);
@@ -117,9 +117,9 @@ public class UnitTestingFunctions {
 
     private static IExpr getURL(URL url, IAST ast, EvalEngine engine) {
       // boolean packageMode = engine.isPackageMode();
-      try {
+      try (InputStream in = url.openStream()) {
         // engine.setPackageMode(true);
-        String str = Resources.toString(url, StandardCharsets.UTF_8);
+        String str = new String(in.readAllBytes(), StandardCharsets.UTF_8);
         return runTests(engine, str);
       } catch (IOException e) {
         LOGGER.debug("TestReport.getURL() failed", e);

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/WL.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/WL.java
@@ -35,7 +35,6 @@ import org.matheclipse.core.interfaces.IRational;
 import org.matheclipse.core.interfaces.IStringX;
 import org.matheclipse.core.interfaces.ISymbol;
 import org.matheclipse.core.tensor.qty.IQuantity;
-import com.google.common.io.ByteStreams;
 
 /**
  * Methods for handling the WXF serialization format.
@@ -1089,7 +1088,7 @@ public class WL {
       if (resourceAsStream == null) {
         return F.NIL;
       } else {
-        byte[] byteArray = ByteStreams.toByteArray(resourceAsStream);
+        byte[] byteArray = resourceAsStream.readAllBytes();
         return deserializeInternal(byteArray);
       }
     } catch (IOException ex) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/data/InputStreamExpr.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/data/InputStreamExpr.java
@@ -9,17 +9,16 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.io.Reader;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.expression.DataExpr;
 import org.matheclipse.core.expression.S;
 import org.matheclipse.core.interfaces.IExpr;
-import com.google.common.base.Charsets;
 import com.google.common.io.CharStreams;
 
 public class InputStreamExpr extends DataExpr<InputStream> implements Externalizable {
@@ -63,7 +62,7 @@ public class InputStreamExpr extends DataExpr<InputStream> implements Externaliz
    */
   public Reader getReader() throws IOException {
     if (reader == null) {
-      String str = CharStreams.toString(new InputStreamReader(fData, Charsets.UTF_8));
+      String str = new String(fData.readAllBytes(), StandardCharsets.UTF_8);
       if (dataIn != null) {
         dataIn = null;
       }
@@ -108,10 +107,9 @@ public class InputStreamExpr extends DataExpr<InputStream> implements Externaliz
     return new InputStreamExpr(new FileInputStream(file), streamName, reader);
   }
 
-  public static InputStreamExpr newInstance(final Reader reader)
-      throws IOException, FileNotFoundException {
+  public static InputStreamExpr newInstance(final Reader reader) throws IOException {
     InputStream targetStream =
-        new ByteArrayInputStream(CharStreams.toString(reader).getBytes(Charsets.UTF_8));
+        new ByteArrayInputStream(CharStreams.toString(reader).getBytes(StandardCharsets.UTF_8));
     reader.reset();
     return new InputStreamExpr(targetStream, "String", reader);
   }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/tex/TeXSegmentParser.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/tex/TeXSegmentParser.java
@@ -29,7 +29,6 @@ import org.matheclipse.parser.trie.TrieBuilder;
 import org.matheclipse.parser.trie.TrieMatch;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-import com.google.common.base.CharMatcher;
 import uk.ac.ed.ph.snuggletex.InputError;
 import uk.ac.ed.ph.snuggletex.SnuggleEngine;
 import uk.ac.ed.ph.snuggletex.SnuggleInput;
@@ -610,7 +609,7 @@ class TeXSegmentParser {
   }
 
   protected static ISymbol createFunction(String str) {
-    if (CharMatcher.javaLetterOrDigit().matchesAllOf(str)) {
+    if (str.chars().allMatch(Character::isLetterOrDigit)) {
       return F.symbol(str);
     }
     return F.$s(str);
@@ -630,7 +629,7 @@ class TeXSegmentParser {
         return S.E;
       }
     }
-    if (CharMatcher.javaLetterOrDigit().matchesAllOf(str)) {
+    if (str.chars().allMatch(Character::isLetterOrDigit)) {
       return F.symbol(str);
     }
     return F.$s(str);

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/Export.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/Export.java
@@ -1,13 +1,14 @@
 package org.matheclipse.core.reflection.system;
 
 import java.awt.image.BufferedImage;
-import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -116,13 +117,11 @@ public class Export extends AbstractEvaluator {
             }
           }
         } else if (format.equals(Extension.DAT)) {
-          File file = new File(filename);
-          com.google.common.io.Files.write(arg2.toString(), file, Charset.defaultCharset());
+          Files.writeString(Path.of(filename), arg2.toString(), Charset.defaultCharset());
           return arg1;
         } else if (format.equals(Extension.WXF)) {
-          File file = new File(filename);
           byte[] bArray = WL.serialize(arg2);
-          com.google.common.io.Files.write(bArray, file);
+          Files.write(Path.of(filename), bArray);
           return arg1;
         }
 

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/ExportString.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/ExportString.java
@@ -93,13 +93,13 @@ public class ExportString extends AbstractEvaluator {
           }
         }
         // } else if (format.equals(Extension.DAT)) {
-        // File file = new File(arg1.toString());
-        // com.google.common.io.Files.write(arg2.toString(), file, Charset.defaultCharset());
+        // Path file = Path.of(arg1.toString());
+        // Files.writeString(file, arg2.toString(), Charset.defaultCharset());
         // return arg1;
         // } else if (format.equals(Extension.WXF)) {
-        // File file = new File(arg1.toString());
+        // Path file = Path.of(arg1.toString());
         // byte[] bArray = WL.serialize(arg2);
-        // com.google.common.io.Files.write(bArray, file);
+        // Files.write(file, bArray);
         // return arg1;
       }
 

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/sympy/core/Expr.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/sympy/core/Expr.java
@@ -15,7 +15,6 @@ import org.matheclipse.core.interfaces.IExpr;
 import org.matheclipse.core.interfaces.INumber;
 import org.matheclipse.core.sympy.utilities.Iterables;
 import com.google.common.collect.Sets;
-import com.google.common.collect.Sets.SetView;
 
 public class Expr {
 
@@ -87,12 +86,12 @@ public class Expr {
 
   private static boolean asIndependentHas(IExpr e, IASTAppendable other, Set<IExpr> sym) {
     boolean hasOther = e.has(x -> other.indexOf(x) >= 0, true);
-    if (sym.size() == 0) {
+    if (sym.isEmpty()) {
       return hasOther;
     }
     VariablesSet vs = new VariablesSet(e);
-    SetView<IExpr> intersection = Sets.intersection(sym, vs.getVariablesSet());
-    return hasOther || e.has(x -> intersection.contains(x), true);
+    Set<IExpr> intersection = Sets.intersection(sym, vs.getVariablesSet());
+    return hasOther || e.has(intersection::contains, true);
   }
 
   public static Pair asIndependent(IExpr self, IAST deps) {


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Guava can be a dependency difficult to handle due to its many major versions. At the same time many of its great features have been migrated to the JDK and the Java standard library. If possible standard Java should be used if easily possible.