### PR TITLE
Throw BigIntegerLimitExceeded instead of IterationLimitExceeded in NumberTheory#fibonacci

### DIFF
--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/NumberTheory.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/NumberTheory.java
@@ -6084,8 +6084,8 @@ public final class NumberTheory {
       if ((temp & 0x00000001) == 0x00000001) { // odd?
         d = result.multiply(c);
         result = a.multiply(c).add(result.multiply(b).add(d));
-        if (result.bitLength() > Config.MAX_AST_SIZE * 8) {
-          IterationLimitExceeded.throwIt(result.bitLength(), F.Fibonacci(F.ZZ(iArg)));
+        if (result.bitLength() > Config.MAX_BIT_LENGTH) {
+          BigIntegerLimitExceeded.throwIt(result.bitLength());
         }
         a = a.multiply(b).add(d);
       }

--- a/symja_android_library/matheclipse-core/src/test/java/org/matheclipse/core/system/LowercaseTestCase.java
+++ b/symja_android_library/matheclipse-core/src/test/java/org/matheclipse/core/system/LowercaseTestCase.java
@@ -8361,9 +8361,9 @@ public class LowercaseTestCase extends ExprEvaluatorTestCase {
     check("Fibonacci(151,11/9223372036854775807)", //
         "Fibonacci(151,11/9223372036854775807)");
 
-    // iter limit
+    // big integer limit
     check("Fibonacci(2147483647)", //
-        "Hold(Fibonacci(2147483647))");
+        "Fibonacci(2147483647)");
 
     check("Fibonacci(0.2114411444411100011, 5)", //
         "0.1598551917369153725");


### PR DESCRIPTION
Throw BigIntegerLimitExceeded instead of IterationLimitExceeded in NumberTheory#fibonacci