### PR TITLE
[OSGi] Import Guava packages without upper bound

### DIFF
--- a/symja_android_library/pom.xml
+++ b/symja_android_library/pom.xml
@@ -106,8 +106,8 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>11</java.version>
 		<release.build>false</release.build>
-		<deployment.suppress>false</deployment.suppress> <!-- child modules can
-		set this true to not be published -->
+		<deployment.suppress>false</deployment.suppress> <!-- child modules can set this true to not be published -->
+		<guava.minimal.version>32.0</guava.minimal.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
@@ -594,6 +594,8 @@
 							Bundle-Name: ${project.artifactId}
 							# Suppress import of own exported packages
 							-exportcontents: *;-noimport:=true
+							#Import Guava without upper bound
+							Import-Package: com.google.common.*;version="${guava.minimal.version}", *
 							-noextraheaders: true
 						]]></bnd></configuration>
 					</execution>


### PR DESCRIPTION

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

This avoids re-releases of Symja for each new major version of Guava and in general relaxes the version restrictions for Symja regarding Guava in OSGi runtimes.

Requires https://github.com/axkr/symja_android_library/pull/893