### PR TITLE
Rethrows interrupt exceptions from libraries to top level call.

### DIFF
--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/Algebra.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/Algebra.java
@@ -878,6 +878,7 @@ public class Algebra {
         }
         return arg1;
       } catch (Exception e) {
+        Errors.rethrowsInterruptException(e);
         LOGGER.debug("Collect.evaluate() failed", e);
       }
       return F.NIL;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/Algebra.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/Algebra.java
@@ -34,6 +34,7 @@ import java.util.function.Predicate;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.builtin.Combinatoric.KPermutationsIterable;
 import org.matheclipse.core.convert.JASConvert;
 import org.matheclipse.core.convert.JASIExpr;
@@ -2332,6 +2333,7 @@ public class Algebra {
           // } catch (TimeExceededException texex) {
           // LOGGER.debug("Factor.factor() time limit exceeded", texex);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           LOGGER.debug("Factor.factor() failed", rex);
           return expr;
         }
@@ -2784,6 +2786,7 @@ public class Algebra {
           map = factorAbstract.factors(poly);
         }
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         // JAS may throw RuntimeExceptions
         return F.list(expr);
       }
@@ -3206,6 +3209,7 @@ public class Algebra {
           }
           return F.NIL;
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           LOGGER.debug("PolynomialExtendedGCD.evaluate() failed", rex);
         }
       }
@@ -3341,6 +3345,7 @@ public class Algebra {
             // }
             // return jas.exprPoly2Expr(p1);
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             LOGGER.debug("PolynomialGCD.evaluate() failed", rex);
           }
         }
@@ -3507,6 +3512,7 @@ public class Algebra {
                 }
                 return jas.exprPoly2Expr(p1);
               } catch (RuntimeException rex) {
+                Errors.rethrowsInterruptException(rex);
                 LOGGER.debug("PolynomialLCM.evaluate() failed", rex);
               }
             }
@@ -3798,6 +3804,7 @@ public class Algebra {
         } catch (LimitException le) {
           throw le;
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           // rex.printStackTrace();
           LOGGER.debug("PolynomialQuotientRemainder.quotientRemainder() failed", rex);
         }
@@ -3873,6 +3880,7 @@ public class Algebra {
         // division by zero
         LOGGER.log(engine.getLogLevel(), S.PolynomialQuotientRemainder, aex);
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         LOGGER.debug("PolynomialQuotientRemainder.evaluate() failed", rex);
       }
       return F.NIL;
@@ -3990,6 +3998,7 @@ public class Algebra {
         // division by zero
         LOGGER.log(engine.getLogLevel(), S.PolynomialRemainder, aex);
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         LOGGER.debug("PolynomialRemainder.evaluate() failed", rex);
       }
       return F.NIL;
@@ -4786,6 +4795,7 @@ public class Algebra {
         result[2] = substitutions.replaceBackward(result[2]);
         return Optional.of(result);
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
 
       }
       List<IExpr> varList = eVar.getVarList().copyTo();
@@ -4817,6 +4827,7 @@ public class Algebra {
       result[2] = substitutions.replaceBackward(result[2]);
       return Optional.of(result);
     } catch (RuntimeException e) {
+      Errors.rethrowsInterruptException(e);
       LOGGER.debug("Algebra.cancelGCD() failed", e);
     }
     return Optional.empty();
@@ -5224,6 +5235,7 @@ public class Algebra {
         return factorRational(polyRat, jas, head);
       }
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       LOGGER.debug("Algebra.factorComplex() failed", rex);
     }
     return expr;
@@ -5303,6 +5315,7 @@ public class Algebra {
         map = factorAbstract.factors(poly);
       }
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       // JAS may throw RuntimeExceptions
       return F.NIL;
     }
@@ -5909,6 +5922,7 @@ public class Algebra {
         return pf.getResult();
       }
     } catch (RuntimeException e) {
+      Errors.rethrowsInterruptException(e);
       // JAS may throw JASConversionException and RuntimeExceptions
       LOGGER.debug("Algebra.partialFractionDecompositionRational() failed", e);
     }
@@ -5930,6 +5944,7 @@ public class Algebra {
       }
       return seriesData;
     } catch (RuntimeException e) {
+      Errors.rethrowsInterruptException(e);
       // JAS may throw JASConversionException and RuntimeExceptions
       LOGGER.debug("Algebra.polynomialTaylorSeries() failed", e);
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/Arithmetic.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/Arithmetic.java
@@ -724,6 +724,7 @@ public final class Arithmetic {
       try {
         return F.subst(expr, x -> chopNumber(x, delta));
       } catch (Exception e) {
+        Errors.rethrowsInterruptException(e);
         LOGGER.debug("Chop.evaluate() failed", e);
       }
 
@@ -877,6 +878,7 @@ public final class Arithmetic {
           // }
         }
       } catch (Exception e) {
+        Errors.rethrowsInterruptException(e);
         LOGGER.debug("Complex.evaluate() failed", e);
       }
 

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/Arithmetic.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/Arithmetic.java
@@ -59,6 +59,7 @@ import org.hipparchus.fraction.BigFraction;
 import org.hipparchus.linear.Array2DRowRealMatrix;
 import org.hipparchus.linear.ArrayRealVector;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.PlusOp;
@@ -1119,6 +1120,7 @@ public final class Arithmetic {
             try {
               return F.num(h.cbrt(((IReal) base).apfloatValue()));
             } catch (RuntimeException rex) {
+              Errors.rethrowsInterruptException(rex);
               //
             }
           }
@@ -5131,6 +5133,7 @@ public final class Arithmetic {
           return F.fraction(numerator, denominator);
 
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           return Errors.printMessage(S.Rational, rex, engine);
         }
       }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/BesselFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/BesselFunctions.java
@@ -13,6 +13,7 @@ import static org.matheclipse.core.expression.F.Sqrt;
 import static org.matheclipse.core.expression.F.Times;
 import java.math.RoundingMode;
 import org.hipparchus.complex.Complex;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.builtin.functions.BesselJS;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
@@ -536,6 +537,7 @@ public class BesselFunctions {
           } catch (ValidateException ve) {
             return Errors.printMessage(S.BesselJ, ve, engine);
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             return Errors.printMessage(S.BesselJ, rex, engine);
           }
         }
@@ -600,6 +602,7 @@ public class BesselFunctions {
               return F.num(BesselJS.besselJZero(n.evalf(), k));
             }
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             // org.hipparchus.exception.MathIllegalArgumentException:
             // interval does not bracket a root
             return Errors.printMessage(S.BesselJZero, rex, engine);
@@ -722,6 +725,7 @@ public class BesselFunctions {
           } catch (ValidateException ve) {
             return Errors.printMessage(ast.topHead(), ve, engine);
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             return Errors.printMessage(S.BesselI, rex, engine);
           }
         }
@@ -831,6 +835,7 @@ public class BesselFunctions {
           } catch (ValidateException ve) {
             return Errors.printMessage(S.BesselK, ve, engine);
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             return Errors.printMessage(S.BesselK, rex, engine);
           }
         }
@@ -941,6 +946,7 @@ public class BesselFunctions {
           } catch (ValidateException ve) {
             return Errors.printMessage(S.BesselY, ve, engine);
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             return Errors.printMessage(S.BesselY, rex, engine);
           }
         }
@@ -975,6 +981,7 @@ public class BesselFunctions {
             return F.num(BesselJS.besselYZero(n.evalf(), k));
           }
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           // org.hipparchus.exception.MathIllegalArgumentException: interval does not bracket a root
           return Errors.printMessage(S.BesselYZero, rex, engine);
         }
@@ -1035,6 +1042,7 @@ public class BesselFunctions {
             }
 
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             return Errors.printMessage(S.HankelH1, rex, engine);
           }
         } else if (engine.isArbitraryMode()) {
@@ -1095,6 +1103,7 @@ public class BesselFunctions {
             }
 
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             return Errors.printMessage(S.HankelH2, rex, engine);
           }
         } else if (engine.isArbitraryMode()) {
@@ -1205,6 +1214,7 @@ public class BesselFunctions {
           }
 
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           return Errors.printMessage(S.SphericalBesselJ, rex, engine);
         }
       }
@@ -1303,6 +1313,7 @@ public class BesselFunctions {
           // return FunctionExpand.callMatcher(F.FunctionExpand(ast), ast, engine);
           return functionExpand(ast, engine);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           return Errors.printMessage(S.SphericalHankelH1, rex, engine);
         }
       }
@@ -1372,6 +1383,7 @@ public class BesselFunctions {
         try {
           return functionExpand(ast, engine);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           return Errors.printMessage(S.SphericalHankelH2, rex, engine);
         }
       }
@@ -1458,6 +1470,7 @@ public class BesselFunctions {
             return F.complexNum(BesselJS.sphericalBesselY(nDouble, zDouble));
           }
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           return Errors.printMessage(S.SphericalBesselY, rex, engine);
         }
       }
@@ -1531,6 +1544,7 @@ public class BesselFunctions {
               return FunctionExpand.callMatcher(F.FunctionExpand(ast), ast, engine);
 
             } catch (RuntimeException rex) {
+              Errors.rethrowsInterruptException(rex);
               return Errors.printMessage(S.WeberE, rex, engine);
             }
           }
@@ -1545,6 +1559,7 @@ public class BesselFunctions {
             try {
               return FunctionExpand.callMatcher(F.FunctionExpand(ast), ast, engine);
             } catch (RuntimeException rex) {
+              Errors.rethrowsInterruptException(rex);
               return Errors.printMessage(S.WeberE, rex, engine);
             }
           }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/BooleanFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/BooleanFunctions.java
@@ -28,6 +28,7 @@ import org.logicng.transformations.cnf.BDDCNFTransformation;
 import org.logicng.transformations.cnf.CNFFactorization;
 import org.logicng.transformations.dnf.DNFFactorization;
 import org.logicng.transformations.simplification.AdvancedSimplifier;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.convert.VariablesSet;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalAttributes;
@@ -1277,6 +1278,7 @@ public final class BooleanFunctions {
         // int number validation
         Errors.printMessage(ast.topHead(), ve, engine);
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
 
       }
       return ast.arg1();
@@ -4904,7 +4906,7 @@ public final class BooleanFunctions {
         return F.booleSymbol(q1.value().equals(q2.value()));
       }
     } catch (RuntimeException rex) {
-      //
+      Errors.rethrowsInterruptException(rex);
     }
     return F.NIL;
   }
@@ -4929,7 +4931,7 @@ public final class BooleanFunctions {
         return F.booleSymbol(!q1.value().equals(q2.value()));
       }
     } catch (RuntimeException rex) {
-      //
+      Errors.rethrowsInterruptException(rex);
     }
     return F.NIL;
   }
@@ -4955,7 +4957,7 @@ public final class BooleanFunctions {
         return q1.value().compareTo(q2.value());
       }
     } catch (RuntimeException rex) {
-      //
+      Errors.rethrowsInterruptException(rex);
     }
     return Integer.MIN_VALUE;
   }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/Combinatoric.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/Combinatoric.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.combinatoric.KPartitionsIterable;
 import org.matheclipse.core.combinatoric.KPartitionsList;
 import org.matheclipse.core.combinatoric.KSubsetsIterable;
@@ -935,6 +936,7 @@ public final class Combinatoric {
         } catch (LimitException le) {
           throw le;
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           Errors.printMessage(S.IntegerPartitions, rex, engine);
         }
       }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/CompilerFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/CompilerFunctions.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import org.codehaus.commons.compiler.CompileException;
 import org.codehaus.janino.SimpleCompiler;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.basic.ToggleFeature;
 import org.matheclipse.core.builtin.OutputFunctions.VariableManager;
 import org.matheclipse.core.eval.Errors;
@@ -637,6 +638,7 @@ public class CompilerFunctions {
         }
 
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         //
       }
       try {
@@ -656,7 +658,7 @@ public class CompilerFunctions {
         return 2;
 
       } catch (RuntimeException rex) {
-        //
+        Errors.rethrowsInterruptException(rex);
       }
       return 0;
     }
@@ -672,7 +674,7 @@ public class CompilerFunctions {
             }));
         return true;
       } catch (RuntimeException rex) {
-        //
+        Errors.rethrowsInterruptException(rex);
       }
       return false;
     }
@@ -699,6 +701,7 @@ public class CompilerFunctions {
         try {
           result = compiledFunction.evaluate(ast, engine);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           return Errors.printMessage(S.CompiledFunction, rex, engine);
         }
         if (result.isPresent()) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/CurveFitterFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/CurveFitterFunctions.java
@@ -8,6 +8,7 @@ import org.hipparchus.fitting.SimpleCurveFitter;
 import org.hipparchus.fitting.WeightedObservedPoints;
 import org.hipparchus.stat.regression.SimpleRegression;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.convert.Convert;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
@@ -250,6 +251,7 @@ public class CurveFitterFunctions {
           } catch (ValidateException ve) {
             return Errors.printMessage(ast.topHead(), ve, engine);
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             return Errors.printMessage(S.FindFit, rex, engine);
           }
         }
@@ -304,6 +306,7 @@ public class CurveFitterFunctions {
             try {
               return Convert.polynomialFunction2Expr(fitter.fit(obs.toList()), ast.arg3());
             } catch (RuntimeException rex) {
+              Errors.rethrowsInterruptException(rex);
               return Errors.printMessage(S.Fit, rex, engine);
             }
           }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/EllipticIntegrals.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/EllipticIntegrals.java
@@ -4,6 +4,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hipparchus.complex.Complex;
 import org.hipparchus.special.elliptic.carlson.CarlsonEllipticIntegral;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.builtin.functions.EllipticFunctionsJS;
 import org.matheclipse.core.builtin.functions.EllipticIntegralsJS;
 import org.matheclipse.core.convert.Object2Expr;
@@ -357,6 +358,7 @@ public class EllipticIntegrals {
         } catch (ValidateException ve) {
           LOGGER.debug("CarlsonRG.evaluate() failed", ve);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
         }
       }
@@ -427,6 +429,7 @@ public class EllipticIntegrals {
         } catch (ValidateException ve) {
           LOGGER.debug("CarlsonRJ.evaluate() failed", ve);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
         }
       }
@@ -520,6 +523,7 @@ public class EllipticIntegrals {
           } catch (ValidateException ve) {
             LOGGER.debug("EllipticE.evaluate() failed", ve);
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
             return F.NIL;
           }
@@ -689,6 +693,7 @@ public class EllipticIntegrals {
         } catch (ValidateException ve) {
           LOGGER.debug("EllipticF.evaluate() failed", ve);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
           return F.NIL;
         }
@@ -900,6 +905,7 @@ public class EllipticIntegrals {
           } catch (ValidateException ve) {
             LOGGER.debug("EllipticPi.evaluate() failed", ve);
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
             return F.NIL;
           }
@@ -959,6 +965,7 @@ public class EllipticIntegrals {
         } catch (ValidateException ve) {
           LOGGER.debug("EllipticPi.evaluate() failed", ve);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
           return F.NIL;
         }
@@ -1025,6 +1032,7 @@ public class EllipticIntegrals {
               try {
                 return F.complexNum(EllipticFunctionsJS.jacobiTheta(a, x.evalf(), m.evalf()));
               } catch (RuntimeException rex) {
+                Errors.rethrowsInterruptException(rex);
                 LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
               }
             } else if (x.isInexactNumber() && m.isInexactNumber()) {
@@ -1033,6 +1041,7 @@ public class EllipticIntegrals {
               } catch (ValidateException ve) {
                 return Errors.printMessage(ast.topHead(), ve, engine);
               } catch (RuntimeException rex) {
+                Errors.rethrowsInterruptException(rex);
                 LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
               }
             }
@@ -1058,6 +1067,7 @@ public class EllipticIntegrals {
             try {
               return F.complexNum(EllipticFunctionsJS.jacobiTheta(a, 0.0, m.evalf()));
             } catch (RuntimeException rex) {
+              Errors.rethrowsInterruptException(rex);
               LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
             }
           } else if (m.isInexactNumber()) {
@@ -1065,6 +1075,7 @@ public class EllipticIntegrals {
               return F.complexNum(EllipticFunctionsJS.jacobiTheta(a,
                   org.hipparchus.complex.Complex.ZERO, m.evalfc()));
             } catch (RuntimeException rex) {
+              Errors.rethrowsInterruptException(rex);
               LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
             }
           }
@@ -1155,6 +1166,7 @@ public class EllipticIntegrals {
         } catch (ValidateException ve) {
           LOGGER.debug("InverseJacobiCD.evaluate() failed", ve);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
         }
       }
@@ -1214,6 +1226,7 @@ public class EllipticIntegrals {
         } catch (ValidateException ve) {
           LOGGER.debug("InverseJacobiCN.evaluate() failed", ve);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
         }
       }
@@ -1264,6 +1277,7 @@ public class EllipticIntegrals {
         } catch (ValidateException ve) {
           LOGGER.debug("InverseJacobiDN.evaluate() failed", ve);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
         }
       }
@@ -1324,6 +1338,7 @@ public class EllipticIntegrals {
         } catch (ValidateException ve) {
           LOGGER.debug("InverseJacobiSC.evaluate() failed", ve);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
         }
       }
