### PR TITLE
Remove unused hard-coded Config.getVersion() fallback

### DIFF
--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/basic/Config.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/basic/Config.java
@@ -653,7 +653,7 @@ public class Config {
       // don't use a Logger in Config startup methods. Print the message to console instead:
       System.out.println("Config.getVersion() failed: " + e.getMessage());
     }
-    return "3.1.1";
+    return null;
   }
 
   /** A trie builder for mapping int[] sequences to IExpr. */


### PR DESCRIPTION
By default the math-eclipse version is read from the embedded pom.properties file, which already exists for built MathEclipse jars (if not it's a build configuration error).
And even when building and running Symja from the Eclipse IDE (and probably also others), the pom.properties file exists. So there is actually no case where that file is missing and where the fallback is used.
Just removing it, simplifies the RelEng process.

And in the worst-case, if in some not foreseen scenario that file indeed is missing, the version not being available shouldn't be a big problem.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)
