### PR TITLE
Use collected variables in Solve if specified variables are NIL or empty

### DIFF
--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/Solve.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/Solve.java
@@ -1281,7 +1281,7 @@ public class Solve extends AbstractFunctionOptionEvaluator {
         }
         IAST equationVariables = VariablesSet.getVariables(ast.arg1());
         IAST variables = F.NIL;
-        if (ast.argSize() > 1) {
+        if (ast.argSize() > 1 && !ast.arg2().isNIL() && !ast.arg2().isEmptyList()) {
           variables = Validate.checkIsVariableOrVariableList(ast, 2, ast.topHead(), engine);
         } else {
           variables = equationVariables;

--- a/symja_android_library/matheclipse-core/src/test/java/org/matheclipse/core/system/SolveTest.java
+++ b/symja_android_library/matheclipse-core/src/test/java/org/matheclipse/core/system/SolveTest.java
@@ -2480,6 +2480,20 @@ public class SolveTest extends ExprEvaluatorTestCase {
   }
 
   @Test
+  public void testNoExplicitVariableList() {
+    check("Solve(x^2 - 1 == 0)", //
+        "{{x->-1},{x->1}}");
+  }
+
+  @Test
+  public void testEmptyVariableList() {
+    // In case the specified variable list is empty, fall back to implicit search
+    check("Solve(x^2 - 1 == 0,{})", //
+        "{{x->-1},{x->1}}");
+  }
+
+
+  @Test
   public void testCasusIrreducibilisRealRoots() {
     // Edge Case: (x-1)*(x-2)*(x-3)*(x-4) == 0
     // Expanded: x^4 - 10*x^3 + 35*x^2 - 50*x + 24 == 0


### PR DESCRIPTION
## Description
Use collected variables in Solve if specified variables are NIL or empty.

This makes the use of Solve a bit simpler in these cases.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)
