### PR TITLE
Fix two argument ArcTan for tiny but non zero arguments

### DIFF
--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/ExpTrigsFunctions.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/ExpTrigsFunctions.java
@@ -1,5 +1,7 @@
 package org.matheclipse.core.builtin;
 
+import static org.matheclipse.core.builtin.ExpTrigsFunctionsExt.divideExact;
+import static org.matheclipse.core.builtin.ExpTrigsFunctionsExt.isExactZero;
 import static org.matheclipse.core.expression.F.ArcCot;
 import static org.matheclipse.core.expression.F.ArcCoth;
 import static org.matheclipse.core.expression.F.ArcCsc;
@@ -1149,8 +1151,12 @@ public class ExpTrigsFunctions {
 
     @Override
     public IExpr e2ObjArg(IExpr x, IExpr y) {
-      if (x.isZero() && y.isRealResult()) {
-        if (y.isZero()) {
+      // isExactZero() instead of isZero(): the angle of (x,y) is scale invariant, so "is this
+      // coordinate the origin?" has to be decided without a tolerance. isZero() would map every
+      // point closer to the origin than Config.DOUBLE_TOLERANCE onto the undefined ArcTan(0,0).
+      if (isExactZero(x) && y.isRealResult()) {
+        if (isExactZero(y)) {
+          // only the true origin has no angle
           return S.Indeterminate;
         }
         if (y.isPositiveResult()) {
@@ -1161,20 +1167,21 @@ public class ExpTrigsFunctions {
         }
         return F.NIL;
       }
-      if (y.isZero() && x.isNumericFunction(true) && !x.isZero()) {
+      // the point lies exactly on the x axis: 0 for a positive and Pi for a negative x
+      if (isExactZero(y) && x.isNumericFunction(true) && !isExactZero(x)) {
         return F.Times(F.Subtract(F.C1, x.unitStep()), S.Pi);
       }
       IExpr yUnitStep = y.unitStep();
       if (x.isNumericFunction(true) && yUnitStep.isInteger()) {
         if (x.re().isNegative()) {
-          return F.Plus(F.ArcTan(F.Divide(y, x)),
+          return F.Plus(F.ArcTan(divideExact(y, x)),
               F.Times(F.Subtract(F.Times(F.C2, yUnitStep), F.C1), S.Pi));
         }
         IExpr argX = x.complexArg();
         // -Pi/2 < Arg(x) <= Pi/2
         if (argX.isPresent()
             && F.evalTrue(F.And(F.Less(F.CNPiHalf, argX), F.LessEqual(argX, F.CPiHalf)))) {
-          return F.ArcTan(F.Divide(y, x));
+          return F.ArcTan(divideExact(y, x));
         }
       }
       if (x.isInfinity()) {

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/ExpTrigsFunctionsExt.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/builtin/ExpTrigsFunctionsExt.java
@@ -1,0 +1,87 @@
+package org.matheclipse.core.builtin;
+
+import org.matheclipse.core.basic.Config;
+import org.matheclipse.core.expression.ApfloatNum;
+import org.matheclipse.core.expression.F;
+import org.matheclipse.core.expression.Num;
+import org.matheclipse.core.expression.S;
+import org.matheclipse.core.interfaces.IExpr;
+import org.matheclipse.core.interfaces.INumber;
+
+/**
+ * Helpers of {@link ExpTrigsFunctions} which answer a <i>scale free</i> question about a number and
+ * therefore must not use the numerical tolerance of {@link IExpr#isZero()}.
+ */
+public final class ExpTrigsFunctionsExt {
+
+  private ExpTrigsFunctionsExt() {
+    // utility class, not instantiable
+  }
+
+  /**
+   * Test if <code>expr</code> is exactly the number <code>0</code>.
+   *
+   * <p>
+   * {@link IExpr#isZero()} is <em>tolerance</em> based for inexact numbers: {@link Num} compares
+   * against {@link Config#DOUBLE_TOLERANCE} (about <code>1.11*10^-15</code>), {@link ApfloatNum}
+   * against <code>10^-precision</code>. That answers the question &quot;did this numeric
+   * computation cancel to zero?&quot; and it is the right default nearly everywhere - but not for a
+   * question which is scale free. <code>ArcTan(x,y)</code> for example is the polar angle of the
+   * point <code>(x,y)</code> and that angle is scale invariant:
+   * <code>(3.0*10^-20,4.0*10^-20)</code> is the very same 3-4-5 direction as <code>(3,4)</code>.
+   * Only the true origin has no angle, so the origin test must not use a tolerance.
+   * </p>
+   *
+   * <p>
+   * A tolerance of <code>0.0</code> switches {@link INumber#isZero(double)} to an exact comparison
+   * for every inexact number type: <code>F#isFuzzyEquals</code> keeps its <code>a == b</code> case,
+   * so the machine zeros <code>0.0</code> and <code>-0.0</code> are still zero. The exact number
+   * types ignore the tolerance argument, and every expression which is not an {@link INumber} keeps
+   * the plain {@link IExpr#isZero()}.
+   * </p>
+   *
+   * @param expr the expression to test
+   * @return <code>true</code> if <code>expr</code> is exactly the number <code>0</code>
+   */
+  public static boolean isExactZero(IExpr expr) {
+    if (expr instanceof INumber) {
+      return ((INumber) expr).isZero(0.0);
+    }
+    return expr.isZero();
+  }
+
+  /**
+   * Calculate <code>y/x</code> for a denominator which {@link #isExactZero(IExpr)} has already
+   * accepted as non zero.
+   *
+   * <p>
+   * {@link F#Divide(IExpr, IExpr)} rejects its denominator with the same tolerance based
+   * {@link IExpr#isZero()} and answers {@link S#Indeterminate} for a tiny but perfectly
+   * representable denominator such as <code>3.0*10^-20</code> - the quadrant the caller just
+   * determined correctly would be thrown away again. Only in that narrow window (a number which is
+   * &quot;tolerance zero&quot; but not exactly zero) the quotient is built here directly as
+   * <code>y*(1/x)</code>, which is the same calculation {@link F#Divide(IExpr, IExpr)} performs for
+   * a number denominator. Every other denominator - in particular a real zero, with its
+   * <code>Power::indet</code> message - keeps the established {@link F#Divide(IExpr, IExpr)}
+   * behaviour.
+   * </p>
+   *
+   * @param y the numerator
+   * @param x the denominator
+   * @return <code>y/x</code>
+   */
+  public static IExpr divideExact(IExpr y, IExpr x) {
+    if (x.isNumber() && x.isZero() && !isExactZero(x)) {
+      // x is zero for the tolerance based test only, so form the quotient without that test.
+      // Power(x,-1) must not be used for the reciprocal: the Power evaluator applies the same
+      // tolerance to its base and would answer ComplexInfinity.
+      IExpr inverseX = ((INumber) x).inverse();
+      if (y.isNumber()) {
+        // the same shortcut F#Divide() takes for a number numerator
+        return y.times(inverseX);
+      }
+      return F.Times(y, inverseX);
+    }
+    return F.Divide(y, x);
+  }
+}

--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/rules/ArcTanRules.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/reflection/system/rules/ArcTanRules.java
@@ -94,12 +94,18 @@ public class ArcTanRules {
       CNPiHalf, true),
     // ArcTan(ComplexInfinity)=Indeterminate
     ISet(ArcTan(CComplexInfinity),
-      Indeterminate, true),
-    // ArcTan(x_?RealValuedNumberQ,y_?RealValuedNumberQ):=If(x==0,If(y==0,Indeterminate,If(y>0,Pi/2,(-1)*1/2*Pi)),If(x>0,ArcTan(y/x),If(y>=0,ArcTan(y/x)+Pi,-Pi+ArcTan(y/x))))
-    ISetDelayed(ArcTan(PatternTest(x_,RealValuedNumberQ),PatternTest(y_,RealValuedNumberQ)),
-      If(Equal(x,C0),If(Equal(y,C0),Indeterminate,If(Greater(y,C0),CPiHalf,Times(CN1,C1D2,Pi))),If(Greater(x,C0),ArcTan(Times(Power(x,CN1),y)),If(GreaterEqual(y,C0),Plus(ArcTan(Times(Power(x,CN1),y)),Pi),Plus(CNPi,ArcTan(Times(Power(x,CN1),y))))))),
-    // ArcTan(x_?NumberQ,y_?NumberQ):=(Pi*(-x+2*Sqrt(x^2)))/(4*y)/;x^2==y^2
-    ISetDelayed(ArcTan(PatternTest(x_,NumberQ),PatternTest(y_,NumberQ)),
-      Condition(Times(Pi,Plus(Negate(x),Times(C2,Sqrt(Sqr(x)))),Power(Times(C4,y),CN1)),Equal(Sqr(x),Sqr(y))))
+      Indeterminate, true)
+    // The two 2-argument down rules that used to stand here were deleted on purpose - see
+    // rules/ArcTanRules.m for the same note in the generator source:
+    //   ArcTan(x_?RealValuedNumberQ,y_?RealValuedNumberQ) := If(x==0, ...)
+    //   ArcTan(x_?NumberQ,y_?NumberQ) := (Pi*(-x+2*Sqrt(x^2)))/(4*y) /; x^2==y^2
+    // EvalEngine consults the down rules of a symbol BEFORE the built-in evaluator, so both rules
+    // shadowed ExpTrigsFunctions.ArcTan#e2ObjArg for every pair of numbers. Both decide their case
+    // with Equal, which is tolerance based for inexact numbers, and both therefore answered
+    // nonsense for arguments below that tolerance: for ArcTan(3.0*10^-20,4.0*10^-20) the first
+    // rule saw x==0 and y==0 and returned Indeterminate, the second saw x^2==y^2 and returned
+    // 3/16*Pi - although the point (3*10^-20,4*10^-20) has the very same direction as (3,4).
+    // Neither is repairable in rule syntax because there is no exact zero predicate at rule level.
+    // Both rules are redundant: e2ObjArg computes the same quadrant corrected angle exactly.
   );
 }

--- a/symja_android_library/matheclipse-core/src/test/java/org/matheclipse/core/system/ExpTrigsFunctionsTest.java
+++ b/symja_android_library/matheclipse-core/src/test/java/org/matheclipse/core/system/ExpTrigsFunctionsTest.java
@@ -1,0 +1,149 @@
+package org.matheclipse.core.system;
+
+import org.junit.jupiter.api.Test;
+
+public class ExpTrigsFunctionsTest extends ExprEvaluatorTestCase {
+
+  /**
+   * <code>ArcTan(x,y)</code> is the polar angle of the point <code>(x,y)</code> and that angle is
+   * scale invariant: <code>(3*10^-20, 4*10^-20)</code> is the very same 3-4-5 direction as
+   * <code>(3,4)</code>, so the answer is <code>ArcTan(4/3) = 0.927295...</code> no matter how short
+   * the vector is.
+   *
+   * <p>
+   * This used to answer <code>Indeterminate</code> resp. <code>3/16*Pi</code>, because the zero
+   * test was tolerance based (<code>Config#DOUBLE_TOLERANCE</code>, about <code>1.11*10^-15</code>)
+   * and every point closer to the origin than that collapsed onto the undefined
+   * <code>ArcTan(0,0)</code>.
+   * </p>
+   */
+  @Test
+  public void testArcTanTwoArgumentsTinyValues() {
+    // all four quadrants far below the zero tolerance ...
+    check("ArcTan(3.0*10^-20,4.0*10^-20)", //
+        "0.927295");
+    check("ArcTan(-3.0*10^-20,4.0*10^-20)", //
+        "2.2143");
+    check("ArcTan(-3.0*10^-20,-4.0*10^-20)", //
+        "-2.2143");
+    check("ArcTan(3.0*10^-20,-4.0*10^-20)", //
+        "-0.927295");
+
+    // ... are the same angles as at ordinary magnitude
+    check("ArcTan(3.0,4.0)", //
+        "0.927295");
+    check("ArcTan(-3.0,4.0)", //
+        "2.2143");
+    check("ArcTan(-3.0,-4.0)", //
+        "-2.2143");
+    check("ArcTan(3.0,-4.0)", //
+        "-0.927295");
+  }
+
+  /** The angle does not depend on the length of the vector, for any number type. */
+  @Test
+  public void testArcTanTwoArgumentsScaleInvariance() {
+    // exact rationals
+    check("ArcTan(3/10^20,4/10^20)", //
+        "ArcTan(4/3)");
+    check("N(ArcTan(3/10^20,4/10^20),50)", //
+        "0.92729521800161223242851246292242880405707410857224");
+
+    // machine precision doubles, above and below the zero tolerance
+    check("ArcTan(3.0*10^-13,4.0*10^-13)", //
+        "0.927295");
+    check("ArcTan(3.0*10^-16,4.0*10^-16)", //
+        "0.927295");
+    check("ArcTan(3.0*10^-300,4.0*10^-300)", //
+        "0.927295");
+    check("ArcTan(-3.0*10^-300,4.0*10^-300)", //
+        "2.2143");
+
+    // arbitrary precision reals
+    check("ArcTan(3`20*10^-20,4`20*10^-20)", //
+        "0.92729521800161223242");
+
+    // the same direction reached through Arg() of a tiny complex number
+    check("Arg(3.0*10^-20+I*4.0*10^-20)", //
+        "0.927295");
+  }
+
+  /** Only the true origin has no angle. */
+  @Test
+  public void testArcTanTwoArgumentsOrigin() {
+    check("ArcTan(0,0)", //
+        "Indeterminate");
+    check("ArcTan(0.0,0.0)", //
+        "Indeterminate");
+
+    // a point on the y axis keeps its right angle, however tiny it is
+    check("ArcTan(0,1)", //
+        "Pi/2");
+    check("ArcTan(0,-1)", //
+        "-Pi/2");
+    check("ArcTan(0,4.0*10^-20)", //
+        "Pi/2");
+    check("ArcTan(0,-4.0*10^-20)", //
+        "-Pi/2");
+
+    // a point on the x axis: 0 for a positive and Pi for a negative x
+    check("ArcTan(1.0*10^-20,0)", //
+        "0");
+    check("ArcTan(-1.0*10^-20,0)", //
+        "Pi");
+  }
+
+  /** A tiny coordinate combined with an ordinary one must not collapse either. */
+  @Test
+  public void testArcTanTwoArgumentsMixedMagnitudes() {
+    check("ArcTan(1.0*10^-20,1.0)", //
+        "1.5708");
+    check("ArcTan(-1.0*10^-20,1.0)", //
+        "1.5708");
+    check("ArcTan(1.0,1.0*10^-20)", //
+        "1.*10^-20");
+    check("ArcTan(1.0,-1.0*10^-20)", //
+        "-1.*10^-20");
+
+    // a symbolic numerator over a tiny denominator still has to divide
+    check("ArcTan(3.0*10^-20,Pi)", //
+        "1.5708");
+  }
+
+  /** The established values of the two argument form must not regress. */
+  @Test
+  public void testArcTanTwoArgumentsOrdinaryValues() {
+    check("ArcTan(1,1)", //
+        "Pi/4");
+    check("ArcTan(-1,-1)", //
+        "-3/4*Pi");
+    check("ArcTan(-1,1)", //
+        "3/4*Pi");
+    check("ArcTan(1,-1)", //
+        "-Pi/4");
+    check("ArcTan(1,0)", //
+        "0");
+    check("ArcTan(-1,0)", //
+        "Pi");
+    check("ArcTan(1,Sqrt(3))", //
+        "Pi/3");
+    check("ArcTan(Infinity,1)", //
+        "0");
+    check("N(ArcTan(2, 1), 50)", //
+        "0.4636476090008061162142562314612144020285370542861");
+
+    // the diagonals at inexact magnitude are numeric, in every quadrant
+    check("ArcTan(2.0,2.0)", //
+        "0.785398");
+    check("ArcTan(-2.0,-2.0)", //
+        "-2.35619");
+    check("ArcTan(2.0*10^-20,2.0*10^-20)", //
+        "0.785398");
+    check("ArcTan(-2.0*10^-20,-2.0*10^-20)", //
+        "-2.35619");
+
+    // symbolic arguments stay unevaluated
+    check("ArcTan(x,y)", //
+        "ArcTan(x,y)");
+  }
+}

--- a/symja_android_library/rules/ArcTanRules.m
+++ b/symja_android_library/rules/ArcTanRules.m
@@ -27,10 +27,18 @@
  ArcTan(-Infinity)=-Pi/2,
  ArcTan(I*Infinity)=Pi/2,
  ArcTan(-I*Infinity)=-Pi/2,
- ArcTan(ComplexInfinity)=Indeterminate,
- ArcTan(x_?RealValuedNumberQ, y_?RealValuedNumberQ) :=  
-   If(x == 0, If(y == 0, Indeterminate, If(y > 0, Pi/2, -Pi/2)), If(x > 0,
-        ArcTan(y/x), If(y >= 0, ArcTan(y/x) + Pi, ArcTan(y/x) - Pi))),
- ArcTan(x_?NumberQ, y_?NumberQ) := (Pi*(2*Sqrt(x^2) - x))/(4*y) 
-   /; (x^2 == y^2)
+ ArcTan(ComplexInfinity)=Indeterminate
+ (* The two 2-argument down rules that used to stand here were deleted on purpose:
+      ArcTan(x_?RealValuedNumberQ, y_?RealValuedNumberQ) := If(x == 0, ...)
+      ArcTan(x_?NumberQ, y_?NumberQ) := (Pi*(2*Sqrt(x^2) - x))/(4*y) /; (x^2 == y^2)
+    1) They are redundant: the built-in evaluator ExpTrigsFunctions.ArcTan#e2ObjArg computes the
+       same quadrant corrected angle for every pair of numbers.
+    2) They are harmful: EvalEngine tries the down rules BEFORE the built-in evaluator, so these
+       rules hid the built-in completely and any fix made there was dead code.
+    3) They cannot be repaired in rule syntax: both decide their case with Equal, which is
+       tolerance based for inexact numbers, and there is no exact zero predicate at rule level.
+       For ArcTan(3.0*10^-20, 4.0*10^-20) the first rule saw x == 0 and y == 0 and answered
+       Indeterminate, the second saw x^2 == y^2 and answered 3/16*Pi - although the point
+       (3*10^-20, 4*10^-20) has the very same direction as the point (3, 4).
+    See ExpTrigsFunctionsTest#testArcTanTwoArgumentsTinyValues. *)
  }


### PR DESCRIPTION
ArcTan(x,y) is the polar angle of the point (x,y) and that angle is scale invariant: (3*10^-20, 4*10^-20) is the very same 3-4-5 direction as (3,4). The engine answered Indeterminate for the machine precision spelling and 3/16*Pi for the arbitrary precision one.

Two independent tolerance based zero tests caused this, both applied to a question that is scale free:

1. The two 2-argument down rules of ArcTanRules decide their case with Equal, which is tolerance based for inexact numbers. Down rules are consulted before the built-in evaluator, so they shadowed ExpTrigsFunctions.ArcTan entirely: the first rule saw x==0 and y==0 and returned Indeterminate, the second saw x^2==y^2 and returned (Pi*(-x+2*Sqrt(x^2)))/(4*y) = 3/16*Pi. Neither is repairable in rule syntax because there is no exact zero predicate at rule level, and both are redundant with the built-in, so both are removed - in the generated file and in rules/ArcTanRules.m.

2. ExpTrigsFunctions.ArcTan#e2ObjArg decided "is this coordinate the origin?" with the tolerance based IExpr#isZero(), and F#Divide rejected the tiny denominator with the same test. Both now go through the new ExpTrigsFunctionsExt#isExactZero() resp. #divideExact(). divideExact() deviates from F#Divide only for a denominator which is "tolerance zero" but not exactly zero; a real zero keeps its Power::indet message.

ArcTan(0,0) stays Indeterminate, ArcTan(0,y) keeps its right angle, and Arg() of a tiny complex number is fixed by the same change.

Covered by the new ExpTrigsFunctionsTest.