@@ -1378,6 +1393,7 @@ public class EllipticIntegrals {
         } catch (ValidateException ve) {
           LOGGER.debug("InverseJacobiSD.evaluate() failed", ve);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
         }
       }
@@ -1438,6 +1454,7 @@ public class EllipticIntegrals {
         } catch (ValidateException ve) {
           LOGGER.debug("InverseJacobiSN.evaluate() failed", ve);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
         }
       }
@@ -1504,6 +1521,7 @@ public class EllipticIntegrals {
           }
           return F.complexNum(EllipticFunctionsJS.jacobiAmplitude(z.evalfc(), m.evalfc()));
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
           return F.NIL;
         }
@@ -1584,6 +1602,7 @@ public class EllipticIntegrals {
         } catch (ValidateException ve) {
           LOGGER.debug("JacobiCD.evaluate() failed", ve);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
         }
       }
@@ -1662,6 +1681,7 @@ public class EllipticIntegrals {
         } catch (ValidateException ve) {
           LOGGER.debug("JacobiCN.evaluate() failed", ve);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
         }
       }
@@ -1740,6 +1760,7 @@ public class EllipticIntegrals {
         } catch (ValidateException ve) {
           LOGGER.debug("JacobiDN.evaluate() failed", ve);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
         }
       }
@@ -1818,6 +1839,7 @@ public class EllipticIntegrals {
         } catch (ValidateException ve) {
           LOGGER.debug("JacobiSC.evaluate() failed", ve);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
         }
       }
@@ -1896,6 +1918,7 @@ public class EllipticIntegrals {
         } catch (ValidateException ve) {
           LOGGER.debug("JacobiSD.evaluate() failed", ve);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
         }
       }
@@ -1974,6 +1997,7 @@ public class EllipticIntegrals {
         } catch (ValidateException ve) {
           LOGGER.debug("JacobiSN.evaluate() failed", ve);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
         }
       }
@@ -2072,6 +2096,7 @@ public class EllipticIntegrals {
         } catch (ValidateException ve) {
           LOGGER.debug("KleinInvariantJ.evaluate() failed", ve);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
         }
       }
@@ -2106,6 +2131,7 @@ public class EllipticIntegrals {
                   EllipticFunctionsJS.weierstrassHalfPeriods(g2.evalfc(), g3.evalfc());
               return Object2Expr.convertComplex(false, invariants);
             } catch (RuntimeException rex) {
+              Errors.rethrowsInterruptException(rex);
               LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
             }
           }
@@ -2144,6 +2170,7 @@ public class EllipticIntegrals {
             } catch (ValidateException ve) {
               return Errors.printMessage(ast.topHead(), ve, engine);
             } catch (RuntimeException rex) {
+              Errors.rethrowsInterruptException(rex);
               LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
             }
           }
@@ -2189,6 +2216,7 @@ public class EllipticIntegrals {
             return F
                 .complexNum(EllipticFunctionsJS.weierstrassP(u.evalfc(), g2.evalfc(), g3.evalfc()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
           }
         }
@@ -2234,6 +2262,7 @@ public class EllipticIntegrals {
             return F.complexNum(
                 EllipticFunctionsJS.weierstrassPPrime(u.evalfc(), g2.evalfc(), g3.evalfc()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
           }
         }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/ExpTrigsFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/ExpTrigsFunctions.java
@@ -40,6 +40,7 @@ import org.apfloat.FixedPrecisionApfloatHelper;
 import org.hipparchus.complex.Complex;
 import org.hipparchus.util.FastMath;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.exception.ValidateException;
@@ -2071,6 +2072,7 @@ public class ExpTrigsFunctions {
         } catch (ValidateException ve) {
           return Errors.printMessage(ast.topHead(), ve, engine);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           return Errors.printMessage(ast.topHead(), rex, engine);
         }
       }
@@ -2118,6 +2120,7 @@ public class ExpTrigsFunctions {
         } catch (ValidateException ve) {
           return Errors.printMessage(ast.topHead(), ve, engine);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           return Errors.printMessage(ast.topHead(), rex, engine);
         }
       }
@@ -2189,6 +2192,7 @@ public class ExpTrigsFunctions {
         } catch (ValidateException ve) {
           return Errors.printMessage(ast.topHead(), ve, engine);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           return Errors.printMessage(ast.topHead(), rex, engine);
         }
       }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/FileFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/FileFunctions.java
@@ -27,6 +27,7 @@ import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.convert.AST2Expr;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
@@ -270,6 +271,7 @@ public class FileFunctions {
             return S.Null;
           }
         } catch (RuntimeException | RangeException | TypeException | IOException e) {
+          Errors.rethrowsInterruptException(e);
           LOGGER.log(engine.getLogLevel(), ast.topHead(), e);
           return F.$Failed;
         }
@@ -497,6 +499,7 @@ public class FileFunctions {
             return FileExpr.newInstance(arg1.toString());
           }
         } catch (RuntimeException ex) {
+          Errors.rethrowsInterruptException(ex);
           LOGGER.log(engine.getLogLevel(), ast.topHead(), ex);
         }
       }
@@ -1313,6 +1316,7 @@ public class FileFunctions {
             }
           }
         } catch (RuntimeException | IOException ex) {
+          Errors.rethrowsInterruptException(ex);
           LOGGER.log(engine.getLogLevel(), ast.topHead(), ex);
         }
       }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/FilterFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/FilterFunctions.java
@@ -1,5 +1,6 @@
 package org.matheclipse.core.builtin;
 
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.interfaces.AbstractEvaluator;
@@ -49,6 +50,7 @@ public class FilterFunctions {
           }
         }
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         return Errors.printMessage(S.MinFilter, rex, engine);
       }
       return F.NIL;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/FinancialFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/FinancialFunctions.java
@@ -1,5 +1,6 @@
 package org.matheclipse.core.builtin;
 
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.interfaces.AbstractEvaluator;
@@ -148,6 +149,7 @@ public class FinancialFunctions {
               p); // $$;
 
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           return Errors.printMessage(S.TimeValue, rex, engine);
         }
       }
@@ -183,6 +185,7 @@ public class FinancialFunctions {
           }
 
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           return Errors.printMessage(S.TimeValue, rex, engine);
         }
       }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/GraphFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/GraphFunctions.java
@@ -40,6 +40,7 @@ import org.jgrapht.graph.DefaultDirectedGraph;
 import org.jgrapht.graph.DefaultDirectedWeightedGraph;
 import org.jgrapht.graph.DefaultUndirectedGraph;
 import org.jgrapht.graph.DefaultUndirectedWeightedGraph;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.convert.Object2Expr;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
@@ -154,6 +155,7 @@ public class GraphFunctions {
         return GraphExpr.newInstance(resultGraph);
 
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         Errors.printMessage(S.GraphIntersection, rex, engine);
       }
       return F.NIL;
@@ -229,6 +231,7 @@ public class GraphFunctions {
 
 
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         Errors.printMessage(S.GraphComplement, rex, engine);
       }
       return F.NIL;
@@ -269,6 +272,7 @@ public class GraphFunctions {
         }
 
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         Errors.printMessage(S.GraphDifference, rex, engine);
       }
       return F.NIL;
@@ -326,6 +330,7 @@ public class GraphFunctions {
         }
 
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         Errors.printMessage(S.IndexGraph, rex, engine);
       }
       return F.NIL;
@@ -474,6 +479,7 @@ public class GraphFunctions {
           }
         }
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         Errors.printMessage(S.Graph, rex, engine);
       }
       return F.NIL;
@@ -532,6 +538,7 @@ public class GraphFunctions {
         IASTMutable list = F.ListAlloc(centerSet);
         return list;
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         Errors.printMessage(S.GraphCenter, rex, engine);
       }
       return F.NIL;
@@ -589,6 +596,7 @@ public class GraphFunctions {
         }
         return diameter;
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         Errors.printMessage(S.GraphDiameter, rex, engine);
       }
       return F.NIL;
@@ -643,6 +651,7 @@ public class GraphFunctions {
         Set<IExpr> centerSet = graphMeasurer.getGraphPeriphery();
         return F.ListAlloc(centerSet);
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         Errors.printMessage(S.GraphPeriphery, rex, engine);
       }
       return F.NIL;
@@ -672,6 +681,7 @@ public class GraphFunctions {
           }
 
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           Errors.printMessage(S.GraphPower, rex, engine);
         }
       }
@@ -770,6 +780,7 @@ public class GraphFunctions {
           }
         }
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         Errors.printMessage(S.GraphQ, rex, engine);
       }
       return S.False;
@@ -824,6 +835,7 @@ public class GraphFunctions {
         }
         return radius;
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         Errors.printMessage(S.GraphRadius, rex, engine);
       }
       return F.NIL;
@@ -977,6 +989,7 @@ public class GraphFunctions {
           }
         }
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         Errors.printMessage(S.FindShortestTour, rex, engine);
       }
       return F.NIL;
@@ -1050,6 +1063,7 @@ public class GraphFunctions {
           }
         }
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         Errors.printMessage(S.FindSpanningTree, rex, engine);
       }
       return F.NIL;
@@ -1842,6 +1856,7 @@ public class GraphFunctions {
         // Graph must be undirected
         Errors.printMessage(S.FindVertexCover, iae, engine);
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         Errors.printMessage(S.FindVertexCover, rex, engine);
       }
       return F.NIL;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/GraphicsFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/GraphicsFunctions.java
@@ -4,6 +4,7 @@ import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.Locale;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.convert.RGBColor;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
@@ -1524,6 +1525,7 @@ public class GraphicsFunctions {
           try {
             opacity = ast.arg1().evalf();
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
           GraphicsOptions.optionDouble(arrayNode, "opacity", opacity);
@@ -1744,6 +1746,7 @@ public class GraphicsFunctions {
         }
         return true;
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         Errors.printMessage(S.Graphics, rex, EvalEngine.get());
       }
     }
@@ -1862,6 +1865,7 @@ public class GraphicsFunctions {
         }
         return true;
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         Errors.printMessage(S.Graphics3D, rex, EvalEngine.get());
       }
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/HypergeometricFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/HypergeometricFunctions.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.Logger;
 import org.apfloat.NumericComputationException;
 import org.hipparchus.complex.Complex;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.builtin.functions.HypergeometricJS;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalAttributes;
@@ -819,6 +820,7 @@ public class HypergeometricFunctions {
         } catch (ValidateException ve) {
           return Errors.printMessage(ast.topHead(), ve, engine);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
         }
       }
@@ -1421,6 +1423,7 @@ public class HypergeometricFunctions {
       } catch (ValidateException ve) {
         return Errors.printMessage(ast.topHead(), ve, engine);
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
       }
 
@@ -1502,6 +1505,7 @@ public class HypergeometricFunctions {
           } catch (ValidateException ve) {
             return Errors.printMessage(ast.topHead(), ve, engine);
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
           }
         } else if (engine.isDoubleMode()) {
@@ -1513,6 +1517,7 @@ public class HypergeometricFunctions {
           } catch (ValidateException ve) {
             return Errors.printMessage(ast.topHead(), ve, engine);
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
           }
 
@@ -1560,6 +1565,7 @@ public class HypergeometricFunctions {
       } catch (ValidateException ve) {
         return Errors.printMessage(ast.topHead(), ve, engine);
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
       }
       return F.NIL;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/IntegerFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/IntegerFunctions.java
@@ -8,6 +8,7 @@ import org.apache.logging.log4j.Logger;
 import org.apfloat.Apfloat;
 import org.hipparchus.complex.Complex;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.exception.ASTElementLimitExceeded;
@@ -798,6 +799,7 @@ public class IntegerFunctions {
           }
         }
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         LOGGER.debug("FractionalPart.evaluate() failed", rex);
       }
       return F.NIL;
@@ -834,6 +836,7 @@ public class IntegerFunctions {
           try {
             return F.ZZ(new BigInteger(str.toString(), radix));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -1055,6 +1058,7 @@ public class IntegerFunctions {
           }
         }
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         // IReal#floor() or #ceil() may throw ArithmeticException
         LOGGER.debug("IntegerPart.evaluate() failed", rex);
       }
@@ -1344,6 +1348,7 @@ public class IntegerFunctions {
               zDouble = z.evalf();
               nDouble = n.evalf();
             } catch (RuntimeException ve) {
+              Errors.rethrowsInterruptException(ve);
             }
             if (Double.isNaN(zDouble) || Double.isNaN(nDouble)) {
               Complex zComplex = z.evalfc();
@@ -1356,6 +1361,7 @@ public class IntegerFunctions {
           } catch (ValidateException ve) {
             return Errors.printMessage(ast.topHead(), ve, engine);
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
           }
         }
@@ -1478,6 +1484,7 @@ public class IntegerFunctions {
               zDouble = arg1.evalf();
               nDouble = arg2.evalf();
             } catch (RuntimeException ve) {
+              Errors.rethrowsInterruptException(ve);
             }
             if (Double.isNaN(zDouble) || Double.isNaN(nDouble)) {
               Complex zComplex = arg1.evalfc();
@@ -1492,10 +1499,12 @@ public class IntegerFunctions {
           } catch (ValidateException ve) {
             return Errors.printMessage(ast.topHead(), ve, engine);
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
           }
         }
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         LOGGER.log(engine.getLogLevel(), "QuotientRemainder", rex);
       }
       return F.NIL;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/LinearAlgebra.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/LinearAlgebra.java
@@ -55,6 +55,7 @@ import org.hipparchus.linear.RiccatiEquationSolver;
 import org.hipparchus.linear.RiccatiEquationSolverImpl;
 import org.hipparchus.linear.SchurTransformer;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.basic.ToggleFeature;
 import org.matheclipse.core.combinatoric.KSubsetsIterable;
 import org.matheclipse.core.convert.Convert;
@@ -2032,6 +2033,7 @@ public final class LinearAlgebra {
             j -> S.Normalize.of(engine, Convert.complexVector2List(ced.getEigenvector(j))));
         return F.List(values, vectors);
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
 
       }
       EigenDecompositionNonSymmetric edns = new EigenDecompositionNonSymmetric(matrix);
@@ -2271,6 +2273,7 @@ public final class LinearAlgebra {
           return F.complexNum(eigenvalues[i].getReal(), eigenvalues[i].getImaginary());
         });
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         // rex.printStackTrace();
       }
       EigenDecompositionNonSymmetric edns = new EigenDecompositionNonSymmetric(matrix);
@@ -2593,6 +2596,7 @@ public final class LinearAlgebra {
         return F.mapRange(0, vectorSize,
             j -> S.Normalize.of(engine, Convert.complexVector2List(ced.getEigenvector(j))));
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
 
       }
       EigenDecompositionNonSymmetric edns = new EigenDecompositionNonSymmetric(matrix);

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/ListFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/ListFunctions.java
@@ -20,6 +20,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import org.hipparchus.stat.StatUtils;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.convert.Convert;
 import org.matheclipse.core.convert.VariablesSet;
 import org.matheclipse.core.eval.Errors;
@@ -3339,6 +3340,7 @@ public final class ListFunctions {
           return evaluateNestList4(ast, engine);
         }
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         Errors.printMessage(S.FoldList, rex, engine);
       }
       return F.NIL;
@@ -4474,6 +4476,7 @@ public final class ListFunctions {
         }
         return result;
       } catch (RuntimeException e) {
+        Errors.rethrowsInterruptException(e);
       }
       return F.NIL;
     }
@@ -7285,6 +7288,7 @@ public final class ListFunctions {
         engine.setReapList(null);
         return engine.evalBlock(expr, localVariablesList);
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         // ignore
       } finally {
         engine.setReapList(reapList);
@@ -7681,6 +7685,7 @@ public final class ListFunctions {
             }
           }
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           return Errors.printMessage(S.TakeLargest, rex, EvalEngine.get());
         }
       }
@@ -7741,6 +7746,7 @@ public final class ListFunctions {
             }
           }
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           return Errors.printMessage(S.TakeLargestBy, rex, EvalEngine.get());
         }
       }
@@ -7790,6 +7796,7 @@ public final class ListFunctions {
             }
           }
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           return Errors.printMessage(S.TakeSmallest, rex, EvalEngine.get());
         }
       }
@@ -7848,6 +7855,7 @@ public final class ListFunctions {
             }
           }
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           return Errors.printMessage(S.TakeSmallestBy, rex, EvalEngine.get());
         }
       }
@@ -8006,6 +8014,7 @@ public final class ListFunctions {
             }
             return engine.evaluate(temp);
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             Errors.printMessage(S.Total, rex, EvalEngine.get());
             return F.NIL;
           }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/ManipulateFunction.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/ManipulateFunction.java
@@ -10,6 +10,7 @@ import org.hipparchus.stat.StatUtils;
 import org.hipparchus.stat.descriptive.moment.Mean;
 import org.hipparchus.stat.descriptive.moment.StandardDeviation;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.basic.ToggleFeature;
 import org.matheclipse.core.convert.Convert;
 import org.matheclipse.core.convert.RGBColor;
