### PR TITLE
Fix ChannelFactory.terminate() to close all queued SocketChannels 

### DIFF
--- a/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/ChannelFactory.java
+++ b/symja_android_library/matheclipse-external/src/main/java/edu/jas/util/ChannelFactory.java
@@ -254,12 +254,20 @@ public class ChannelFactory extends Thread {
                 srvrun = false;
             }
             this.interrupt();
+            IOException first = null;
             while (!buf.isEmpty()) {
                 logger.debug("closing unused SocketChannel");
                 SocketChannel c  = buf.poll();
                 if ( c != null ) {
-                    c.close();
-                }
+                    try {
+                        c.close();
+                    } catch (IOException) {
+                        if (first == null) first = e;
+                        else first.addSuppressed(e);
+                    }
+            }
+            if (first != null) {
+                logger.info("One or more SocketChannels failed to close during terminate()", first);
             }
         } catch (IOException e) {
             //} catch (InterruptedException e) {


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

`ChannelFactory#terminate()` closes pending `SocketChannels` from an internal queue. Previously, if closing one channel threw `IOException`, the method stopped closing the remaining queued channels. This change closes all queued channels, aggregates the first `IOException` (suppressing subsequent ones), and logs once at the end.

## Testing
Existing CI/tests.
