### PR TITLE
Added Config#MAX_POLYNOMIAL_DEGREE_LAGUERRE_SOLVER option

### DIFF
--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/basic/Config.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/basic/Config.java
@@ -148,6 +148,9 @@ public class Config {
   /** Maximum degree of a polynomial generating function */
   public static int MAX_POLYNOMIAL_DEGREE = Integer.MAX_VALUE;
 
+  /** Maximum degree of a polynomial for Laguerre solver */
+  public static int MAX_POLYNOMIAL_DEGREE_LAGUERRE_SOLVER = Integer.MAX_VALUE;
+
   /** Maximum number of loop runs in some Symja functions */
   public static long MAX_LOOP_COUNT = Long.MAX_VALUE;
 

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/RootsFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/RootsFunctions.java
@@ -17,6 +17,7 @@ import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalAttributes;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.exception.JASConversionException;
+import org.matheclipse.core.eval.exception.PolynomialDegreeLimitExceeded;
 import org.matheclipse.core.eval.exception.Validate;
 import org.matheclipse.core.eval.interfaces.AbstractFunctionEvaluator;
 import org.matheclipse.core.expression.F;
@@ -1011,6 +1012,12 @@ public class RootsFunctions {
    */
   private static org.hipparchus.complex.Complex[] allComplexRootsLaguerre(
       @Nonnull double[] coefficients) {
+
+    if (coefficients.length > Config.MAX_POLYNOMIAL_DEGREE_LAGUERRE_SOLVER) {
+      // PolynomialDegreeLimitExceeded.throwIt(coefficients.length);
+      return null;
+    }
+
     for (int j = 0; j < coefficients.length; j++) {
       if (!Double.isFinite(coefficients[j])) {
         return null;

--- a/symja_android_library/matheclipse-core/src/test/java/org/matheclipse/core/system/ExprEvaluatorTestCase.java
+++ b/symja_android_library/matheclipse-core/src/test/java/org/matheclipse/core/system/ExprEvaluatorTestCase.java
@@ -255,6 +255,7 @@ public abstract class ExprEvaluatorTestCase {
       Config.MAX_MATRIX_DIMENSION_SIZE = 100;
       Config.MAX_BIT_LENGTH = 200000;
       Config.MAX_POLYNOMIAL_DEGREE = 150;
+      Config.MAX_POLYNOMIAL_DEGREE_LAGUERRE_SOLVER = 500;
       Config.FILESYSTEM_ENABLED = false;
       Config.ROUNDING_MODE = RoundingMode.HALF_EVEN;
       // fScriptEngine = fScriptManager.getEngineByExtension("m");

--- a/symja_android_library/matheclipse-core/src/test/java/org/matheclipse/core/system/SolveTest.java
+++ b/symja_android_library/matheclipse-core/src/test/java/org/matheclipse/core/system/SolveTest.java
@@ -2087,6 +2087,13 @@ public class SolveTest extends ExprEvaluatorTestCase {
         "{{x->(1250000*Log(2))/Log(500)}}");
   }
 
+  @Test
+  public void testSolveBigExponent() {
+    // message: Exponent ist out of bounds for function Factor.
+    check("Solve(40==5000000/E^(x/(2*1/10^6)),x)", //
+        "{{x->ConditionalExpression(I*1/250000*Pi*C(1)+Log(125000)/500000,C(1)∈Integers)}}");
+  }
+
   /** The JUnit setup method */
   @Override
   public void setUp() {


### PR DESCRIPTION
Dear @axkr ,

I added an option `Config#MAX_POLYNOMIAL_DEGREE_LAGUERRE_SOLVER` to limit the maximum degree of a polynomial before passing to `LaguerreSolver`

## Testing

SolveTest#testSolveBigExponent

```java
  @Test
  public void testSolveBigExponent() {
    // message: Exponent ist out of bounds for function Factor.
    check("Solve(40==5000000/E^(x/(2*1/10^6)),x)", //
        "{{x->ConditionalExpression(I*1/250000*Pi*C(1)+Log(125000)/500000,C(1)∈Integers)}}");
  }

```