@@ -1063,6 +1064,7 @@ public class ManipulateFunction {
           plotRangeXMin = engine.evalDouble(plotRangeX.arg2());
           plotRangeXMax = engine.evalDouble(plotRangeX.arg3());
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
         }
       }
       IExpr option = options.getOption(S.PlotStyle);
@@ -1096,6 +1098,7 @@ public class ManipulateFunction {
             }
             plotRangeEvaled = true;
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
           }
         } else if (plotRangeY.isReal()) {
           if ((plotID == ID.Plot) //
@@ -1106,6 +1109,7 @@ public class ManipulateFunction {
               plotRangeYMax = engine.evalDouble(plotRangeY);
               plotRangeEvaled = true;
             } catch (RuntimeException rex) {
+              Errors.rethrowsInterruptException(rex);
             }
           }
         } else if (plotRangeY == S.Automatic) {
@@ -1142,6 +1146,7 @@ public class ManipulateFunction {
           plotRangeXMin = plotRangeYMin;
           plotRangeXMax = plotRangeYMax;
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
         }
       }
 
@@ -2120,6 +2125,7 @@ public class ManipulateFunction {
       } catch (ValidateException ve) {
         return Errors.printMessage(manipulateAST.topHead(), ve, engine);
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         return Errors.printMessage(manipulateAST.topHead(), rex, engine);
       }
       return F.NIL;
@@ -2674,7 +2680,7 @@ public class ManipulateFunction {
         }
       }
     } catch (RuntimeException rex) {
-      //
+      Errors.rethrowsInterruptException(rex);
     }
   }
 
@@ -2742,7 +2748,7 @@ public class ManipulateFunction {
             }
           }
         } catch (RuntimeException rex) {
-          //
+          Errors.rethrowsInterruptException(rex);
         }
       }
       if (u.isPresent()) {
@@ -2754,7 +2760,7 @@ public class ManipulateFunction {
             }
           }
         } catch (RuntimeException rex) {
-          //
+          Errors.rethrowsInterruptException(rex);
         }
       }
     }
@@ -2790,7 +2796,7 @@ public class ManipulateFunction {
             }
           }
         } catch (RuntimeException rex) {
-          //
+          Errors.rethrowsInterruptException(rex);
         }
       }
       if (u.isPresent()) {
@@ -2802,7 +2808,7 @@ public class ManipulateFunction {
             }
           }
         } catch (RuntimeException rex) {
-          //
+          Errors.rethrowsInterruptException(rex);
         }
       }
     }
@@ -2820,7 +2826,7 @@ public class ManipulateFunction {
         }
       }
     } catch (RuntimeException rex) {
-      //
+      Errors.rethrowsInterruptException(rex);
     }
   }
 

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/MinMaxFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/MinMaxFunctions.java
@@ -24,6 +24,7 @@ import org.hipparchus.optim.nonlinear.scalar.MultivariateOptimizer;
 import org.hipparchus.optim.nonlinear.scalar.ObjectiveFunction;
 import org.hipparchus.optim.nonlinear.scalar.noderiv.PowellOptimizer;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.convert.Expr2LP;
 import org.matheclipse.core.convert.VariablesSet;
 import org.matheclipse.core.eval.Errors;
@@ -450,7 +451,8 @@ public class MinMaxFunctions {
         }
 
       } catch (RuntimeException rex) {
-        rex.printStackTrace();
+        Errors.rethrowsInterruptException(rex);
+        //rex.printStackTrace();
         LOGGER.debug("FunctionRange.evaluate() failed", rex);
       }
       return F.NIL;
@@ -1306,6 +1308,7 @@ public class MinMaxFunctions {
         return F.CEmptyList;
       }
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       LOGGER.log(engine.getLogLevel(), head, rex);
     }
     return F.NIL;
@@ -1461,6 +1464,7 @@ public class MinMaxFunctions {
         return F.CEmptyList;
       }
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       LOGGER.log(engine.getLogLevel(), head, rex);
     }
     return F.NIL;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/NumberTheory.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/NumberTheory.java
@@ -31,6 +31,7 @@ import org.hipparchus.exception.MathRuntimeException;
 import org.hipparchus.fraction.BigFraction;
 import org.hipparchus.util.CombinatoricsUtils;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.convert.JASConvert;
 import org.matheclipse.core.convert.VariablesSet;
 import org.matheclipse.core.eval.Errors;
@@ -226,6 +227,7 @@ public final class NumberTheory {
           }
         }
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         Errors.printMessage(S.BellB, rex, engine);
       }
       return F.NIL;
@@ -706,6 +708,7 @@ public final class NumberTheory {
       } catch (LimitException le) {
         throw le;
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         return Errors.printMessage(S.CatalanNumber, rex, engine);
       }
       return F.NIL;
@@ -4766,6 +4769,7 @@ public final class NumberTheory {
         try {
           return F.ZZ(Primality.prime(nthPrime));
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           Errors.printMessage(S.Prime, rex, engine);
         }
       }
@@ -5006,6 +5010,7 @@ public final class NumberTheory {
         } catch (LimitException le) {
           throw le;
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           Errors.printMessage(S.PrimitiveRoot, rex, engine);
         }
       }
@@ -5071,6 +5076,7 @@ public final class NumberTheory {
         } catch (LimitException le) {
           throw le;
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           Errors.printMessage(S.PrimitiveRootList, rex, engine);
         }
       }
@@ -5263,6 +5269,7 @@ public final class NumberTheory {
         // try to convert into a fractional number
         return rationalize(arg1, epsilon, useConvergenceMethod).orElse(arg1);
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         // ex.printStackTrace();
         Errors.printMessage(S.Rationalize, rex, engine);
       }
@@ -5414,6 +5421,7 @@ public final class NumberTheory {
         }
         return F.booleSymbol(isSquarefree(expr, varList));
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         // JAS may throw RuntimeExceptions
         Errors.printMessage(S.SquareFreeQ, rex, engine);
       }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/NumberTheory.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/NumberTheory.java
@@ -292,14 +292,14 @@ public final class NumberTheory {
               try {
                 return F.num(h.bernoulli(ln));
               } catch (Exception ce) {
-                //
+                Errors.rethrowsInterruptException(ce);
               }
             } else {
               h = EvalEngine.getApfloatDouble(engine);
               try {
                 return F.num(h.bernoulli(ln).doubleValue());
               } catch (Exception ce) {
-                //
+                Errors.rethrowsInterruptException(ce);
               }
             }
 
@@ -449,7 +449,7 @@ public final class NumberTheory {
       try {
         return F.num(h.binomial(a1.apfloatValue(), a2.apfloatValue()));
       } catch (Exception ce) {
-        //
+        Errors.rethrowsInterruptException(ce);
       }
       return F.NIL;
     }
@@ -460,7 +460,7 @@ public final class NumberTheory {
       try {
         return F.complexNum(h.binomial(a1.apcomplexValue(), a2.apcomplexValue()));
       } catch (Exception ce) {
-        //
+        Errors.rethrowsInterruptException(ce);
       }
       return F.NIL;
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/OutputFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/OutputFunctions.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import org.hipparchus.linear.FieldMatrix;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.convert.Convert;
 import org.matheclipse.core.convert.VariablesSet;
 import org.matheclipse.core.eval.Errors;
@@ -258,6 +259,7 @@ public final class OutputFunctions {
           int result = RomanArabicConverter.romanToArabic(romanNumber);
           return F.ZZ(result);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           return Errors.printMessage(S.FromRomanNumeral, rex, engine);
         }
       }
@@ -563,6 +565,7 @@ public final class OutputFunctions {
         String resultStr = javaForm(arg1, strictJava, usePrefix).toString();
         return F.$str(resultStr, IStringX.APPLICATION_JAVA);
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         return Errors.printMessage(S.JavaForm, rex, engine);
       }
     }
@@ -604,6 +607,7 @@ public final class OutputFunctions {
       } catch (IOException ioex) {
         return Errors.printMessage(S.JSForm, ioex, engine);
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         return Errors.printMessage(S.JSForm, rex, engine);
       }
     }
@@ -673,6 +677,7 @@ public final class OutputFunctions {
           String result = RomanArabicConverter.arabicToRoman(value);
           return F.stringx(result);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           return Errors.printMessage(S.RomanNumeral, rex, engine);
         }
       }
@@ -974,6 +979,7 @@ public final class OutputFunctions {
         }
 
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         return Errors.printMessage(S.TreeForm, rex, engine);
       }
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/PatternMatching.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/PatternMatching.java
@@ -9,6 +9,7 @@ import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.Map;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.exception.ConditionException;
@@ -1083,6 +1084,7 @@ public final class PatternMatching {
           }
           return S.Null;
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           return Errors.printMessage(S.Information, rex, engine);
         }
       }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/PolynomialFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/PolynomialFunctions.java
@@ -8,6 +8,7 @@ import java.util.TreeSet;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.convert.JASConvert;
 import org.matheclipse.core.convert.JASIExpr;
 import org.matheclipse.core.convert.JASModInteger;
@@ -217,6 +218,7 @@ public class PolynomialFunctions {
       } catch (LimitException le) {
         throw le;
       } catch (RuntimeException ae) {
+        Errors.rethrowsInterruptException(ae);
         LOGGER.debug("Coefficient.evaluate() failed", ae);
         return F.C0;
       }
@@ -280,6 +282,7 @@ public class PolynomialFunctions {
         ExprPolynomial poly = ring.create(expr, false, true, true);
         return poly.coefficientArrays((int) poly.degree());
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         LOGGER.debug("CoefficientArrays.evaluate() failed", rex);
       }
 
@@ -354,6 +357,7 @@ public class PolynomialFunctions {
             try {
               return coefficientRulesModulus(expr, varList, termOrder, option);
             } catch (RuntimeException rex) {
+              Errors.rethrowsInterruptException(rex);
               // toInt() conversion failed
               LOGGER.debug("CoefficientRules.evaluate() failed", rex);
             }
@@ -368,6 +372,7 @@ public class PolynomialFunctions {
         ExprPolynomial poly = ring.create(expr, false, true, true);
         return poly.coefficientRules();
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         LOGGER.debug("CoefficientRules.evaluate() failed", rex);
       }
       // default mapping
@@ -733,6 +738,7 @@ public class PolynomialFunctions {
         return F.Divide(F.Times(F.Power(F.CN1, (n * (n - 1) / 2)),
             F.Resultant(poly.getExpr(), polyDiff.getExpr(), arg2)), fN);
       } catch (RuntimeException ex) {
+        Errors.rethrowsInterruptException(ex);
         LOGGER.log(engine.getLogLevel(), "{}: polynomial expected at position 1 instead of {}",
             ast.topHead(), ast.arg1());
         return F.NIL;
@@ -979,6 +985,7 @@ public class PolynomialFunctions {
           // check if a is a polynomial otherwise check ArithmeticException, ClassCastException
           ring.create(a);
         } catch (RuntimeException ex) {
+          Errors.rethrowsInterruptException(ex);
           // Polynomial expected at position `1` in `2`.
           return Errors.printMessage(ast.topHead(), "polynomial", F.list(ast.get(1), F.C1), engine);
         }
@@ -990,6 +997,7 @@ public class PolynomialFunctions {
             return F.Together(resultant);
           }
         } catch (RuntimeException ex) {
+          Errors.rethrowsInterruptException(ex);
           // Polynomial expected at position `1` in `2`.
           return Errors.printMessage(ast.topHead(), "polynomial", F.list(ast.get(2), F.C2), engine);
         }
@@ -1064,6 +1072,7 @@ public class PolynomialFunctions {
           p1 = factory.resultant(p1, p2);
           return jas.exprPoly2Expr(p1);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           LOGGER.debug("Resultant.jasResultant() failed", rex);
         }
       }
@@ -2324,6 +2333,7 @@ public class PolynomialFunctions {
             try {
               return monomialListModulus(expr, varList, termOrder, option);
             } catch (RuntimeException rex) {
+              Errors.rethrowsInterruptException(rex);
               LOGGER.debug("MonomialList.evaluate() failed", rex);
             }
           }
@@ -2337,6 +2347,7 @@ public class PolynomialFunctions {
         ExprPolynomial poly = ring.create(expr, false, true, true);
         return poly.monomialList();
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         LOGGER.debug("MonomialList.evaluate() failed", rex);
       }
       // default mapping
@@ -2446,6 +2457,7 @@ public class PolynomialFunctions {
     } catch (LimitException le) {
       throw le;
     } catch (RuntimeException ex) {
+      Errors.rethrowsInterruptException(ex);
       // org.matheclipse.core.polynomials.longexponent.ExprPolynomialRing.create()
       LOGGER.debug("PolynomialFunctions.coefficientList() failed", ex);
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/PredicateQ.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/PredicateQ.java
@@ -6,6 +6,7 @@ import java.util.function.Predicate;
 import org.hipparchus.linear.FieldMatrix;
 import org.hipparchus.linear.FieldVector;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.convert.Convert;
 import org.matheclipse.core.convert.VariablesSet;
 import org.matheclipse.core.eval.Errors;
@@ -1997,7 +1998,7 @@ public class PredicateQ {
         // }
       }
     } catch (RuntimeException rex) {
-      //
+      Errors.rethrowsInterruptException(rex);
     }
     return IExpr.COMPARE_TERNARY.UNDECIDABLE;
   }
@@ -2027,7 +2028,7 @@ public class PredicateQ {
         }
       }
     } catch (RuntimeException rex) {
-      //
+      Errors.rethrowsInterruptException(rex);
     }
     return IExpr.COMPARE_TERNARY.UNDECIDABLE;
   }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/Programming.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/Programming.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hipparchus.stat.descriptive.DescriptiveStatistics;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.convert.VariablesSet;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
@@ -3370,6 +3371,7 @@ public final class Programming {
 
           return engine.evalTrace(temp, matcher);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           Errors.printMessage(S.Trace, rex, EvalEngine.get());
         }
       }
@@ -3404,6 +3406,7 @@ public final class Programming {
             createTree(jsControl, temp);
             return F.JSFormData(jsControl.toString(), "traceform");
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             Errors.printMessage(S.TraceForm, rex, EvalEngine.get());
           }
         }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/QuantityFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/QuantityFunctions.java
@@ -14,6 +14,7 @@ import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.interfaces.AbstractCoreFunctionEvaluator;
@@ -117,6 +118,7 @@ public class QuantityFunctions {
           }
         }
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
       }
       return F.NIL;
@@ -151,6 +153,7 @@ public class QuantityFunctions {
           }
         }
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
       }
       return F.NIL;
@@ -198,6 +201,7 @@ public class QuantityFunctions {
           return F.NIL;
         }
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
       }
       return F.NIL;
@@ -243,6 +247,7 @@ public class QuantityFunctions {
           return F.NIL;
         }
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
       }
       return F.NIL;
@@ -301,6 +306,7 @@ public class QuantityFunctions {
 
         }
       } catch (RuntimeException e) {
+        Errors.rethrowsInterruptException(e);
         LOGGER.log(engine.getLogLevel(), "Quantity", e);
       }
       return F.NIL;
@@ -367,6 +373,7 @@ public class QuantityFunctions {
           }
         }
       } catch (RuntimeException e) {
+        Errors.rethrowsInterruptException(e);
         LOGGER.log(engine.getLogLevel(), "QuantityMagnitude", e);
       }
       return F.NIL;
@@ -443,6 +450,7 @@ public class QuantityFunctions {
           }
         }
       } catch (RuntimeException e) {
+        Errors.rethrowsInterruptException(e);
         LOGGER.log(engine.getLogLevel(), "UnitConvert", e);
       }
       return F.NIL;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/RandomFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/RandomFunctions.java
@@ -8,6 +8,7 @@ import org.hipparchus.complex.Complex;
 import org.hipparchus.random.RandomDataGenerator;
 import org.hipparchus.util.MathArrays;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.builtin.StatisticsFunctions.IRandomVariate;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
@@ -307,6 +308,7 @@ public final class RandomFunctions {
       } catch (ValidateException ve) {
         return Errors.printMessage(ast.topHead(), ve, engine);
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         //
       }
       return F.NIL;
@@ -531,6 +533,7 @@ public final class RandomFunctions {
           }
           return randomPrime(lowerLimit, upperLimit, engine);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           // There are no primes in the specified interval.
           return Errors.printMessage(ast.topHead(), "noprime", F.CEmptyList, engine);
         }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/RootsFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/RootsFunctions.java
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.Logger;
 import org.hipparchus.analysis.solvers.LaguerreSolver;
 import org.hipparchus.exception.MathRuntimeException;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.convert.Expr2Object;
 import org.matheclipse.core.convert.JASConvert;
 import org.matheclipse.core.convert.Object2Expr;
@@ -540,6 +541,7 @@ public class RootsFunctions {
           i -> F.chopExpr(F.complexNum(complexRoots[i].getReal(), complexRoots[i].getImaginary()),
               Config.DEFAULT_ROOTS_CHOP_DELTA));
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       // solveAllComplex may throw MathIllegalArgumentException, NullArgumentException,
       // MathIllegalStateException
       Errors.printMessage(S.Roots, rex, EvalEngine.get());
