### PR TITLE
Bracket a scientific-notation number under Power and Divide

### DIFF
--- a/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/output/OutputFormFactory.java
+++ b/symja_android_library/matheclipse-core/src/main/java/org/matheclipse/core/form/output/OutputFormFactory.java
@@ -640,11 +640,18 @@ public class OutputFormFactory {
 
   private void convertDoubleString(final Appendable buf, final String d, final int precedence,
       final boolean isNegative) throws IOException {
-    if (isNegative && (Precedence.PLUS < precedence)) {
+    // A number rendered in scientific notation ("1.5*10^30", see ApfloatToMMA and DoubleToMMA) is
+    // a Times expression, not an atom, so it needs parentheses under every operator that binds
+    // tighter than Times - Power and Divide. Without them the printed form denotes something else:
+    // Power(2, 1.5*10^30) would print as 2^1.5*10^30, which reads as (2^1.5)*10^30.
+    final boolean isProduct = d.indexOf("*10^") > 0;
+    final boolean parenthesize = (isNegative && (Precedence.PLUS < precedence))
+        || (isProduct && (Precedence.TIMES < precedence));
+    if (parenthesize) {
       append(buf, "(");
     }
     append(buf, d);
-    if (isNegative && (Precedence.PLUS < precedence)) {
+    if (parenthesize) {
       append(buf, ")");
     }
   }

--- a/symja_android_library/matheclipse-core/src/test/java/org/matheclipse/core/system/OutputFormTest.java
+++ b/symja_android_library/matheclipse-core/src/test/java/org/matheclipse/core/system/OutputFormTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 import org.matheclipse.core.basic.Config;
 import org.matheclipse.core.eval.ExprEvaluator;
+import org.matheclipse.core.expression.F;
 import org.matheclipse.core.form.output.OutputFormFactory;
 import org.matheclipse.core.interfaces.IExpr;
 
@@ -235,5 +236,36 @@ public class OutputFormTest extends ExprEvaluatorTestCase {
     check("Head(TableForm({{a,b},{c,d}}))", "TableForm");
     check("FullForm(TableForm({{a,b},{c,d}}))", "TableForm(List(List(a, b), List(c, d)))");
     check("TableForm({{a,b},{c,d}})", " a  b \n c  d ");
+  }
+
+  /**
+   * A number rendered in scientific notation (<code>1.5*10^30</code>) is a <code>Times</code>
+   * expression, not an atom, so it needs parentheses under every operator that binds tighter than
+   * <code>Times</code>. Printed without them, <code>Power(2.0, 1.5*10^30)</code> came out as
+   * <code>2.0^1.500000000000000*10^30</code>, which reads back as <code>(2.0^1.5)*10^30</code> - a
+   * different, finite value.
+   */
+  @Test
+  public void testScientificNotationIsParenthesizedUnderPower() {
+    ExprEvaluator evaluator = new ExprEvaluator();
+    OutputFormFactory outputFormFactory = OutputFormFactory.get(true, false);
+
+    // the exponent is a single number, however many operators its printed form takes
+    IExpr exponent = evaluator.eval("2^N(1.5*10^30, 30)");
+    assertEquals(exponent.fullFormString(), "Power(2.0`, 1.5`16*^30)");
+    assertEquals(outputFormFactory.toString(exponent), "2.0^(1.500000000000000*10^30)");
+
+    // and the same in the base, where dropping them would read as 1.5*(10^30^2)
+    IExpr base = F.Power(evaluator.eval("N(1.5*10^30, 30)"), F.C2);
+    assertEquals(outputFormFactory.toString(base), "(1.500000000000000*10^30)^2");
+
+    // Times and Plus bind no tighter than the printed product, and the top level binds nothing,
+    // so none of those gain parentheses
+    assertEquals(outputFormFactory.toString(evaluator.eval("x*N(1.5*10^30, 30)")),
+        "1.500000000000000*10^30*x");
+    assertEquals(outputFormFactory.toString(evaluator.eval("x+N(1.5*10^30, 30)")),
+        "1.500000000000000*10^30+x");
+    assertEquals(outputFormFactory.toString(evaluator.eval("N(1.5*10^30, 30)")),
+        "1.500000000000000*10^30");
   }
 }


### PR DESCRIPTION
ApfloatToMMA and DoubleToMMA render a number as "1.5*10^30", which is a Times expression rather than an atom. convertDoubleString appended it unbracketed unless it was negative, so Power(2, 1.5*10^30) printed as 2^1.5*10^30 - a string that reads as (2^1.5)*10^30, a different and finite value.

Give the rendered form the precedence it actually has and bracket it under every operator binding tighter than Times. Times, Plus and top-level output are unchanged.


