### PR TITLE
Clean-up and simplify build configuration and workflows

### DIFF
--- a/.github/actions/setup-java-for-deployment/action.yml
+++ b/.github/actions/setup-java-for-deployment/action.yml
@@ -9,11 +9,11 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up JDK 17 for Maven Central Repository deployment
+    - name: Set up JDK for Maven Central Repository deployment
       uses: actions/setup-java@v4
       with:
         # Also generates a corresponding Maven toolchains.xml
-        java-version: '17.0.17'
+        java-version: '17'
         distribution: 'temurin'
         cache: 'maven' # Cache Maven dependencies between workflow runs
         # Properties for deployment to OSSRH:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,9 @@ on:
   schedule:
     - cron: '36 17 * * 2'
 
+env:
+  MAVEN_ARGS: --batch-mode --no-transfer-progress
+
 jobs:
   analyze:
     name: Analyze
@@ -54,11 +57,11 @@ jobs:
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
-
     - name: Set up Java
       uses: ./.github/actions/setup-java-for-deployment
 
-    - run: mvn -f symja_android_library -B -U -Pexact-target-jdk -DskipTests verify
+    - run: mvn verify -DskipTests
+      working-directory: symja_android_library
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4

--- a/.github/workflows/maven-build-master-and-publish-snapshot.yml
+++ b/.github/workflows/maven-build-master-and-publish-snapshot.yml
@@ -9,6 +9,9 @@ on:
   push:
     branches: [ master ]
 
+env:
+  MAVEN_ARGS: --batch-mode --no-transfer-progress
+
 jobs:
   maven-build-master-and-publish-to-maven-central:
     runs-on: ubuntu-latest
@@ -22,7 +25,8 @@ jobs:
       with:
         gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
 
-    - run: mvn -f symja_android_library -B -U -P publish-to-maven-central,exact-target-jdk deploy -Dgpg.skip=true
+    - run: mvn deploy -Ppublish-to-maven-central -Dgpg.skip=true
+      working-directory: symja_android_library
       # Deployment of all modules is deferred to the last module by nexus-staging-maven-plugin
       env:
         MAVEN_USERNAME: ${{ secrets.OSSRH_TOKEN_USERNAME }}

--- a/.github/workflows/maven-build-pr.yml
+++ b/.github/workflows/maven-build-pr.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  MAVEN_ARGS: --batch-mode --no-transfer-progress
+
 jobs:
   maven-build-pr:
     runs-on: ubuntu-latest
@@ -18,7 +21,8 @@ jobs:
     - name: Set up Java
       uses: ./.github/actions/setup-java-for-deployment
 
-    - run: mvn -f symja_android_library -B -U -Pexact-target-jdk verify
+    - run: mvn verify
+      working-directory: symja_android_library
 
     - uses: actions/upload-artifact@v6
       with:

--- a/.github/workflows/maven-perform-release.yml
+++ b/.github/workflows/maven-perform-release.yml
@@ -5,6 +5,9 @@ name: Release to Maven-Central
 on:
   workflow_dispatch
 
+env:
+  MAVEN_ARGS: --batch-mode --no-transfer-progress
+
 jobs:
   maven-perform-release:
     runs-on: ubuntu-latest
@@ -27,10 +30,11 @@ jobs:
     # Perform the usual maven-release-plugin procedure, but prevent the release commits
     # and tag from being pushed to the master immediately. They are only pushed after
     # the release is performed successfully. This avoids to have the release
-    # commits on the master in case release publication fails in the last step).
+    # commits on the master in case release publication fails in the last step.
     # All file-system/git-operations are performed on the runnner's clone of this repo
 
-    - run: mvn -f symja_android_library -B release:clean release:prepare -DpushChanges=false
+    - run: mvn release:clean release:prepare -DpushChanges=false
+      working-directory: symja_android_library
 
     - name: Read release version
       run: | # Create environment variables associcated to release version, derived from the release tag
@@ -61,7 +65,8 @@ jobs:
       # are not on the master in case performing/publishing the release fails
       run: git push origin HEAD:refs/heads/draft_${{ env.release_version }}
 
-    - run: mvn -f symja_android_library -B release:perform -DlocalCheckout=true
+    - run: mvn release:perform -DlocalCheckout=true
+      working-directory: symja_android_library
       # Deployment of all modules is deferred to the last module by nexus-staging-maven-plugin
       env:
         MAVEN_USERNAME: ${{ secrets.OSSRH_TOKEN_USERNAME }}

--- a/symja_android_library/.mvn/maven.config
+++ b/symja_android_library/.mvn/maven.config
@@ -1,0 +1,3 @@
+--show-version
+--update-snapshots
+--errors

--- a/symja_android_library/pom.xml
+++ b/symja_android_library/pom.xml
@@ -95,7 +95,7 @@
 			</snapshots>
 		</repository>
 		<repository>
-			<id>maven-snapshots</id>
+			<id>maven-central-snapshots</id>
 			<url>https://central.sonatype.com/repository/maven-snapshots/</url>
 			<layout>default</layout>
 			<releases>
@@ -512,8 +512,7 @@
 						<tagNameFormat>v@{project.version}</tagNameFormat>
 						<autoVersionSubmodules>true</autoVersionSubmodules>
 						<useReleaseProfile>false</useReleaseProfile>
-						<releaseProfiles>
-							publish-to-maven-central,exact-target-jdk</releaseProfiles>
+						<releaseProfiles>publish-to-maven-central</releaseProfiles>
 						<arguments>-Drelease.build=true</arguments>
 					</configuration>
 				</plugin>
@@ -631,7 +630,7 @@
 						<configuration>
 							<rules>
 								<requireMavenVersion>
-									<version>3.2.0</version>
+									<version>3.9.0</version>
 								</requireMavenVersion>
 								<banDuplicatePomDependencyVersions />
 						        <requireJavaVersion>
@@ -649,8 +648,7 @@
 							<skip>${release.build}</skip>
 							<rules>
 								<requireSnapshotVersion>
-									<message>Release versions only permitted for
-										releases!</message>
+									<message>Release versions only permitted for releases!</message>
 								</requireSnapshotVersion>
 								<requireJavaVersion>
                                   <version>[17,)</version>
@@ -686,34 +684,6 @@
 		</plugins>
 	</build>
 	<profiles>
-		<profile>
-			<id>exact-target-jdk</id>
-			<build>
-				<plugins>
-					<!-- Activate toolchains only on demand to not require a set
-					up toolchains.xml for everyone building Symja-->
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-toolchains-plugin</artifactId>
-						<executions>
-							<execution>
-								<goals>
-									<goal>toolchain</goal>
-								</goals>
-							</execution>
-						</executions>
-						<configuration>
-							<toolchains>
-								<jdk>
-									<version>${java.version}</version>
-								</jdk>
-							</toolchains>
-						</configuration>
-					</plugin>
-
-				</plugins>
-			</build>
-		</profile>
 		<profile>
 			<id>publish-to-maven-central</id>
 			<build>


### PR DESCRIPTION
## Description

Remove effectively unused 'exact-target-jdk' profile. The workflow run with only Java-17 and do not install Java-11. Instead the compiler is instructed to target the 11 release using the '-release' option.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)