@@ -989,6 +991,7 @@ public class RootsFunctions {
       }
       return QuarticSolver.evalAndSort(newResult, sort);
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       // JAS or "findRoots" may throw RuntimeExceptions
       result = rootsOfExprPolynomial(expr, variables, true);
     }
@@ -1083,6 +1086,7 @@ public class RootsFunctions {
       }
       return result;
     } catch (RuntimeException ex) {
+      Errors.rethrowsInterruptException(ex);
       // Polynomial expected!
       return null;
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/SeriesFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/SeriesFunctions.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.basic.ToggleFeature;
 import org.matheclipse.core.convert.JASConvert;
 import org.matheclipse.core.convert.JASIExpr;
@@ -883,6 +884,7 @@ public class SeriesFunctions {
           }
           return evalLimitQuiet(F.Times(coeff, F.CInfinity), data);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
         }
       }
       IAST mapLimit = data.mapLimit(plusAST);
@@ -1149,6 +1151,7 @@ public class SeriesFunctions {
             return limitsInfinityOfRationalFunctions(numeratorPoly, denominatorPoly, symbol, limit,
                 data);
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
           }
         }
 
@@ -1893,6 +1896,7 @@ public class SeriesFunctions {
         return coefficientPlus.oneIdentity0();
         // }
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         Errors.printMessage(S.SeriesCoefficient, rex, engine);
       }
       return F.NIL;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/SimplifyFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/SimplifyFunctions.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.convert.VariablesSet;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
@@ -300,6 +301,7 @@ public class SimplifyFunctions {
             result = temp;
           }
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           //
         }
 
@@ -373,6 +375,7 @@ public class SimplifyFunctions {
             expandAllCounter = fComplexityFunction.apply(temp);
             simplifiedResult.checkLess(temp);
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
 
@@ -853,6 +856,7 @@ public class SimplifyFunctions {
             }
 
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             Errors.printMessage(fFullSimplify ? S.FullSimplify : S.Simplify, rex, EvalEngine.get());
           }
         }
@@ -1212,6 +1216,7 @@ public class SimplifyFunctions {
             sResult.checkLess(expr);
             return;
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         } else if (fFullSimplify) {
@@ -1222,6 +1227,7 @@ public class SimplifyFunctions {
               IExpr temp = argReXImY(re, im, fEngine);
               sResult.checkLess(temp);
             } catch (RuntimeException rex) {
+              Errors.rethrowsInterruptException(rex);
               //
             }
           } else if (expr.isTimes()) {
@@ -1234,6 +1240,7 @@ public class SimplifyFunctions {
                 }
               }
             } catch (RuntimeException rex) {
+              Errors.rethrowsInterruptException(rex);
               //
             }
           }
@@ -1241,6 +1248,7 @@ public class SimplifyFunctions {
             expr = eval(F.FunctionExpand(expr));
             sResult.checkLess(expr);
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         } else {
@@ -1250,6 +1258,7 @@ public class SimplifyFunctions {
               expr = eval(F.FunctionExpand(expr));
               sResult.checkLessEqual(expr);
             } catch (RuntimeException rex) {
+              Errors.rethrowsInterruptException(rex);
               //
             }
           }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/SpecialFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/SpecialFunctions.java
@@ -1064,7 +1064,7 @@ public class SpecialFunctions {
       try {
         return F.num(h.zeta(a1.apfloatValue(), a2.apfloatValue()));
       } catch (Exception ce) {
-        //
+        Errors.rethrowsInterruptException(ce);
       }
       return F.NIL;
     }
@@ -1074,7 +1074,8 @@ public class SpecialFunctions {
       try {
         return F.complexNum(h.zeta(a1.apcomplexValue(), a2.apcomplexValue()));
       } catch (Exception ce) {
-        //
+        Errors.rethrowsInterruptException(ce);
+
       }
       return F.NIL;
     }
@@ -1628,7 +1629,8 @@ public class SpecialFunctions {
       try {
         return F.num(h.digamma(arg1));
       } catch (Exception ce) {
-        //
+        Errors.rethrowsInterruptException(ce);
+
       }
       return F.NIL;
     }
@@ -1638,7 +1640,8 @@ public class SpecialFunctions {
       try {
         return F.complexNum(h.digamma(arg1));
       } catch (Exception ce) {
-        //
+        Errors.rethrowsInterruptException(ce);
+
       }
       return F.NIL;
     }
@@ -2002,6 +2005,7 @@ public class SpecialFunctions {
         Apcomplex productLog = h.w(ac);
         return F.complexNum(productLog.real().doubleValue(), productLog.imag().doubleValue());
       } catch (Exception ce) {
+        Errors.rethrowsInterruptException(ce);
 
       }
       Apcomplex c = ApcomplexMath.w(new Apfloat(d.doubleValue()));
@@ -2028,6 +2032,7 @@ public class SpecialFunctions {
       try {
         return F.num(h.w(arg1));
       } catch (Exception ce) {
+        Errors.rethrowsInterruptException(ce);
 
       }
       return F.complexNum(h.w(arg1, 0));
@@ -2415,7 +2420,8 @@ public class SpecialFunctions {
       try {
         return F.num(h.zeta(arg1));
       } catch (Exception ce) {
-        //
+        Errors.rethrowsInterruptException(ce);
+
       }
       return F.NIL;
     }
@@ -2426,7 +2432,7 @@ public class SpecialFunctions {
       try {
         return F.complexNum(h.zeta(arg1));
       } catch (Exception ce) {
-        //
+        Errors.rethrowsInterruptException(ce);
       }
       return F.NIL;
     }
@@ -2438,7 +2444,7 @@ public class SpecialFunctions {
         Apcomplex zeta = h.zeta(num.apfloatValue());
         return F.num(zeta.doubleValue());
       } catch (Exception ce) {
-        //
+        Errors.rethrowsInterruptException(ce);
       }
       return F.NIL;
     }
@@ -2450,7 +2456,7 @@ public class SpecialFunctions {
         Apcomplex zeta = h.zeta(cNum.apcomplexValue());
         return F.complexNum(zeta.real().doubleValue(), zeta.imag().doubleValue());
       } catch (Exception ce) {
-        //
+        Errors.rethrowsInterruptException(ce);
       }
       return F.NIL;
     }
@@ -2461,7 +2467,7 @@ public class SpecialFunctions {
       try {
         return F.num(h.zeta(a1.apfloatValue(), a2.apfloatValue()));
       } catch (Exception ce) {
-        //
+        Errors.rethrowsInterruptException(ce);
       }
       return F.NIL;
     }
@@ -2472,7 +2478,7 @@ public class SpecialFunctions {
       try {
         return F.complexNum(h.zeta(a1.apcomplexValue(), a2.apcomplexValue()));
       } catch (Exception ce) {
-        //
+        Errors.rethrowsInterruptException(ce);
       }
       return F.NIL;
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/SpecialFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/SpecialFunctions.java
@@ -29,6 +29,7 @@ import org.hipparchus.complex.Complex;
 import org.hipparchus.exception.MathIllegalArgumentException;
 import org.hipparchus.exception.MathIllegalStateException;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.builtin.functions.BesselJS;
 import org.matheclipse.core.builtin.functions.GammaJS;
 import org.matheclipse.core.builtin.functions.ZetaJS;
@@ -244,6 +245,7 @@ public class SpecialFunctions {
       } catch (ValidateException ve) {
         return Errors.printMessage(S.Beta, ve, engine);
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         Errors.printMessage(S.Beta, rex, engine);
       }
       return F.NIL;
@@ -316,6 +318,7 @@ public class SpecialFunctions {
       } catch (ValidateException ve) {
         return Errors.printMessage(S.Beta, ve, engine);
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         Errors.printMessage(S.Beta, rex, engine);
       }
       return F.NIL;
@@ -509,6 +512,7 @@ public class SpecialFunctions {
           return F.Times(F.Power(z, a), sum);
         }
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         Errors.printMessage(S.BetaRegularized, rex, engine);
       }
       return F.NIL;
@@ -540,6 +544,7 @@ public class SpecialFunctions {
           }
         }
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         Errors.printMessage(S.BetaRegularized, rex, engine);
       }
       return F.NIL;
@@ -905,6 +910,7 @@ public class SpecialFunctions {
         return Errors.printMessage(S.GammaRegularized, "argillegal",
             F.list(F.stringx(miae.getMessage()), ast), engine);
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         return Errors.printMessage(S.GammaRegularized, "argillegal",
             F.list(F.stringx(rex.getMessage()), ast), engine);
       }
@@ -1153,6 +1159,7 @@ public class SpecialFunctions {
           Errors.printMessage(S.HurwitzZeta, te, engine);
           return te.getValue();
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           Errors.printMessage(S.HurwitzZeta, rex, engine);
         }
       }
@@ -1399,6 +1406,7 @@ public class SpecialFunctions {
         return Errors.printMessage(S.InverseBetaRegularized, "argillegal",
             F.list(F.stringx(miae.getMessage()), ast), engine);
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         return Errors.printMessage(S.InverseBetaRegularized, "argillegal",
             F.list(F.stringx(rex.getMessage()), ast), engine);
       }
@@ -2275,6 +2283,7 @@ public class SpecialFunctions {
           }
         }
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         Errors.printMessage(S.StruveH, rex, engine);
       }
       return F.NIL;
@@ -2374,6 +2383,7 @@ public class SpecialFunctions {
           }
         }
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         Errors.printMessage(S.StruveL, rex, engine);
       }
       return F.NIL;
@@ -2559,6 +2569,7 @@ public class SpecialFunctions {
             Errors.printMessage(S.Zeta, te, engine);
             return te.getValue();
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             Errors.printMessage(S.Zeta, rex, engine);
           }
         }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/StatisticsFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/StatisticsFunctions.java
@@ -17,6 +17,7 @@ import org.hipparchus.stat.descriptive.StreamingStatistics;
 import org.hipparchus.stat.projection.PCA;
 import org.hipparchus.util.MathUtils;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.convert.Convert;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalAttributes;
@@ -250,6 +251,7 @@ public class StatisticsFunctions {
             }
           }
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           return Errors.printMessage(S.InverseCDF, rex, engine);
         }
       }
@@ -501,6 +503,7 @@ public class StatisticsFunctions {
             }
           }
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           return Errors.printMessage(S.CDF, rex, engine);
         }
       }
