### PR TITLE
Resolve used but undeclared dependencies of core modules

### DIFF
--- a/symja_android_library/matheclipse-core/pom.xml
+++ b/symja_android_library/matheclipse-core/pom.xml
@@ -42,6 +42,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.hipparchus</groupId>
+			<artifactId>hipparchus-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.hipparchus</groupId>
 			<artifactId>hipparchus-clustering</artifactId>
 		</dependency>
 		<dependency>
@@ -65,8 +69,16 @@
 			<artifactId>hipparchus-optim</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.hipparchus</groupId>
+			<artifactId>hipparchus-stat</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.jgrapht</groupId>
 			<artifactId>jgrapht-io</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
@@ -74,7 +86,15 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-text</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-csv</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>

--- a/symja_android_library/matheclipse-external/pom.xml
+++ b/symja_android_library/matheclipse-external/pom.xml
@@ -45,10 +45,6 @@
 			<artifactId>log4j-api</artifactId>
 		</dependency>
 		
-		<dependency>
-			<groupId>org.hipparchus</groupId>
-			<artifactId>hipparchus-core</artifactId> 
-		</dependency>
 		<!-- test dependencies -->
 		<dependency>
 			<groupId>${project.groupId}</groupId>

--- a/symja_android_library/matheclipse-gpl/pom.xml
+++ b/symja_android_library/matheclipse-gpl/pom.xml
@@ -25,8 +25,17 @@
 	<dependencies>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
+			<artifactId>matheclipse-external</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>matheclipse-core</artifactId>
 			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>it.unimi.dsi</groupId>
+			<artifactId>fastutil-core</artifactId>
 		</dependency>
 
 		<!-- logging dependencies -->

--- a/symja_android_library/matheclipse-image/pom.xml
+++ b/symja_android_library/matheclipse-image/pom.xml
@@ -26,6 +26,11 @@
 
 		<dependency>
 			<groupId>${project.groupId}</groupId>
+			<artifactId>matheclipse-external</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>matheclipse-core</artifactId>
 			<version>${project.version}</version>
 		</dependency>
@@ -37,6 +42,20 @@
 			<artifactId>matheclipse-logging</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.hipparchus</groupId>
+			<artifactId>hipparchus-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.hipparchus</groupId>
+			<artifactId>hipparchus-stat</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>it.unimi.dsi</groupId>
+			<artifactId>fastutil-core</artifactId>
+		</dependency>
+
 		<dependency>
     			<groupId>com.github.weisj</groupId>
     			<artifactId>jsvg</artifactId> 

--- a/symja_android_library/matheclipse-script/pom.xml
+++ b/symja_android_library/matheclipse-script/pom.xml
@@ -25,6 +25,11 @@
 	<dependencies>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
+			<artifactId>matheclipse-parser</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>matheclipse-core</artifactId>
 			<version>${project.version}</version>
 		</dependency>
@@ -37,6 +42,14 @@
 			<groupId>${project.groupId}</groupId>
 			<artifactId>matheclipse-gpl</artifactId>
 			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apfloat</groupId>
+			<artifactId>apfloat</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
 		</dependency>
 	</dependencies>
  

--- a/symja_android_library/pom.xml
+++ b/symja_android_library/pom.xml
@@ -160,11 +160,6 @@
 				<version>2.9.1</version>
 			</dependency>
 			<dependency>
-				<groupId>commons-codec</groupId>
-				<artifactId>commons-codec</artifactId>
-				<version>1.22.0</version>
-			</dependency>
-			<dependency>
 				<groupId>io.github.classgraph</groupId>
 				<artifactId>classgraph</artifactId>
 				<version>4.8.184</version>
@@ -200,14 +195,24 @@
 				<version>1.14.1</version>
 			</dependency>
 			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-lang3</artifactId>
+				<version>3.20.0</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-text</artifactId>
+				<version>1.15.0</version>
+			</dependency>
+			<dependency>
 				<groupId>commons-io</groupId>
 				<artifactId>commons-io</artifactId>
 				<version>2.22.0</version>
 			</dependency>
 			<dependency>
-				<groupId>org.apache.commons</groupId>
-				<artifactId>commons-lang3</artifactId>
-				<version>3.20.0</version>
+				<groupId>commons-codec</groupId>
+				<artifactId>commons-codec</artifactId>
+				<version>1.22.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.lucene</groupId>
@@ -272,6 +277,11 @@
 			<dependency>
 				<groupId>org.hipparchus</groupId>
 				<artifactId>hipparchus-optim</artifactId>
+				<version>4.0.3</version>
+			</dependency>
+			<dependency>
+				<groupId>org.hipparchus</groupId>
+				<artifactId>hipparchus-stat</artifactId>
 				<version>4.0.3</version>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
## Description

Resolves used but undeclared dependencies of core modules

Uses `mvn dependency:analyze` to identify used but undeclared and unused declared dependencies.

Avoiding used undeclared dependencies (i.e. just transitively declared dependencies) ensures that the required versions in the OSGi metadata match the declared Maven dependencies.
If transitive dependency versions are overridden through a dependencyManagement section it can lead to missmatches.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

