### PR TITLE
[Build|OSGi] Migrate from Maven-Bundle-Plugin to Bnd-Maven-Plugin

### DIFF
--- a/.github/actions/setup-java-for-deployment/action.yml
+++ b/.github/actions/setup-java-for-deployment/action.yml
@@ -12,7 +12,10 @@ runs:
     - name: Set up JDK 11 for Maven Central Repository deployment
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        # Also generates a corresponding Maven toolchains.xml
+        java-version: |
+          11
+          17
         distribution: 'temurin'
         cache: 'maven' # Cache Maven dependencies between workflow runs
         # Properties for deployment to OSSRH:

--- a/.github/workflows/maven-build-master-and-publish-snapshot.yml
+++ b/.github/workflows/maven-build-master-and-publish-snapshot.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
 
-    - run: mvn -f symja_android_library -B -U -P publish-to-maven-central deploy -Dgpg.skip=true
+    - run: mvn -f symja_android_library -B -U -P publish-to-maven-central,exact-target-jdk deploy -Dgpg.skip=true
       # Deployment of all modules is deferred to the last module by nexus-staging-maven-plugin
       env:
         MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}

--- a/.github/workflows/maven-build-pr.yml
+++ b/.github/workflows/maven-build-pr.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Java
       uses: ./.github/actions/setup-java-for-deployment
 
-    - run: mvn -f symja_android_library -B -U verify
+    - run: mvn -f symja_android_library -B -U -Pexact-target-jdk verify
 
     - uses: actions/upload-artifact@v4
       with:

--- a/symja_android_library/matheclipse-external/pom.xml
+++ b/symja_android_library/matheclipse-external/pom.xml
@@ -57,12 +57,12 @@
 		<plugins>
 
 			<plugin>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>maven-bundle-plugin</artifactId>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
 				<configuration>
-					<instructions>
-						<Import-Package>!net.sf.saxon,*</Import-Package>
-					</instructions>
+					<bnd><![CDATA[
+						Import-Package: !net.sf.saxon,*
+					]]></bnd>
 				</configuration>
 			</plugin>
 

--- a/symja_android_library/pom.xml
+++ b/symja_android_library/pom.xml
@@ -399,9 +399,9 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
-					<groupId>org.apache.felix</groupId>
-					<artifactId>maven-bundle-plugin</artifactId>
-					<version>5.1.9</version>
+					<groupId>biz.aQute.bnd</groupId>
+					<artifactId>bnd-maven-plugin</artifactId>
+					<version>7.0.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -444,8 +444,7 @@
 					<version>3.3.0</version>
 					<configuration>
 						<archive>
-							<manifestFile>
-								${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+							<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
 						</archive>
 					</configuration>
 				</plugin>
@@ -582,22 +581,21 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>maven-bundle-plugin</artifactId>
-				<configuration>
-					<instructions>
-						<Bundle-Name>${project.artifactId}</Bundle-Name>
-						<!-- Suppress import of own exported packages -->
-						<Export-Package>*;-noimport:=true</Export-Package>
-						<_nouses>true</_nouses>
-					</instructions>
-					<niceManifest>true</niceManifest>
-				</configuration>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
 				<executions>
 					<execution>
+						<id>generate-manifest</id>
 						<goals>
-							<goal>manifest</goal>
+							<goal>bnd-process</goal>
 						</goals>
+						<configuration><bnd><![CDATA[
+							Bundle-SymbolicName: org.$[replacestring;${artifactId};-;.]
+							Bundle-Name: ${project.artifactId}
+							# Suppress import of own exported packages
+							-exportcontents: *;-noimport:=true
+							-noextraheaders: true
+						]]></bnd></configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/symja_android_library/pom.xml
+++ b/symja_android_library/pom.xml
@@ -415,6 +415,11 @@
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-toolchains-plugin</artifactId>
+					<version>3.1.0</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-deploy-plugin</artifactId>
 					<version>3.1.1</version>
 				</plugin>
@@ -457,7 +462,7 @@
 						<tagNameFormat>v@{project.version}</tagNameFormat>
 						<autoVersionSubmodules>true</autoVersionSubmodules>
 						<useReleaseProfile>false</useReleaseProfile>
-						<releaseProfiles>publish-to-maven-central</releaseProfiles>
+						<releaseProfiles>publish-to-maven-central,exact-target-jdk</releaseProfiles>
 						<arguments>-Drelease.build=true</arguments>
 					</configuration>
 				</plugin>
@@ -599,6 +604,33 @@
 		</plugins>
 	</build>
 	<profiles>
+		<profile>
+			<id>exact-target-jdk</id>
+			<build>
+				<plugins>
+					<!-- Activate toolchains only on demand to not require a set up toolchains.xml for everyone building Symja-->
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-toolchains-plugin</artifactId>
+						<executions>
+							<execution>
+								<goals>
+									<goal>toolchain</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<toolchains>
+								<jdk>
+									<version>${java.version}</version>
+								</jdk>
+							</toolchains>
+						</configuration>
+					</plugin>
+
+				</plugins>
+			</build>
+		</profile>
 		<profile>
 			<id>publish-to-maven-central</id>
 			<build>


### PR DESCRIPTION
The former uses the latter under the hood, thus the latter is always more recent and more powerful.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)