@@ -778,6 +781,7 @@ public class StatisticsFunctions {
                 new org.hipparchus.distribution.continuous.BetaDistribution(a.evalf(), b.evalf()) //
                     .cumulativeProbability(k.evalf()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -806,6 +810,7 @@ public class StatisticsFunctions {
                 new org.hipparchus.distribution.continuous.BetaDistribution(a.evalf(), b.evalf()) //
                     .inverseCumulativeProbability(k.evalf()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -902,6 +907,7 @@ public class StatisticsFunctions {
                 new org.hipparchus.distribution.continuous.BetaDistribution(a.evalf(), b.evalf()) //
                     .density(k.evalf()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -1416,6 +1422,7 @@ public class StatisticsFunctions {
           }
         }
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         return Errors.printMessage(S.CentralMoment, rex, engine);
       }
       return F.NIL;
@@ -1475,6 +1482,7 @@ public class StatisticsFunctions {
                 .num(new org.hipparchus.distribution.continuous.ChiSquaredDistribution(v.evalf()) //
                     .cumulativeProbability(k.evalf()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -1522,6 +1530,7 @@ public class StatisticsFunctions {
                 .num(new org.hipparchus.distribution.continuous.ChiSquaredDistribution(v.evalf()) //
                     .inverseCumulativeProbability(k.evalf()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -1556,6 +1565,7 @@ public class StatisticsFunctions {
                 .num(new org.hipparchus.distribution.continuous.ChiSquaredDistribution(v.evalf()) //
                     .density(k.evalf()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -1983,6 +1993,7 @@ public class StatisticsFunctions {
                 .num(new org.hipparchus.distribution.continuous.FDistribution(n.evalf(), m.evalf()) //
                     .cumulativeProbability(k.evalf()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -2008,6 +2019,7 @@ public class StatisticsFunctions {
                 .num(new org.hipparchus.distribution.continuous.FDistribution(n.evalf(), m.evalf()) //
                     .inverseCumulativeProbability(k.evalf()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -2044,6 +2056,7 @@ public class StatisticsFunctions {
                 .num(new org.hipparchus.distribution.continuous.FDistribution(n.evalf(), m.evalf()) //
                     .density(k.evalf()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -2362,6 +2375,7 @@ public class StatisticsFunctions {
                 new org.hipparchus.distribution.continuous.GammaDistribution(a.evalf(), b.evalf()) //
                     .cumulativeProbability(k.evalf()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -2403,6 +2417,7 @@ public class StatisticsFunctions {
                 new org.hipparchus.distribution.continuous.GammaDistribution(a.evalf(), b.evalf()) //
                     .inverseCumulativeProbability(k.evalf()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -2532,6 +2547,7 @@ public class StatisticsFunctions {
                 new org.hipparchus.distribution.continuous.GammaDistribution(a.evalf(), b.evalf()) //
                     .density(k.evalf()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -2969,6 +2985,7 @@ public class StatisticsFunctions {
             // m.evalDouble()) //
             // .cumulativeProbability(k.evalDouble()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -3002,6 +3019,7 @@ public class StatisticsFunctions {
             // m.evalDouble()) //
             // .inverseCumulativeProbability(k.evalDouble()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -3728,6 +3746,7 @@ public class StatisticsFunctions {
             double x = k.evalf();
             return F.num(empiricalDistribution.cumulativeProbability(x));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
           // }
@@ -3769,6 +3788,7 @@ public class StatisticsFunctions {
             double x = k.evalf();
             return F.num(empiricalDistribution.density(x));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
           // }
@@ -4066,6 +4086,7 @@ public class StatisticsFunctions {
           }
         }
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         return Errors.printMessage(S.Expectation, rex, engine);
       }
 
@@ -4144,6 +4165,7 @@ public class StatisticsFunctions {
           }
         }
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         return Errors.printMessage(S.Expectation, rex, engine);
       }
 
@@ -4223,6 +4245,7 @@ public class StatisticsFunctions {
             }
           }
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           return Errors.printMessage(S.Probability, rex, engine);
         }
       }
@@ -4306,6 +4329,7 @@ public class StatisticsFunctions {
             // org.hipparchus.distribution.continuous.ExponentialDistribution(n.evalDouble()) //
             // .cumulativeProbability(k.evalDouble()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -4353,6 +4377,7 @@ public class StatisticsFunctions {
             // org.hipparchus.distribution.continuous.ExponentialDistribution(n.evalDouble()) //
             // .inverseCumulativeProbability(k.evalDouble()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -4735,6 +4760,7 @@ public class StatisticsFunctions {
                 m.evalf()) //
                     .cumulativeProbability(k.evalf()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -4784,6 +4810,7 @@ public class StatisticsFunctions {
                 m.evalf()) //
                     .inverseCumulativeProbability(k.evalf()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -4821,6 +4848,7 @@ public class StatisticsFunctions {
                 m.evalf()) //
                     .density(k.evalf()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -4970,6 +4998,7 @@ public class StatisticsFunctions {
           return getDistribution(arg1).mean((IAST) arg1);
         }
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         return Errors.printMessage(S.Mean, rex, engine);
       }
       return F.NIL;
@@ -5310,6 +5339,7 @@ public class StatisticsFunctions {
                 m.evalf()) //
                     .cumulativeProbability(k.evalf()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -5336,6 +5366,7 @@ public class StatisticsFunctions {
                 m.evalf()) //
                     .inverseCumulativeProbability(k.evalf()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -5372,6 +5403,7 @@ public class StatisticsFunctions {
                 m.evalf()) //
                     .density(k.evalf()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -5620,6 +5652,7 @@ public class StatisticsFunctions {
                 new org.hipparchus.distribution.continuous.NormalDistribution(n.evalf(), m.evalf()) //
                     .cumulativeProbability(k.evalf()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -5651,6 +5684,7 @@ public class StatisticsFunctions {
                 new org.hipparchus.distribution.continuous.NormalDistribution(n.evalf(), m.evalf()) //
                     .inverseCumulativeProbability(k.evalf()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -5683,6 +5717,7 @@ public class StatisticsFunctions {
                 new org.hipparchus.distribution.continuous.NormalDistribution(n.evalf(), m.evalf()) //
                     .density(k.evalf()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -5893,6 +5928,7 @@ public class StatisticsFunctions {
             }
           }
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           return Errors.printMessage(S.Probability, rex, engine);
         }
       }
@@ -6013,6 +6049,7 @@ public class StatisticsFunctions {
             }
           }
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           return Errors.printMessage(S.PDF, rex, engine);
         }
       }
@@ -6965,6 +7002,7 @@ public class StatisticsFunctions {
               return printMessageUdist(head, ast, dist, engine);
             }
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             return Errors.printMessage(S.RandomVariate, rex, engine);
           }
         }
@@ -7367,6 +7405,7 @@ public class StatisticsFunctions {
             return F.num(new org.hipparchus.distribution.continuous.TDistribution(n.evalf()) //
                 .cumulativeProbability(k.evalf()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -7399,6 +7438,7 @@ public class StatisticsFunctions {
             return F.num(new org.hipparchus.distribution.continuous.TDistribution(n.evalf()) //
                 .inverseCumulativeProbability(k.evalf()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -7446,6 +7486,7 @@ public class StatisticsFunctions {
             return F.num(new org.hipparchus.distribution.continuous.TDistribution(n.evalf()) //
                 .density(k.evalf()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -7722,6 +7763,7 @@ public class StatisticsFunctions {
                     b.evalf()) //
                         .cumulativeProbability(k.evalf()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -7751,6 +7793,7 @@ public class StatisticsFunctions {
                     b.evalf()) //
                         .inverseCumulativeProbability(k.evalf()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -7921,6 +7964,7 @@ public class StatisticsFunctions {
             }
           }
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           return Errors.printMessage(S.Variance, rex, engine);
         }
       }
@@ -8025,6 +8069,7 @@ public class StatisticsFunctions {
                 new org.hipparchus.distribution.continuous.WeibullDistribution(n.evalf(), m.evalf()) //
                     .cumulativeProbability(k.evalf()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -8050,6 +8095,7 @@ public class StatisticsFunctions {
                 new org.hipparchus.distribution.continuous.WeibullDistribution(n.evalf(), m.evalf()) //
                     .inverseCumulativeProbability(k.evalf()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }
@@ -8086,6 +8132,7 @@ public class StatisticsFunctions {
                 new org.hipparchus.distribution.continuous.WeibullDistribution(n.evalf(), m.evalf()) //
                     .density(k.evalf()));
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
         }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/StringFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/StringFunctions.java
@@ -17,6 +17,7 @@ import org.apache.commons.text.similarity.LevenshteinDistance;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.exception.ASTElementLimitExceeded;
@@ -1671,6 +1672,7 @@ public final class StringFunctions {
         buf.append(str1.substring(lastPos));
         return F.$str(buf.toString());
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         // example java.lang.StringIndexOutOfBoundsException
         LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
         return F.NIL;
@@ -3058,6 +3060,7 @@ public final class StringFunctions {
             return temp;
           }
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           LOGGER.debug("ToExpression.evaluate() failed", rex);
           return S.$Aborted;
         }
@@ -3308,6 +3311,7 @@ public final class StringFunctions {
         return buf.toString();
       }
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       LOGGER.debug("StringFunctions.inputForm() failed", rex);
     }
     return null;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/StructureFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/StructureFunctions.java
@@ -7,6 +7,8 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
+
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.convert.Convert;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalAttributes;
@@ -993,6 +995,7 @@ public class StructureFunctions {
           } catch (final ValidateException ve) {
             return Errors.printMessage(ast.topHead(), ve, engine);
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             return Errors.printMessage(S.MapAt, rex, engine);
           }
         }
@@ -1930,6 +1933,7 @@ public class StructureFunctions {
           }
           return shallowCopy;
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           return Errors.printMessage(S.Sort, rex, engine);
         }
       } else {
@@ -2024,6 +2028,7 @@ public class StructureFunctions {
         } catch (ValidateException ve) {
           return Errors.printMessage(S.SortBy, ve, engine);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           return Errors.printMessage(S.SortBy, rex, engine);
         }
       }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/UnitTestingFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/UnitTestingFunctions.java
@@ -207,6 +207,7 @@ public class UnitTestingFunctions {
         actualOutput = engine.evaluate(input);
 
       } catch (Exception ex) {
+        Errors.rethrowsInterruptException(ex);
         LOGGER.debug("VerificationTest.evaluate", ex);
         actualOutput = S.None;
       }
@@ -248,6 +249,7 @@ public class UnitTestingFunctions {
         assoc.appendRule(F.Rule("TestID", testID));
         return TestResultObjectExpr.newInstance(assoc);
       } catch (Exception ex) {
+        Errors.rethrowsInterruptException(ex);
         LOGGER.debug("VerificationTest.evaluate() failed", ex);
       }
       return F.NIL;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/convert/Expr2Object.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/convert/Expr2Object.java
@@ -2,6 +2,8 @@ package org.matheclipse.core.convert;
 
 import java.math.RoundingMode;
 import org.hipparchus.util.OpenIntToDoubleHashMap;
+import org.matheclipse.core.basic.OperationSystem;
+import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.expression.F;
 import org.matheclipse.core.interfaces.IAST;
 import org.matheclipse.core.interfaces.IExpr;
@@ -140,6 +142,7 @@ public class Expr2Object {
         return map;
       }
     } catch (RuntimeException ex) {
+      Errors.rethrowsInterruptException(ex);
       // roundToInt() throws ArithmeticException
     }
     return null;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/convert/JASConvert.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/convert/JASConvert.java
@@ -6,6 +6,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
+
+import org.matheclipse.core.basic.OperationSystem;
+import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.exception.JASConversionException;
 import org.matheclipse.core.expression.F;
 import org.matheclipse.core.expression.S;
@@ -302,6 +305,7 @@ public class JASConvert<C extends RingElem<C>> {
     } catch (JASConversionException jce) {
       throw jce;
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       throw new JASConversionException();
     }
   }
@@ -662,6 +666,7 @@ public class JASConvert<C extends RingElem<C>> {
     try {
       return numericExpr2Poly(exprPoly);
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       throw new JASConversionException();
     }
   }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/convert/JASIExpr.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/convert/JASIExpr.java
@@ -5,6 +5,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.SortedMap;
+
+import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.exception.JASConversionException;
 import org.matheclipse.core.eval.util.OptionArgs;
 import org.matheclipse.core.expression.ASTSeriesData;
@@ -169,6 +171,7 @@ public class JASIExpr {
     try {
       return expr2IExprPoly(exprPoly);
     } catch (Exception ae) {
+      Errors.rethrowsInterruptException(ae);
       throw new JASConversionException();
     }
   }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/convert/JASModInteger.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/convert/JASModInteger.java
@@ -3,6 +3,8 @@ package org.matheclipse.core.convert;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.exception.JASConversionException;
 import org.matheclipse.core.expression.F;
 import org.matheclipse.core.interfaces.IAST;
@@ -75,6 +77,7 @@ public class JASModInteger {
     try {
       return expr2Poly(exprPoly, false);
     } catch (Exception ae) {
+      Errors.rethrowsInterruptException(ae);
       throw new JASConversionException();
     }
   }
@@ -93,6 +96,7 @@ public class JASModInteger {
     try {
       return numericExpr2Poly(exprPoly);
     } catch (Exception ae) {
+      Errors.rethrowsInterruptException(ae);
       throw new JASConversionException();
     }
   }
@@ -110,6 +114,7 @@ public class JASModInteger {
     try {
       return expr2IExprPoly(exprPoly);
     } catch (Exception ae) {
+      Errors.rethrowsInterruptException(ae);
       throw new JASConversionException();
     }
   }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/Errors.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/Errors.java
@@ -7,9 +7,12 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import edu.jas.kern.PreemptingException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apfloat.ApfloatInterruptedException;
 import org.matheclipse.core.basic.Config;
 import org.matheclipse.core.expression.F;
 import org.matheclipse.core.expression.S;
@@ -846,4 +849,13 @@ public class Errors {
     return templateStr;
   }
 
+
+  public static void rethrowsInterruptException(Exception e) {
+    if (e instanceof ApfloatInterruptedException || e instanceof PreemptingException) {
+      throw (RuntimeException) e;
+    }
+    if (e instanceof RuntimeException && e.getCause() instanceof InterruptedException) {
+      throw (RuntimeException)  e;
+    }
+  }
 }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/Errors.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/Errors.java
@@ -14,6 +14,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apfloat.ApfloatInterruptedException;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.eval.exception.TimeoutException;
 import org.matheclipse.core.expression.F;
 import org.matheclipse.core.expression.S;
 import org.matheclipse.core.interfaces.IAST;
@@ -851,7 +852,7 @@ public class Errors {
 
 
   public static void rethrowsInterruptException(Exception e) {
-    if (e instanceof ApfloatInterruptedException || e instanceof PreemptingException) {
+    if (e instanceof ApfloatInterruptedException || e instanceof PreemptingException || e instanceof TimeoutException) {
       throw (RuntimeException) e;
     }
     if (e instanceof RuntimeException && e.getCause() instanceof InterruptedException) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/ExprEvaluator.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/ExprEvaluator.java
@@ -10,6 +10,7 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.concurrent.NotThreadSafe;
 import org.apfloat.ApfloatInterruptedException;
 import org.hipparchus.complex.Complex;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.eval.exception.AbortException;
 import org.matheclipse.core.eval.exception.BreakException;
 import org.matheclipse.core.eval.exception.ContinueException;
@@ -587,7 +588,7 @@ public class ExprEvaluator {
         return eval(function);
       }
     } catch (RuntimeException rex) {
-
+      Errors.rethrowsInterruptException(rex);
     }
     return F.NIL;
   }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/MathUtils.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/MathUtils.java
@@ -333,6 +333,8 @@ public class MathUtils {
       dEval.parse(fun);
       return true;
     } catch (Exception e) {
+      Errors.rethrowsInterruptException(e);
+
       return false;
     }
   }
@@ -348,6 +350,7 @@ public class MathUtils {
         dEval.parse(fun[i]);
         b[i] = true;
       } catch (Exception e) {
+        Errors.rethrowsInterruptException(e);
         b[i] = false;
       }
     }
@@ -568,6 +571,7 @@ public class MathUtils {
         // throws MathException exception, if syntax isn't valid
         return p.parse(evalStr);
       } catch (Exception e2) {
+        Errors.rethrowsInterruptException(e2);
         return null;
       }
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/Validate.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/exception/Validate.java
@@ -2,6 +2,8 @@ package org.matheclipse.core.eval.exception;
 
 import java.io.IOException;
 import java.math.BigInteger;
+
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.expression.Context;
@@ -69,6 +71,7 @@ public final class Validate {
           }
           return result;
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           //
         }
       }
@@ -114,6 +117,7 @@ public final class Validate {
           }
           return result;
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           Errors.printMessage(ast.topHead(), rex, engine);
         }
       }
@@ -164,6 +168,7 @@ public final class Validate {
           }
           return result;
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           // `1`.
           Errors.printMessage(ast.topHead(), "error",
               F.List("RuntimeException in Validate#checkListOfInts()"));
@@ -213,6 +218,7 @@ public final class Validate {
           }
           return result;
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           //
         }
       }
@@ -285,6 +291,7 @@ public final class Validate {
           }
           return result;
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           //
         }
       }
@@ -327,6 +334,7 @@ public final class Validate {
           }
           return result;
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           //
         }
       }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/interfaces/AbstractArg1.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/interfaces/AbstractArg1.java
@@ -3,6 +3,8 @@ package org.matheclipse.core.eval.interfaces;
 import org.apfloat.Apcomplex;
 import org.apfloat.Apfloat;
 import org.hipparchus.complex.Complex;
+import org.matheclipse.core.basic.OperationSystem;
+import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.exception.LimitException;
 import org.matheclipse.core.expression.ApcomplexNum;
@@ -49,6 +51,7 @@ public abstract class AbstractArg1 extends AbstractFunctionEvaluator {
         } catch (LimitException le) {
           throw le;
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           // EvalEngine.get().printMessage(ast.topHead().toString() + ": " + rex.getMessage());
           return F.NIL;
         }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/interfaces/AbstractArg12.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/interfaces/AbstractArg12.java
@@ -4,6 +4,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apfloat.Apcomplex;
 import org.apfloat.Apfloat;
+import org.matheclipse.core.basic.OperationSystem;
+import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.exception.LimitException;
 import org.matheclipse.core.expression.ApcomplexNum;
@@ -164,6 +166,7 @@ public abstract class AbstractArg12 extends AbstractFunctionEvaluator {
       } catch (LimitException le) {
         throw le;
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         LOGGER.debug("AbstractArg12.binaryOperator() failed", rex);
         return F.NIL;
       }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/interfaces/AbstractArg2.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/interfaces/AbstractArg2.java
@@ -2,6 +2,8 @@ package org.matheclipse.core.eval.interfaces;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.matheclipse.core.basic.OperationSystem;
+import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.exception.LimitException;
 import org.matheclipse.core.expression.ApcomplexNum;
@@ -143,6 +145,7 @@ public abstract class AbstractArg2 extends AbstractFunctionEvaluator {
     } catch (LimitException le) {
       throw le;
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       // EvalEngine.get().printMessage(ast.topHead().toString() + ": " + rex.getMessage());
     }
 

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/interfaces/AbstractArgMultiple.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/interfaces/AbstractArgMultiple.java
@@ -2,6 +2,7 @@ package org.matheclipse.core.eval.interfaces;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.exception.LimitException;
@@ -300,6 +301,7 @@ public abstract class AbstractArgMultiple extends AbstractArg2 {
     } catch (LimitException le) {
       throw le;
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       LOGGER.log(engine.getLogLevel(), ast.topHead(), rex);
     }
     return F.NIL;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/interfaces/AbstractEvaluator.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/interfaces/AbstractEvaluator.java
@@ -1,5 +1,6 @@
 package org.matheclipse.core.eval.interfaces;
 
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.expression.F;
@@ -75,6 +76,7 @@ public abstract class AbstractEvaluator implements IFunctionEvaluator {
     try {
       return evalCatched(ast, engine);
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       Errors.printMessage(ast.topHead(), rex, engine);
     }
     return defaultReturn();

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/interfaces/AbstractTrigArg1.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/interfaces/AbstractTrigArg1.java
@@ -3,6 +3,8 @@ package org.matheclipse.core.eval.interfaces;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hipparchus.complex.Complex;
+import org.matheclipse.core.basic.OperationSystem;
+import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.exception.LimitException;
 import org.matheclipse.core.expression.ApcomplexNum;
@@ -48,6 +50,7 @@ public abstract class AbstractTrigArg1 extends AbstractArg1 {
     } catch (LimitException le) {
       throw le;
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       LOGGER.log(EvalEngine.get().getLogLevel(), ast.topHead(), rex);
       return F.NIL;
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/steps/RuleDescription.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/steps/RuleDescription.java
@@ -11,6 +11,7 @@ import org.apache.commons.io.IOUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
+import org.matheclipse.core.eval.Errors;
 
 /** A map for the description templates of the rule steps. */
 public class RuleDescription {
@@ -44,8 +45,9 @@ public class RuleDescription {
         }
       }
 
-    } catch (Exception ignored) {
-      ignored.printStackTrace();
+    } catch (Exception e) {
+      Errors.rethrowsInterruptException(e);
+      e.printStackTrace();
     }
   }
 

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/util/Iterator.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/util/Iterator.java
@@ -4,6 +4,7 @@ import static org.matheclipse.core.expression.F.Divide;
 import static org.matheclipse.core.expression.F.Less;
 import static org.matheclipse.core.expression.F.Subtract;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.builtin.QuantityFunctions;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
@@ -1356,6 +1357,7 @@ public class Iterator {
     } catch (ArgumentTypeException atex) {
       throw atex;
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       // Argument `1` at position `2` does not have the correct form for an iterator.
       String str = Errors.getMessage("itform", F.list(list, F.ZZ(position)), EvalEngine.get());
       throw new ArgumentTypeException(str);
@@ -1516,6 +1518,7 @@ public class Iterator {
     } catch (ArgumentTypeException atex) {
       throw atex;
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       throw new ClassCastException();
     } finally {
       evalEngine.setNumericMode(localNumericMode);

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/util/OptionArgs.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/eval/util/OptionArgs.java
@@ -329,7 +329,7 @@ public class OptionArgs {
           return rule[0].arg2();
         }
       } catch (Exception e) {
-
+        Errors.rethrowsInterruptException(e);
       }
     }
     if (fDefaultOptionsList.isPresent()) {
@@ -347,7 +347,7 @@ public class OptionArgs {
           return rule[0].arg2();
         }
       } catch (Exception e) {
-
+        Errors.rethrowsInterruptException(e);
       }
     }
     return F.NIL;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/ASTAssociation.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/ASTAssociation.java
@@ -11,6 +11,9 @@ import java.util.function.Function;
 import java.util.function.ObjIntConsumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+
+import org.matheclipse.core.basic.OperationSystem;
+import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalAttributes;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.exception.ArgumentTypeException;
@@ -652,6 +655,7 @@ public final class ASTAssociation extends ASTRRBTree implements IAssociation {
         }
       }
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       numericKeys = false;
     }
     if (numericKeys) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/ApcomplexNum.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/ApcomplexNum.java
@@ -1663,6 +1663,7 @@ public class ApcomplexNum implements IComplexNum {
           OutputFormFactory.NO_PLUS_CALL);
       return sb.toString();
     } catch (Exception e1) {
+      Errors.rethrowsInterruptException(e1);
       // fall back to simple output format
     }
 

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/ApfloatNum.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/ApfloatNum.java
@@ -13,6 +13,7 @@ import org.apfloat.LossOfPrecisionException;
 import org.apfloat.NumericComputationException;
 import org.apfloat.OverflowException;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.interfaces.IComplexNum;
@@ -694,6 +695,7 @@ public class ApfloatNum implements INum {
       return fApfloat.intValueExact() == i;
     } catch (RuntimeException rex) {
       // ArithmeticException
+      Errors.rethrowsInterruptException(rex);
     }
     return false;
   }
@@ -1969,6 +1971,7 @@ public class ApfloatNum implements INum {
       return fApfloat.intValueExact();
     } catch (RuntimeException rex) {
       // ArithmeticException
+      Errors.rethrowsInterruptException(rex);
     }
     return defaultValue;
   }
@@ -1986,6 +1989,7 @@ public class ApfloatNum implements INum {
       return fApfloat.longValueExact();
     } catch (RuntimeException rex) {
       // ArithmeticException
+      Errors.rethrowsInterruptException(rex);
     }
     return defaultValue;
   }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/BigFractionSym.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/BigFractionSym.java
@@ -5,6 +5,7 @@ import java.math.BigInteger;
 import java.util.function.Function;
 import org.hipparchus.fraction.BigFraction;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.exception.BigIntegerLimitExceeded;
 import org.matheclipse.core.eval.util.SourceCodeProperties;
 import org.matheclipse.core.form.output.OutputFormFactory;
@@ -677,6 +678,7 @@ public class BigFractionSym extends AbstractFractionSym {
           OutputFormFactory.NO_PLUS_CALL);
       return sb.toString();
     } catch (Exception e1) {
+      Errors.rethrowsInterruptException(e1);
       // fall back to simple output format
       return fFraction.getNumerator().toString() + "/" + fFraction.getDenominator().toString();
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/BigIntegerSym.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/BigIntegerSym.java
@@ -9,6 +9,8 @@ import java.math.RoundingMode;
 import java.util.function.Function;
 import org.hipparchus.fraction.BigFraction;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
+import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.exception.BigIntegerLimitExceeded;
 import org.matheclipse.core.eval.exception.LimitException;
 import org.matheclipse.core.eval.util.SourceCodeProperties;
@@ -799,6 +801,7 @@ public class BigIntegerSym extends AbstractIntegerSym {
     } catch (LimitException lime) {
       throw lime;
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       return F.Sqrt(this);
     }
   }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/BuiltInDummy.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/BuiltInDummy.java
@@ -1074,6 +1074,7 @@ public class BuiltInDummy implements IBuiltInSymbol, Serializable {
       OutputFormFactory.get(EvalEngine.get().isRelaxedSyntax()).convertSymbol(sb, this);
       return sb.toString();
     } catch (Exception e1) {
+      Errors.rethrowsInterruptException(e1);
       return fSymbolName;
     }
   }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/ComplexNum.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/ComplexNum.java
@@ -12,6 +12,7 @@ import org.apfloat.OverflowException;
 import org.hipparchus.complex.Complex;
 import org.hipparchus.exception.NullArgumentException;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.builtin.Arithmetic;
 import org.matheclipse.core.builtin.functions.HypergeometricJS;
 import org.matheclipse.core.eval.Errors;
@@ -726,6 +727,7 @@ public class ComplexNum implements IComplexNum {
           return F.complexNum(complexErfc);
         }
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
       }
       Apcomplex erfc = EvalEngine.getApfloatDouble().erfc(apcomplexValue());
       return F.complexNum(erfc.real().doubleValue(), erfc.imag().doubleValue());
@@ -1083,6 +1085,7 @@ public class ComplexNum implements IComplexNum {
       return F
           .complexNum(HypergeometricJS.hypergeometric0F1(fComplex, ((ComplexNum) arg2).evalfc()));
     } catch (RuntimeException e) {
+      Errors.rethrowsInterruptException(e);
       // try as computation with complex numbers
     }
     return IComplexNum.super.hypergeometric0F1(arg2);
@@ -1106,6 +1109,7 @@ public class ComplexNum implements IComplexNum {
           arg2.evalfc(), //
           arg3.evalfc()));
     } catch (RuntimeException e) {
+      Errors.rethrowsInterruptException(e);
       // try as computation with complex numbers
     }
     return IComplexNum.super.hypergeometric1F1(arg2, arg3);

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/ComplexSym.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/ComplexSym.java
@@ -976,6 +976,7 @@ public class ComplexSym implements IComplex {
           OutputFormFactory.NO_PLUS_CALL);
       return sb.toString();
     } catch (Exception e1) {
+      Errors.rethrowsInterruptException(e1);
       // fall back to simple output format
       final StringBuilder tb = new StringBuilder();
       tb.append('(');

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/F.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/F.java
@@ -39,6 +39,7 @@ import org.hipparchus.complex.Complex;
 import org.hipparchus.fraction.BigFraction;
 import org.matheclipse.core.basic.AndroidLoggerFix;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.builtin.Algebra;
 import org.matheclipse.core.builtin.Arithmetic;
 import org.matheclipse.core.builtin.AssociationFunctions;
@@ -5237,6 +5238,7 @@ public class F extends S {
           // no read access for current user
           LOGGER.warn("Cannot read packages in autoload folder:", acex);
         } catch (RuntimeException ex) {
+          Errors.rethrowsInterruptException(ex);
           LOGGER.error(ex);
         }
         // if (!noPackageLoading) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/F.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/F.java
@@ -10957,7 +10957,8 @@ public class F extends S {
     try {
       return QuantityParser.of(string);
     } catch (Exception exception) {
-      // ---
+      Errors.rethrowsInterruptException(exception);
+
     }
     return stringx(string);
   }
@@ -10983,6 +10984,8 @@ public class F extends S {
       }
       return showGraphic(expr);
     } catch (Exception ex) {
+      Errors.rethrowsInterruptException(ex);
+
       LOGGER.debug("F.show() failed", ex);
     }
     return null;
@@ -10998,6 +11001,7 @@ public class F extends S {
             String html = JSBuilder.buildGraphics2D(JSBuilder.GRAPHICS2D_TEMPLATE, graphicsStr);
             return openHTMLOnDesktop(html);
           } catch (Exception ex) {
+            Errors.rethrowsInterruptException(ex);
             LOGGER.debug("JSBuilder.buildGraphics2D() failed", ex);
           }
         }
@@ -11010,6 +11014,7 @@ public class F extends S {
             String html = JSBuilder.buildGraphics3D(JSBuilder.GRAPHICS3D_TEMPLATE, graphics3DStr);
             return openHTMLOnDesktop(html);
           } catch (Exception ex) {
+            Errors.rethrowsInterruptException(ex);
             LOGGER.debug("JSBuilder.buildGraphics3D() failed", ex);
           }
         }
@@ -11035,6 +11040,7 @@ public class F extends S {
         return buf.toString();
       }
     } catch (Exception ex) {
+      Errors.rethrowsInterruptException(ex);
       LOGGER.debug("F.showGraphic() failed", ex);
     }
     return null;
@@ -11048,6 +11054,7 @@ public class F extends S {
         String html = JSBuilder.buildMathcell(JSBuilder.MATHCELL_TEMPLATE, manipulateStr);
         return openHTMLOnDesktop(html);
       } catch (Exception ex) {
+        Errors.rethrowsInterruptException(ex);
         LOGGER.debug("F.printJSFormData() failed", ex);
       }
       // } else if (jsFormData.arg2().toString().equals("graphics3d")) {
@@ -11065,6 +11072,7 @@ public class F extends S {
         String html = JSBuilder.buildJSXGraph(JSBuilder.JSXGRAPH_TEMPLATE, manipulateStr);
         return openHTMLOnDesktop(html);
       } catch (Exception ex) {
+        Errors.rethrowsInterruptException(ex);
         LOGGER.debug("F.printJSFormData() failed", ex);
       }
     } else if (jsFormData.arg2().toString().equals("mermaid")) {
@@ -11073,6 +11081,7 @@ public class F extends S {
         String html = JSBuilder.buildMermaid(JSBuilder.MERMAID_TEMPLATE, manipulateStr);
         return openHTMLOnDesktop(html);
       } catch (Exception ex) {
+        Errors.rethrowsInterruptException(ex);
         LOGGER.debug("F.printJSFormData() failed", ex);
       }
     } else if (jsFormData.arg2().toString().equals("plotly")) {
@@ -11081,6 +11090,7 @@ public class F extends S {
         String html = JSBuilder.buildPlotly(JSBuilder.PLOTLY_TEMPLATE, manipulateStr);
         return openHTMLOnDesktop(html);
       } catch (Exception ex) {
+        Errors.rethrowsInterruptException(ex);
         LOGGER.debug("F.printJSFormData() failed", ex);
       }
     } else if (jsFormData.arg2().toString().equals("treeform")) {
@@ -11100,6 +11110,7 @@ public class F extends S {
         );
         return openHTMLOnDesktop(html);
       } catch (Exception ex) {
+        Errors.rethrowsInterruptException(ex);
         LOGGER.debug("F.printJSFormData() failed", ex);
       }
     } else if (jsFormData.arg2().toString().equals("traceform")) {
@@ -11109,6 +11120,7 @@ public class F extends S {
         html = StringUtils.replace(html, "`1`", jsStr);
         return openHTMLOnDesktop(html);
       } catch (Exception ex) {
+        Errors.rethrowsInterruptException(ex);
         LOGGER.debug("F.printJSFormData() failed", ex);
       }
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/FractionSym.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/FractionSym.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.function.Function;
 import org.hipparchus.fraction.BigFraction;
+import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.util.SourceCodeProperties;
 import org.matheclipse.core.form.output.OutputFormFactory;
 import org.matheclipse.core.interfaces.IExpr;
@@ -747,6 +748,7 @@ public class FractionSym extends AbstractFractionSym {
           Integer.MIN_VALUE, OutputFormFactory.NO_PLUS_CALL);
       return sb.toString();
     } catch (Exception e1) {
+      Errors.rethrowsInterruptException(e1);
       // fall back to simple output format
       return toBigNumerator().toString() + "/" + toBigDenominator().toString();
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/IntervalSym.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/IntervalSym.java
@@ -3,6 +3,7 @@ package org.matheclipse.core.expression;
 import java.util.Comparator;
 import org.apfloat.Apfloat;
 import org.apfloat.FixedPrecisionApfloatHelper;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalAttributes;
 import org.matheclipse.core.eval.EvalEngine;
@@ -139,6 +140,7 @@ public class IntervalSym {
       }
       return F.NIL;
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       Errors.printMessage(S.Interval, rex, engine);
     }
     return F.NIL;
@@ -297,6 +299,7 @@ public class IntervalSym {
           }
           return result;
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           //
         }
       }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Num.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Num.java
@@ -11,6 +11,7 @@ import org.apfloat.OverflowException;
 import org.hipparchus.complex.Complex;
 import org.hipparchus.util.MathUtils;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.builtin.functions.HypergeometricJS;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
@@ -1111,12 +1112,14 @@ public class Num implements INum {
     try {
       return F.num(HypergeometricJS.hypergeometric0F1(value, arg2.evalf()));
     } catch (RuntimeException e) {
+      Errors.rethrowsInterruptException(e);
       // try as computation with complex numbers
     }
     try {
       return F.complexNum(
           HypergeometricJS.hypergeometric0F1(new Complex(value), ((ComplexNum) arg2).evalfc()));
     } catch (RuntimeException e) {
+      Errors.rethrowsInterruptException(e);
       // try as computation with complex numbers
     }
     return INum.super.hypergeometric0F1(arg2);
@@ -1150,6 +1153,7 @@ public class Num implements INum {
           arg2.evalf(), //
           arg3.evalf()));
     } catch (RuntimeException e) {
+      Errors.rethrowsInterruptException(e);
       // try as computation with complex numbers
     }
 
@@ -1158,6 +1162,7 @@ public class Num implements INum {
           arg2.evalfc(), //
           arg3.evalfc()));
     } catch (RuntimeException e) {
+      Errors.rethrowsInterruptException(e);
       // try as computation with complex numbers
     }
     return INum.super.hypergeometric1F1(arg2, arg3);

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Symbol.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/Symbol.java
@@ -442,6 +442,7 @@ public class Symbol implements ISymbol, Serializable {
       OutputFormFactory.get(EvalEngine.get().isRelaxedSyntax()).convertSymbol(sb, this);
       return sb.toString();
     } catch (Exception e1) {
+      Errors.rethrowsInterruptException(e1);
       return fSymbolName;
     }
   }
@@ -1087,6 +1088,7 @@ public class Symbol implements ISymbol, Serializable {
       OutputFormFactory.get(EvalEngine.get().isRelaxedSyntax()).convertSymbol(sb, this);
       return sb.toString();
     } catch (Exception e1) {
+      Errors.rethrowsInterruptException(e1);
       return fSymbolName;
     }
   }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/data/NumericArrayExpr.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/data/NumericArrayExpr.java
@@ -10,7 +10,9 @@ import java.util.Arrays;
 import java.util.Map;
 import org.hipparchus.complex.Complex;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.builtin.LinearAlgebra;
+import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.exception.ArgumentTypeException;
 import org.matheclipse.core.expression.DataExpr;
 import org.matheclipse.core.expression.F;
@@ -574,6 +576,7 @@ public class NumericArrayExpr extends DataExpr<Object> implements INumericArray,
             break;
         }
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
 
       }
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/data/SparseArrayExpr.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/expression/data/SparseArrayExpr.java
@@ -22,6 +22,7 @@ import org.hipparchus.linear.RealMatrix;
 import org.hipparchus.linear.RealVector;
 import org.hipparchus.util.MathUtils;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.builtin.LinearAlgebra;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
@@ -955,6 +956,7 @@ public class SparseArrayExpr extends DataExpr<Trie<int[], IExpr>>
         }
         return result;
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         Errors.printMessage(S.SparseArray, rex, engine);
       }
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/mathml/MathMLFormFactory.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/mathml/MathMLFormFactory.java
@@ -2278,6 +2278,7 @@ public class MathMLFormFactory extends AbstractMathMLFormFactory {
       }
 
     } catch (Exception ex) {
+      Errors.rethrowsInterruptException(ex);
       LOGGER.debug("MathMLFormFactory.convertSeriesData() failed", ex);
       return false;
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/mathml/MathMLFormFactory.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/mathml/MathMLFormFactory.java
@@ -12,8 +12,10 @@ import org.apache.logging.log4j.Logger;
 import org.apfloat.Apcomplex;
 import org.apfloat.Apfloat;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.builtin.Algebra;
 import org.matheclipse.core.convert.AST2Expr;
+import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalAttributes;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.exception.ArgumentTypeException;
@@ -1172,6 +1174,7 @@ public class MathMLFormFactory extends AbstractMathMLFormFactory {
       }
       return true;
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       LOGGER.debug("OutputFormFactory.toString() failed", rex);
     } catch (OutOfMemoryError oome) {
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/output/ComplexFormFactory.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/output/ComplexFormFactory.java
@@ -825,6 +825,7 @@ public abstract class ComplexFormFactory {
     try {
       buf.append(quantity.toString());
     } catch (Exception ex) {
+      Errors.rethrowsInterruptException(ex);
       return false;
     }
     if (Precedence.PLUS < precedence) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/output/ComplexFormFactory.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/output/ComplexFormFactory.java
@@ -8,7 +8,9 @@ import org.hipparchus.complex.Complex;
 import org.hipparchus.linear.RealMatrix;
 import org.hipparchus.linear.RealVector;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.convert.AST2Expr;
+import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.expression.ASTRealMatrix;
 import org.matheclipse.core.expression.ASTRealVector;
@@ -352,6 +354,7 @@ public abstract class ComplexFormFactory {
         buf.append("(" + value + ")");
         return;
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         //
       }
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/output/DoubleFormFactory.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/output/DoubleFormFactory.java
@@ -8,8 +8,10 @@ import org.apfloat.Apfloat;
 import org.hipparchus.linear.RealMatrix;
 import org.hipparchus.linear.RealVector;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.builtin.Algebra;
 import org.matheclipse.core.convert.AST2Expr;
+import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.expression.ASTRealMatrix;
 import org.matheclipse.core.expression.ASTRealVector;
@@ -435,6 +437,7 @@ public abstract class DoubleFormFactory {
         buf.append("(" + value + ")");
         return;
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         //
       }
     }
@@ -1255,6 +1258,7 @@ public abstract class DoubleFormFactory {
         buf.append("(" + value + ")");
         return;
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         //
       }
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/output/DoubleFormFactory.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/output/DoubleFormFactory.java
@@ -1153,6 +1153,7 @@ public abstract class DoubleFormFactory {
         call = PLUS_CALL;
       }
     } catch (Exception ex) {
+      Errors.rethrowsInterruptException(ex);
       return false;
     }
     if (Precedence.PLUS < precedence) {
@@ -1172,6 +1173,7 @@ public abstract class DoubleFormFactory {
     try {
       buf.append(quantity.toString());
     } catch (Exception ex) {
+      Errors.rethrowsInterruptException(ex);
       return false;
     }
     if (Precedence.PLUS < precedence) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/output/JavaComplexFormFactory.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/output/JavaComplexFormFactory.java
@@ -2,6 +2,8 @@ package org.matheclipse.core.form.output;
 
 import java.util.Map;
 import org.hipparchus.complex.Complex;
+import org.matheclipse.core.basic.OperationSystem;
+import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.expression.F;
 import org.matheclipse.core.expression.S;
@@ -132,6 +134,7 @@ public class JavaComplexFormFactory extends ComplexFormFactory {
           return;
         }
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         //
       }
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/output/JavaDoubleFormFactory.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/output/JavaDoubleFormFactory.java
@@ -1,6 +1,9 @@
 package org.matheclipse.core.form.output;
 
 import java.util.Map;
+
+import org.matheclipse.core.basic.OperationSystem;
+import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.expression.F;
 import org.matheclipse.core.expression.S;
@@ -120,6 +123,7 @@ public class JavaDoubleFormFactory extends DoubleFormFactory {
         buf.append(")");
         return;
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         //
       }
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/output/JavaScriptFormFactory.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/output/JavaScriptFormFactory.java
@@ -4,7 +4,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.builtin.PiecewiseFunctions;
+import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.exception.ArgumentTypeException;
 import org.matheclipse.core.expression.F;
@@ -380,6 +382,7 @@ public class JavaScriptFormFactory extends DoubleFormFactory {
         buf.append("(" + value + ")");
         return;
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         //
       }
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/output/OutputFormFactory.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/output/OutputFormFactory.java
@@ -14,6 +14,7 @@ import org.matheclipse.core.basic.Config;
 import org.matheclipse.core.builtin.Algebra;
 import org.matheclipse.core.builtin.LinearAlgebra;
 import org.matheclipse.core.convert.AST2Expr;
+import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.expression.ASTRealMatrix;
 import org.matheclipse.core.expression.ASTRealVector;
@@ -1863,6 +1864,7 @@ public class OutputFormFactory {
         call = PLUS_CALL;
       }
     } catch (Exception ex) {
+      Errors.rethrowsInterruptException(ex);
       return false;
     }
     if (Precedence.PLUS < precedence) {
@@ -1882,6 +1884,7 @@ public class OutputFormFactory {
     try {
       buf.append(quantity.toString());
     } catch (Exception ex) {
+      Errors.rethrowsInterruptException(ex);
       return false;
     }
     if (Precedence.PLUS < precedence) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/tex/TeXFormFactory.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/tex/TeXFormFactory.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.Logger;
 import org.apfloat.Apcomplex;
 import org.apfloat.Apfloat;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.builtin.Algebra;
 import org.matheclipse.core.convert.AST2Expr;
 import org.matheclipse.core.eval.Errors;
@@ -1425,6 +1426,7 @@ public class TeXFormFactory {
       }
       return true;
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       LOGGER.debug("TeXFormFactory.convert() failed", rex);
     } catch (OutOfMemoryError oome) {
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/tex/TeXScanner.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/tex/TeXScanner.java
@@ -1,5 +1,7 @@
 package org.matheclipse.core.form.tex;
 
+import org.matheclipse.core.basic.OperationSystem;
+import org.matheclipse.core.eval.Errors;
 import org.matheclipse.parser.client.Characters;
 
 public abstract class TeXScanner {
@@ -754,6 +756,7 @@ public abstract class TeXScanner {
               return result;
             }
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             //
           }
           throwSyntaxError(

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/tex/TeXSegmentParser.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/tex/TeXSegmentParser.java
@@ -1232,6 +1232,7 @@ class TeXSegmentParser {
         LOGGER.warn(errors.get(i));
       }
     } catch (Exception e) {
+      Errors.rethrowsInterruptException(e);
       if (Config.SHOW_STACKTRACE) {
         System.out.println(texStr);
         e.printStackTrace();

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/tex/TeXSegmentParser.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/tex/TeXSegmentParser.java
@@ -9,6 +9,7 @@ import java.util.function.Function;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.exception.AbortException;
 import org.matheclipse.core.eval.interfaces.IFunctionEvaluator;
@@ -831,6 +832,7 @@ class TeXSegmentParser {
       }
       return F.ZZ(text, 10);
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       LOGGER.debug("TeXParser.mn() failed", rex);
     }
     throw new AbortException();

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/generic/BinaryNumerical.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/generic/BinaryNumerical.java
@@ -3,6 +3,7 @@ package org.matheclipse.core.generic;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import org.hipparchus.analysis.BivariateFunction;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.exception.ArgumentTypeException;
@@ -69,6 +70,7 @@ public final class BinaryNumerical implements BinaryOperator<IExpr>, BivariateFu
       };
       result = fun.evalf(function);
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       return Double.NaN;
     }
     return result;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/generic/ComplexUnaryNumerical.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/generic/ComplexUnaryNumerical.java
@@ -2,6 +2,7 @@ package org.matheclipse.core.generic;
 
 import org.hipparchus.analysis.CalculusFieldUnivariateFunction;
 import org.hipparchus.complex.Complex;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.exception.ArgumentTypeException;
@@ -37,6 +38,7 @@ public final class ComplexUnaryNumerical
     try {
       return fEngine.evalComplex(F.subst(fUnaryFunction, F.Rule(fVariable, F.complexNum(value))));
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       return Complex.NaN;
     }
   }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/generic/MultiVariateNumerical.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/generic/MultiVariateNumerical.java
@@ -2,6 +2,7 @@ package org.matheclipse.core.generic;
 
 import java.util.ArrayList;
 import org.hipparchus.analysis.MultivariateFunction;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.exception.ArgumentTypeException;
@@ -48,6 +49,7 @@ public class MultiVariateNumerical implements MultivariateFunction {
       }
       return fFunction.evalf();
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       return Double.NaN;
     }
   }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/generic/MultiVariateVectorGradient.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/generic/MultiVariateVectorGradient.java
@@ -2,6 +2,7 @@ package org.matheclipse.core.generic;
 
 import java.util.function.Function;
 import org.hipparchus.analysis.MultivariateVectorFunction;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.exception.ArgumentTypeException;
@@ -95,6 +96,7 @@ public final class MultiVariateVectorGradient implements MultivariateVectorFunct
       try {
         result[i - 1] = fGradientFunctions.get(i).evalf(function);
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         result[i - 1] = Double.NaN;
       }
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/generic/MultivariateJacobianGradient.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/generic/MultivariateJacobianGradient.java
@@ -7,6 +7,7 @@ import org.hipparchus.linear.RealMatrix;
 import org.hipparchus.linear.RealVector;
 import org.hipparchus.optim.nonlinear.vector.leastsquares.MultivariateJacobianFunction;
 import org.hipparchus.util.Pair;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.exception.ArgumentTypeException;
@@ -104,6 +105,7 @@ public final class MultivariateJacobianGradient implements MultivariateJacobianF
           double entry = row.get(j).evalf(function);
           jacobian.setEntry(i - 1, j - 1, entry);
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           jacobian.setEntry(i - 1, j - 1, Double.NaN);
         }
       }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/generic/TwiceDifferentiableMultiVariateNumerical.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/generic/TwiceDifferentiableMultiVariateNumerical.java
@@ -7,6 +7,7 @@ import org.hipparchus.linear.FieldMatrix;
 import org.hipparchus.linear.RealMatrix;
 import org.hipparchus.linear.RealVector;
 import org.hipparchus.optim.nonlinear.vector.constrained.TwiceDifferentiableFunction;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.convert.Convert;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
@@ -153,6 +154,7 @@ public final class TwiceDifferentiableMultiVariateNumerical extends TwiceDiffere
       };
       return fFunction.evalf(function);
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       return Double.NaN;
     }
   }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/generic/UnaryCompiled.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/generic/UnaryCompiled.java
@@ -8,6 +8,7 @@ import org.hipparchus.analysis.differentiation.Derivative;
 import org.hipparchus.analysis.differentiation.UnivariateDifferentiableFunction;
 import org.hipparchus.complex.Complex;
 import org.hipparchus.exception.MathIllegalArgumentException;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.builtin.CompilerFunctions;
 import org.matheclipse.core.builtin.CompilerFunctions.CompiledFunctionArg;
 import org.matheclipse.core.eval.Errors;
@@ -115,6 +116,7 @@ public final class UnaryCompiled implements UnaryOperator<IExpr>, UnivariateDiff
     try {
       return fEngine.evalNumericFunction(F.Limit(fUnaryFunction, F.Rule(fVariable, value)));
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       return S.Indeterminate;
     }
   }
@@ -130,6 +132,7 @@ public final class UnaryCompiled implements UnaryOperator<IExpr>, UnivariateDiff
     try {
       return fEngine.evalNumericFunction(F.subst(fUnaryFunction, F.Rule(fVariable, F.num(value))));
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       return S.Indeterminate;
     }
   }
@@ -149,6 +152,7 @@ public final class UnaryCompiled implements UnaryOperator<IExpr>, UnivariateDiff
         return evaluated.evalf();
       }
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
 
     }
     return Double.NaN;
@@ -166,6 +170,7 @@ public final class UnaryCompiled implements UnaryOperator<IExpr>, UnivariateDiff
     try {
       return fEngine.evalDouble(F.Limit(fUnaryFunction, F.Rule(fVariable, F.num(value))));
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       return Double.NaN;
     }
   }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/generic/UnaryNumerical.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/generic/UnaryNumerical.java
@@ -8,6 +8,7 @@ import org.hipparchus.analysis.differentiation.Derivative;
 import org.hipparchus.analysis.differentiation.UnivariateDifferentiableFunction;
 import org.hipparchus.complex.Complex;
 import org.hipparchus.exception.MathIllegalArgumentException;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.exception.ArgumentTypeException;
@@ -133,6 +134,7 @@ public final class UnaryNumerical implements UnaryOperator<IExpr>, UnivariateDif
     try {
       return fEngine.evalNumericFunction(F.Limit(fUnaryFunction, F.Rule(fDummyVariable, value)));
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       return S.Indeterminate;
     }
   }
@@ -149,6 +151,7 @@ public final class UnaryNumerical implements UnaryOperator<IExpr>, UnivariateDif
       fDummyVariable.assignValue(F.num(value));
       return fEngine.evalNumericFunction(fUnaryFunction);
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       return S.Indeterminate;
     }
   }
@@ -166,6 +169,7 @@ public final class UnaryNumerical implements UnaryOperator<IExpr>, UnivariateDif
       fDummyVariable.assignValue(F.num(value));
       return fUnaryFunction.evalf();
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       return Double.NaN;
     }
   }
@@ -182,6 +186,7 @@ public final class UnaryNumerical implements UnaryOperator<IExpr>, UnivariateDif
     try {
       return fEngine.evalDouble(F.Limit(fUnaryFunction, F.Rule(fDummyVariable, F.num(value))));
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       return Double.NaN;
     }
   }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/graphics/GraphicsOptions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/graphics/GraphicsOptions.java
@@ -2,9 +2,12 @@ package org.matheclipse.core.graphics;
 
 import java.util.Locale;
 import java.util.function.Function;
+
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.builtin.GraphicsFunctions;
 import org.matheclipse.core.convert.Convert;
 import org.matheclipse.core.convert.RGBColor;
+import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.exception.ArgumentTypeException;
 import org.matheclipse.core.eval.util.OptionArgs;
@@ -637,6 +640,7 @@ public class GraphicsOptions {
           pointSize = pointSizeAST.arg1().evalf();
         }
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         pointSize = MEDIUM_POINTSIZE;
       }
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/interfaces/IExpr.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/interfaces/IExpr.java
@@ -25,6 +25,7 @@ import org.hipparchus.util.FieldSinCos;
 import org.hipparchus.util.FieldSinhCosh;
 import org.jgrapht.GraphType;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.builtin.BooleanFunctions;
 import org.matheclipse.core.builtin.PredicateQ;
 import org.matheclipse.core.convert.VariablesSet;
@@ -6005,6 +6006,7 @@ public interface IExpr
     try {
       return accept(new VisitorReplaceAll(function));
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       if (Config.SHOW_STACKTRACE) {
         rex.printStackTrace();
       }
@@ -6024,6 +6026,7 @@ public interface IExpr
     try {
       return accept(new VisitorReplaceAll(listOfRules));
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       if (Config.SHOW_STACKTRACE) {
         rex.printStackTrace();
       }
@@ -6043,6 +6046,7 @@ public interface IExpr
     try {
       return accept(new VisitorReplaceAll(map));
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       if (Config.SHOW_STACKTRACE) {
         rex.printStackTrace();
       }
@@ -6064,6 +6068,7 @@ public interface IExpr
     try {
       return this.accept(new VisitorReplacePart(astRules, heads));
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       if (Config.SHOW_STACKTRACE) {
         rex.printStackTrace();
       }
@@ -6126,6 +6131,7 @@ public interface IExpr
       }
       return result;
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       if (Config.SHOW_STACKTRACE) {
         rex.printStackTrace();
       }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/io/Extension.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/io/Extension.java
@@ -1,5 +1,8 @@
 package org.matheclipse.core.io;
 
+import org.matheclipse.core.basic.OperationSystem;
+import org.matheclipse.core.eval.Errors;
+
 import java.util.Locale;
 
 /**
@@ -57,7 +60,7 @@ public enum Extension {
         return true;
       }
     } catch (RuntimeException rex) {
-      //
+      Errors.rethrowsInterruptException(rex);
     }
     return false;
   }
@@ -86,7 +89,7 @@ public enum Extension {
         return valueOf(ucExtension);
       }
     } catch (RuntimeException rex) {
-      //
+      Errors.rethrowsInterruptException(rex);
     }
     return DAT;
   }
@@ -112,7 +115,7 @@ public enum Extension {
       }
       return valueOf(extensionString.toUpperCase(Locale.US));
     } catch (RuntimeException rex) {
-      //
+      Errors.rethrowsInterruptException(rex);
     }
     return DAT;
   }
@@ -141,7 +144,7 @@ public enum Extension {
         return valueOf(extensionString);
       }
     } catch (RuntimeException rex) {
-      //
+      Errors.rethrowsInterruptException(rex);
     }
     return STRING;
   }
@@ -157,7 +160,7 @@ public enum Extension {
     try {
       return valueOf(extensionString.toUpperCase(Locale.US));
     } catch (RuntimeException rex) {
-      //
+      Errors.rethrowsInterruptException(rex);
     }
     if (extensionString.equals("Text")) {
       return TXT;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/BezierFunction.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/BezierFunction.java
@@ -1,5 +1,6 @@
 package org.matheclipse.core.reflection.system;
 
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.interfaces.AbstractEvaluator;
@@ -22,6 +23,7 @@ public class BezierFunction extends AbstractEvaluator {
       try {
         return ((BezierFunctionExpr) head).evaluate(ast, engine);
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         return Errors.printMessage(S.BezierFunction, rex, engine);
       }
     } else if (head == S.BezierFunction && ast.isAST1()) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/DSolve.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/DSolve.java
@@ -1,5 +1,6 @@
 package org.matheclipse.core.reflection.system;
 
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.basic.ToggleFeature;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
@@ -204,6 +205,7 @@ public class DSolve extends AbstractFunctionEvaluator {
             return linearODE(p, q, xVar, C_1, engine);
           }
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           return Errors.printMessage(S.DSolve, rex, engine);
         }
       }
@@ -222,6 +224,7 @@ public class DSolve extends AbstractFunctionEvaluator {
         }
       }
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       Errors.printMessage(S.DSolve, rex, EvalEngine.get());
     }
     return order;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/Eliminate.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/Eliminate.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.builtin.Algebra;
 import org.matheclipse.core.builtin.BooleanFunctions;
 import org.matheclipse.core.builtin.RootsFunctions;
@@ -808,6 +809,7 @@ public class Eliminate extends AbstractFunctionEvaluator implements EliminateRul
       }
       return resultAsAndEquations(result);
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       return Errors.printMessage(S.Eliminate, rex, EvalEngine.get());
     }
   }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/Export.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/Export.java
@@ -135,6 +135,7 @@ public class Export extends AbstractEvaluator {
       } catch (IOException ioe) {
         LOGGER.log(engine.getLogLevel(), "Export: file {} not found!", arg1, ioe);
       } catch (Exception ex) {
+        Errors.rethrowsInterruptException(ex);
         LOGGER.log(engine.getLogLevel(), "Export: file {}", arg1, ex);
       }
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/Export.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/Export.java
@@ -26,6 +26,8 @@ import org.jgrapht.nio.csv.CSVExporter;
 import org.jgrapht.nio.dot.DOTExporter;
 import org.jgrapht.nio.graphml.GraphMLExporter;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
+import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.interfaces.AbstractEvaluator;
 import org.matheclipse.core.eval.interfaces.IFunctionEvaluator;
@@ -76,6 +78,7 @@ public class Export extends AbstractEvaluator {
             return arg1;
           }
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           rex.printStackTrace();
         }
         // }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/ExportString.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/ExportString.java
@@ -16,6 +16,7 @@ import org.jgrapht.nio.GraphExporter;
 import org.jgrapht.nio.csv.CSVExporter;
 import org.jgrapht.nio.dot.DOTExporter;
 import org.jgrapht.nio.graphml.GraphMLExporter;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.convert.ExpressionJSONConvert;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
@@ -115,6 +116,7 @@ public class ExportString extends AbstractEvaluator {
     } catch (IOException ioex) {
       return Errors.printMessage(S.ExportString, ioex, EvalEngine.get());
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       return Errors.printMessage(S.ExportString, rex, EvalEngine.get());
     }
     return F.NIL;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/FindInstance.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/FindInstance.java
@@ -1,5 +1,6 @@
 package org.matheclipse.core.reflection.system;
 
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.builtin.BooleanFunctions;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
@@ -84,6 +85,7 @@ public class FindInstance extends Solve {
           }
         }
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
       }
 
       ISymbol domain = S.Complexes;
@@ -110,6 +112,7 @@ public class FindInstance extends Solve {
     } catch (final ValidateException ve) {
       return Errors.printMessage(ast.topHead(), ve, engine);
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       return Errors.printMessage(S.FindInstance, rex, engine);
     }
   }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/FindMinimum.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/FindMinimum.java
@@ -28,6 +28,7 @@ import org.hipparchus.random.GaussianRandomGenerator;
 import org.hipparchus.random.JDKRandomGenerator;
 import org.hipparchus.random.RandomVectorGenerator;
 import org.hipparchus.random.UncorrelatedRandomVectorGenerator;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.convert.Convert;
 import org.matheclipse.core.convert.VariablesSet;
 import org.matheclipse.core.eval.Errors;
@@ -502,7 +503,7 @@ public class FindMinimum extends AbstractFunctionOptionEvaluator {
       }
       return realNumber;
     } catch (RuntimeException rex) {
-      //
+      Errors.rethrowsInterruptException(rex);
     }
     // The Function value `1` is not a real number at `2`=`3`.
     return Errors.printMessage(goalType == GoalType.MINIMIZE ? S.FindMinimum : S.FindMaximum,
@@ -559,6 +560,7 @@ public class FindMinimum extends AbstractFunctionOptionEvaluator {
           }
           return F.NIL;
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           rex.printStackTrace();
           method = "Powell";
         }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/Fourier.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/Fourier.java
@@ -1,6 +1,7 @@
 package org.matheclipse.core.reflection.system;
 
 import org.hipparchus.complex.Complex;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.convert.Convert;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
@@ -32,7 +33,7 @@ public class Fourier extends AbstractFunctionEvaluator {
         }
       }
     } catch (RuntimeException rex) {
-      //
+      Errors.rethrowsInterruptException(rex);
     }
     // Argument `1` is not a non-empty list or rectangular array of numeric quantities.
     return Errors.printMessage(S.Fourier, "fftl", F.list(expr), engine);

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/FrobeniusSolve.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/FrobeniusSolve.java
@@ -1,6 +1,7 @@
 package org.matheclipse.core.reflection.system;
 
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.exception.ASTElementLimitExceeded;
@@ -95,6 +96,7 @@ public class FrobeniusSolve extends AbstractEvaluator {
       } catch (LimitException le) {
         throw le;
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         return Errors.printMessage(S.FrobeniusSolve, rex, engine);
       }
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/ImportString.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/ImportString.java
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.Logger;
 import org.matheclipse.core.convert.AST2Expr;
 import org.matheclipse.core.convert.ExpressionJSONConvert;
 import org.matheclipse.core.convert.JSONConvert;
+import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.interfaces.AbstractEvaluator;
 import org.matheclipse.core.eval.interfaces.IFunctionEvaluator;
@@ -83,6 +84,7 @@ public class ImportString extends AbstractEvaluator {
     } catch (SyntaxError se) {
       LOGGER.log(engine.getLogLevel(), "ImportString: syntax error!", se);
     } catch (Exception ex) {
+      Errors.rethrowsInterruptException(ex);
       LOGGER.log(engine.getLogLevel(), "ImportString", ex);
     }
     return F.NIL;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/Integrate.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/Integrate.java
@@ -16,6 +16,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apfloat.ApfloatInterruptedException;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.builtin.Algebra;
 import org.matheclipse.core.builtin.NumberTheory;
 import org.matheclipse.core.eval.Errors;
@@ -839,6 +840,7 @@ public class Integrate extends AbstractFunctionOptionEvaluator {
           } catch (ApfloatInterruptedException | PreemptingException ex) {
             throw ex;
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             engine.setRecursionLimit(limit);
             LOGGER.log(engine.getLogLevel(),
                 "Integrate Rubi recursion limit {} RuntimeException: {}",

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/InterpolatingFunction.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/InterpolatingFunction.java
@@ -1,5 +1,6 @@
 package org.matheclipse.core.reflection.system;
 
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.interfaces.AbstractEvaluator;
@@ -22,6 +23,7 @@ public class InterpolatingFunction extends AbstractEvaluator {
       try {
         return ((InterpolatingFunctionExpr<IExpr>) head).evaluate(ast, engine);
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         return Errors.printMessage(S.InterpolatingFunction, rex, engine);
       }
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/InverseFourier.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/InverseFourier.java
@@ -1,6 +1,7 @@
 package org.matheclipse.core.reflection.system;
 
 import org.hipparchus.complex.Complex;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.convert.Convert;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
@@ -32,7 +33,8 @@ public class InverseFourier extends AbstractFunctionEvaluator {
         }
       }
     } catch (RuntimeException rex) {
-      //
+      Errors.rethrowsInterruptException(rex);
+
     }
     // Argument `1` is not a non-empty list or rectangular array of numeric quantities.
     return Errors.printMessage(S.InverseFourier, "fftl", F.list(expr), engine);

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/ListPlot.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/ListPlot.java
@@ -1,8 +1,11 @@
 package org.matheclipse.core.reflection.system;
 
 import java.util.function.Function;
+
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.builtin.GraphicsFunctions;
 import org.matheclipse.core.builtin.LinearAlgebra;
+import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.interfaces.AbstractFunctionOptionEvaluator;
 import org.matheclipse.core.eval.interfaces.IFunctionEvaluator;
@@ -499,7 +502,7 @@ public class ListPlot extends AbstractFunctionOptionEvaluator {
       }
       return true;
     } catch (RuntimeException rex) {
-      //
+      Errors.rethrowsInterruptException(rex);
     }
     return false;
   }
@@ -517,7 +520,7 @@ public class ListPlot extends AbstractFunctionOptionEvaluator {
       }
       return true;
     } catch (RuntimeException rex) {
-      //
+      Errors.rethrowsInterruptException(rex);
     }
     return false;
   }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/NDSolve.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/NDSolve.java
@@ -5,6 +5,7 @@ import org.hipparchus.ode.ODEState;
 import org.hipparchus.ode.ODEStateAndDerivative;
 import org.hipparchus.ode.OrdinaryDifferentialEquation;
 import org.hipparchus.ode.nonstiff.DormandPrince853Integrator;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.basic.ToggleFeature;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
@@ -168,6 +169,7 @@ public class NDSolve extends AbstractFunctionEvaluator {
       } catch (LimitException le) {
         throw le;
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         return Errors.printMessage(S.FindInstance, rex, engine);
       }
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/NIntegrate.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/NIntegrate.java
@@ -14,6 +14,7 @@ import org.hipparchus.exception.MathIllegalStateException;
 import org.hipparchus.exception.MathRuntimeException;
 import org.hipparchus.util.Precision;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.exception.ArgumentTypeException;
@@ -297,6 +298,7 @@ public class NIntegrate extends AbstractFunctionEvaluator {
         } catch (MathRuntimeException mre) {
           return Errors.printMessage(ast.topHead(), mre, engine);
         } catch (RuntimeException e) {
+          Errors.rethrowsInterruptException(e);
           return Errors.printMessage(ast.topHead(), e, engine);
         }
       }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/NSum.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/NSum.java
@@ -2,6 +2,8 @@ package org.matheclipse.core.reflection.system;
 
 import java.util.function.Function;
 import org.hipparchus.complex.Complex;
+import org.matheclipse.core.basic.OperationSystem;
+import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.expression.F;
 import org.matheclipse.core.expression.ImplementationStatus;
@@ -34,6 +36,7 @@ public class NSum extends Sum {
       try {
         return unaryFunction.evalf(x -> x.equals(variable) ? F.ZZ(value) : F.NIL);
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         return Double.NaN;
       }
     }
@@ -53,6 +56,7 @@ public class NSum extends Sum {
       try {
         return unaryFunction.evalfc(x -> x.equals(variable) ? F.ZZ(value) : F.NIL);
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         return Complex.NaN;
       }
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/Plot.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/Plot.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.hipparchus.stat.descriptive.moment.Mean;
 import org.hipparchus.stat.descriptive.moment.StandardDeviation;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.interfaces.IFunctionEvaluator;
@@ -219,6 +220,7 @@ public class Plot extends ListPlot {
 
           }
         } catch (RuntimeException rex) {
+          Errors.rethrowsInterruptException(rex);
           rex.printStackTrace();
         }
       }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/Plot3D.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/Plot3D.java
@@ -3,6 +3,8 @@ package org.matheclipse.core.reflection.system;
 import static org.matheclipse.core.expression.F.Rule;
 import static org.matheclipse.core.expression.F.Show;
 import static org.matheclipse.core.expression.F.SurfaceGraphics;
+
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.convert.Object2Expr;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
@@ -101,6 +103,7 @@ public class Plot3D extends AbstractFunctionOptionEvaluator {
           return Show(graphics);
         }
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         return Errors.printMessage(S.Plot3D, rex, engine);
       }
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/Reduce.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/Reduce.java
@@ -3,6 +3,7 @@ package org.matheclipse.core.reflection.system;
 import java.util.Map;
 import java.util.Set;
 import org.hipparchus.complex.Complex;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.convert.VariablesSet;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
@@ -624,6 +625,7 @@ public class Reduce extends AbstractEvaluator {
       IExpr reduced = rc.evaluate(logicalExpand);
       return reduced.orElse(logicalExpand);
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       rex.printStackTrace();
     }
     return F.NIL;

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/Solve.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/Solve.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.Logger;
 import org.chocosolver.solver.constraints.extension.hybrid.HybridTuples;
 import org.hipparchus.linear.FieldMatrix;
 import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.basic.ToggleFeature;
 import org.matheclipse.core.builtin.Algebra;
 import org.matheclipse.core.builtin.BooleanFunctions;
@@ -1020,6 +1021,7 @@ public class Solve extends AbstractFunctionOptionEvaluator {
         LOGGER.debug("Solve.solveTimesEquationsRecursively() failed", le);
         throw le;
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         LOGGER.debug("Solve.solveTimesEquationsRecursively() failed", rex);
         if (Config.SHOW_STACKTRACE) {
           rex.printStackTrace();
@@ -1231,6 +1233,7 @@ public class Solve extends AbstractFunctionOptionEvaluator {
       } catch (LimitException e) {
         LOGGER.log(engine.getLogLevel(), S.Solve, e);
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         LOGGER.debug("Solve.of() failed() failed", rex);
       }
       return F.NIL;
@@ -1327,6 +1330,7 @@ public class Solve extends AbstractFunctionOptionEvaluator {
               return resultList;
             }
           } catch (RuntimeException rex) {
+            Errors.rethrowsInterruptException(rex);
             // try 2nd solver
             // if (Config.SHOW_STACKTRACE) {
             rex.printStackTrace();
@@ -1347,6 +1351,7 @@ public class Solve extends AbstractFunctionOptionEvaluator {
         LOGGER.debug("Solve.of() failed", le);
         throw le;
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         LOGGER.log(engine.getLogLevel(), "Integers solution not found", rex);
         return F.NIL;
       }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/sympy/series/Formal.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/sympy/series/Formal.java
@@ -3,6 +3,8 @@ package org.matheclipse.core.sympy.series;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Set;
+
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.convert.VariablesSet;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
@@ -246,6 +248,7 @@ public class Formal {
         term = pt_ak.times(pt_xk);
         // } catch( IndexError ie) {
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
         term = F.C0;
       }
 

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/tensor/QuantityParser.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/tensor/QuantityParser.java
@@ -1,6 +1,7 @@
 // code adapted from https://github.com/datahaki/tensor
 package org.matheclipse.core.tensor;
 
+import org.matheclipse.core.basic.OperationSystem;
 import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.expression.F;
@@ -31,6 +32,7 @@ public class QuantityParser {
       EvalEngine engine = new EvalEngine(true);
       return engine.evaluate(string, true);
     } catch (RuntimeException rex) {
+      Errors.rethrowsInterruptException(rex);
       Errors.printMessage(S.Quantity, rex, EvalEngine.get());
       throw new IllegalArgumentException(string, rex);
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/tensor/io/ResourceData.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/tensor/io/ResourceData.java
@@ -4,6 +4,8 @@ package org.matheclipse.core.tensor.io;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
+
+import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.interfaces.IAST;
 
 /**
@@ -38,6 +40,7 @@ public class ResourceData {
     try (InputStream inputStream = ResourceData.class.getResourceAsStream(string)) {
       return ImportHelper.of(new Filename(string), inputStream);
     } catch (Exception exception) {
+      Errors.rethrowsInterruptException(exception);
       throw new RuntimeException(exception);
     }
   }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/tensor/nrm/Vector2Norm.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/tensor/nrm/Vector2Norm.java
@@ -1,6 +1,7 @@
 // code adapted from https://github.com/datahaki/tensor
 package org.matheclipse.core.tensor.nrm;
 
+import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.expression.F;
 import org.matheclipse.core.interfaces.IAST;
 import org.matheclipse.core.interfaces.IExpr;
@@ -23,6 +24,7 @@ public class Vector2Norm {
       // Hypot prevents the incorrect evaluation: Norm_2[ {1e-300, 1e-300} ] == 0
       return Hypot.ofVector(vector);
     } catch (Exception exception) {
+      Errors.rethrowsInterruptException(exception);
       // <- when vector is a scalar
       // <- when vector is empty, or contains NaN
     }

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/tensor/qty/QuantityImpl.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/tensor/qty/QuantityImpl.java
@@ -7,6 +7,9 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.Objects;
 import java.util.function.Function;
+
+import org.matheclipse.core.basic.OperationSystem;
+import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.exception.ArgumentTypeException;
 import org.matheclipse.core.eval.util.SourceCodeProperties;
@@ -108,6 +111,7 @@ public class QuantityImpl extends DataExpr<IUnit> implements IQuantity, External
         double qDouble = value.evalf();
         return ofUnit(F.num(qDouble));
       } catch (RuntimeException rex) {
+        Errors.rethrowsInterruptException(rex);
       }
     }
     return F.NIL;

--- a/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/builtin/Import.java
+++ b/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/builtin/Import.java
@@ -24,6 +24,7 @@ import org.matheclipse.core.convert.Convert;
 import org.matheclipse.core.convert.ExpressionJSONConvert;
 import org.matheclipse.core.convert.JSONConvert;
 import org.matheclipse.core.convert.matlab.Mat5Symja;
+import org.matheclipse.core.eval.Errors;
 import org.matheclipse.core.eval.EvalEngine;
 import org.matheclipse.core.eval.interfaces.AbstractEvaluator;
 import org.matheclipse.core.eval.interfaces.IFunctionEvaluator;
@@ -144,6 +145,7 @@ public class Import extends AbstractEvaluator {
     } catch (SyntaxError se) {
       LOGGER.log(engine.getLogLevel(), "Import: file {} syntax error!", fileName, se);
     } catch (Exception ex) {
+      Errors.rethrowsInterruptException(ex);
       LOGGER.log(engine.getLogLevel(), "Import: file {} ", fileName, ex);
     } finally {
       if (reader != null) {

--- a/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/builtin/SemanticImportString.java
+++ b/symja_android_library/matheclipse-io/src/main/java/org/matheclipse/io/builtin/SemanticImportString.java
@@ -107,6 +107,7 @@ public class SemanticImportString extends AbstractFunctionOptionEvaluator {
       Errors.printMessage(S.SemanticImport, "shapespec", F.List(formShape), engine);
       return S.$Failed;
     } catch (Exception rex) {
+      Errors.rethrowsInterruptException(rex);
       LOGGER.log(engine.getLogLevel(), "SemanticImportString ", rex);
       return F.NIL;
     }


### PR DESCRIPTION
Interrupt exceptions should be rethrows to top-level call.
Some internal libraries, like **JAS** and **Apfloat**, especially the **Apfloat** library catch the `InterruptException`, it also clears the current interrupt flag of current thread (I'm not understand why this is intentional). 

If we catch all `RuntimeException` without rethrowing,  it will prevent current thread from stopping and run forever.


```java
public class ApfloatContext
    implements Cloneable
{
    /**
     * Checks if the current thread was interrupted. If yes, throws an
     * {@link ApfloatInterruptedException}.<p>
     *
     * This method calls {@link Thread#interrupted()} so if the thread was
     * interrupted, it clears the interrupted status.
     *
     * @throws ApfloatInterruptedException If the current thread was interrupted.
     *
     * @since 1.14.0
     */

    public static void checkInterrupted()
        throws ApfloatInterruptedException
    {
        if (Thread.interrupted())
        {
            throw new ApfloatInterruptedException("Interrupted", "interrupted");
        }
    }
}

```